### PR TITLE
[Slack] Add group DM AI tool

### DIFF
--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Slack Changelog
 
+## [Add Slack group DM AI tool] - 2026-07-21
+
+- Add an `open-group-dm` AI tool that opens or resumes a group DM with 2 to 8 users and returns its conversation ID for messaging or file uploads.
+
 ## [Add Slack Huddle link AI tool] - 2026-07-21
 
 - Add a `get-huddle-link` AI tool that returns a Huddle join link for a channel, DM, group DM, or user.

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -440,9 +440,14 @@
             "callsTool": {
               "name": "open-group-dm",
               "arguments": {
-                "userIds": {
-                  "includes": "U12345678"
-                }
+                "userIds": [
+                  {
+                    "includes": "U12345678"
+                  },
+                  {
+                    "includes": "U87654321"
+                  }
+                ]
               }
             }
           },

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -200,6 +200,11 @@
       "description": "Read a bounded page of messages in a Slack thread. Use this when the user asks to summarize, inspect, or answer questions about a specific threaded conversation. Requires the channel ID and the parent message timestamp, which can come from Get Channel History or Search Messages. The response includes hasMore and nextCursor so more messages can be fetched when needed."
     },
     {
+      "title": "Open Group DM",
+      "name": "open-group-dm",
+      "description": "Open or resume a Slack group DM with 2 to 8 users. Use Find Users first to resolve each person to a user ID. Do not include the authenticated user. Returns a group conversation ID that can be passed to Send Message or Upload Files."
+    },
+    {
       "title": "Send Message",
       "name": "send-message",
       "description": "Send a Slack message to a channel, group DM, existing DM, or user. Pass a conversation ID or user ID and the message text. When given a user ID, the tool opens or finds the DM first. For messages with file attachments, use Upload Files instead."
@@ -406,6 +411,74 @@
             "channel": "D12345678",
             "url": "https://app.slack.com/huddle/T12345678/D12345678"
           }
+        }
+      },
+      {
+        "input": "@slack create a group DM with Alicia and Roy and send them this screenshot: /Users/me/Desktop/test.png",
+        "expected": [
+          {
+            "callsTool": {
+              "name": "find-users",
+              "arguments": {
+                "query": {
+                  "includes": "Alicia"
+                }
+              }
+            }
+          },
+          {
+            "callsTool": {
+              "name": "find-users",
+              "arguments": {
+                "query": {
+                  "includes": "Roy"
+                }
+              }
+            }
+          },
+          {
+            "callsTool": {
+              "name": "open-group-dm",
+              "arguments": {
+                "userIds": {
+                  "includes": "U12345678"
+                }
+              }
+            }
+          },
+          {
+            "callsTool": {
+              "name": "upload-files",
+              "arguments": {
+                "channel": {
+                  "includes": "G12345678"
+                },
+                "filePaths": {
+                  "includes": "/Users/me/Desktop/test.png"
+                }
+              }
+            }
+          }
+        ],
+        "mocks": {
+          "find-users": [
+            {
+              "id": "U12345678",
+              "displayName": "Alicia"
+            },
+            {
+              "id": "U87654321",
+              "displayName": "Roy"
+            }
+          ],
+          "open-group-dm": {
+            "channel": "G12345678",
+            "userIds": [
+              "U12345678",
+              "U87654321"
+            ]
+          },
+          "upload-files": "success"
         }
       }
     ]

--- a/extensions/slack/src/tools/open-group-dm.ts
+++ b/extensions/slack/src/tools/open-group-dm.ts
@@ -1,0 +1,52 @@
+import { getSlackWebClient } from "../shared/client/WebClient";
+import { withSlackClient } from "../shared/withSlackClient";
+
+type Input = {
+  /**
+   * Slack user IDs to include in the group DM, one per line. Do not include the authenticated user; Slack adds them automatically. Use Find Users to resolve names to IDs first.
+   *
+   * @example "U12345678\nU87654321"
+   */
+  userIds: string;
+};
+
+const USER_ID_PATTERN = /^[UW][A-Z0-9]{8,}$/;
+const MIN_GROUP_DM_USERS = 2;
+const MAX_GROUP_DM_USERS = 8;
+
+async function openGroupDm(input: Input) {
+  const userIds = [
+    ...new Set(
+      input.userIds
+        .split(/[,\s]+/)
+        .map((userId) => userId.trim())
+        .filter(Boolean),
+    ),
+  ];
+
+  if (userIds.length < MIN_GROUP_DM_USERS || userIds.length > MAX_GROUP_DM_USERS) {
+    throw new Error(`A group DM requires ${MIN_GROUP_DM_USERS} to ${MAX_GROUP_DM_USERS} other users`);
+  }
+
+  const invalidUserId = userIds.find((userId) => !USER_ID_PATTERN.test(userId));
+  if (invalidUserId) {
+    throw new Error(`Invalid Slack user ID: ${invalidUserId}`);
+  }
+
+  const slackWebClient = getSlackWebClient();
+  const response = await slackWebClient.conversations.open({ users: userIds.join(",") });
+
+  if (response.error) {
+    throw new Error(response.error);
+  }
+  if (!response.channel?.id) {
+    throw new Error("Slack did not return a group DM conversation ID");
+  }
+
+  return {
+    channel: response.channel.id,
+    userIds,
+  };
+}
+
+export default withSlackClient(openGroupDm);


### PR DESCRIPTION
## Description

- add an `open-group-dm` AI tool that opens or resumes a Slack group DM with 2 to 8 users
- return the group conversation ID for the existing send-message and upload-files tools
- add an AI eval covering resolving users, opening the group DM, and uploading a screenshot

## Test plan

- `npm run build`
- `npm run lint`