### PR TITLE
Improve Visual Studio Code recent projects

### DIFF
--- a/extensions/visual-studio-code-recent-projects/CHANGELOG.md
+++ b/extensions/visual-studio-code-recent-projects/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Visual Studio Code Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Resolved the shortcut conflict between `Open With…` and `Open with Terminal`. The terminal action now uses `Cmd` + `Shift` + `T` (`Ctrl` + `Shift` + `T` on Windows). Fixes [#28408](https://github.com/raycast/extensions/issues/28408).
+- Limited concurrent Git branch lookups and briefly cached results so `Search Recent Projects` stays responsive with large project lists.
+
 ## [Revert: Windows project opening] - 2026-06-21
 
 - `getSelectedFinderItems` works on Windows; reverted.

--- a/extensions/visual-studio-code-recent-projects/package.json
+++ b/extensions/visual-studio-code-recent-projects/package.json
@@ -33,7 +33,8 @@
     "raxityo",
     "yusifaliyevpro",
     "jkker",
-    "sillashead"
+    "sillashead",
+    "kenan"
   ],
   "keywords": [
     "vscode",

--- a/extensions/visual-studio-code-recent-projects/src/index.tsx
+++ b/extensions/visual-studio-code-recent-projects/src/index.tsx
@@ -160,11 +160,12 @@ function LocalItem(
   });
 
   useEffect(() => {
+    const controller = new AbortController();
     let mounted = true;
 
     async function fetchGitBranch() {
       try {
-        const branch = await getGitBranch(path);
+        const branch = await getGitBranch(path, controller.signal);
         if (mounted) {
           setGitBranch(branch);
         }
@@ -178,8 +179,9 @@ function LocalItem(
     }
     return () => {
       mounted = false;
+      controller.abort();
     };
-  }, [path, name]);
+  }, [path]);
 
   const getTitle = (revert = false) => {
     return `Open in ${build} ${closeOtherWindows !== revert ? "and Close Other" : ""}`;

--- a/extensions/visual-studio-code-recent-projects/src/lib/shortcuts.ts
+++ b/extensions/visual-studio-code-recent-projects/src/lib/shortcuts.ts
@@ -37,7 +37,7 @@ export const Shortcut = {
   CopyTertiary: platformShortcut(",", ["cmd", "shift"]),
   CreateQuickLink: platformShortcut("l", ["cmd"]),
   OpenInBrowser: platformShortcut("b", ["cmd"]),
-  OpenInTerminal: platformShortcut("o", ["cmd", "shift"]),
+  OpenInTerminal: platformShortcut("t", ["cmd", "shift"]),
   RevealInFileManager: platformShortcut("f", ["cmd", "shift"]),
   Pin: platformShortcut("p", ["cmd", "shift"]),
   UnpinAll: sharedShortcut("x", ["ctrl", "shift"]),

--- a/extensions/visual-studio-code-recent-projects/src/utils/git.ts
+++ b/extensions/visual-studio-code-recent-projects/src/utils/git.ts
@@ -7,7 +7,59 @@ import { promisify } from "util";
 
 const execFileAsync = promisify(execFile);
 
+const MAX_CONCURRENT_BRANCH_LOOKUPS = 4;
+const BRANCH_LOOKUP_CACHE_TTL_MS = 15_000;
+const MAX_CACHED_BRANCH_LOOKUPS = 100;
+const branchLookups = new Map<string, { expiresAt: number; promise: Promise<string | null> }>();
+let activeBranchLookups = 0;
+const queuedBranchLookups: (() => void)[] = [];
+
+async function withBranchLookupSlot<T>(operation: () => Promise<T>): Promise<T> {
+  if (activeBranchLookups >= MAX_CONCURRENT_BRANCH_LOOKUPS) {
+    await new Promise<void>((resolve) => queuedBranchLookups.push(resolve));
+  }
+
+  activeBranchLookups += 1;
+
+  try {
+    return await operation();
+  } finally {
+    activeBranchLookups -= 1;
+    queuedBranchLookups.shift()?.();
+  }
+}
+
 export async function getGitBranch(directoryPath: string): Promise<string | null> {
+  const now = Date.now();
+  const cachedLookup = branchLookups.get(directoryPath);
+  if (cachedLookup && cachedLookup.expiresAt > now) {
+    return cachedLookup.promise;
+  }
+
+  pruneBranchLookupCache(now);
+  const lookup = withBranchLookupSlot(() => getGitBranchUncached(directoryPath));
+  branchLookups.set(directoryPath, { promise: lookup, expiresAt: now + BRANCH_LOOKUP_CACHE_TTL_MS });
+
+  return lookup;
+}
+
+function pruneBranchLookupCache(now: number) {
+  for (const [path, lookup] of branchLookups) {
+    if (lookup.expiresAt <= now) {
+      branchLookups.delete(path);
+    }
+  }
+
+  while (branchLookups.size >= MAX_CACHED_BRANCH_LOOKUPS) {
+    const oldestPath = branchLookups.keys().next().value;
+    if (!oldestPath) {
+      return;
+    }
+    branchLookups.delete(oldestPath);
+  }
+}
+
+async function getGitBranchUncached(directoryPath: string): Promise<string | null> {
   try {
     // If it's a file URL, convert it to a file path
     if (directoryPath.startsWith("file://")) {

--- a/extensions/visual-studio-code-recent-projects/src/utils/git.ts
+++ b/extensions/visual-studio-code-recent-projects/src/utils/git.ts
@@ -10,37 +10,78 @@ const execFileAsync = promisify(execFile);
 const MAX_CONCURRENT_BRANCH_LOOKUPS = 4;
 const BRANCH_LOOKUP_CACHE_TTL_MS = 15_000;
 const MAX_CACHED_BRANCH_LOOKUPS = 100;
-const branchLookups = new Map<string, { expiresAt: number; promise: Promise<string | null> }>();
+const branchLookups = new Map<string, { branch: string | null; expiresAt: number }>();
 let activeBranchLookups = 0;
-const queuedBranchLookups: (() => void)[] = [];
+const queuedBranchLookups: { resolve: () => void; reject: (error: Error) => void; signal?: AbortSignal }[] = [];
 
-async function withBranchLookupSlot<T>(operation: () => Promise<T>): Promise<T> {
-  if (activeBranchLookups >= MAX_CONCURRENT_BRANCH_LOOKUPS) {
-    await new Promise<void>((resolve) => queuedBranchLookups.push(resolve));
-  }
-
-  activeBranchLookups += 1;
+async function withBranchLookupSlot<T>(operation: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+  await waitForBranchLookupSlot(signal);
 
   try {
+    if (signal?.aborted) {
+      throw new Error("Git branch lookup aborted");
+    }
+
     return await operation();
   } finally {
-    activeBranchLookups -= 1;
-    queuedBranchLookups.shift()?.();
+    releaseBranchLookupSlot();
   }
 }
 
-export async function getGitBranch(directoryPath: string): Promise<string | null> {
+async function waitForBranchLookupSlot(signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    throw new Error("Git branch lookup aborted");
+  }
+
+  if (activeBranchLookups < MAX_CONCURRENT_BRANCH_LOOKUPS) {
+    activeBranchLookups += 1;
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const queuedLookup = { resolve, reject, signal };
+    queuedBranchLookups.push(queuedLookup);
+
+    signal?.addEventListener(
+      "abort",
+      () => {
+        const queuedLookupIndex = queuedBranchLookups.indexOf(queuedLookup);
+        if (queuedLookupIndex >= 0) {
+          queuedBranchLookups.splice(queuedLookupIndex, 1);
+          reject(new Error("Git branch lookup aborted"));
+        }
+      },
+      { once: true },
+    );
+  });
+}
+
+function releaseBranchLookupSlot() {
+  const nextLookup = queuedBranchLookups.shift();
+
+  if (nextLookup) {
+    nextLookup.resolve();
+    return;
+  }
+
+  activeBranchLookups -= 1;
+}
+
+export async function getGitBranch(directoryPath: string, signal?: AbortSignal): Promise<string | null> {
   const now = Date.now();
   const cachedLookup = branchLookups.get(directoryPath);
   if (cachedLookup && cachedLookup.expiresAt > now) {
-    return cachedLookup.promise;
+    return cachedLookup.branch;
   }
 
   pruneBranchLookupCache(now);
-  const lookup = withBranchLookupSlot(() => getGitBranchUncached(directoryPath));
-  branchLookups.set(directoryPath, { promise: lookup, expiresAt: now + BRANCH_LOOKUP_CACHE_TTL_MS });
+  const branch = await withBranchLookupSlot(() => getGitBranchUncached(directoryPath, signal), signal);
 
-  return lookup;
+  if (!signal?.aborted) {
+    branchLookups.set(directoryPath, { branch, expiresAt: Date.now() + BRANCH_LOOKUP_CACHE_TTL_MS });
+  }
+
+  return branch;
 }
 
 function pruneBranchLookupCache(now: number) {
@@ -59,7 +100,7 @@ function pruneBranchLookupCache(now: number) {
   }
 }
 
-async function getGitBranchUncached(directoryPath: string): Promise<string | null> {
+async function getGitBranchUncached(directoryPath: string, signal?: AbortSignal): Promise<string | null> {
   try {
     // If it's a file URL, convert it to a file path
     if (directoryPath.startsWith("file://")) {
@@ -87,11 +128,15 @@ async function getGitBranchUncached(directoryPath: string): Promise<string | nul
     const { stdout } = await execFileAsync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
       cwd: directoryPath,
       encoding: "utf-8",
+      signal,
     });
 
     const branch = stdout.trim();
     return branch || null;
   } catch (error) {
+    if (signal?.aborted) {
+      return null;
+    }
     // Only show error if it's not the common "not a git repository" error and not the "ambiguous argument 'HEAD'" error
     if (
       error instanceof Error &&


### PR DESCRIPTION
## Description

- Fixes the `Open with Terminal` shortcut conflict with `Open With…`. Fixes #28408.
- Limits Git branch lookups, briefly reuses completed results, and cancels queued or active lookups for projects that are no longer visible. This keeps large recent-project lists responsive.

## Validation

- `npm run lint`
- `npm run build`
- Raycast was not launched for manual UI testing.
