### PR TITLE
Update file-provider-progress extension

### DIFF
--- a/extensions/file-provider-progress/CHANGELOG.md
+++ b/extensions/file-provider-progress/CHANGELOG.md
@@ -1,6 +1,6 @@
 # File Provider Progress Changelog
 
-## [Harden Helper Permission Repair] - {PR_MERGE_DATE}
+## [Harden Helper Permission Repair] - 2026-07-23
 
 - Repair any bundled helper mode that is not executable by the current Raycast process.
 

--- a/extensions/file-provider-progress/CHANGELOG.md
+++ b/extensions/file-provider-progress/CHANGELOG.md
@@ -1,5 +1,9 @@
 # File Provider Progress Changelog
 
+## [Harden Helper Permission Repair] - {PR_MERGE_DATE}
+
+- Repair any bundled helper mode that is not executable by the current Raycast process.
+
 ## [Fix Bundled Helper Permissions] - 2026-07-22
 
 - Restore executable permissions for the bundled helper during packaging and at runtime.

--- a/extensions/file-provider-progress/src/executable.test.ts
+++ b/extensions/file-provider-progress/src/executable.test.ts
@@ -31,6 +31,18 @@ test("leaves an executable bundled helper's mode unchanged", async (context) => 
   assert.equal(helperStats.mode & 0o777, 0o700);
 });
 
+test("repairs a helper when only another permission class has execute access", async (context) => {
+  const directory = await mkdtemp(path.join(tmpdir(), "fp-progress-executable-"));
+  context.after(() => rm(directory, { force: true, recursive: true }));
+  const helperPath = path.join(directory, "fp-progress");
+
+  await writeFile(helperPath, "test helper\n", { mode: 0o645 });
+  await ensureExecutable(helperPath);
+
+  const helperStats = await stat(helperPath);
+  assert.equal(helperStats.mode & 0o777, 0o755);
+});
+
 test("refuses to repair a symlink", async (context) => {
   const directory = await mkdtemp(path.join(tmpdir(), "fp-progress-executable-"));
   context.after(() => rm(directory, { force: true, recursive: true }));

--- a/extensions/file-provider-progress/src/executable.ts
+++ b/extensions/file-provider-progress/src/executable.ts
@@ -8,7 +8,10 @@ export async function ensureExecutable(filePath: string): Promise<void> {
     throw new Error(`Bundled fp-progress helper is not a regular file: ${filePath}`);
   }
 
-  if ((stats.mode & 0o111) === 0) {
+  try {
+    await access(filePath, constants.X_OK);
+    return;
+  } catch {
     await chmod(filePath, stats.mode | 0o111);
   }
 


### PR DESCRIPTION
## Description

Follow-up to #29658 addressing the execute-bit review edge case:

- Check actual `X_OK` access for the current Raycast process instead of assuming any execute bit is sufficient.
- If access fails, add execute bits while preserving all existing permissions, then verify `X_OK` again.
- Keep the existing safety boundary: only the exact bundled regular file is eligible; symlinks and custom CLI paths are never modified.

This only changes permission metadata on the extension-owned helper. It does not alter contents, ownership, read/write permissions, ACLs, or other extensions.

## Testing

- `make raycast-check`
- Added regression coverage proving mode `0645` is repaired to `0755` for the owning Raycast user.
- Existing tests continue to cover `0644`, already executable `0700`, content preservation, and symlink rejection.

## Screencast

Not applicable; this is a permission-repair edge case with no UI changes.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
