### PR TITLE
Update safari extension

### DIFF
--- a/extensions/safari/CHANGELOG.md
+++ b/extensions/safari/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Safari Changelog
 
+## [New Command] - {PR_MERGE_DATE}
+
+- Add `Search Tabs, Bookmarks and History` command to search open tabs, bookmarks and history in one place.
+- Replace `pinyin` with the much lighter `pinyin-pro` to fix commands crashing against the extension memory limit (bundle size reduced from ~28 MB to ~6 MB per command).
+
 ## [Bugfix] - 2026-05-22
 
 - Clarify the Full Disk Access requirement when Safari history cannot be opened.

--- a/extensions/safari/CHANGELOG.md
+++ b/extensions/safari/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Safari Changelog
 
-## [New Command] - {PR_MERGE_DATE}
+## [New Command] - 2026-07-24
 
 - Add `Search Tabs, Bookmarks and History` command to search open tabs, bookmarks and history in one place.
 - Replace `pinyin` with the much lighter `pinyin-pro` to fix commands crashing against the extension memory limit (bundle size reduced from ~28 MB to ~6 MB per command).

--- a/extensions/safari/package-lock.json
+++ b/extensions/safari/package-lock.json
@@ -15,14 +15,13 @@
         "lodash": "^4.17.21",
         "lru-cache": "^11.0.2",
         "osascript-tag": "^0.1.2",
-        "pinyin": "^4.0.0-alpha.2",
+        "pinyin-pro": "^3.28.2",
         "simple-plist": "^1.4.0"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.1.1",
         "@types/lodash": "^4.17.7",
         "@types/node": "22.13.10",
-        "@types/pinyin": "^2.10.2",
         "@types/react": "19.0.10",
         "eslint": "^9.22.0",
         "prettier": "^3.5.3",
@@ -1303,13 +1302,6 @@
         "undici-types": "~6.20.0"
       }
     },
-    "node_modules/@types/pinyin": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@types/pinyin/-/pinyin-2.10.2.tgz",
-      "integrity": "sha512-jLzlRkaLRLg+lgYPjOuP3HX2cozUkhXls5GTXopsKuKJ9lDGlIAb88OoIztH6TbNUsoJnl/7e/kjaumA5IKKJg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
       "version": "19.0.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
