### PR TITLE
Update file-provider-progress extension

### DIFF
--- a/extensions/file-provider-progress/CHANGELOG.md
+++ b/extensions/file-provider-progress/CHANGELOG.md
@@ -1,5 +1,9 @@
 # File Provider Progress Changelog
 
+## [Fix Bundled Helper Permissions] - {PR_MERGE_DATE}
+
+- Restore executable permissions for the bundled helper during packaging and at runtime.
+
 ## [Initial Release] - 2026-06-30
 
 - Add the first Store-ready version of File Provider Progress.

--- a/extensions/file-provider-progress/CHANGELOG.md
+++ b/extensions/file-provider-progress/CHANGELOG.md
@@ -1,6 +1,6 @@
 # File Provider Progress Changelog
 
-## [Fix Bundled Helper Permissions] - {PR_MERGE_DATE}
+## [Fix Bundled Helper Permissions] - 2026-07-22
 
 - Restore executable permissions for the bundled helper during packaging and at runtime.
 

--- a/extensions/file-provider-progress/package.json
+++ b/extensions/file-provider-progress/package.json
@@ -65,6 +65,7 @@
     "lint:store": "ray lint && npm run lint:eslint",
     "publish": "npm run package-swift -- release && npm run build && npx @raycast/api@latest publish",
     "sync-native": "scripts/sync-native.sh",
+    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types --test src/executable.test.ts",
     "verify-native": "scripts/verify-native.sh",
     "typecheck": "tsc --noEmit",
     "package-swift": "scripts/package-swift-binary.sh"

--- a/extensions/file-provider-progress/scripts/package-swift-binary.sh
+++ b/extensions/file-provider-progress/scripts/package-swift-binary.sh
@@ -83,6 +83,7 @@ if cmp -s "$PRODUCT_BIN" "$OUTPUT_BIN"; then
   printf "Bundled release helper is unchanged at %s\n" "$OUTPUT_BIN"
 else
   cp "$PRODUCT_BIN" "$OUTPUT_BIN"
-  chmod +x "$OUTPUT_BIN"
   printf "Bundled universal release build at %s\n" "$OUTPUT_BIN"
 fi
+
+chmod +x "$OUTPUT_BIN"

--- a/extensions/file-provider-progress/src/executable.test.ts
+++ b/extensions/file-provider-progress/src/executable.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { ensureExecutable } from "./executable.ts";
+
+test("adds execute bits to a bundled helper without changing its contents", async (context) => {
+  const directory = await mkdtemp(path.join(tmpdir(), "fp-progress-executable-"));
+  context.after(() => rm(directory, { force: true, recursive: true }));
+  const helperPath = path.join(directory, "fp-progress");
+  const contents = "test helper\n";
+
+  await writeFile(helperPath, contents, { mode: 0o644 });
+  await ensureExecutable(helperPath);
+
+  const helperStats = await stat(helperPath);
+  assert.equal(helperStats.mode & 0o777, 0o755);
+  assert.equal(await readFile(helperPath, "utf8"), contents);
+});
+
+test("leaves an executable bundled helper's mode unchanged", async (context) => {
+  const directory = await mkdtemp(path.join(tmpdir(), "fp-progress-executable-"));
+  context.after(() => rm(directory, { force: true, recursive: true }));
+  const helperPath = path.join(directory, "fp-progress");
+
+  await writeFile(helperPath, "test helper\n", { mode: 0o700 });
+  await ensureExecutable(helperPath);
+
+  const helperStats = await stat(helperPath);
+  assert.equal(helperStats.mode & 0o777, 0o700);
+});
+
+test("refuses to repair a symlink", async (context) => {
+  const directory = await mkdtemp(path.join(tmpdir(), "fp-progress-executable-"));
+  context.after(() => rm(directory, { force: true, recursive: true }));
+  const targetPath = path.join(directory, "target");
+  const helperPath = path.join(directory, "fp-progress");
+
+  await writeFile(targetPath, "test helper\n", { mode: 0o644 });
+  await symlink(targetPath, helperPath);
+
+  await assert.rejects(ensureExecutable(helperPath), /not a regular file/);
+  const targetStats = await stat(targetPath);
+  assert.equal(targetStats.mode & 0o777, 0o644);
+});

--- a/extensions/file-provider-progress/src/executable.ts
+++ b/extensions/file-provider-progress/src/executable.ts
@@ -1,0 +1,16 @@
+import { constants } from "node:fs";
+import { access, chmod, lstat } from "node:fs/promises";
+
+export async function ensureExecutable(filePath: string): Promise<void> {
+  const stats = await lstat(filePath);
+
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    throw new Error(`Bundled fp-progress helper is not a regular file: ${filePath}`);
+  }
+
+  if ((stats.mode & 0o111) === 0) {
+    await chmod(filePath, stats.mode | 0o111);
+  }
+
+  await access(filePath, constants.X_OK);
+}

--- a/extensions/file-provider-progress/src/probe.ts
+++ b/extensions/file-provider-progress/src/probe.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import path from "node:path";
 import { promisify } from "node:util";
 import { environment, getPreferenceValues } from "@raycast/api";
+import { ensureExecutable } from "./executable";
 import type { StatusReport } from "./models";
 
 const execFileAsync = promisify(execFile);
@@ -11,12 +12,20 @@ export async function loadStatusReport(): Promise<StatusReport> {
   const cliPath = resolveCliPath(preferences.cliPath);
   const timeoutSeconds = parseTimeout(preferences.timeoutSeconds);
 
+  if (usesBundledCli(preferences.cliPath)) {
+    await ensureExecutable(cliPath);
+  }
+
   const { stdout } = await execFileAsync(cliPath, ["status", "--json"], {
     timeout: timeoutSeconds * 1000,
     maxBuffer: 1024 * 1024 * 8,
   });
 
   return parseStatusReport(stdout);
+}
+
+function usesBundledCli(preferencePath: string | undefined): boolean {
+  return !preferencePath?.trim() && !process.env.FP_PROGRESS_BIN;
 }
 
 export function resolveCliPath(preferencePath: string | undefined): string {

--- a/extensions/file-provider-progress/tsconfig.json
+++ b/extensions/file-provider-progress/tsconfig.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
+    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,


### PR DESCRIPTION
## Description

- Fixes the `spawn .../assets/bin/fp-progress EACCES` failure reported in #29153 by restoring missing execute bits on the bundled helper before spawning it.
- Limits runtime permission repair to the default bundled helper; custom `cliPath` and `FP_PROGRESS_BIN` paths are never modified.
- Refuses to repair symlinks and verifies executable access after applying permissions.
- Makes release packaging restore execute bits even when the helper bytes are unchanged.

## Testing

- `make test`
- `make raycast-check`
- Packaging regression: changed the bundled helper to mode `644`, ran the release packaging script, and verified it restored mode `755`.
- End-to-end Raycast test: development install copied the helper as mode `644`; opening the command repaired the installed copy to `755` and successfully loaded all File Provider domains.

## Screencast

Not applicable; this fixes helper startup without changing the extension UI.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
