### PR TITLE
fix(confluence-search): add Create Whiteboard to README

### DIFF
--- a/extensions/confluence-search/CHANGELOG.md
+++ b/extensions/confluence-search/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Confluence Changelog
 
+## [Fix README] - 2026-07-22
+
+- Update README to include `Create Whiteboard` command
+
 ## [Add Create Whiteboard Command] - 2026-07-22
 
 - Add `Create Whiteboard` command to quickly create a new whiteboard in Confluence

--- a/extensions/confluence-search/CHANGELOG.md
+++ b/extensions/confluence-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Confluence Changelog
 
-## [Fix README] - {PR_MERGE_DATE}
+## [Fix README] - 2026-07-22
 
 - Update README to include `Create Whiteboard` command
 

--- a/extensions/confluence-search/CHANGELOG.md
+++ b/extensions/confluence-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Confluence Changelog
 
-## [Fix README] - 2026-07-22
+## [Fix README] - {PR_MERGE_DATE}
 
 - Update README to include `Create Whiteboard` command
 

--- a/extensions/confluence-search/README.md
+++ b/extensions/confluence-search/README.md
@@ -7,7 +7,7 @@ Atlassian's Confluence extension, allowing you to:
  - `People` to search for people
  - `Go` to quickly jump to useful places in Confluence
  - `Recent` for super snappy access to pages you've viewed
- - `Create Page`, `Create Blog`
+ - `Create Page`, `Create Blog`, `Create Whiteboard`
  - `Switch Site` to allow to change connected Confluence site
 
  We’d like to acknowledge, and say thanks for, the excellent prior work of daviddkkim who built the original version of this extension that we have replaced.”


### PR DESCRIPTION
## Description

The `Create Whiteboard` command was added in a previous PR but the README was not updated to mention it.

### Changes
- Updated `README.md` to include `Create Whiteboard` alongside `Create Page` and `Create Blog` in the list of commands.