@@ -1860,17 +1852,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
-    },
-    "node_modules/commander": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
-      "integrity": "sha512-71Rod2AhcH3JhkBikVpNd0pA+fWsmAaVoti6OR38T76chA7vE3pSerS0Jor4wDw+tOueD2zLVvFOw5H0Rcj7rA==",
-      "dependencies": {
-        "keypress": "0.1.x"
-      },
-      "engines": {
-        "node": ">= 0.6.x"
-      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2600,12 +2581,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/keypress": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
-      "integrity": "sha512-x0yf9PL/nx9Nw9oLL8ZVErFAk85/lslwEP7Vz7s5SI1ODXZIgit3C5qyWjw4DxOuO/3Hb4866SQh28a1V1d+WA==",
-      "license": "MIT"
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -2833,36 +2808,11 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pinyin": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pinyin/-/pinyin-4.0.0.tgz",
-      "integrity": "sha512-vHpV5K+vpp6XUUpZNGRDuHoN+1xcmieM3EWlH4QjSX2kkpG/gVOwpqwV9EOJ9x9c9UERFKeLml5XVSukE/PLgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "commander": "~1.1.1"
-      },
-      "bin": {
-        "pinyin": "bin/pinyin"
-      },
-      "engines": {
-        "install-node": "^18.0.0"
-      },
-      "peerDependencies": {
-        "@node-rs/jieba": "^1.6.0",
-        "nodejieba": "^3.4.4",
-        "segmentit": "^2.0.3"
-      },
-      "peerDependenciesMeta": {
-        "@node-rs/jieba": {
-          "optional": true
-        },
-        "nodejieba": {
-          "optional": true
-        },
-        "segmentit": {
-          "optional": true
-        }
-      }
+    "node_modules/pinyin-pro": {
+      "version": "3.28.2",
+      "resolved": "https://registry.npmjs.org/pinyin-pro/-/pinyin-pro-3.28.2.tgz",
+      "integrity": "sha512-jV38yxXHLfidirMC4hrXasLDozLCSq/4DfX88GnHcSEJ2+GpSedG6I9VOiEXJu6iQ5dbJC/RjmzyMuS5h/wH5A==",
+      "license": "MIT"
     },
     "node_modules/plist": {
       "version": "3.1.0",

--- a/extensions/safari/package.json
+++ b/extensions/safari/package.json
@@ -65,6 +65,42 @@
       ]
     },
     {
+      "name": "search-all",
+      "title": "Search Tabs, Bookmarks and History",
+      "subtitle": "Safari",
+      "description": "Search your open tabs, bookmarks and history in one place",
+      "mode": "view",
+      "preferences": [
+        {
+          "name": "areRemoteTabsUsed",
+          "type": "checkbox",
+          "required": false,
+          "title": "Devices",
+          "description": "Include iCloud tabs across all your devices",
+          "default": true,
+          "label": "iCloud"
+        },
+        {
+          "name": "fallbackSearchType",
+          "type": "dropdown",
+          "required": false,
+          "title": "Fallback Search",
+          "description": "Switch between Safari search and Safari search history.",
+          "default": "Search",
+          "data": [
+            {
+              "value": "search",
+              "title": "Search"
+            },
+            {
+              "value": "searchHistory",
+              "title": "Search History"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "reading-list",
       "title": "Search Reading List",
       "subtitle": "Safari",
@@ -527,18 +563,17 @@
     "lodash": "^4.17.21",
     "lru-cache": "^11.0.2",
     "osascript-tag": "^0.1.2",
-    "pinyin": "^4.0.0-alpha.2",
+    "pinyin-pro": "^3.28.2",
     "simple-plist": "^1.4.0"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.1.1",
+    "@types/lodash": "^4.17.7",
     "@types/node": "22.13.10",
     "@types/react": "19.0.10",
     "eslint": "^9.22.0",
     "prettier": "^3.5.3",
-    "typescript": "^5.8.2",
-    "@types/lodash": "^4.17.7",
-    "@types/pinyin": "^2.10.2"
+    "typescript": "^5.8.2"
   },
   "scripts": {
     "build": "ray build",

--- a/extensions/safari/package.json
+++ b/extensions/safari/package.json
@@ -86,7 +86,7 @@
           "required": false,
           "title": "Fallback Search",
           "description": "Switch between Safari search and Safari search history.",
-          "default": "Search",
+          "default": "search",
           "data": [
             {
               "value": "search",

--- a/extensions/safari/src/lang-adaptor/base.ts
+++ b/extensions/safari/src/lang-adaptor/base.ts
@@ -48,6 +48,10 @@ export class LanguageAdaptor {
     }
   }
 
+  hasHandlers() {
+    return this.langHandlers.size > 0;
+  }
+
   registerLang(lang: string, handler: LanguageHandler) {
     if (this.langHandlers.has(lang)) {
       return;

--- a/extensions/safari/src/lang-adaptor/pinyin.ts
+++ b/extensions/safari/src/lang-adaptor/pinyin.ts
@@ -1,4 +1,4 @@
-import pinyin from "pinyin";
+import { pinyin } from "pinyin-pro";
 import { LanguageHandler } from "./base";
 
 export class PinyinHandler implements LanguageHandler {
@@ -21,7 +21,7 @@ export class PinyinHandler implements LanguageHandler {
     if (chineseChars.length > 0) {
       return chineseChars.reduce((formatted, matchItem) => {
         const [char] = matchItem;
-        const pinyinCollection = pinyin(char, { style: pinyin.STYLE_NORMAL });
+        const pinyinCollection = pinyin(char, { toneType: "none", type: "array", v: true });
         return formatted.replace(char, pinyinCollection.join("") + " ");
       }, text);
     } else {

--- a/extensions/safari/src/search-all.tsx
+++ b/extensions/safari/src/search-all.tsx
@@ -1,0 +1,98 @@
+import { getPreferenceValues, List } from "@raycast/api";
+import { useThrottle } from "ahooks";
+import _ from "lodash";
+import { useMemo, useState } from "react";
+import { FallbackSearchSection, PermissionError } from "./components";
+import BookmarkListItem from "./components/BookmarkListItem";
+import HistoryListItem from "./components/HistoryListItem";
+import TabListItem from "./components/TabListItem";
+import { useBookmarks, useDevices, useHistorySearch } from "./hooks";
+import { Device, GeneralBookmark, HistoryItem, Tab } from "./types";
+import { search } from "./utils";
+
+const LIMITS = { tabs: 6, bookmarks: 6, history: 8 };
+
+const SEARCH_KEYS = [
+  { name: "title", weight: 3 },
+  { name: "title_formatted", weight: 2 },
+  { name: "url", weight: 1 },
+];
+
+export default function Command() {
+  const [searchText, setSearchText] = useState("");
+  const throttledSearchText = useThrottle(searchText, { wait: 200 });
+  const hasSearchText = throttledSearchText.trim().length > 0;
+
+  const { devices, permissionView, refreshDevices } = useDevices();
+  const { bookmarks, hasPermission } = useBookmarks(false);
+  const {
+    data: historyEntries,
+    permissionView: historyPermissionView,
+    isLoading: isLoadingHistory,
+  } = useHistorySearch(hasSearchText ? throttledSearchText : undefined);
+
+  const allTabs = useMemo(() => _.flatMap(devices, (device: Device) => device.tabs ?? []), [devices]);
+
+  // Memoize the searches so re-renders triggered by unrelated state changes
+  // (e.g. history results arriving) don't rebuild the Fuse indexes.
+  const tabSection = useMemo(() => {
+    const filteredTabs = search(allTabs, SEARCH_KEYS, throttledSearchText) as Tab[];
+    return hasSearchText ? filteredTabs.slice(0, LIMITS.tabs) : filteredTabs;
+  }, [allTabs, throttledSearchText, hasSearchText]);
+
+  const bookmarkSection = useMemo(
+    () =>
+      hasSearchText
+        ? (search((bookmarks as GeneralBookmark[]) ?? [], SEARCH_KEYS, throttledSearchText) as GeneralBookmark[]).slice(
+            0,
+            LIMITS.bookmarks,
+          )
+        : [],
+    [bookmarks, throttledSearchText, hasSearchText],
+  );
+
+  const historySection: HistoryItem[] = hasSearchText ? (historyEntries ?? []).slice(0, LIMITS.history) : [];
+
+  if (permissionView.current) {
+    return permissionView.current;
+  }
+
+  if (historyPermissionView) {
+    return historyPermissionView;
+  }
+
+  if (!hasPermission) {
+    return <PermissionError />;
+  }
+
+  return (
+    <List
+      isLoading={!devices || !bookmarks || isLoadingHistory}
+      onSearchTextChange={setSearchText}
+      searchBarPlaceholder="Search tabs, bookmarks and history"
+    >
+      {tabSection.length > 0 && (
+        <List.Section title="Open Tabs">
+          {tabSection.map((tab) => (
+            <TabListItem key={tab.uuid} tab={tab} refresh={refreshDevices} />
+          ))}
+        </List.Section>
+      )}
+      {bookmarkSection.length > 0 && (
+        <List.Section title="Bookmarks">
+          {bookmarkSection.map((bookmark) => (
+            <BookmarkListItem key={bookmark.uuid} bookmark={bookmark} />
+          ))}
+        </List.Section>
+      )}
+      {historySection.length > 0 && (
+        <List.Section title="History">
+          {historySection.map((entry) => (
+            <HistoryListItem key={entry.id} entry={entry} searchText={throttledSearchText} />
+          ))}
+        </List.Section>
+      )}
+      <FallbackSearchSection searchText={searchText} fallbackSearchType={getPreferenceValues().fallbackSearchType} />
+    </List>
+  );
+}

--- a/extensions/safari/src/search-all.tsx
+++ b/extensions/safari/src/search-all.tsx
@@ -1,6 +1,5 @@
 import { getPreferenceValues, List } from "@raycast/api";
 import { useThrottle } from "ahooks";
-import _ from "lodash";
 import { useMemo, useState } from "react";
 import { FallbackSearchSection, PermissionError } from "./components";
 import BookmarkListItem from "./components/BookmarkListItem";
@@ -31,7 +30,10 @@ export default function Command() {
     isLoading: isLoadingHistory,
   } = useHistorySearch(hasSearchText ? throttledSearchText : undefined);
 
-  const allTabs = useMemo(() => _.flatMap(devices, (device: Device) => device.tabs ?? []), [devices]);
+  const allTabs = useMemo<Tab[]>(
+    () => (devices ?? []).flatMap((device: Device): Tab[] => device.tabs ?? []),
+    [devices],
+  );
 
   // Memoize the searches so re-renders triggered by unrelated state changes
   // (e.g. history results arriving) don't rebuild the Fuse indexes.

--- a/extensions/safari/src/utils.ts
+++ b/extensions/safari/src/utils.ts
@@ -86,12 +86,14 @@ export const search = function (collection: LooseTab[], keys: Array<FuseOptionKe
   }
 
   const _formatPerf = performance.now();
-  const formattedCollection = collection.map((item) => {
-    return {
-      ...item,
-      title_formatted: langAdaptor.formatString(searchText, item.title, { id: item.uuid }),
-    };
-  });
+  const formattedCollection = langAdaptor.hasHandlers()
+    ? collection.map((item) => {
+        return {
+          ...item,
+          title_formatted: langAdaptor.formatString(searchText, item.title, { id: item.uuid }),
+        };
+      })
+    : collection;
   const _formatCost = performance.now() - _formatPerf;
 
   const _searchPerf = performance.now();


### PR DESCRIPTION
## Description

- Add `Search Tabs, Bookmarks and History` command to search open tabs, bookmarks and history in one place. Close #29518.
- Replace `pinyin` with the much lighter `pinyin-pro` to fix commands crashing against the extension memory limit (bundle size reduced from ~28 MB to ~6 MB per command).
<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast
<img width="1807" height="1257" alt="Safari 2026-07-23 21 24 05" src="https://github.com/user-attachments/assets/3346835c-7dee-4b71-9333-4ef92a10dee7" />

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
