### PR TITLE
Update cursors extension

### DIFF
--- a/extensions/cursors/CHANGELOG.md
+++ b/extensions/cursors/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Cursors Changelog
 
+## [Fix stuck loading spinner] - {PR_MERGE_DATE}
+
+- Fixed the cursor grid getting stuck on a permanent loading spinner when Quick Look preview generation failed (e.g. the PNG renderer couldn't load). The tiles are fully usable without Quick Look, so the grid now finishes loading and just skips the failed previews.
+
 ## [PNG export, Quick Look, backdrops & modernization] - 2026-07-19
 
 - Added **Copy as PNG**, **Paste as PNG**, and **Save as PNG** submenus — export any cursor as a transparent PNG at 16, 32, 64, 128, 256, or 512px. PNGs are vector-rendered from the source SVG, so they stay crisp at every size.

--- a/extensions/cursors/CHANGELOG.md
+++ b/extensions/cursors/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Cursors Changelog
 
-## [Fix stuck loading spinner] - {PR_MERGE_DATE}
+## [Fix stuck loading spinner] - 2026-07-23
 
 - Fixed the cursor grid getting stuck on a permanent loading spinner when Quick Look preview generation failed (e.g. the PNG renderer couldn't load). The tiles are fully usable without Quick Look, so the grid now finishes loading and just skips the failed previews.
 

--- a/extensions/cursors/src/index.tsx
+++ b/extensions/cursors/src/index.tsx
@@ -29,7 +29,12 @@ export default function Command() {
   useEffect(() => {
     prepareQuickLook(cursors)
       .then(() => setQuickLookReady(true))
-      .catch((error) => reportFailure("Couldn't prepare Quick Look previews", error));
+      .catch((error) => {
+        reportFailure("Couldn't prepare Quick Look previews", error);
+        // Dismiss the spinner even on failure — the tiles are fully functional
+        // without Quick Look, so never wedge the grid on a permanent loader.
+        setQuickLookReady(true);
+      });
   }, []);
 
   return (

--- a/extensions/cursors/src/index.tsx
+++ b/extensions/cursors/src/index.tsx
@@ -22,30 +22,29 @@ export default function Command() {
   const inset = activeBackdrop === DEFAULT_BACKDROP ? Grid.Inset.Large : undefined;
 
   // Pre-render PNGs once so Quick Look (⌘Y) has a file ready to preview. The
-  // path is deterministic, but the file doesn't exist until this resolves —
-  // gate the `quickLook` prop on `quickLookReady` so ⌘Y can't point at a
-  // missing file on first launch.
-  const [quickLookReady, setQuickLookReady] = useState(false);
+  // path is deterministic, but the file doesn't exist until it's rendered, so
+  // track two things separately: whether prep has finished (drives the spinner)
+  // and which cursors actually landed on disk (gates each tile's `quickLook`).
+  // A per-cursor render failure must not expose ⌘Y on a missing file, and the
+  // spinner must clear regardless — the tiles work fine without Quick Look.
+  const [prepDone, setPrepDone] = useState(false);
+  const [readyIds, setReadyIds] = useState<Set<string>>(new Set());
   useEffect(() => {
     prepareQuickLook(cursors)
-      .then(() => setQuickLookReady(true))
-      .catch((error) => {
-        reportFailure("Couldn't prepare Quick Look previews", error);
-        // Dismiss the spinner even on failure — the tiles are fully functional
-        // without Quick Look, so never wedge the grid on a permanent loader.
-        setQuickLookReady(true);
-      });
+      .then(setReadyIds)
+      .catch((error) => reportFailure("Couldn't prepare Quick Look previews", error))
+      .finally(() => setPrepDone(true));
   }, []);
 
   return (
-    <Grid columns={columns} inset={inset} isLoading={isLoading || !quickLookReady}>
+    <Grid columns={columns} inset={inset} isLoading={isLoading || !prepDone}>
       {cursors.map((cursor) => (
         <Grid.Item
           key={cursor.id}
           title={cursor.name}
           subtitle={cursor.nonStandard ? "macOS-only" : undefined}
           content={{ value: svgToDataUri(withBackdrop(cursor.svg, activeBackdrop)), tooltip: cursor.name }}
-          quickLook={quickLookReady ? { path: quickLookPath(cursor.id), name: cursor.name } : undefined}
+          quickLook={readyIds.has(cursor.id) ? { path: quickLookPath(cursor.id), name: cursor.name } : undefined}
           accessory={
             cursor.nonStandard ? { icon: Icon.Star, tooltip: "macOS-specific cursor (no CSS equivalent)" } : undefined
           }

--- a/extensions/cursors/src/lib/png.ts
+++ b/extensions/cursors/src/lib/png.ts
@@ -46,16 +46,29 @@ export function quickLookPath(id: string): string {
  * Pre-render every cursor to a PNG so Quick Look (⌘Y) has a file ready the
  * instant it's toggled. Idempotent — re-rendering overwrites in place. Runs
  * once on grid mount; the whole set is ~40 small PNGs.
+ *
+ * Each cursor renders independently: one failure never blocks the rest, and
+ * only the ids that actually landed on disk are returned. Callers must gate a
+ * tile's Quick Look on membership in this set — a cursor missing from it has no
+ * file to preview. Rejects only if the WASM renderer itself can't load (in
+ * which case nothing rendered).
  */
-export async function prepareQuickLook(cursors: Cursor[]): Promise<void> {
+export async function prepareQuickLook(cursors: Cursor[]): Promise<Set<string>> {
   await ensureWasm(loadWasm);
   const dir = pngDir();
   await mkdir(dir, { recursive: true });
 
-  await Promise.all(
+  const results = await Promise.all(
     cursors.map(async (cursor) => {
-      const png = renderCursorPng(cursor.svg, QUICK_LOOK_SIZE);
-      await writeFile(join(dir, `${cursor.id}-${QUICK_LOOK_SIZE}.png`), png);
+      try {
+        const png = renderCursorPng(cursor.svg, QUICK_LOOK_SIZE);
+        await writeFile(join(dir, `${cursor.id}-${QUICK_LOOK_SIZE}.png`), png);
+        return cursor.id;
+      } catch {
+        return null;
+      }
     }),
   );
+
+  return new Set(results.filter((id): id is string => id !== null));
 }


### PR DESCRIPTION
## Description

Minor fix for the Cursors extension.

The grid could get stuck on a permanent loading spinner when Quick Look preview generation failed (e.g. the WASM PNG renderer couldn't load). The readiness gate that drives `isLoading` was only dismissed on success — its `.catch` showed a toast but never flipped the flag, so a single non-critical failure wedged the whole grid even though the cursor tiles are fully functional without Quick Look.

Now the failure path dismisses the gate too: the grid finishes loading and simply skips the unavailable previews.

Fixes the permanent-loading-spinner issue flagged during review of #29493 ([review comment](https://github.com/raycast/extensions/pull/29493#discussion_r3610299025)).

## Changes

- `src/index.tsx` — resolve the Quick Look readiness gate on the `.catch` path (toast **and** dismiss, not just toast).
- `CHANGELOG.md` — new entry.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that this change does not break existing behavior