### PR TITLE
Update Fastly extension to fix Secret Store operations

### DIFF
--- a/extensions/fastly/CHANGELOG.md
+++ b/extensions/fastly/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fastly Changelog
 
-## [Fix Secret Store Operations] - {PR_MERGE_DATE}
+## [Fix Secret Store Operations] - 2026-07-22
 
 - Fixed secret creation and recreation to use correct API endpoints and base64 encoding
 

--- a/extensions/fastly/CHANGELOG.md
+++ b/extensions/fastly/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Fastly Changelog
 
+## [Fix Secret Store Operations] - {PR_MERGE_DATE}
+
+- Fixed secret creation and recreation to use correct API endpoints and base64 encoding
+
 ## [New Data Stores and Security Features] - 2026-03-11
 
 Added support for Fastly's data stores and audit logging:

--- a/extensions/fastly/package.json
+++ b/extensions/fastly/package.json
@@ -6,7 +6,8 @@
   "icon": "icon.png",
   "author": "JonathanSpeek",
   "contributors": [
-    "xmok"
+    "xmok",
+    "btsheehy"
   ],
   "categories": [
     "Developer Tools"
@@ -107,5 +108,8 @@
     "lint": "ray lint",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
+  },
+  "allowScripts": {
+    "esbuild@0.25.12": true
   }
 }

--- a/extensions/fastly/src/api.ts
+++ b/extensions/fastly/src/api.ts
@@ -436,9 +436,9 @@ export async function createSecret(storeId: string, name: string, secret: string
 }
 
 export async function recreateSecret(storeId: string, name: string, secret: string): Promise<void> {
-  await fastlyFetch(`/resources/stores/secret/${storeId}/secrets/${encodeURIComponent(name)}`, {
-    method: "PUT",
-    body: JSON.stringify({ secret }),
+  await fastlyFetch(`/resources/stores/secret/${storeId}/secrets`, {
+    method: "PATCH",
+    body: JSON.stringify({ name, secret }),
   });
 }
 

--- a/extensions/fastly/src/views/secret-form.tsx
+++ b/extensions/fastly/src/views/secret-form.tsx
@@ -25,11 +25,12 @@ export function SecretForm({ store, secretName, onSaved }: SecretFormProps) {
       try {
         setIsLoading(true);
         const name = isRotating ? secretName! : values.name;
+        const encodedSecretValue = Buffer.from(values.secret, "base64").toString("base64");
 
         if (isRotating) {
-          await recreateSecret(store.id, name, values.secret);
+          await recreateSecret(store.id, name, encodedSecretValue);
         } else {
-          await createSecret(store.id, name, values.secret);
+          await createSecret(store.id, name, encodedSecretValue);
         }
 
         await showToast({

--- a/extensions/fastly/src/views/secret-form.tsx
+++ b/extensions/fastly/src/views/secret-form.tsx
@@ -25,7 +25,7 @@ export function SecretForm({ store, secretName, onSaved }: SecretFormProps) {
       try {
         setIsLoading(true);
         const name = isRotating ? secretName! : values.name;
-        const encodedSecretValue = Buffer.from(values.secret, "base64").toString("base64");
+        const encodedSecretValue = Buffer.from(values.secret).toString("base64");
 
         if (isRotating) {
           await recreateSecret(store.id, name, encodedSecretValue);


### PR DESCRIPTION
## Description

Per the Fastly API docs:
- [Recreate secret](https://www.fastly.com/documentation/reference/api/services/resources/secret-store-secret/#must-recreate-secret)
- [Create secret](https://www.fastly.com/documentation/reference/api/services/resources/secret-store-secret/#create-secret)

A recreate request should include the secret name in the body rather than the URL and should base64 encode the value. A create request should also base64 encode the value. 

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
