### PR TITLE
[Is It Alive?] Restore site creation fix

### DIFF
--- a/extensions/is-it-alive/CHANGELOG.md
+++ b/extensions/is-it-alive/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Is It Alive? Changelog
 
+## [Restore Site Creation Fix] - {PR_MERGE_DATE}
+
+- Restore adding sites in Raycast runtimes where the Web Crypto global is unavailable
+
 ## [Google Cloud and Google AI Studio Support] - 2026-07-12
 
 - Add support for the Google Cloud Service Health dashboard (status.cloud.google.com), including per-product monitoring via `/products/{name}` URLs (e.g. vertex-gemini-api)

--- a/extensions/is-it-alive/src/hooks/use-sites.ts
+++ b/extensions/is-it-alive/src/hooks/use-sites.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { useLocalStorage } from "@raycast/utils";
+import { randomUUID } from "node:crypto";
 import type { MonitoredSite, SiteProvider } from "@/types";
 
 const STORAGE_KEY = "sites";
@@ -12,7 +13,7 @@ export interface SiteInput {
 }
 
 function createId(): string {
-  return crypto.randomUUID();
+  return randomUUID();
 }
 
 export function useSites() {


### PR DESCRIPTION
## Description

Restore site creation in Raycast runtimes that do not expose Web Crypto globally.

This imports `randomUUID` explicitly from `node:crypto` instead of calling `crypto.randomUUID()` as a global.

## Context

#29343 fixed the same `crypto is not defined` failure with reproduction evidence and local validation. #29360 later reintroduced the global call while adding AWS region filtering.

## Validation

- `npm run lint`
- `npm run build`
- Verified imported `randomUUID` works in a runtime context without a global `crypto`
