### PR TITLE
[Things] Fix marking to-dos completed or canceled

### DIFF
--- a/extensions/things/CHANGELOG.md
+++ b/extensions/things/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Things Changelog
 
+## [Fix Marking To-Dos Completed] - {PR_MERGE_DATE}
+
+- Restore marking to-dos completed or canceled from list rows and the Today menu bar. The previous release's writable-key allowlist in the property setter rejected `status`, so those actions threw an error.
+
 ## [Expanded AI Tools and Optional Database Reading] - 2026-07-10
 
 - Added AI tools: `get-todos` (replaces `get-list-todos`, supports list/project/area filters), `search-todos` (keyword search in title and notes), `get-todo-details`, `get-todos-details` (batch), `get-project-details`, `get-area-details`, and `add-json` (create projects with headings and nested to-dos in one call).

--- a/extensions/things/CHANGELOG.md
+++ b/extensions/things/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Things Changelog
 
-## [Fix Marking To-Dos Completed] - {PR_MERGE_DATE}
+## [Fix Marking To-Dos Completed] - 2026-07-22
 
 - Restore marking to-dos completed or canceled from list rows and the Today menu bar. The previous release's writable-key allowlist in the property setter rejected `status`, so those actions threw an error.
 

--- a/extensions/things/src/api.ts
+++ b/extensions/things/src/api.ts
@@ -137,19 +137,29 @@ export const getProjectName = (projectId: string) =>
     'Get project name',
   );
 
-const DATE_KEYS = new Set(['dueDate', 'activationDate', 'completionDate', 'cancellationDate']);
+// Properties the set-todo-property AI tool exposes. `status` is intentionally absent:
+// completing or canceling a to-do goes through update-todo (see the tool description).
+// Spelled out rather than derived (indexed-access or Exclude) because Raycast's AI-tool
+// schema extractor only resolves a plain literal union into an enum.
+export type SettableTodoProperty =
+  'dueDate' | 'activationDate' | 'completionDate' | 'cancellationDate' | 'name' | 'notes' | 'tagNames';
 
-const WRITABLE_KEYS = new Set([...DATE_KEYS, 'name', 'notes', 'tagNames']);
+// setTodoProperty also writes `status` for the complete/cancel list and menu-bar actions.
+export type WritableTodoProperty = SettableTodoProperty | 'status';
 
-export const setTodoProperty = (todoId: string, key: string, value: string) => {
-  if (!WRITABLE_KEYS.has(key)) {
-    throw new Error(`Unsupported property "${key}". Allowed: ${[...WRITABLE_KEYS].join(', ')}`);
-  }
+const DATE_PROPERTIES = [
+  'dueDate',
+  'activationDate',
+  'completionDate',
+  'cancellationDate',
+] as const satisfies readonly WritableTodoProperty[];
+
+export const setTodoProperty = (todoId: string, key: WritableTodoProperty, value: string) => {
   // Date keys must be passed as JS Date objects in JXA — plain strings crash Things.
   // Use the local-time constructor (y, m-1, d) instead of new Date('YYYY-MM-DD') which
   // parses as UTC midnight and shifts the date by one day in negative-offset timezones.
   let valueExpr: string;
-  if (DATE_KEYS.has(key)) {
+  if ((DATE_PROPERTIES as readonly string[]).includes(key)) {
     const [y, m, d] = value.split('-').map(Number);
     valueExpr = `new Date(${y}, ${m - 1}, ${d})`;
   } else {

--- a/extensions/things/src/tools/set-todo-property.ts
+++ b/extensions/things/src/tools/set-todo-property.ts
@@ -1,10 +1,10 @@
-import { setTodoProperty } from '../api';
+import { setTodoProperty, SettableTodoProperty } from '../api';
 
 type Input = {
   /** The to-do id to update */
   todoId: string;
   /** The key to update */
-  key: string;
+  key: SettableTodoProperty;
   /** The value to update */
   value: string;
 };


### PR DESCRIPTION
## Description

Marking a to-do completed or canceled throws `Unsupported property "status". Allowed: dueDate, activationDate, completionDate, cancellationDate, name, notes, tagNames`. Every "Mark as Completed" and "Mark as Canceled" action is affected: list rows, the detail view, and the Today menu bar. The regression shipped in the previous release (#28555).

### Root cause

Before that release, `setTodoProperty` assigned the property directly:

```js
things.toDos.byId(todoId).status = 'completed';
```

The property name was a literal at every call site, so the set of writable keys was already fixed and checked by the compiler. #28555 replaced that with a runtime `WRITABLE_KEYS` Set and a throw for any key not in it. The Set omitted `status`, so the guard rejects the exact key every completion path passes.

The allowlist is the wrong mechanism, not merely misconfigured. It reimplements as runtime strings a constraint the type system was already enforcing for free, and it does so at internal call sites where the key is always a literal. That buys nothing except a new way to be wrong. A missing entry turns a typo-proof assignment into a runtime throw, and the omission cleared review and release precisely because nothing checked the Set against the keys the code actually uses. Runtime validation earns its place only at an untrusted boundary. There is exactly one here, the `set-todo-property` AI tool input, and the allowlist was not scoped to it.

### Fix

Delete the Set and the throw. `setTodoProperty` now takes a `WritableTodoProperty` union, so the list and menu-bar callers are checked at compile time and `status` is a member. For `status`, the setter regenerates the pre-#28555 JXA verbatim.

The `set-todo-property` AI tool input takes the narrower `SettableTodoProperty`, which omits `status` so the enum Raycast generates matches the tool's contract of routing completion through `update-todo`. That keeps runtime validation where it belongs, at the untrusted boundary, expressed as a type the compiler and the tool schema both enforce.

The one branch left is date serialization, which is genuine: dates must be JS `Date` objects in JXA or Things crashes. `DATE_PROPERTIES` drives that branch and carries a `satisfies readonly WritableTodoProperty[]`, so the runtime date list cannot drift out of the union.

### Verification

`npm run build` passes, including the tool schema extraction and the TypeScript check, so the internal call sites type-check against the new union. The JXA emitted for `status` is identical to the pre-regression code that shipped for months.

## Screencast

<!-- Reviewer: a screencast of marking a to-do complete from a list row will go here. -->

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
