### PR TITLE
[Windows Terminal] Add non-quake admin action when quake preference is on

### DIFF
--- a/extensions/windows-terminal/CHANGELOG.md
+++ b/extensions/windows-terminal/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Windows Terminal Changelog
 
-## [Non-Quake Admin Action] - {PR_MERGE_DATE}
+## [Non-Quake Admin Action] - 2026-07-22
 
 - Added an "Open as Administrator (Non-Quake)" action (⌃↵) that appears while the `Open profiles in quake window` preference is on, so users can still open an elevated session in a normal window — elevated quake windows don't respond to the global quake shortcut (Win+`).
 

--- a/extensions/windows-terminal/CHANGELOG.md
+++ b/extensions/windows-terminal/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Windows Terminal Changelog
 
+## [Non-Quake Admin Action] - {PR_MERGE_DATE}
+
+- Added an "Open as Administrator (Non-Quake)" action (⌃↵) that appears while the `Open profiles in quake window` preference is on, so users can still open an elevated session in a normal window — elevated quake windows don't respond to the global quake shortcut (Win+`).
+
 ## [Fix Starting Directory] - 2026-07-01
 
 - Fixed profiles launching in System32 instead of the user's home when no `startingDirectory` is set

--- a/extensions/windows-terminal/src/open-profile.tsx
+++ b/extensions/windows-terminal/src/open-profile.tsx
@@ -95,6 +95,29 @@ function Actions(props: { name: string; quake: boolean }) {
           await closeMainWindow();
         }}
       />
+      {props.quake ? (
+        // Elevated quake windows don't respond to Windows Terminal's global quake shortcut
+        // (Win+`), so once the admin drop-down loses focus there's no way to summon it back.
+        // This gives users an escape hatch to open the admin session in a normal window even
+        // when the quake preference is on.
+        <Action
+          icon={Icon.Shield}
+          title="Open as Administrator (Non-Quake)"
+          shortcut={{ modifiers: ["ctrl"], key: "enter" }}
+          onAction={async () => {
+            const escapedName = props.name.replace(/'/g, "''");
+            execFile("powershell", [
+              "Start-Process",
+              "wt.exe",
+              "-ArgumentList",
+              `'-p "${escapedName}"'`,
+              "-Verb",
+              "RunAs",
+            ]);
+            await closeMainWindow();
+          }}
+        />
+      ) : null}
       <ActionPanel.Section>
         <Action.Open
           icon={Icon.Code}

--- a/extensions/windows-terminal/src/open-profile.tsx
+++ b/extensions/windows-terminal/src/open-profile.tsx
@@ -49,6 +49,28 @@ function getSpawnOptions() {
   return { env: getWindowsTerminalEnv(), cwd: os.homedir() };
 }
 
+function launchElevated(name: string, quake: boolean) {
+  // Start-Process -Verb RunAs joins ArgumentList tokens with spaces and does not re-quote them
+  // before invoking ShellExecute, so the profile name has to arrive pre-quoted. Single quotes in
+  // the name would end our PowerShell single-quoted string; double quotes in the name would end
+  // the inner "..." wt.exe sees. Escape both.
+  const escapedName = name.replace(/'/g, "''").replace(/"/g, '\\"');
+  const argumentList = quake ? `'-w _quake new-tab -p "${escapedName}"'` : `'-p "${escapedName}"'`;
+  // Elevation resets the CWD to System32, so pin the elevated wt.exe to home.
+  // Profiles with their own startingDirectory still win.
+  const workingDirectory = `'${os.homedir().replace(/'/g, "''")}'`;
+  execFile("powershell", [
+    "Start-Process",
+    "wt.exe",
+    "-ArgumentList",
+    argumentList,
+    "-WorkingDirectory",
+    workingDirectory,
+    "-Verb",
+    "RunAs",
+  ]);
+}
+
 function Actions(props: { name: string; quake: boolean }) {
   return (
     <ActionPanel title={props.name}>
@@ -74,24 +96,7 @@ function Actions(props: { name: string; quake: boolean }) {
         title={props.quake ? "Open as Administrator (Quake)" : "Open as Administrator"}
         shortcut={{ modifiers: ["ctrl", "shift"], key: "enter" }}
         onAction={async () => {
-          // Quote the profile name so names containing spaces (e.g. "Command Prompt") survive
-          // Start-Process -Verb RunAs, which joins ArgumentList tokens with spaces and does not
-          // re-quote them before invoking ShellExecute.
-          const escapedName = props.name.replace(/'/g, "''");
-          const argumentList = props.quake ? `'-w _quake new-tab -p "${escapedName}"'` : `'-p "${escapedName}"'`;
-          // Elevation resets the CWD to System32, so pin the elevated wt.exe to home.
-          // Profiles with their own startingDirectory still win.
-          const workingDirectory = `'${os.homedir().replace(/'/g, "''")}'`;
-          execFile("powershell", [
-            "Start-Process",
-            "wt.exe",
-            "-ArgumentList",
-            argumentList,
-            "-WorkingDirectory",
-            workingDirectory,
-            "-Verb",
-            "RunAs",
-          ]);
+          launchElevated(props.name, props.quake);
           await closeMainWindow();
         }}
       />
@@ -105,15 +110,7 @@ function Actions(props: { name: string; quake: boolean }) {
           title="Open as Administrator (Non-Quake)"
           shortcut={{ modifiers: ["ctrl"], key: "enter" }}
           onAction={async () => {
-            const escapedName = props.name.replace(/'/g, "''");
-            execFile("powershell", [
-              "Start-Process",
-              "wt.exe",
-              "-ArgumentList",
-              `'-p "${escapedName}"'`,
-              "-Verb",
-              "RunAs",
-            ]);
+            launchElevated(props.name, false);
             await closeMainWindow();
           }}
         />


### PR DESCRIPTION
## Description

Follow-up to #28197. When the `Open profiles in quake window` preference is on, all admin launches route into the quake window — but elevated quake windows don't respond to Windows Terminal's global quake shortcut (Win+`), so once the drop-down loses focus there's no way to summon it back.

This adds an escape hatch: while the preference is on, an additional **Open as Administrator (Non-Quake)** action (⌃↵) is exposed alongside the quake admin action (⌃⇧↵), letting users open an elevated session in a normal window.

## Screencast / Screenshot

_The action only appears when the preference is enabled._

## Checklist

- [x] I read the [contribution guidelines](https://github.com/raycast/extensions/blob/main/CONTRIBUTING.md).
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/prepare-an-extension-for-store).
- [x] I ran `npm run build` and tested that this distribution build works as expected.
- [x] I ran `npm run lint` and it passed.
- [x] I made this pull request with the intended target branch.
- [x] My extension is compatible with all supported OSes (or I checked "compatible" with only the supported ones).
- [x] I updated the CHANGELOG file with the `{PR_MERGE_DATE}` placeholder.