### PR TITLE
[Windows Terminal] Always open administrator in a normal window

### DIFF
--- a/extensions/windows-terminal/CHANGELOG.md
+++ b/extensions/windows-terminal/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Windows Terminal Changelog
 
+## [Always Open Administrator in a Normal Window] - {PR_MERGE_DATE}
+
+- "Open as Administrator" now always launches into a regular window, regardless of the `Open profiles in quake window` preference. Elevated quake windows don't respond to Windows Terminal's global quake shortcut (Win+`), so routing admin through quake left users unable to summon the drop-down back once it lost focus. The separate "Open as Administrator (Non-Quake)" action added in the previous release is no longer needed and has been removed.
+- Skipped loading the PowerShell profile when spawning the elevated launcher (`powershell -NoProfile`), which noticeably cuts the delay between triggering the action and the UAC prompt.
+
 ## [Non-Quake Admin Action] - 2026-07-22
 
 - Added an "Open as Administrator (Non-Quake)" action (⌃↵) that appears while the `Open profiles in quake window` preference is on, so users can still open an elevated session in a normal window — elevated quake windows don't respond to the global quake shortcut (Win+`).

--- a/extensions/windows-terminal/CHANGELOG.md
+++ b/extensions/windows-terminal/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Windows Terminal Changelog
 
-## [Always Open Administrator in a Normal Window] - {PR_MERGE_DATE}
+## [Always Open Administrator in a Normal Window] - 2026-07-22
 
 - "Open as Administrator" now always launches into a regular window, regardless of the `Open profiles in quake window` preference. Elevated quake windows don't respond to Windows Terminal's global quake shortcut (Win+`), so routing admin through quake left users unable to summon the drop-down back once it lost focus. The separate "Open as Administrator (Non-Quake)" action added in the previous release is no longer needed and has been removed.
 - Skipped loading the PowerShell profile when spawning the elevated launcher (`powershell -NoProfile`), which noticeably cuts the delay between triggering the action and the UAC prompt.

--- a/extensions/windows-terminal/src/open-profile.tsx
+++ b/extensions/windows-terminal/src/open-profile.tsx
@@ -49,17 +49,19 @@ function getSpawnOptions() {
   return { env: getWindowsTerminalEnv(), cwd: os.homedir() };
 }
 
-function launchElevated(name: string, quake: boolean) {
+function launchElevated(name: string) {
   // Start-Process -Verb RunAs joins ArgumentList tokens with spaces and does not re-quote them
   // before invoking ShellExecute, so the profile name has to arrive pre-quoted. Single quotes in
   // the name would end our PowerShell single-quoted string; double quotes in the name would end
   // the inner "..." wt.exe sees. Escape both.
   const escapedName = name.replace(/'/g, "''").replace(/"/g, '\\"');
-  const argumentList = quake ? `'-w _quake new-tab -p "${escapedName}"'` : `'-p "${escapedName}"'`;
+  const argumentList = `'-p "${escapedName}"'`;
   // Elevation resets the CWD to System32, so pin the elevated wt.exe to home.
   // Profiles with their own startingDirectory still win.
   const workingDirectory = `'${os.homedir().replace(/'/g, "''")}'`;
   execFile("powershell", [
+    "-NoProfile",
+    "-Command",
     "Start-Process",
     "wt.exe",
     "-ArgumentList",
@@ -93,28 +95,16 @@ function Actions(props: { name: string; quake: boolean }) {
       />
       <Action
         icon={Icon.Shield}
-        title={props.quake ? "Open as Administrator (Quake)" : "Open as Administrator"}
+        title="Open as Administrator"
         shortcut={{ modifiers: ["ctrl", "shift"], key: "enter" }}
         onAction={async () => {
-          launchElevated(props.name, props.quake);
+          // Always launch elevated in a normal window. Elevated quake windows don't respond to
+          // Windows Terminal's global quake shortcut (Win+`), so once the admin drop-down loses
+          // focus there's no way to summon it back — a regular window avoids that trap.
+          launchElevated(props.name);
           await closeMainWindow();
         }}
       />
-      {props.quake ? (
-        // Elevated quake windows don't respond to Windows Terminal's global quake shortcut
-        // (Win+`), so once the admin drop-down loses focus there's no way to summon it back.
-        // This gives users an escape hatch to open the admin session in a normal window even
-        // when the quake preference is on.
-        <Action
-          icon={Icon.Shield}
-          title="Open as Administrator (Non-Quake)"
-          shortcut={{ modifiers: ["ctrl"], key: "enter" }}
-          onAction={async () => {
-            launchElevated(props.name, false);
-            await closeMainWindow();
-          }}
-        />
-      ) : null}
       <ActionPanel.Section>
         <Action.Open
           icon={Icon.Code}


### PR DESCRIPTION
## Description

Follow-up to #29646. Instead of exposing two separate admin actions when the `Open profiles in quake window` preference is on, "Open as Administrator" now always launches into a regular window — regardless of the preference. Elevated quake windows don't respond to Windows Terminal's global quake shortcut (Win+`), so routing admin through quake left users unable to summon the drop-down back once it lost focus. The separate "Open as Administrator (Non-Quake)" action from the previous release is no longer needed and has been removed.

Also skipped loading the PowerShell profile when spawning the elevated launcher (`powershell -NoProfile`), which noticeably cuts the delay between triggering the action and the UAC prompt.

## Checklist

- [x] I read the [contribution guidelines](https://github.com/raycast/extensions/blob/main/CONTRIBUTING.md).
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/prepare-an-extension-for-store).
- [x] I ran `npm run build` and tested that this distribution build works as expected.
- [x] I ran `npm run lint` and it passed.
- [x] I made this pull request with the intended target branch.
- [x] My extension is compatible with all supported OSes (or I checked "compatible" with only the supported ones).
- [x] I updated the CHANGELOG file with the `{PR_MERGE_DATE}` placeholder.