### PR TITLE
Update stock tracker extension

### DIFF
--- a/extensions/stock-tracker/CHANGELOG.md
+++ b/extensions/stock-tracker/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Stock Tracker Changelog
 
+## [Menu Bar Stocks] - {PR_MERGE_DATE}
+
+- Add a new Menu Bar Stocks command that shows live prices for selected stocks in the macOS menu bar, refreshing every minute
+- Add "Add to Menu Bar" / "Remove from Menu Bar" actions (⌘⇧M) to stock list items, with a pin accessory showing which stocks are in the menu bar
+
 ## [Fix] - 2026-06-11
 - Assets denominated in pence are now displayed properly, rather than being taken at face value for pounds.
 

--- a/extensions/stock-tracker/CHANGELOG.md
+++ b/extensions/stock-tracker/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Stock Tracker Changelog
 
-## [Menu Bar Stocks] - {PR_MERGE_DATE}
+## [Menu Bar Stocks] - 2026-07-23
 
 - Add a new Menu Bar Stocks command that shows live prices for selected stocks in the macOS menu bar, refreshing every minute
 - Add "Add to Menu Bar" / "Remove from Menu Bar" actions (⌘⇧M) to stock list items, with a pin accessory showing which stocks are in the menu bar

--- a/extensions/stock-tracker/package.json
+++ b/extensions/stock-tracker/package.json
@@ -8,7 +8,8 @@
   "contributors": [
     "ericchernuka",
     "kristoffermelen",
-    "vinayh"
+    "vinayh",
+    "ridemountainpig"
   ],
   "categories": [
     "Finance"
@@ -20,6 +21,13 @@
       "title": "View Stocks",
       "description": "Look up stocks by symbol",
       "mode": "view"
+    },
+    {
+      "name": "menubar",
+      "title": "Menu Bar Stocks",
+      "description": "Show live prices for your selected stocks in the menu bar",
+      "mode": "menu-bar",
+      "interval": "1m"
     }
   ],
   "dependencies": {

--- a/extensions/stock-tracker/src/favorites-list.tsx
+++ b/extensions/stock-tracker/src/favorites-list.tsx
@@ -1,6 +1,8 @@
 import { List, Icon, ActionPanel, Action } from "@raycast/api";
 import { Quote } from "./yahoo-finance";
 import { FavoritesStore } from "./favorites-store";
+import { MenuBarStore } from "./menubar-store";
+import { MenuBarAddRemoveAction } from "./menubar-actions";
 import StockListItem from "./stock-list-item";
 import { formatTime } from "./utils";
 
@@ -8,11 +10,15 @@ export default function FavoritesList({
   favorites,
   favoriteSymbols,
   favoritesStore,
+  menuBarSymbols,
+  menuBarStore,
   lastUpdated,
 }: {
   favorites: Quote[];
   favoriteSymbols: string[];
   favoritesStore: FavoritesStore;
+  menuBarSymbols: string[];
+  menuBarStore: MenuBarStore;
   lastUpdated: Date | null;
 }) {
   return (
@@ -21,7 +27,16 @@ export default function FavoritesList({
         <StockListItem
           key={quote.symbol}
           quote={quote}
-          actions={<FavouritesActions favorites={favoriteSymbols} quote={quote} favoritesStore={favoritesStore} />}
+          isInMenuBar={!!quote.symbol && menuBarSymbols.includes(quote.symbol)}
+          actions={
+            <FavouritesActions
+              favorites={favoriteSymbols}
+              quote={quote}
+              favoritesStore={favoritesStore}
+              menuBarSymbols={menuBarSymbols}
+              menuBarStore={menuBarStore}
+            />
+          }
         />
       ))}
     </List.Section>
@@ -32,9 +47,11 @@ interface FavouritesActionsProps {
   favorites: string[];
   quote: Quote;
   favoritesStore: FavoritesStore;
+  menuBarSymbols: string[];
+  menuBarStore: MenuBarStore;
 }
 
-function FavouritesActions({ favorites, quote, favoritesStore }: FavouritesActionsProps) {
+function FavouritesActions({ favorites, quote, favoritesStore, menuBarSymbols, menuBarStore }: FavouritesActionsProps) {
   return (
     <ActionPanel.Section>
       <Action
@@ -50,6 +67,7 @@ function FavouritesActions({ favorites, quote, favoritesStore }: FavouritesActio
         onAction={() => favoritesStore.moveDown(quote.symbol!)}
       />
       <FavoritesAddRemoveAction favorites={favorites} favoritesStore={favoritesStore} symbol={quote.symbol!} />
+      <MenuBarAddRemoveAction menuBarSymbols={menuBarSymbols} menuBarStore={menuBarStore} symbol={quote.symbol!} />
     </ActionPanel.Section>
   );
 }

--- a/extensions/stock-tracker/src/index.tsx
+++ b/extensions/stock-tracker/src/index.tsx
@@ -13,7 +13,7 @@ export default function Command() {
   const isSearching = searchText.length > 0;
 
   const { favorites: favoriteSymbols, favoritesStore, isLoading: favoritesLoading } = useFavorites();
-  const { menuBarSymbols, menuBarStore } = useMenuBarSymbols();
+  const { menuBarSymbols, menuBarStore, isLoading: menuBarLoading } = useMenuBarSymbols();
 
   const {
     searchResults,
@@ -33,7 +33,7 @@ export default function Command() {
     [favoriteSymbols, favoriteQuotesMap],
   );
 
-  const isLoading = isSearching ? searchLoading : favoritesLoading || favoritesQuotesLoading;
+  const isLoading = (isSearching ? searchLoading : favoritesLoading || favoritesQuotesLoading) || menuBarLoading;
   const lastUpdated = isSearching ? searchLastUpdated : favoritesLastUpdated;
 
   return (

--- a/extensions/stock-tracker/src/index.tsx
+++ b/extensions/stock-tracker/src/index.tsx
@@ -1,6 +1,7 @@
 import { List } from "@raycast/api";
 import { useMemo, useState } from "react";
 import { useFavorites } from "./favorites-store";
+import { useMenuBarSymbols } from "./menubar-store";
 import { useStockInfo } from "./use-stock-info";
 import { useStockSearch } from "./use-stock-search";
 import { Quote } from "./yahoo-finance";
@@ -12,6 +13,7 @@ export default function Command() {
   const isSearching = searchText.length > 0;
 
   const { favorites: favoriteSymbols, favoritesStore, isLoading: favoritesLoading } = useFavorites();
+  const { menuBarSymbols, menuBarStore } = useMenuBarSymbols();
 
   const {
     searchResults,
@@ -47,6 +49,8 @@ export default function Command() {
           searchResults={searchResults}
           favoriteSymbols={favoriteSymbols}
           favoritesStore={favoritesStore}
+          menuBarSymbols={menuBarSymbols}
+          menuBarStore={menuBarStore}
           lastUpdated={lastUpdated}
         />
       ) : (
@@ -54,6 +58,8 @@ export default function Command() {
           favorites={favoriteQuotes}
           favoriteSymbols={favoriteSymbols}
           favoritesStore={favoritesStore}
+          menuBarSymbols={menuBarSymbols}
+          menuBarStore={menuBarStore}
           lastUpdated={lastUpdated}
         />
       )}

--- a/extensions/stock-tracker/src/menubar-actions.tsx
+++ b/extensions/stock-tracker/src/menubar-actions.tsx
@@ -1,0 +1,31 @@
+import { Action, Icon } from "@raycast/api";
+import { MenuBarStore } from "./menubar-store";
+
+export function MenuBarAddRemoveAction({
+  menuBarSymbols,
+  menuBarStore,
+  symbol,
+}: {
+  menuBarSymbols: string[];
+  menuBarStore: MenuBarStore;
+  symbol: string;
+}) {
+  if (!menuBarSymbols.includes(symbol)) {
+    return (
+      <Action
+        title="Add to Menu Bar"
+        icon={Icon.Pin}
+        shortcut={{ modifiers: ["cmd", "shift"], key: "m" }}
+        onAction={() => menuBarStore.add(symbol)}
+      />
+    );
+  }
+  return (
+    <Action
+      title="Remove from Menu Bar"
+      icon={Icon.PinDisabled}
+      shortcut={{ modifiers: ["cmd", "shift"], key: "m" }}
+      onAction={() => menuBarStore.remove(symbol)}
+    />
+  );
+}

--- a/extensions/stock-tracker/src/menubar-store.ts
+++ b/extensions/stock-tracker/src/menubar-store.ts
@@ -1,0 +1,87 @@
+import { LaunchType, LocalStorage, launchCommand, showToast } from "@raycast/api";
+import { useCallback, useEffect, useState } from "react";
+
+const STORAGE_KEY = "menubar-symbols";
+
+export interface MenuBarStore {
+  add: (symbol: string) => void;
+  remove: (symbol: string) => void;
+}
+
+export async function loadMenuBarSymbols(): Promise<string[]> {
+  const stored = await LocalStorage.getItem<string>(STORAGE_KEY);
+  if (!stored) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(stored);
+    if (Array.isArray(parsed) && parsed.every((s) => typeof s === "string")) {
+      return parsed;
+    }
+    console.warn("menubar: stored value is not a string array, resetting");
+  } catch (e) {
+    console.warn("menubar: failed to parse stored value, resetting", e);
+  }
+  return [];
+}
+
+async function refreshMenuBarCommand() {
+  try {
+    await launchCommand({ name: "menubar", type: LaunchType.Background });
+  } catch (e) {
+    // The menu bar command may not be activated yet, in which case there's nothing to refresh.
+    console.warn("menubar: unable to refresh menu bar command", e);
+  }
+}
+
+export function useMenuBarSymbols(): {
+  menuBarSymbols: string[];
+  menuBarStore: MenuBarStore;
+  isLoading: boolean;
+} {
+  const [symbols, setSymbols] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Load from local storage on mount
+  useEffect(() => {
+    const update = async () => {
+      const stored = await loadMenuBarSymbols();
+      setSymbols(stored);
+      setIsLoading(false);
+    };
+    update();
+  }, []);
+
+  const updateSymbols = useCallback(
+    async (newSymbols: string[]) => {
+      setSymbols(newSymbols);
+      await LocalStorage.setItem(STORAGE_KEY, JSON.stringify(newSymbols));
+      await refreshMenuBarCommand();
+    },
+    [setSymbols],
+  );
+
+  const add = useCallback(
+    (symbol: string) => {
+      if (symbols.includes(symbol)) {
+        return;
+      }
+      updateSymbols([...symbols, symbol]);
+      showToast({ title: `Added ${symbol} to menu bar` });
+    },
+    [symbols, updateSymbols],
+  );
+
+  const remove = useCallback(
+    (symbol: string) => {
+      if (!symbols.includes(symbol)) {
+        return;
+      }
+      updateSymbols(symbols.filter((s) => s !== symbol));
+      showToast({ title: `Removed ${symbol} from menu bar` });
+    },
+    [symbols, updateSymbols],
+  );
+
+  return { menuBarSymbols: symbols, menuBarStore: { add, remove }, isLoading };
+}

--- a/extensions/stock-tracker/src/menubar-store.ts
+++ b/extensions/stock-tracker/src/menubar-store.ts
@@ -25,6 +25,16 @@ export async function loadMenuBarSymbols(): Promise<string[]> {
   return [];
 }
 
+let mutationQueue: Promise<void> = Promise.resolve();
+
+function enqueueMutation(run: () => Promise<void>): Promise<void> {
+  const next = mutationQueue.then(run, run);
+  mutationQueue = next.catch((e) => {
+    console.error("menubar: failed to update symbols", e);
+  });
+  return next;
+}
+
 async function refreshMenuBarCommand() {
   try {
     await launchCommand({ name: "menubar", type: LaunchType.Background });
@@ -52,15 +62,17 @@ export function useMenuBarSymbols(): {
     update();
   }, []);
 
-  const mutateSymbols = useCallback(async (mutate: (current: string[]) => string[]) => {
-    const current = await loadMenuBarSymbols();
-    const next = mutate(current);
-    setSymbols(next);
-    if (next.length === current.length && next.every((s, i) => s === current[i])) {
-      return;
-    }
-    await LocalStorage.setItem(STORAGE_KEY, JSON.stringify(next));
-    await refreshMenuBarCommand();
+  const mutateSymbols = useCallback((mutate: (current: string[]) => string[]) => {
+    return enqueueMutation(async () => {
+      const current = await loadMenuBarSymbols();
+      const next = mutate(current);
+      setSymbols(next);
+      if (next.length === current.length && next.every((s, i) => s === current[i])) {
+        return;
+      }
+      await LocalStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      await refreshMenuBarCommand();
+    });
   }, []);
 
   const add = useCallback(

--- a/extensions/stock-tracker/src/menubar-store.ts
+++ b/extensions/stock-tracker/src/menubar-store.ts
@@ -52,35 +52,31 @@ export function useMenuBarSymbols(): {
     update();
   }, []);
 
-  const updateSymbols = useCallback(
-    async (newSymbols: string[]) => {
-      setSymbols(newSymbols);
-      await LocalStorage.setItem(STORAGE_KEY, JSON.stringify(newSymbols));
-      await refreshMenuBarCommand();
-    },
-    [setSymbols],
-  );
+  const mutateSymbols = useCallback(async (mutate: (current: string[]) => string[]) => {
+    const current = await loadMenuBarSymbols();
+    const next = mutate(current);
+    setSymbols(next);
+    if (next.length === current.length && next.every((s, i) => s === current[i])) {
+      return;
+    }
+    await LocalStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    await refreshMenuBarCommand();
+  }, []);
 
   const add = useCallback(
     (symbol: string) => {
-      if (symbols.includes(symbol)) {
-        return;
-      }
-      updateSymbols([...symbols, symbol]);
+      mutateSymbols((current) => (current.includes(symbol) ? current : [...current, symbol]));
       showToast({ title: `Added ${symbol} to menu bar` });
     },
-    [symbols, updateSymbols],
+    [mutateSymbols],
   );
 
   const remove = useCallback(
     (symbol: string) => {
-      if (!symbols.includes(symbol)) {
-        return;
-      }
-      updateSymbols(symbols.filter((s) => s !== symbol));
+      mutateSymbols((current) => current.filter((s) => s !== symbol));
       showToast({ title: `Removed ${symbol} from menu bar` });
     },
-    [symbols, updateSymbols],
+    [mutateSymbols],
   );
 
   return { menuBarSymbols: symbols, menuBarStore: { add, remove }, isLoading };

--- a/extensions/stock-tracker/src/menubar.tsx
+++ b/extensions/stock-tracker/src/menubar.tsx
@@ -1,0 +1,106 @@
+import { Cache, Icon, LaunchType, MenuBarExtra, launchCommand, open } from "@raycast/api";
+import { useEffect, useState } from "react";
+import { loadMenuBarSymbols } from "./menubar-store";
+import { changeIcon, formatChangePercent, formatMoney, formatTime } from "./utils";
+import yahooFinance, { Quote } from "./yahoo-finance";
+
+const cache = new Cache();
+const QUOTES_CACHE_KEY = "menubar-quotes";
+
+interface CachedQuotes {
+  quotes: Quote[];
+  updatedAt: string;
+}
+
+function loadCachedQuotes(): CachedQuotes | undefined {
+  const stored = cache.get(QUOTES_CACHE_KEY);
+  if (!stored) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(stored) as CachedQuotes;
+  } catch (e) {
+    console.warn("menubar: failed to parse cached quotes", e);
+    return undefined;
+  }
+}
+
+export default function Command() {
+  const [isLoading, setIsLoading] = useState(true);
+  // Start from the cached quotes so the menu renders immediately while fresh data loads.
+  const [{ quotes, updatedAt }, setState] = useState<{ quotes: Quote[]; updatedAt: Date | null }>(() => {
+    const cached = loadCachedQuotes();
+    return cached ? { quotes: cached.quotes, updatedAt: new Date(cached.updatedAt) } : { quotes: [], updatedAt: null };
+  });
+
+  useEffect(() => {
+    const update = async () => {
+      try {
+        const symbols = await loadMenuBarSymbols();
+        if (symbols.length === 0) {
+          setState({ quotes: [], updatedAt: null });
+          cache.remove(QUOTES_CACHE_KEY);
+          return;
+        }
+        const response = await yahooFinance.quote(symbols, new AbortController().signal);
+        const bySymbol = new Map(
+          (response?.result ?? []).filter((q): q is Quote & { symbol: string } => !!q.symbol).map((q) => [q.symbol, q]),
+        );
+        const ordered = symbols.flatMap((s) => bySymbol.get(s) ?? []);
+        const now = new Date();
+        setState({ quotes: ordered, updatedAt: now });
+        cache.set(QUOTES_CACHE_KEY, JSON.stringify({ quotes: ordered, updatedAt: now.toISOString() }));
+      } catch (e) {
+        console.error("menubar: failed to fetch quotes", e);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    update();
+  }, []);
+
+  const primary = quotes.at(0);
+  const primaryInfo = primary ? yahooFinance.currentPriceInfo(primary) : undefined;
+
+  return (
+    <MenuBarExtra
+      isLoading={isLoading}
+      icon={primaryInfo ? changeIcon(primaryInfo.change) : "extension-icon.png"}
+      title={primary ? `${primary.symbol} ${formatMoney(primaryInfo?.price, primary.currency)}` : undefined}
+      tooltip="Stock Tracker"
+    >
+      {quotes.length > 0 ? (
+        <MenuBarExtra.Section title={updatedAt ? `Updated ${formatTime(updatedAt)}` : undefined}>
+          {quotes.map((quote) => {
+            const priceInfo = yahooFinance.currentPriceInfo(quote);
+            return (
+              <MenuBarExtra.Item
+                key={quote.symbol}
+                icon={changeIcon(priceInfo.change)}
+                title={quote.symbol!}
+                subtitle={`${formatMoney(priceInfo.price, quote.currency)} (${formatChangePercent(priceInfo.changePercent)})`}
+                tooltip={quote.shortName ?? quote.displayName}
+                onAction={() => open(`https://finance.yahoo.com/quote/${quote.symbol}`)}
+              />
+            );
+          })}
+        </MenuBarExtra.Section>
+      ) : (
+        <MenuBarExtra.Section>
+          <MenuBarExtra.Item
+            title="No Stocks in Menu Bar"
+            subtitle="Add stocks from the View Stocks command"
+            icon={Icon.Info}
+          />
+        </MenuBarExtra.Section>
+      )}
+      <MenuBarExtra.Section>
+        <MenuBarExtra.Item
+          title="Open Stock Tracker"
+          icon={Icon.LineChart}
+          onAction={() => launchCommand({ name: "index", type: LaunchType.UserInitiated })}
+        />
+      </MenuBarExtra.Section>
+    </MenuBarExtra>
+  );
+}

--- a/extensions/stock-tracker/src/menubar.tsx
+++ b/extensions/stock-tracker/src/menubar.tsx
@@ -32,29 +32,33 @@ export default function Command() {
     const cached = loadCachedQuotes();
     return cached ? { quotes: cached.quotes, updatedAt: new Date(cached.updatedAt) } : { quotes: [], updatedAt: null };
   });
+  const [symbols, setSymbols] = useState<string[]>(() =>
+    (loadCachedQuotes()?.quotes ?? []).flatMap((q) => (q.symbol ? [q.symbol] : [])),
+  );
 
   useEffect(() => {
     const update = async () => {
       try {
-        const symbols = await loadMenuBarSymbols();
-        if (symbols.length === 0) {
+        const stored = await loadMenuBarSymbols();
+        setSymbols(stored);
+        if (stored.length === 0) {
           setState({ quotes: [], updatedAt: null });
           cache.remove(QUOTES_CACHE_KEY);
           return;
         }
         const cached = loadCachedQuotes();
         if (cached) {
-          const kept = cached.quotes.filter((q) => !!q.symbol && symbols.includes(q.symbol));
+          const kept = cached.quotes.filter((q) => !!q.symbol && stored.includes(q.symbol));
           if (kept.length !== cached.quotes.length) {
             setState({ quotes: kept, updatedAt: new Date(cached.updatedAt) });
             cache.set(QUOTES_CACHE_KEY, JSON.stringify({ quotes: kept, updatedAt: cached.updatedAt }));
           }
         }
-        const response = await yahooFinance.quote(symbols, new AbortController().signal);
+        const response = await yahooFinance.quote(stored, new AbortController().signal);
         const bySymbol = new Map(
           (response?.result ?? []).filter((q): q is Quote & { symbol: string } => !!q.symbol).map((q) => [q.symbol, q]),
         );
-        const ordered = symbols.flatMap((s) => bySymbol.get(s) ?? []);
+        const ordered = stored.flatMap((s) => bySymbol.get(s) ?? []);
         const now = new Date();
         setState({ quotes: ordered, updatedAt: now });
         cache.set(QUOTES_CACHE_KEY, JSON.stringify({ quotes: ordered, updatedAt: now.toISOString() }));
@@ -67,28 +71,43 @@ export default function Command() {
     update();
   }, []);
 
-  const primary = quotes.at(0);
-  const primaryInfo = primary ? yahooFinance.currentPriceInfo(primary) : undefined;
+  const quotesBySymbol = new Map(
+    quotes.filter((q): q is Quote & { symbol: string } => !!q.symbol).map((q) => [q.symbol, q]),
+  );
+  const primarySymbol = symbols.at(0);
+  const primaryQuote = primarySymbol ? quotesBySymbol.get(primarySymbol) : undefined;
+  const primaryInfo = primaryQuote ? yahooFinance.currentPriceInfo(primaryQuote) : undefined;
 
   return (
     <MenuBarExtra
       isLoading={isLoading}
       icon={primaryInfo ? changeIcon(primaryInfo.change) : "extension-icon.png"}
-      title={primary ? `${primary.symbol} ${formatMoney(primaryInfo?.price, primary.currency)}` : undefined}
+      title={
+        primarySymbol
+          ? primaryInfo
+            ? `${primarySymbol} ${formatMoney(primaryInfo.price, primaryQuote?.currency)}`
+            : primarySymbol
+          : undefined
+      }
       tooltip="Stock Tracker"
     >
-      {quotes.length > 0 ? (
+      {symbols.length > 0 ? (
         <MenuBarExtra.Section title={updatedAt ? `Updated ${formatTime(updatedAt)}` : undefined}>
-          {quotes.map((quote) => {
-            const priceInfo = yahooFinance.currentPriceInfo(quote);
+          {symbols.map((symbol) => {
+            const quote = quotesBySymbol.get(symbol);
+            const priceInfo = quote ? yahooFinance.currentPriceInfo(quote) : undefined;
             return (
               <MenuBarExtra.Item
-                key={quote.symbol}
-                icon={changeIcon(priceInfo.change)}
-                title={quote.symbol!}
-                subtitle={`${formatMoney(priceInfo.price, quote.currency)} (${formatChangePercent(priceInfo.changePercent)})`}
-                tooltip={quote.shortName ?? quote.displayName}
-                onAction={() => open(`https://finance.yahoo.com/quote/${quote.symbol}`)}
+                key={symbol}
+                icon={changeIcon(priceInfo?.change)}
+                title={symbol}
+                subtitle={
+                  priceInfo
+                    ? `${formatMoney(priceInfo.price, quote?.currency)} (${formatChangePercent(priceInfo.changePercent)})`
+                    : "—"
+                }
+                tooltip={quote?.shortName ?? quote?.displayName ?? "Waiting for quote data"}
+                onAction={() => open(`https://finance.yahoo.com/quote/${symbol}`)}
               />
             );
           })}

--- a/extensions/stock-tracker/src/menubar.tsx
+++ b/extensions/stock-tracker/src/menubar.tsx
@@ -42,6 +42,14 @@ export default function Command() {
           cache.remove(QUOTES_CACHE_KEY);
           return;
         }
+        const cached = loadCachedQuotes();
+        if (cached) {
+          const kept = cached.quotes.filter((q) => !!q.symbol && symbols.includes(q.symbol));
+          if (kept.length !== cached.quotes.length) {
+            setState({ quotes: kept, updatedAt: new Date(cached.updatedAt) });
+            cache.set(QUOTES_CACHE_KEY, JSON.stringify({ quotes: kept, updatedAt: cached.updatedAt }));
+          }
+        }
         const response = await yahooFinance.quote(symbols, new AbortController().signal);
         const bySymbol = new Map(
           (response?.result ?? []).filter((q): q is Quote & { symbol: string } => !!q.symbol).map((q) => [q.symbol, q]),

--- a/extensions/stock-tracker/src/search-list.tsx
+++ b/extensions/stock-tracker/src/search-list.tsx
@@ -3,6 +3,8 @@ import { useMemo } from "react";
 import StockListItem from "./stock-list-item";
 import { FavoritesStore } from "./favorites-store";
 import { FavoritesAddRemoveAction } from "./favorites-list";
+import { MenuBarStore } from "./menubar-store";
+import { MenuBarAddRemoveAction } from "./menubar-actions";
 import { Quote } from "./yahoo-finance";
 import { formatTime } from "./utils";
 
@@ -10,11 +12,15 @@ export default function SearchList({
   searchResults,
   favoriteSymbols,
   favoritesStore,
+  menuBarSymbols,
+  menuBarStore,
   lastUpdated,
 }: {
   searchResults: Quote[];
   favoriteSymbols: string[];
   favoritesStore: FavoritesStore;
+  menuBarSymbols: string[];
+  menuBarStore: MenuBarStore;
   lastUpdated: Date | null;
 }) {
   const favoriteSet = useMemo(() => new Set(favoriteSymbols), [favoriteSymbols]);
@@ -26,11 +32,17 @@ export default function SearchList({
           key={quote.symbol + i.toString()}
           quote={quote}
           isFavorite={!!quote.symbol && favoriteSet.has(quote.symbol)}
+          isInMenuBar={!!quote.symbol && menuBarSymbols.includes(quote.symbol)}
           actions={
             <ActionPanel.Section>
               <FavoritesAddRemoveAction
                 favorites={favoriteSymbols}
                 favoritesStore={favoritesStore}
+                symbol={quote.symbol!}
+              />
+              <MenuBarAddRemoveAction
+                menuBarSymbols={menuBarSymbols}
+                menuBarStore={menuBarStore}
                 symbol={quote.symbol!}
               />
             </ActionPanel.Section>

--- a/extensions/stock-tracker/src/stock-list-item.tsx
+++ b/extensions/stock-tracker/src/stock-list-item.tsx
@@ -15,10 +15,12 @@ export default function StockListItem({
   quote,
   actions,
   isFavorite,
+  isInMenuBar,
 }: {
   quote: Quote;
   actions: ReactNode;
   isFavorite?: boolean;
+  isInMenuBar?: boolean;
 }) {
   const priceInfo = yahooFinance.currentPriceInfo(quote);
   const icon = changeIcon(priceInfo.change);
@@ -32,6 +34,7 @@ export default function StockListItem({
       title={quote.symbol!}
       subtitle={subtitle}
       accessories={[
+        ...(isInMenuBar ? [{ icon: Icon.Pin, tooltip: "Shown in menu bar" }] : []),
         ...(stateAccessory ? [stateAccessory] : []),
         { text: { value: formatMoney(priceInfo.price, quote.currency), color: icon.tintColor } },
       ]}

--- a/extensions/stock-tracker/src/utils.ts
+++ b/extensions/stock-tracker/src/utils.ts
@@ -28,6 +28,14 @@ export function formatMoney(value?: number, currency?: string, marketCap?: boole
   return strValue + suffix;
 }
 
+export function formatChangePercent(changePercent?: number) {
+  if (changePercent === undefined || changePercent === null || Number.isNaN(changePercent)) {
+    return "—";
+  }
+  const sign = changePercent > 0 ? "+" : "";
+  return `${sign}${changePercent.toFixed(2)}%`;
+}
+
 export function formatTime(date: Date) {
   return date.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit", second: "2-digit" });
 }


### PR DESCRIPTION
## Description
- Add a new Menu Bar Stocks command that shows live prices for selected stocks in the macOS menu bar, refreshing every minute
- Add "Add to Menu Bar" / "Remove from Menu Bar" actions (⌘⇧M) to stock list items, with a pin accessory showing which stocks are in the menu bar
<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast
<img width="1000" height="625" alt="stock-tracker 2026-07-23 at 13 52 55" src="https://github.com/user-attachments/assets/16ec0263-faab-473e-b12f-8b38f8b1d00b" />
<img width="466" height="350" alt="GitHub Desktop 2026-07-23 13 52 06" src="https://github.com/user-attachments/assets/ea377b87-6bac-4f39-a16e-7c15d682315a" />

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
