### PR TITLE
ci: bump Xcode 26.4.x and runner to macos-26

### DIFF
--- a/.github/workflows/extensions_build_publish.yml
+++ b/.github/workflows/extensions_build_publish.yml
@@ -31,10 +31,10 @@ jobs:
   extensions_build_publish:
     if: github.repository == 'raycast/extensions'
     name: "${{ github.event_name == 'push' && 'Publish' || (github.event_name == 'pull_request' && 'Check' || github.event_name == 'workflow_dispatch' && inputs.command || github.event_name ) }}"
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - name: Setup Xcode
-        uses: raycast/github-actions/setup-xcode@xcode-15.4.x
+        uses: raycast/github-actions/setup-xcode@xcode-26.4.x
       - uses: actions/checkout@v4
         with:
           path: github_utils


### PR DESCRIPTION
## Summary

Updates the `extensions_build_publish` workflow to use a newer macOS runner and Xcode toolchain:

- `runs-on`: `macos-14` → `macos-26`
- `setup-xcode` action: `raycast/github-actions/setup-xcode@xcode-15.4.x` → `@xcode-26.4.x`

## Why

The extension build/publish pipeline was pinned to macOS 14 with Xcode 15.4. Moving to macOS 26 with Xcode 26.4 keeps the CI toolchain current for building and publishing extensions.

## Impact

Affects all extension `Check` (PR) and `Publish` (push) runs going through this workflow. No changes to extensions themselves.