### PR TITLE
Fix gh-pr-tracker Extension

### DIFF
--- a/extensions/gh-pr-tracker/CHANGELOG.md
+++ b/extensions/gh-pr-tracker/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to the **GitHub Pull Requests** Raycast extension are docume
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.1] - {PR_MERGE_DATE}
+
+### Added
+
+- Optional **Max Unread PRs** and **Max PRs to Scan** preferences to tune how many pull requests are surfaced and how far the fetch scans on large repositories (both 1–1000; defaults 25 and 150).
+
+### Fixed
+
+- The **Unread PR Alert** badge now refreshes immediately when you open or refresh **View Pull Requests** and when you mark items, PRs, or everything as read — previously it could stay stale until its next 5-minute interval (most noticeable in the published Store build).
+- **View Pull Requests** no longer slows to a crawl or runs out of memory on very large repositories with hundreds of open pull requests.
+
+### Changed
+
+- The **GH Host** preference is now optional and defaults to `github.com` — set it only when using GitHub Enterprise.
+- The list now surfaces up to a configurable number of pull requests with unread activity (default 25, most-recently-updated first, backfilling past already-seen or filtered PRs) so fetches stay fast on large repositories.
+
 ## [1.1.0] - 2026-07-18
 
 ### Added

--- a/extensions/gh-pr-tracker/CHANGELOG.md
+++ b/extensions/gh-pr-tracker/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the **GitHub Pull Requests** Raycast extension are docume
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [1.1.1] - {PR_MERGE_DATE}
+## [1.1.1] - 2026-07-22
 
 ### Added
 

--- a/extensions/gh-pr-tracker/README.md
+++ b/extensions/gh-pr-tracker/README.md
@@ -18,11 +18,13 @@ A [Raycast](https://raycast.com) extension that tracks unread pull request activ
 1. Install the extension in Raycast.
 2. Open **View Pull Requests** and configure the required preferences:
 
-| Preference                | Description                                       |
-| ------------------------- | ------------------------------------------------- |
-| **GH Host**               | GitHub hostname (`github.com` or your GHE server) |
-| **Personal Access Token** | A PAT with `repo` read access                     |
-| **Repositories**          | Comma-separated `owner/repo` list                 |
+| Preference                | Description                                                                |
+| ------------------------- | -------------------------------------------------------------------------- |
+| **GH Host**               | GitHub hostname — defaults to `github.com`; set only for GitHub Enterprise |
+| **Personal Access Token** | A PAT with `repo` read access                                              |
+| **Repositories**          | Comma-separated `owner/repo` list                                          |
+| **Max Unread PRs**        | Max PRs with unread activity to show (1–1000, default 25)                  |
+| **Max PRs to Scan**       | Safety cap on PRs fetched while finding unread ones (1–1000, default 150)   |
 
 ## Usage
 
@@ -35,7 +37,7 @@ Open Raycast and run **View Pull Requests**. The command shows a list of open PR
 
 ### Unread PR Alert (menu bar)
 
-Enable the **Unread PR Alert** command on MacOS to show a menu bar item with the number of PRs that have unread changes. It refreshes automatically every 5 minutes and shares its data with **View Pull Requests**, so opening the main command shows already-cached data. Clicking a PR in the dropdown opens **View Pull Requests** on that PR. The menu bar item disappears if there are no new unread changes.
+Enable the **Unread PR Alert** command on MacOS to show a menu bar item with the number of PRs that have unread changes. It refreshes automatically every 5 minutes, immediately when you open or refresh **View Pull Requests**, and whenever you mark items, PRs, or everything as read — so the badge count stays in sync with what you have seen. It shares its data with **View Pull Requests**, so opening the main command shows already-cached data. Clicking a PR in the dropdown opens **View Pull Requests** with that PR expanded. The menu bar item disappears if there are no new unread changes.
 
 ## License
 

--- a/extensions/gh-pr-tracker/package-lock.json
+++ b/extensions/gh-pr-tracker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gh-pr-tracker",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gh-pr-tracker",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.104.21",

--- a/extensions/gh-pr-tracker/package.json
+++ b/extensions/gh-pr-tracker/package.json
@@ -9,7 +9,7 @@
     "Developer Tools"
   ],
   "license": "MIT",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "commands": [
     {
       "name": "unread-updates",
@@ -31,9 +31,11 @@
     {
       "name": "ghHost",
       "title": "GH Host",
-      "description": "Your GitHub (Enterprise) hostname",
+      "description": "GitHub hostname. Leave as github.com unless you use GitHub Enterprise.",
       "type": "textfield",
-      "required": true
+      "required": false,
+      "default": "github.com",
+      "placeholder": "github.com"
     },
     {
       "name": "token",
@@ -49,6 +51,24 @@
       "type": "textfield",
       "required": true,
       "placeholder": "owner/repo1, owner/repo2"
+    },
+    {
+      "name": "maxUnreadPrs",
+      "title": "Max Unread PRs",
+      "description": "Maximum number of pull requests with unread activity to show (1–1000). Default 25.",
+      "type": "textfield",
+      "required": false,
+      "default": "25",
+      "placeholder": "25"
+    },
+    {
+      "name": "maxScanPrs",
+      "title": "Max PRs to Scan",
+      "description": "Safety cap on how many pull requests to fetch while finding unread ones on large repositories (1–1000). Higher is more thorough but slower and uses more memory. Default 150.",
+      "type": "textfield",
+      "required": false,
+      "default": "150",
+      "placeholder": "150"
     }
   ],
   "dependencies": {

--- a/extensions/gh-pr-tracker/src/api.ts
+++ b/extensions/gh-pr-tracker/src/api.ts
@@ -7,12 +7,20 @@ import type {
   GHIssueEvent,
   GHCommit,
   PRWithActivity,
+  SeenMap,
 } from "./types";
+import { prKey } from "./types";
+import type { EventFilters } from "./event-filters";
+import { getUnseenActivity, MAX_UNREAD_PRS, MAX_SCAN_PRS } from "./utils";
+
+const CONCURRENCY = 5;
 
 function getConfig() {
   const prefs = getPreferenceValues<Preferences>();
-  const isGitHubDotCom = prefs.ghHost === "github.com" || prefs.ghHost === "api.github.com";
-  const base = isGitHubDotCom ? "https://api.github.com" : `https://${prefs.ghHost}/api/v3`;
+  // Optional preference — default to github.com when unset/blank; only GitHub Enterprise needs a host.
+  const host = (prefs.ghHost || "").trim() || "github.com";
+  const isGitHubDotCom = host === "github.com" || host === "api.github.com";
+  const base = isGitHubDotCom ? "https://api.github.com" : `https://${host}/api/v3`;
   const headers = {
     Authorization: `token ${prefs.token}`,
     Accept: "application/vnd.github.v3+json",
@@ -24,9 +32,28 @@ function getConfig() {
   return { base, headers, repos };
 }
 
+/** Parse a numeric textfield preference, falling back to `fallback` and clamping to [1, 1000]. */
+function parseLimit(raw: string | undefined, fallback: number): number {
+  const n = Number.parseInt((raw ?? "").trim(), 10);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(1000, Math.max(1, n));
+}
+
+/**
+ * User-configurable fetch limits (extension preferences), used by both the fetch and the display
+ * caps so the list, badge, and cache all agree on how many unread PRs to surface.
+ */
+export function getFetchLimits(): { maxUnread: number; maxScan: number } {
+  const prefs = getPreferenceValues<Preferences>();
+  return {
+    maxUnread: parseLimit(prefs.maxUnreadPrs, MAX_UNREAD_PRS),
+    maxScan: parseLimit(prefs.maxScanPrs, MAX_SCAN_PRS),
+  };
+}
+
 /** Paginated GET — fetches all pages and concatenates results */
 async function fetchAllPages<T>(url: string, headers: Record<string, string>): Promise<T[]> {
-  let results: T[] = [];
+  const results: T[] = [];
   let page = 1;
   while (true) {
     const separator = url.includes("?") ? "&" : "?";
@@ -38,57 +65,120 @@ async function fetchAllPages<T>(url: string, headers: Record<string, string>): P
     }
     const batch = (await res.json()) as T[];
     if (!Array.isArray(batch) || batch.length === 0) break;
-    results = results.concat(batch);
+    for (const item of batch) results.push(item);
     if (batch.length < 100) break;
     page++;
   }
   return results;
 }
 
-/** Process items in batches to avoid hitting GitHub secondary rate limits */
-async function processInBatches<T, R>(items: T[], fn: (item: T) => Promise<R>, concurrency = 5): Promise<R[]> {
-  const results: R[] = [];
-  for (let i = 0; i < items.length; i += concurrency) {
-    const batch = items.slice(i, i + concurrency);
-    const batchResults = await Promise.all(batch.map(fn));
-    results.push(...batchResults);
-  }
-  return results;
-}
-
-/** Fetch open PRs with all reviews and comments for a single repo */
-async function fetchRepoActivity(
+/** Fetch all reviews / comments / events / commits for a single PR. */
+async function fetchActivity(
   base: string,
   headers: Record<string, string>,
   repo: string,
-): Promise<PRWithActivity[]> {
-  const prs = await fetchAllPages<GHPullRequest>(`${base}/repos/${repo}/pulls?state=open`, headers);
-
-  return processInBatches(prs, async (pr): Promise<PRWithActivity> => {
-    const [reviews, reviewComments, issueComments, events, commits] = await Promise.all([
-      fetchAllPages<GHReview>(`${base}/repos/${repo}/pulls/${pr.number}/reviews`, headers),
-      fetchAllPages<GHReviewComment>(`${base}/repos/${repo}/pulls/${pr.number}/comments`, headers),
-      fetchAllPages<GHIssueComment>(`${base}/repos/${repo}/issues/${pr.number}/comments`, headers),
-      fetchAllPages<GHIssueEvent>(`${base}/repos/${repo}/issues/${pr.number}/events`, headers),
-      fetchAllPages<GHCommit>(`${base}/repos/${repo}/pulls/${pr.number}/commits`, headers),
-    ]);
-    return {
-      ...pr,
-      repo,
-      reviews,
-      reviewComments,
-      issueComments,
-      events,
-      commits,
-    };
-  });
+  pr: GHPullRequest,
+): Promise<PRWithActivity> {
+  const [reviews, reviewComments, issueComments, events, commits] = await Promise.all([
+    fetchAllPages<GHReview>(`${base}/repos/${repo}/pulls/${pr.number}/reviews`, headers),
+    fetchAllPages<GHReviewComment>(`${base}/repos/${repo}/pulls/${pr.number}/comments`, headers),
+    fetchAllPages<GHIssueComment>(`${base}/repos/${repo}/issues/${pr.number}/comments`, headers),
+    fetchAllPages<GHIssueEvent>(`${base}/repos/${repo}/issues/${pr.number}/events`, headers),
+    fetchAllPages<GHCommit>(`${base}/repos/${repo}/pulls/${pr.number}/commits`, headers),
+  ]);
+  return { ...pr, repo, reviews, reviewComments, issueComments, events, commits };
 }
 
-/** Fetch open PRs with activity across all configured repositories */
-export async function fetchPRsWithActivity(): Promise<PRWithActivity[]> {
+/**
+ * Keep only the PR fields we actually consume. The open-PR list for a large repo can be hundreds
+ * of entries; dropping the heavy fields GitHub returns (body, labels, …) keeps the in-memory
+ * index of open PRs small while we scan for unread activity.
+ */
+function slimPr(pr: GHPullRequest): GHPullRequest {
+  return {
+    number: pr.number,
+    title: pr.title,
+    html_url: pr.html_url,
+    created_at: pr.created_at,
+    updated_at: pr.updated_at,
+    user: { login: pr.user.login, avatar_url: pr.user.avatar_url },
+    comments: pr.comments,
+    state: pr.state,
+  };
+}
+
+export interface FetchOptions {
+  /** Current seen state — used to skip PRs with no unread activity while backfilling. */
+  seen: SeenMap;
+  /** Active event filters — a PR whose only activity is filtered out doesn't count as unread. */
+  filters: EventFilters;
+  /** Target number of PRs with unread activity to return. Defaults to MAX_UNREAD_PRS. */
+  maxUnread?: number;
+  /** Safety ceiling on how many PRs we pull sub-resources for. Defaults to MAX_SCAN_PRS. */
+  maxScan?: number;
+}
+
+export interface FetchResult {
+  /** PRs that have unread activity, newest-active first, capped at maxUnread. */
+  prs: PRWithActivity[];
+  /** Keys of every open PR across all repos — used to prune seen state for closed PRs. */
+  activeKeys: string[];
+}
+
+/**
+ * Fetch open PRs with activity across all configured repositories.
+ *
+ * On large repos (e.g. raycast/extensions) fetching full activity for every open PR is both slow
+ * and memory-heavy enough to OOM. Instead we:
+ *   1. List open PRs (cheap metadata only) and sort by most-recently-updated;
+ *   2. Pull each PR's sub-resources in that order, keeping only PRs with unread activity and
+ *      immediately dropping the rest, until we have `maxUnread` unread PRs or have scanned
+ *      `maxScan` PRs.
+ * Because seen / filtered PRs are discarded as we go, peak memory stays ~maxUnread PRs regardless
+ * of how deep we scan. The full open-PR key set is returned separately so callers can prune seen
+ * state without wrongly dropping PRs that simply fell outside the cap.
+ */
+export async function fetchPRsWithActivity(opts: FetchOptions): Promise<FetchResult> {
   const { base, headers, repos } = getConfig();
+  const limits = getFetchLimits();
+  const maxUnread = opts.maxUnread ?? limits.maxUnread;
+  const maxScan = opts.maxScan ?? limits.maxScan;
 
-  const perRepo = await Promise.all(repos.map((repo) => fetchRepoActivity(base, headers, repo)));
+  // 1) Cheap pass: list open PRs (metadata only) across all repos, most-recently-updated first.
+  const listsPerRepo = await Promise.all(
+    repos.map(async (repo) => {
+      const list = await fetchAllPages<GHPullRequest>(
+        `${base}/repos/${repo}/pulls?state=open&sort=updated&direction=desc`,
+        headers,
+      );
+      return list.map((pr) => ({ pr: slimPr(pr), repo }));
+    }),
+  );
+  const openPrs = listsPerRepo.flat();
+  const activeKeys = openPrs.map(({ pr, repo }) => prKey({ repo, number: pr.number }));
+  // Merge repos into a single most-recently-updated-first order so the scan hits fresh activity first.
+  openPrs.sort((a, b) => new Date(b.pr.updated_at).getTime() - new Date(a.pr.updated_at).getTime());
 
-  return perRepo.flat();
+  // 2) Expensive pass: pull sub-resources in order, collecting PRs whose unread activity is
+  //    currently *visible* (seen + active filters) until we have `maxUnread` of them or hit the
+  //    scan cap. Seen/filtered PRs are dropped immediately so peak memory stays ~maxUnread PRs.
+  //    Trade-off: filtered-out PRs aren't cached, so re-enabling a filter reveals them only on the
+  //    next fetch (interval / revalidate); caching them instead would hold up to `maxScan` PRs in
+  //    memory, defeating the bound this pass exists to enforce.
+  const collected: PRWithActivity[] = [];
+  let scanned = 0;
+  for (let i = 0; i < openPrs.length && collected.length < maxUnread && scanned < maxScan; i += CONCURRENCY) {
+    const batch = openPrs.slice(i, i + CONCURRENCY);
+    const built = await Promise.all(batch.map(({ pr, repo }) => fetchActivity(base, headers, repo, pr)));
+    scanned += built.length;
+    for (const pr of built) {
+      const unseen = getUnseenActivity(pr, opts.seen[prKey(pr)]).filter((item) => opts.filters[item.type]);
+      if (unseen.length > 0) {
+        collected.push(pr);
+        if (collected.length >= maxUnread) break;
+      }
+    }
+  }
+
+  return { prs: collected, activeKeys };
 }

--- a/extensions/gh-pr-tracker/src/seen.ts
+++ b/extensions/gh-pr-tracker/src/seen.ts
@@ -55,7 +55,6 @@ export async function markPRSeen(pr: PRWithActivity): Promise<SeenMap> {
 /** Mark all PRs as seen */
 export async function markAllSeen(prs: PRWithActivity[]): Promise<SeenMap> {
   const map = await loadSeen();
-  const activePrKeys = new Set(prs.map((pr) => prKey(pr)));
   for (const pr of prs) {
     const allItems = getAllActivity(pr);
     map[prKey(pr)] = {
@@ -63,6 +62,9 @@ export async function markAllSeen(prs: PRWithActivity[]): Promise<SeenMap> {
       seenItemIds: allItems.map((i) => i.itemKey),
     };
   }
-  await saveSeen(map, activePrKeys);
+  // Do NOT prune here: `prs` is only the capped/displayed subset, so pruning by it would delete
+  // seen state for already-read open PRs outside the subset (they'd resurface as unread). Closed-PR
+  // pruning is handled by the fetch path, which knows the full set of open PR keys.
+  await saveSeen(map);
   return map;
 }

--- a/extensions/gh-pr-tracker/src/unread-menu-bar.tsx
+++ b/extensions/gh-pr-tracker/src/unread-menu-bar.tsx
@@ -1,16 +1,15 @@
 import { MenuBarExtra, Icon, launchCommand, LaunchType, type LaunchProps } from "@raycast/api";
 import { usePromise } from "@raycast/utils";
 import { useEffect, useState } from "react";
-import { fetchPRsWithActivity } from "./api";
+import { fetchPRsWithActivity, getFetchLimits } from "./api";
 import { loadCachedPRs, saveCachedPRs } from "./cache";
 import { loadSeen, saveSeen } from "./seen";
 import { loadEventFilters } from "./event-filters";
-import { computePrsWithUnseen, type PRWithUnseen } from "./utils";
-import { prKey, type PRWithActivity } from "./types";
+import { computePrsWithUnseen, toMenuBarPrs, type PRWithUnseen, type MenuBarPr } from "./utils";
 
 const MENU_ICON = Icon.Bell;
 
-type MenuBarContext = { source?: string };
+type MenuBarContext = { source?: string; items?: MenuBarPr[] };
 
 function truncateTitle(title: string, max = 40): string {
   const clean = title.replace(/\s+/g, " ").trim();
@@ -21,27 +20,26 @@ function truncateTitle(title: string, max = 40): string {
 async function loadFromCache(): Promise<PRWithUnseen[]> {
   const [prs, seen, filters] = await Promise.all([loadCachedPRs(), loadSeen(), loadEventFilters()]);
   if (!prs) return [];
-  return computePrsWithUnseen(prs, seen, filters);
+  return computePrsWithUnseen(prs, seen, filters).slice(0, getFetchLimits().maxUnread);
 }
 
 /** Fetch fresh data, update the shared cache/seen, and compute the unread-PR list. */
 async function fetchAndCompute(): Promise<PRWithUnseen[]> {
-  const prs = await fetchPRsWithActivity();
   const seen = await loadSeen();
-  const activePrKeys = new Set(prs.map((pr) => prKey(pr)));
-  await saveSeen(seen, activePrKeys); // prune seen entries for closed PRs
-  await saveCachedPRs(prs); // shared cache — benefits the main command
   const filters = await loadEventFilters();
-  return computePrsWithUnseen(prs, seen, filters);
+  const { prs, activeKeys } = await fetchPRsWithActivity({ seen, filters });
+  await saveSeen(seen, new Set(activeKeys)); // prune seen entries for closed PRs (full open set)
+  await saveCachedPRs(prs); // shared cache — benefits the main command
+  return computePrsWithUnseen(prs, seen, filters).slice(0, getFetchLimits().maxUnread);
 }
 
 /** Open the main command with this PR expanded and all others collapsed. */
-async function openFocused(pr: PRWithActivity): Promise<void> {
+async function openFocused(key: string): Promise<void> {
   try {
     await launchCommand({
       name: "unread-updates",
       type: LaunchType.UserInitiated,
-      context: { focusPrKey: prKey(pr) },
+      context: { focusPrKey: key },
     });
   } catch {
     // main command may be unavailable; ignore
@@ -58,49 +56,58 @@ async function openAll(): Promise<void> {
 }
 
 export default function Command(props: LaunchProps<{ launchContext?: MenuBarContext }>) {
+  // The view command pushes a precomputed, lean list on every refresh. When present we render
+  // straight from it with isLoading=false, so Raycast captures the updated menu bar within the
+  // short background-launch window. An async cache read here would race that window and the
+  // badge would keep its stale value (especially in Store builds, where the window is tighter).
+  const contextItems = props.launchContext?.items;
+  const hasContextItems = contextItems !== undefined;
   const skipFetch = props.launchContext?.source === "view-refresh";
-  const [cached, setCached] = useState<PRWithUnseen[] | undefined>(undefined);
+  const [cached, setCached] = useState<MenuBarPr[] | undefined>(undefined);
 
-  // Seed instant render from the shared cache.
+  // Seed instant render from the shared cache (only when the caller didn't push a list).
   useEffect(() => {
-    loadFromCache().then(setCached);
-  }, []);
+    if (hasContextItems) return;
+    loadFromCache().then((l) => setCached(toMenuBarPrs(l)));
+  }, [hasContextItems]);
 
   const { data, isLoading } = usePromise(
-    async (skip: boolean) => (skip ? loadFromCache() : fetchAndCompute()),
+    async (skip: boolean) => toMenuBarPrs(skip ? await loadFromCache() : await fetchAndCompute()),
     [skipFetch],
     {
+      execute: !hasContextItems,
       onError: () => {
         // Background command: no toast UI. Keep any stale cached data; retry next interval.
       },
     },
   );
 
-  const list = data ?? cached;
+  const list = hasContextItems ? contextItems : (data ?? cached);
+  const loading = hasContextItems ? false : isLoading;
 
   // Nothing to show yet: while a fetch is in flight, keep the command alive with a bare
   // loading item (never a "0" badge or empty menu); once settled, hide the item entirely
   // (zero unread, or error with no cache — retry on the next interval).
   if (!list || list.length === 0) {
-    return isLoading ? <MenuBarExtra isLoading icon={MENU_ICON} /> : null;
+    return loading ? <MenuBarExtra isLoading icon={MENU_ICON} /> : null;
   }
 
   const count = list.length;
 
   return (
     <MenuBarExtra
-      isLoading={isLoading}
+      isLoading={loading}
       icon={MENU_ICON}
       title={String(count)}
       tooltip={`${count} pull request${count !== 1 ? "s" : ""} with unread changes`}
     >
       <MenuBarExtra.Section title={`${count} PR${count !== 1 ? "s" : ""} with unread changes`}>
-        {list.slice(0, 5).map(({ pr, unseen }) => (
+        {list.slice(0, 5).map((item) => (
           <MenuBarExtra.Item
-            key={prKey(pr)}
-            title={`#${pr.number} — ${truncateTitle(pr.title)}`}
-            subtitle={`${pr.repo.split("/").pop() ?? pr.repo} · ${unseen.length} update${unseen.length !== 1 ? "s" : ""}`}
-            onAction={() => openFocused(pr)}
+            key={item.key}
+            title={`#${item.number} — ${truncateTitle(item.title)}`}
+            subtitle={`${item.repo.split("/").pop() ?? item.repo} · ${item.unseenCount} update${item.unseenCount !== 1 ? "s" : ""}`}
+            onAction={() => openFocused(item.key)}
           />
         ))}
         {count > 5 && (

--- a/extensions/gh-pr-tracker/src/unread-updates.tsx
+++ b/extensions/gh-pr-tracker/src/unread-updates.tsx
@@ -14,7 +14,7 @@ import {
 } from "@raycast/api";
 import { usePromise } from "@raycast/utils";
 import { useState, useEffect } from "react";
-import { fetchPRsWithActivity } from "./api";
+import { fetchPRsWithActivity, getFetchLimits } from "./api";
 import { loadSeen, saveSeen, markItemSeen, markPRSeen, markAllSeen } from "./seen";
 import { loadCachedPRs, saveCachedPRs } from "./cache";
 import { getDemoPRs } from "./demo-data";
@@ -31,6 +31,8 @@ import {
   renderActivityMarkdown,
   renderPRSummaryMarkdown,
   computePrsWithUnseen,
+  toMenuBarPrs,
+  type MenuBarPr,
 } from "./utils";
 import type { ActivityItem, PRWithActivity, SeenMap } from "./types";
 import { prKey } from "./types";
@@ -80,18 +82,23 @@ function isReplyComment(item: ActivityItem, pr: PRWithActivity): boolean {
 // ─── Main command ────────────────────────────────────────────────────────────
 
 /**
- * Nudge the menu-bar command to recompute from the shared cache/seen (no network fetch).
- * Called only on data fetches (view open / revalidate) — NOT on mark-as-read, which stays a
- * purely local update so rapid marking isn't blocked by the launchCommand spawn cost. The
- * badge otherwise refreshes on the menu bar's own interval and whenever the user clicks it
- * (a click re-reads the cache+seen, so it reflects marks immediately).
+ * Push the freshly computed unread list to the menu-bar command so it re-renders.
+ * Called after data fetches (view open / revalidate) and after mark-as-read actions, so the
+ * badge count stays in sync with what the list shows. Mark handlers call this fire-and-forget
+ * (see syncMenuBar) so the local UI update isn't blocked by the launchCommand spawn cost.
+ *
+ * The computed list is passed via launchContext (not just a "refresh" flag) so the menu-bar
+ * command can render synchronously from it. A background-launched menu-bar command only gets a
+ * short execution window; if it had to await an async cache read before rendering, that read
+ * would race the window and the badge would keep its stale value (observed in Store builds,
+ * whose window is tighter than local development's).
  */
-async function refreshMenuBar(): Promise<void> {
+async function refreshMenuBar(items: MenuBarPr[]): Promise<void> {
   try {
     await launchCommand({
       name: "unread-menu-bar",
       type: LaunchType.Background,
-      context: { source: "view-refresh" },
+      context: { source: "view-refresh", items },
     });
   } catch {
     // menu-bar command may be disabled; ignore
@@ -124,19 +131,22 @@ export default function UnreadUpdates(props: LaunchProps<{ launchContext?: Focus
   }, []);
 
   const { isLoading, revalidate, error } = usePromise(async () => {
-    const fetchedPrs = await fetchPRsWithActivity();
-    // Load seen state after the fetch so marks made during the fetch aren't overwritten
+    // Load seen + filters up front: the fetch caps itself to ~MAX_UNREAD_PRS PRs with unread
+    // activity, so it needs to know what's already seen/filtered as it scans (see api.ts).
+    const seenBeforeFetch = await loadSeen();
+    const filters = await loadEventFilters();
+    const { prs: fetchedPrs, activeKeys } = await fetchPRsWithActivity({ seen: seenBeforeFetch, filters });
+
+    // Reload seen + filters after the (potentially long) fetch so marks and filter toggles made
+    // during it aren't overwritten, and the pushed menu-bar count matches what the list now renders.
     const fetchedSeen = await loadSeen();
-    // Prune seen entries for PRs no longer in the open set
-    const activePrKeys = new Set(fetchedPrs.map((pr) => prKey(pr)));
-    for (const key of Object.keys(fetchedSeen)) {
-      if (!activePrKeys.has(key)) delete fetchedSeen[key];
-    }
-    await saveSeen(fetchedSeen);
+    const freshFilters = await loadEventFilters();
+    await saveSeen(fetchedSeen, new Set(activeKeys));
     setSeenMap(fetchedSeen);
     await saveCachedPRs(fetchedPrs);
-    // Nudge the menu-bar command to re-render from the fresh shared cache.
-    await refreshMenuBar();
+    // Push the freshly computed unread list to the menu-bar command so it re-renders
+    // synchronously — see refreshMenuBar for why.
+    await refreshMenuBar(toMenuBarPrs(computePrsWithUnseen(fetchedPrs, fetchedSeen, freshFilters)));
 
     setDisplayPrs(fetchedPrs);
     // Preserve existing collapsed state; default new PRs to collapsed
@@ -144,7 +154,13 @@ export default function UnreadUpdates(props: LaunchProps<{ launchContext?: Focus
       const updated: Record<string, boolean> = {};
       for (const pr of fetchedPrs) {
         const key = prKey(pr);
-        updated[key] = key === focusPrKey ? false : prev[key] !== undefined ? prev[key] : true;
+        // DO NOT change to force-expand focusPrKey here (AI reviewers keep suggesting this).
+        // The mount effect (~line 120) already expands the focused PR via
+        // `allCollapsed[prKey(pr)] = prKey(pr) !== focusPrKey`. This updater must ONLY
+        // preserve existing collapsed state and default NEW PRs to collapsed. Forcing
+        // focusPrKey to expanded on every revalidate (Cmd+R) re-expands PRs the user
+        // deliberately collapsed — a regression, not a fix.
+        updated[key] = prev[key] !== undefined ? prev[key] : key !== focusPrKey;
       }
       return updated;
     });
@@ -162,8 +178,9 @@ export default function UnreadUpdates(props: LaunchProps<{ launchContext?: Focus
 
   const activePrs = demoMode ? getDemoPRs() : displayPrs;
   const activeSeenMap = demoMode ? demoSeenMap : seenMap;
+  const { maxUnread } = getFetchLimits();
 
-  const prsWithUnseen = computePrsWithUnseen(activePrs ?? [], activeSeenMap, eventFilters);
+  const prsWithUnseen = computePrsWithUnseen(activePrs ?? [], activeSeenMap, eventFilters).slice(0, maxUnread);
 
   const toggleCollapse = (pr: PRWithActivity) => {
     const key = prKey(pr);
@@ -180,6 +197,13 @@ export default function UnreadUpdates(props: LaunchProps<{ launchContext?: Focus
 
   const expandAll = () => {
     setCollapsed({});
+  };
+
+  // Keep the menu-bar badge in sync with mark actions. Fire-and-forget: the local seen state is
+  // already updated for instant UI, so pushing to the menu bar must not block the handler.
+  // refreshMenuBar swallows its own errors, so the floating promise is safe.
+  const syncMenuBar = (seen: SeenMap) => {
+    void refreshMenuBar(toMenuBarPrs(computePrsWithUnseen(displayPrs ?? [], seen, eventFilters)));
   };
 
   const handleMarkItemSeen = async (pr: PRWithActivity, item: ActivityItem) => {
@@ -202,6 +226,7 @@ export default function UnreadUpdates(props: LaunchProps<{ launchContext?: Focus
     }
     const updated = await markItemSeen(pr, item);
     setSeenMap(updated);
+    syncMenuBar(updated);
     await showToast({
       style: Toast.Style.Success,
       title: "Item marked as seen",
@@ -225,6 +250,7 @@ export default function UnreadUpdates(props: LaunchProps<{ launchContext?: Focus
     }
     const updated = await markPRSeen(pr);
     setSeenMap(updated);
+    syncMenuBar(updated);
     await showToast({
       style: Toast.Style.Success,
       title: "PR marked as caught up",
@@ -248,6 +274,7 @@ export default function UnreadUpdates(props: LaunchProps<{ launchContext?: Focus
     if (!displayPrs) return;
     const updated = await markAllSeen(displayPrs);
     setSeenMap(updated);
+    syncMenuBar(updated);
     await showToast({ style: Toast.Style.Success, title: "All caught up!" });
   };
 
@@ -335,7 +362,12 @@ export default function UnreadUpdates(props: LaunchProps<{ launchContext?: Focus
                   <Action
                     title="Mark All as Caught up"
                     icon={Icon.CheckCircle}
-                    shortcut={Keyboard.Shortcut.Common.Duplicate}
+                    // Intentional custom shortcut — do NOT replace with Keyboard.Shortcut.Common.*
+                    // eslint-disable-next-line @raycast/prefer-common-shortcut -- keep cmd+shift+s on purpose
+                    shortcut={{
+                      macOS: { modifiers: ["cmd", "shift"], key: "s" },
+                      Windows: { modifiers: ["ctrl", "shift"], key: "s" },
+                    }}
                     onAction={handleMarkAllSeen}
                   />
                   <Action
@@ -560,7 +592,12 @@ function ActivityListItem({
           <Action
             title="Mark All as Caught up"
             icon={Icon.CheckCircle}
-            shortcut={Keyboard.Shortcut.Common.Duplicate}
+            // Intentional custom shortcut — do NOT replace with Keyboard.Shortcut.Common.*
+            // eslint-disable-next-line @raycast/prefer-common-shortcut -- keep cmd+shift+s on purpose
+            shortcut={{
+              macOS: { modifiers: ["cmd", "shift"], key: "s" },
+              Windows: { modifiers: ["ctrl", "shift"], key: "s" },
+            }}
             onAction={onMarkAllSeen}
           />
           <Action.Push title="View PR Summary" icon={Icon.List} target={<PRSummaryDetail pr={pr} />} />

--- a/extensions/gh-pr-tracker/src/utils.ts
+++ b/extensions/gh-pr-tracker/src/utils.ts
@@ -136,6 +136,16 @@ export interface PRWithUnseen {
   unseen: ActivityItem[];
 }
 
+/** Maximum number of unread PRs surfaced by the list and menu-bar commands. */
+export const MAX_UNREAD_PRS = 25;
+
+/**
+ * Safety ceiling on how many PRs the fetch will pull sub-resources for while backfilling to
+ * MAX_UNREAD_PRS. Prevents unbounded scanning (slowness / OOM) on very large repos when few PRs
+ * have unread activity; in that rare case fewer than MAX_UNREAD_PRS PRs may be shown.
+ */
+export const MAX_SCAN_PRS = 150;
+
 /**
  * Returns the PRs that have at least one unseen activity item after applying
  * event filters, sorted by most-recent unseen activity first. This is the
@@ -154,6 +164,33 @@ export function computePrsWithUnseen(prs: PRWithActivity[], seenMap: SeenMap, fi
       const bDate = b.unseen[0]?.date ?? "";
       return new Date(bDate).getTime() - new Date(aDate).getTime();
     });
+}
+
+// ─── Lean menu-bar payload (safe to pass via launchCommand context) ─────────
+
+/** Minimal, JSON-serializable projection of an unread PR for the menu-bar command. */
+export interface MenuBarPr {
+  key: string;
+  number: number;
+  title: string;
+  repo: string;
+  unseenCount: number;
+}
+
+/**
+ * Project the full unread list into a compact shape for the menu-bar command.
+ * Kept intentionally small: the view command pushes this through launchCommand
+ * context on every refresh, so it must not carry the heavy PR activity payload
+ * (reviews, diffs, commits) that could exceed the launch-context size budget.
+ */
+export function toMenuBarPrs(list: PRWithUnseen[]): MenuBarPr[] {
+  return list.map(({ pr, unseen }) => ({
+    key: prKey(pr),
+    number: pr.number,
+    title: pr.title,
+    repo: pr.repo,
+    unseenCount: unseen.length,
+  }));
 }
 
 // ─── Build the conversation thread for a review comment ─────────────────────


### PR DESCRIPTION
## Description

### Added

- Optional **Max Unread PRs** and **Max PRs to Scan** preferences to tune how many pull requests are surfaced and how far the fetch scans on large repositories (both 1–1000; defaults 25 and 150).

### Fixed

- The **Unread PR Alert** badge now refreshes immediately when you open or refresh **View Pull Requests** and when you mark items, PRs, or everything as read — previously it could stay stale until its next 5-minute interval (most noticeable in the published Store build).
- **View Pull Requests** no longer slows to a crawl or runs out of memory on very large repositories with hundreds of open pull requests.

### Changed

- The **GH Host** preference is now optional and defaults to `github.com` — set it only when using GitHub Enterprise.
- The list now surfaces up to a configurable number of pull requests with unread activity (default 25, most-recently-updated first, backfilling past already-seen or filtered PRs) so fetches stay fast on large repositories.

## Checklist

- [X] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [X] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [X] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [X] I checked that files in the `assets` folder are used by the extension itself
- [X] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
