### PR TITLE
[Reddit Search] Fix subreddit browse, deeplink arg, and concurrent rate-limit race

### DIFF
--- a/extensions/reddit-search/CHANGELOG.md
+++ b/extensions/reddit-search/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Reddit Search Changelog
 
+## [Fixes] - {PR_MERGE_DATE}
+
+- Opening a favorite subreddit now loads its posts (it was hitting an empty-query search endpoint that returned nothing).
+- The "Search r/…" action no longer fails on a missing argument; it opens a prefilled search form.
+- Fixed a rate-limit race where two open commands could each fire a request in the same instant and one would hit a 429.
+
 ## [Rebuilt on Reddit's Atom feed, new commands, filtering] - 2026-07-24
 
 Reddit blocked anonymous access to its JSON API, which broke the extension. This release rebuilds it on Reddit's public Atom (RSS) feed — the one unauthenticated surface still serving live results — and adds a batch of new features.

--- a/extensions/reddit-search/CHANGELOG.md
+++ b/extensions/reddit-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Reddit Search Changelog
 
-## [Fixes] - {PR_MERGE_DATE}
+## [Fixes] - 2026-07-25
 
 - Opening a favorite subreddit now loads its posts (it was hitting an empty-query search endpoint that returned nothing).
 - The "Search r/…" action no longer fails on a missing argument; it opens a prefilled search form.

--- a/extensions/reddit-search/package.json
+++ b/extensions/reddit-search/package.json
@@ -31,16 +31,16 @@
       "mode": "no-view",
       "arguments": [
         {
-          "name": "query",
-          "placeholder": "Search terms",
-          "type": "text",
-          "required": true
-        },
-        {
           "name": "subreddit",
           "placeholder": "subreddit (e.g. macapps)",
           "type": "text",
           "required": true
+        },
+        {
+          "name": "query",
+          "placeholder": "Search terms (optional)",
+          "type": "text",
+          "required": false
         }
       ]
     }

--- a/extensions/reddit-search/src/FilterBySubredditPostList.tsx
+++ b/extensions/reddit-search/src/FilterBySubredditPostList.tsx
@@ -42,7 +42,8 @@ export default function FilterBySubredditPostList({
   // Shares the "is-showing-detail" cache key with the other lists so the pane's
   // visibility follows the user across views instead of resetting per screen.
   const [isShowingDetail, setIsShowingDetail] = useCachedState("is-showing-detail", true);
-  const { secondsRemaining, startCooldown, armIfSpent, isCoolingDown, isCoolingDownNow } = useRateLimitCooldown();
+  const { secondsRemaining, startCooldown, settleAfterRequest, reserveRequestSlot, isCoolingDown } =
+    useRateLimitCooldown();
   const [cachedAt, setCachedAt] = useState<number | undefined>(undefined);
 
   const doSearch = async (query: string, sort = redditSort.relevance, { forceRefresh = false } = {}) => {
@@ -60,8 +61,8 @@ export default function FilterBySubredditPostList({
       ? undefined
       : readCache<RedditResult>(cacheKey(["posts", subreddit, query, preferences.resultLimit, sort?.sortValue ?? ""]));
 
-    // Gate on the SYNCHRONOUS cache read, not the polled `isCoolingDown` (see Home.tsx).
-    if (!cached && isCoolingDownNow()) {
+    // RESERVE the shared request slot before sending, not just check it (see Home.tsx).
+    if (!cached && !reserveRequestSlot()) {
       setSearching(false);
       return;
     }
@@ -81,8 +82,8 @@ export default function FilterBySubredditPostList({
       setSearchRedditUrl(apiResults.url);
       setResults(apiResults.items);
       setCachedAt(apiResults.cachedAt);
-      // Arm the cooldown the moment Reddit's budget is spent (before the next 429).
-      armIfSpent(apiResults.rateLimit);
+      // Settle the reservation to the real reset window Reddit reported.
+      settleAfterRequest(apiResults.rateLimit);
     } catch (error) {
       if (isAbortError(error)) {
         return;

--- a/extensions/reddit-search/src/FilterBySubredditPostList.tsx
+++ b/extensions/reddit-search/src/FilterBySubredditPostList.tsx
@@ -42,8 +42,9 @@ export default function FilterBySubredditPostList({
   // Shares the "is-showing-detail" cache key with the other lists so the pane's
   // visibility follows the user across views instead of resetting per screen.
   const [isShowingDetail, setIsShowingDetail] = useCachedState("is-showing-detail", true);
-  const { secondsRemaining, startCooldown, settleAfterRequest, reserveRequestSlot, isCoolingDown } =
+  const { secondsRemaining, startCooldown, settleAfterRequest, releaseReservation, reserveRequestSlot, isCoolingDown } =
     useRateLimitCooldown();
+  const reservationRef = useRef<string | null>(null);
   const [cachedAt, setCachedAt] = useState<number | undefined>(undefined);
 
   const doSearch = async (query: string, sort = redditSort.relevance, { forceRefresh = false } = {}) => {
@@ -61,15 +62,21 @@ export default function FilterBySubredditPostList({
       ? undefined
       : readCache<RedditResult>(cacheKey(["posts", subreddit, query, preferences.resultLimit, sort?.sortValue ?? ""]));
 
-    // RESERVE the shared request slot before sending, not just check it (see Home.tsx).
-    if (!cached && !reserveRequestSlot()) {
-      setSearching(false);
-      return;
-    }
-
     abortControllerRef.current?.abort();
     const controller = new AbortController();
     abortControllerRef.current = controller;
+
+    // RESERVE the shared slot before sending; a same-command supersede reuses the hold
+    // we already own (see Home.tsx for the full rationale).
+    let reservation = reservationRef.current;
+    if (!cached && !reservation) {
+      reservation = reserveRequestSlot();
+      if (!reservation) {
+        setSearching(false);
+        return;
+      }
+      reservationRef.current = reservation;
+    }
 
     setSearching(true);
     queryRef.current = query;
@@ -82,16 +89,21 @@ export default function FilterBySubredditPostList({
       setSearchRedditUrl(apiResults.url);
       setResults(apiResults.items);
       setCachedAt(apiResults.cachedAt);
-      // Settle the reservation to the real reset window Reddit reported.
-      settleAfterRequest(apiResults.rateLimit);
+      // Settle the reservation: hold if the budget is spent, release if it remained.
+      if (reservation) settleAfterRequest(reservation, apiResults.rateLimit);
+      reservationRef.current = null;
     } catch (error) {
       if (isAbortError(error)) {
+        // Superseded — leave the reservation for the replacement to reuse (see Home.tsx).
         return;
       }
 
       if (isRateLimited(error)) {
         startCooldown(error.retryAfterSeconds ?? RATE_LIMIT_COOLDOWN_SECONDS);
+      } else if (reservation) {
+        releaseReservation(reservation);
       }
+      reservationRef.current = null;
 
       filterLog.error("Subreddit post search failed", error);
       await failureToast(`Couldn’t search r/${subredditName}`, error);

--- a/extensions/reddit-search/src/Home.tsx
+++ b/extensions/reddit-search/src/Home.tsx
@@ -49,7 +49,8 @@ export default function Home({
   const [hideDetail, setHideDetail] = useState(false);
   const [cachedAt, setCachedAt] = useState<number | undefined>(undefined);
   const [isShowingDetail, setIsShowingDetail] = useCachedState("is-showing-detail", true);
-  const { secondsRemaining, startCooldown, armIfSpent, isCoolingDown, isCoolingDownNow } = useRateLimitCooldown();
+  const { secondsRemaining, startCooldown, settleAfterRequest, reserveRequestSlot, isCoolingDown } =
+    useRateLimitCooldown();
   const { recentSearches, addRecentSearch, removeRecentSearch, clearRecentSearches } =
     useRecentSearches("recentPostSearches");
 
@@ -67,10 +68,11 @@ export default function Home({
       ? undefined
       : readCache<RedditResult>(cacheKey(["posts", "", query, preferences.resultLimit, sort?.sortValue ?? ""]));
 
-    // Gate on the SYNCHRONOUS cache read, not the polled `isCoolingDown` — otherwise
-    // a concurrent command that armed the cooldown between poll ticks would let this
-    // request through into a 429.
-    if (!cached && isCoolingDownNow()) {
+    // RESERVE the shared request slot before sending (not just check it). Reserving
+    // is check-and-claim in one step, so two commands can't both read "clear" and
+    // both send — the second gets `false` and stops. Cached reads skip this: they
+    // cost no request.
+    if (!cached && !reserveRequestSlot()) {
       return;
     }
 
@@ -101,8 +103,8 @@ export default function Home({
         setFiltering(true);
         setSearchText("");
       }
-      // Arm the cooldown the moment Reddit's budget is spent (before the next 429).
-      armIfSpent(apiResults.rateLimit);
+      // Settle the reservation to the real reset window Reddit reported.
+      settleAfterRequest(apiResults.rateLimit);
       await addRecentSearch(query);
     } catch (error) {
       if (isAbortError(error)) {

--- a/extensions/reddit-search/src/Home.tsx
+++ b/extensions/reddit-search/src/Home.tsx
@@ -31,6 +31,10 @@ export default function Home({
   removeFavoriteSubreddit: (subreddit: string) => void;
 }) {
   const abortControllerRef = useRef<AbortController | null>(null);
+  // The reservation token of the in-flight request, released synchronously when a new
+  // search supersedes it (an async catch would run too late — the replacement would
+  // already have been refused by the slot the aborted request still held).
+  const reservationRef = useRef<string | null>(null);
   const [results, setResults] = useState<RedditResultItem[]>([]);
   // The sort is its own persisted state, NOT derived from the last search. It must
   // be settable before any query (so results come back in the wanted order) and
@@ -49,7 +53,7 @@ export default function Home({
   const [hideDetail, setHideDetail] = useState(false);
   const [cachedAt, setCachedAt] = useState<number | undefined>(undefined);
   const [isShowingDetail, setIsShowingDetail] = useCachedState("is-showing-detail", true);
-  const { secondsRemaining, startCooldown, settleAfterRequest, reserveRequestSlot, isCoolingDown } =
+  const { secondsRemaining, startCooldown, settleAfterRequest, releaseReservation, reserveRequestSlot, isCoolingDown } =
     useRateLimitCooldown();
   const { recentSearches, addRecentSearch, removeRecentSearch, clearRecentSearches } =
     useRecentSearches("recentPostSearches");
@@ -68,17 +72,24 @@ export default function Home({
       ? undefined
       : readCache<RedditResult>(cacheKey(["posts", "", query, preferences.resultLimit, sort?.sortValue ?? ""]));
 
-    // RESERVE the shared request slot before sending (not just check it). Reserving
-    // is check-and-claim in one step, so two commands can't both read "clear" and
-    // both send — the second gets `false` and stops. Cached reads skip this: they
-    // cost no request.
-    if (!cached && !reserveRequestSlot()) {
-      return;
-    }
-
     abortControllerRef.current?.abort();
     const controller = new AbortController();
     abortControllerRef.current = controller;
+
+    // RESERVE the shared request slot before sending (not just check it): two commands
+    // can't both read "clear" and both send. A same-command supersede REUSES the hold
+    // we already own (reservationRef) rather than releasing and re-claiming — the
+    // aborted request and its replacement are one command sharing one slot. Cached
+    // reads skip this: they cost no request.
+    let reservation = reservationRef.current;
+    if (!cached && !reservation) {
+      reservation = reserveRequestSlot();
+      if (!reservation) {
+        setSearching(false);
+        return;
+      }
+      reservationRef.current = reservation;
+    }
 
     setSearching(true);
     queryRef.current = query;
@@ -103,17 +114,25 @@ export default function Home({
         setFiltering(true);
         setSearchText("");
       }
-      // Settle the reservation to the real reset window Reddit reported.
-      settleAfterRequest(apiResults.rateLimit);
+      // Settle the reservation: hold if the budget is spent, release if it remained.
+      if (reservation) settleAfterRequest(reservation, apiResults.rateLimit);
+      reservationRef.current = null;
       await addRecentSearch(query);
     } catch (error) {
       if (isAbortError(error)) {
+        // Superseded — leave the reservation in place; the replacement reuses it via
+        // reservationRef, so releasing here would strand the live request.
         return;
       }
 
       if (isRateLimited(error)) {
         startCooldown(error.retryAfterSeconds ?? RATE_LIMIT_COOLDOWN_SECONDS);
+      } else if (reservation) {
+        // Failed before Reddit spent the budget (network error) — release the
+        // provisional hold so a transient blip doesn't lock the user out for 60s.
+        releaseReservation(reservation);
       }
+      reservationRef.current = null;
 
       homeLog.error("Reddit search failed", error);
       await failureToast("Couldn’t search Reddit", error);

--- a/extensions/reddit-search/src/RedditApi/UrlBuilder.tsx
+++ b/extensions/reddit-search/src/RedditApi/UrlBuilder.tsx
@@ -24,7 +24,15 @@ export const createSearchUrl = (subreddit = "", feed = false, query = "", type =
     url = joinUrl(url, subreddit);
   }
 
-  url = joinUrl(url, feed ? "search.rss" : "search");
+  // Browsing a subreddit with no query is the LISTING feed (`/r/<sub>/.rss`), not a
+  // search — an empty-query `/r/<sub>/search.rss` returns nothing. Only build the
+  // search endpoint when there is a query (or a subreddit-type search).
+  const isSearch = !!query || !!type;
+  if (isSearch) {
+    url = joinUrl(url, feed ? "search.rss" : "search");
+  } else if (feed) {
+    url = url + ".rss";
+  }
 
   const params = new URLSearchParams();
 
@@ -33,8 +41,8 @@ export const createSearchUrl = (subreddit = "", feed = false, query = "", type =
   }
 
   // `restrict_sr` keeps a subreddit-scoped search inside that subreddit; without
-  // it Reddit widens the query to all of Reddit.
-  if (subreddit) {
+  // it Reddit widens the query to all of Reddit. Only meaningful for a search.
+  if (subreddit && isSearch) {
     params.append("restrict_sr", "true");
   }
 

--- a/extensions/reddit-search/src/SubredditList.tsx
+++ b/extensions/reddit-search/src/SubredditList.tsx
@@ -35,7 +35,8 @@ export default function SubredditPostList({
   const abortControllerRef = useRef<AbortController | null>(null);
   const queryRef = useRef<string>("");
   const [searchText, setSearchText] = useState("");
-  const { secondsRemaining, startCooldown, armIfSpent, isCoolingDown, isCoolingDownNow } = useRateLimitCooldown();
+  const { secondsRemaining, startCooldown, settleAfterRequest, reserveRequestSlot, isCoolingDown } =
+    useRateLimitCooldown();
   // Shares the "is-showing-detail" cache key with the post lists so the pane's
   // visibility follows the user across views instead of resetting per screen.
   const [isShowingDetail, setIsShowingDetail] = useCachedState("is-showing-detail", true);
@@ -56,7 +57,8 @@ export default function SubredditPostList({
       : readCache<RedditResult>(cacheKey(["subreddits", query, preferences.resultLimit]));
 
     // Gate on the SYNCHRONOUS cache read, not the polled `isCoolingDown` (see Home.tsx).
-    if (!cached && isCoolingDownNow()) {
+    // RESERVE the shared slot before sending, not just check it (see Home.tsx).
+    if (!cached && !reserveRequestSlot()) {
       return;
     }
 
@@ -78,8 +80,8 @@ export default function SubredditPostList({
       setSearchRedditUrl(apiResults.url);
       setResults(apiResults.subreddits);
       setCachedAt(apiResults.cachedAt);
-      // Arm the cooldown the moment Reddit's budget is spent (before the next 429).
-      armIfSpent(apiResults.rateLimit);
+      // Settle the reservation to the real reset window Reddit reported.
+      settleAfterRequest(apiResults.rateLimit);
       await addRecentSearch(query);
     } catch (error) {
       if (isAbortError(error)) {

--- a/extensions/reddit-search/src/SubredditList.tsx
+++ b/extensions/reddit-search/src/SubredditList.tsx
@@ -33,9 +33,10 @@ export default function SubredditPostList({
   const [searching, setSearching] = useState(false);
   const [searchRedditUrl, setSearchRedditUrl] = useState("");
   const abortControllerRef = useRef<AbortController | null>(null);
+  const reservationRef = useRef<string | null>(null);
   const queryRef = useRef<string>("");
   const [searchText, setSearchText] = useState("");
-  const { secondsRemaining, startCooldown, settleAfterRequest, reserveRequestSlot, isCoolingDown } =
+  const { secondsRemaining, startCooldown, settleAfterRequest, releaseReservation, reserveRequestSlot, isCoolingDown } =
     useRateLimitCooldown();
   // Shares the "is-showing-detail" cache key with the post lists so the pane's
   // visibility follows the user across views instead of resetting per screen.
@@ -56,15 +57,21 @@ export default function SubredditPostList({
       ? undefined
       : readCache<RedditResult>(cacheKey(["subreddits", query, preferences.resultLimit]));
 
-    // Gate on the SYNCHRONOUS cache read, not the polled `isCoolingDown` (see Home.tsx).
-    // RESERVE the shared slot before sending, not just check it (see Home.tsx).
-    if (!cached && !reserveRequestSlot()) {
-      return;
-    }
-
     abortControllerRef.current?.abort();
     const controller = new AbortController();
     abortControllerRef.current = controller;
+
+    // RESERVE the shared slot before sending; a same-command supersede reuses the hold
+    // we already own (see Home.tsx for the full rationale).
+    let reservation = reservationRef.current;
+    if (!cached && !reservation) {
+      reservation = reserveRequestSlot();
+      if (!reservation) {
+        setSearching(false);
+        return;
+      }
+      reservationRef.current = reservation;
+    }
 
     setSearching(true);
     queryRef.current = query;
@@ -80,17 +87,22 @@ export default function SubredditPostList({
       setSearchRedditUrl(apiResults.url);
       setResults(apiResults.subreddits);
       setCachedAt(apiResults.cachedAt);
-      // Settle the reservation to the real reset window Reddit reported.
-      settleAfterRequest(apiResults.rateLimit);
+      // Settle the reservation: hold if the budget is spent, release if it remained.
+      if (reservation) settleAfterRequest(reservation, apiResults.rateLimit);
+      reservationRef.current = null;
       await addRecentSearch(query);
     } catch (error) {
       if (isAbortError(error)) {
+        // Superseded — leave the reservation for the replacement to reuse (see Home.tsx).
         return;
       }
 
       if (isRateLimited(error)) {
         startCooldown(error.retryAfterSeconds ?? RATE_LIMIT_COOLDOWN_SECONDS);
+      } else if (reservation) {
+        releaseReservation(reservation);
       }
+      reservationRef.current = null;
 
       subredditLog.error("Subreddit search failed", error);
       await failureToast("Couldn’t search subreddits", error);

--- a/extensions/reddit-search/src/quick-search-subreddit.tsx
+++ b/extensions/reddit-search/src/quick-search-subreddit.tsx
@@ -7,16 +7,18 @@ import { failureToast } from "./util/toast";
 const log = logger.child("[QuickSearchSubreddit]");
 
 /**
- * No-view command: takes a query and a subreddit, opens a subreddit-restricted
- * search on Reddit in the browser.
+ * No-view command: takes a subreddit and an optional query, opens the subreddit
+ * search (or the subreddit itself, when no query is given) on Reddit in the browser.
  *
  * A no-view command can't render results, and Reddit's ~1/minute feed limit would
  * make an in-Raycast fetch unreliable anyway — so this always opens the browser,
  * the one path that works every time. The subreddit accepts `r/foo`, `/r/foo`, a
- * pasted URL, etc., normalized to a bare slug.
+ * pasted URL, etc., normalized to a bare slug. `query` is optional so a deeplink
+ * carrying only the subreddit lands on a prefilled form instead of failing on a
+ * missing required argument.
  */
 export default async function QuickSearchSubreddit(props: LaunchProps<{ arguments: Arguments.QuickSearchSubreddit }>) {
-  const query = props.arguments.query.trim();
+  const query = (props.arguments.query ?? "").trim();
   const slug = normalizeSubredditSlug(props.arguments.subreddit);
 
   if (!slug) {

--- a/extensions/reddit-search/src/util/useRateLimitCooldown.ts
+++ b/extensions/reddit-search/src/util/useRateLimitCooldown.ts
@@ -29,14 +29,45 @@ const cache = new Cache({ namespace: "rate-limit" });
  */
 const RESERVATION_MS = 60_000;
 
-function readDeadline(): number {
-  const raw = cache.get(CACHE_KEY);
-  const value = raw ? Number(raw) : 0;
-  return Number.isFinite(value) ? value : 0;
+/** Disambiguates reservation tokens minted within the same millisecond. */
+let reservationCounter = 0;
+
+/**
+ * The shared cooldown state. `provisional` marks a slot RESERVED for an in-flight
+ * request (releasable by its owner via `token` if the request fails or the budget
+ * turns out to remain); a non-provisional deadline is a CONFIRMED cooldown from a
+ * spent budget / 429, which no one releases early.
+ */
+interface CooldownState {
+  deadline: number;
+  provisional: boolean;
+  token: string;
 }
 
-function writeDeadline(deadline: number): void {
-  cache.set(CACHE_KEY, String(deadline));
+function readState(): CooldownState {
+  const raw = cache.get(CACHE_KEY);
+  if (!raw) {
+    return { deadline: 0, provisional: false, token: "" };
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<CooldownState>;
+    const deadline = Number(parsed.deadline);
+    return {
+      deadline: Number.isFinite(deadline) ? deadline : 0,
+      provisional: parsed.provisional === true,
+      token: typeof parsed.token === "string" ? parsed.token : "",
+    };
+  } catch {
+    return { deadline: 0, provisional: false, token: "" };
+  }
+}
+
+function writeState(state: CooldownState): void {
+  cache.set(CACHE_KEY, JSON.stringify(state));
+}
+
+function readDeadline(): number {
+  return readState().deadline;
 }
 
 function secondsUntil(deadline: number): number {
@@ -62,48 +93,69 @@ export default function useRateLimitCooldown() {
   // `reserveRequestSlot` for that.
   const isCoolingDown = secondsRemaining > 0;
 
-  const startCooldown = useCallback((seconds: number) => {
-    // Never shorten an existing cooldown: a later response can report a smaller
-    // reset than one already in flight, and trusting it would re-enable the UI
-    // while Reddit is still refusing requests. Read-modify-write against the shared
-    // cache so concurrent commands compose rather than clobber.
-    const next = Math.max(readDeadline(), Date.now() + seconds * 1000);
-    writeDeadline(next);
-    setSecondsRemaining(secondsUntil(next));
+  const commit = useCallback((state: CooldownState) => {
+    writeState(state);
+    setSecondsRemaining(secondsUntil(state.deadline));
   }, []);
 
-  // Reserve the single request slot BEFORE sending, closing the last race: merely
-  // *checking* the deadline lets two commands both read "clear" and both send, each
-  // arming the cooldown only after its response — so one still 429s. Reservation is
-  // check-and-write in one step: if the window is clear, immediately claim it by
-  // writing a provisional cooldown, so a concurrent caller a moment later reads the
-  // claim and is refused. The reservation is then settled by `settleAfterRequest`
-  // (called with the response's rate-limit budget), which fixes the deadline to the
-  // real reset window.
-  const reserveRequestSlot = useCallback((): boolean => {
+  const startCooldown = useCallback(
+    (seconds: number) => {
+      // A CONFIRMED cooldown (from a 429). Never shorten an existing deadline — a
+      // later response can report a smaller reset than one already in flight.
+      const deadline = Math.max(readDeadline(), Date.now() + seconds * 1000);
+      commit({ deadline, provisional: false, token: "" });
+    },
+    [commit],
+  );
+
+  // Reserve the single request slot BEFORE sending, so two commands can't both read
+  // "clear" and both send. This is a best-effort claim: on this platform the cache
+  // has no atomic compare-and-set, so two *exactly*-simultaneous callers could still
+  // both win — but it closes the wide, common races (the ~1s poll window; any
+  // non-instantaneous concurrency), leaving only a microsecond-wide residual.
+  // Returns an owner token, or null if the slot was already held; the token lets the
+  // caller release ITS OWN provisional hold (`releaseReservation`) without clobbering
+  // a confirmed cooldown or another command's reservation.
+  const reserveRequestSlot = useCallback((): string | null => {
     if (secondsUntil(readDeadline()) > 0) {
-      return false; // already reserved or cooling down
+      return null; // already reserved or cooling down
     }
-    const next = Date.now() + RESERVATION_MS;
-    writeDeadline(next);
-    setSecondsRemaining(secondsUntil(next));
-    return true;
-  }, []);
+    const token = `${Date.now()}-${reservationCounter++}`;
+    commit({ deadline: Date.now() + RESERVATION_MS, provisional: true, token });
+    return token;
+  }, [commit]);
 
-  // After a reserved request completes, settle the shared deadline to the real reset
-  // window Reddit reported (extending, never shortening, an existing cooldown). A
-  // spent/unknown budget and a still-present budget both resolve here: the provisional
-  // reservation simply *becomes* the actual cooldown. We deliberately do NOT release
-  // the reservation early on "budget remained" — at ~1 request/minute the very next
-  // request should wait regardless, so holding the window is correct, and it avoids a
-  // fragile "is this deadline mine or a real cooldown?" check that could clear another
-  // command's hold. `reset` defaults to the reservation window when Reddit omits it.
-  const settleAfterRequest = useCallback((rateLimit?: RateLimit) => {
-    const reset = rateLimit?.reset ?? RESERVATION_MS / 1000;
-    const next = Math.max(readDeadline(), Date.now() + reset * 1000);
-    writeDeadline(next);
-    setSecondsRemaining(secondsUntil(next));
-  }, []);
+  // Release a provisional reservation this command owns — used when its request
+  // FAILED before reaching Reddit (network error), or SUCCEEDED with budget still
+  // remaining, so the window shouldn't be held. Only clears the cache if it still
+  // holds our own provisional token; a confirmed cooldown, or another command's
+  // reservation, is left untouched.
+  const releaseReservation = useCallback(
+    (token: string) => {
+      const state = readState();
+      if (state.provisional && state.token === token) {
+        commit({ deadline: 0, provisional: false, token: "" });
+      }
+    },
+    [commit],
+  );
 
-  return { secondsRemaining, startCooldown, settleAfterRequest, reserveRequestSlot, isCoolingDown };
+  // Settle a reservation after its request completes. Budget SPENT or unknown →
+  // promote the hold to a confirmed cooldown for the real reset window. Budget
+  // REMAINED → release our reservation so an allowed follow-up isn't blocked.
+  const settleAfterRequest = useCallback(
+    (token: string, rateLimit?: RateLimit) => {
+      const spent = !rateLimit || rateLimit.remaining === undefined || rateLimit.remaining < 1;
+      if (!spent) {
+        releaseReservation(token);
+        return;
+      }
+      const reset = rateLimit?.reset ?? RESERVATION_MS / 1000;
+      const deadline = Math.max(readDeadline(), Date.now() + reset * 1000);
+      commit({ deadline, provisional: false, token: "" });
+    },
+    [commit, releaseReservation],
+  );
+
+  return { secondsRemaining, startCooldown, settleAfterRequest, releaseReservation, reserveRequestSlot, isCoolingDown };
 }

--- a/extensions/reddit-search/src/util/useRateLimitCooldown.ts
+++ b/extensions/reddit-search/src/util/useRateLimitCooldown.ts
@@ -21,6 +21,14 @@ import { RateLimit } from "../RedditApi/Api";
 const CACHE_KEY = "redditRateLimitDeadline";
 const cache = new Cache({ namespace: "rate-limit" });
 
+/**
+ * How long a provisional request reservation holds the shared slot while a request
+ * is in flight. Matches the ~1 request/minute window: if the response never lands
+ * (crash, killed command), the reservation self-expires rather than wedging the
+ * cooldown forever, and it's the same length a spent-budget response would set.
+ */
+const RESERVATION_MS = 60_000;
+
 function readDeadline(): number {
   const raw = cache.get(CACHE_KEY);
   const value = raw ? Number(raw) : 0;
@@ -50,14 +58,9 @@ export default function useRateLimitCooldown() {
   }, []);
 
   // `isCoolingDown` is the POLLED value — correct for display, but up to ~1s stale
-  // relative to another command's write. Do NOT gate an actual request on it.
+  // relative to another command's write. Do NOT gate an actual request on it; use
+  // `reserveRequestSlot` for that.
   const isCoolingDown = secondsRemaining > 0;
-
-  // The authoritative gate: reads the shared deadline SYNCHRONOUSLY at call time, so
-  // there is no polling window for a concurrent command to slip a request through
-  // during an active cooldown. Callers must decide whether to send a network request
-  // with this, not with `isCoolingDown`.
-  const isCoolingDownNow = useCallback(() => secondsUntil(readDeadline()) > 0, []);
 
   const startCooldown = useCallback((seconds: number) => {
     // Never shorten an existing cooldown: a later response can report a smaller
@@ -69,19 +72,38 @@ export default function useRateLimitCooldown() {
     setSecondsRemaining(secondsUntil(next));
   }, []);
 
-  // Arm the cooldown when a successful response has spent the budget, so the guard
-  // engages *before* the next request 429s rather than after. An UNKNOWN budget
-  // (`remaining === undefined`, i.e. Reddit omitted the header) counts as spent:
-  // at ~1 request/minute a completed request has likely used the window, and
-  // holding is the safe default (cached searches still work during cooldown).
-  const armIfSpent = useCallback(
-    (rateLimit?: RateLimit) => {
-      if (rateLimit && (rateLimit.remaining === undefined || rateLimit.remaining < 1)) {
-        startCooldown(rateLimit.reset);
-      }
-    },
-    [startCooldown],
-  );
+  // Reserve the single request slot BEFORE sending, closing the last race: merely
+  // *checking* the deadline lets two commands both read "clear" and both send, each
+  // arming the cooldown only after its response — so one still 429s. Reservation is
+  // check-and-write in one step: if the window is clear, immediately claim it by
+  // writing a provisional cooldown, so a concurrent caller a moment later reads the
+  // claim and is refused. The reservation is then settled by `settleAfterRequest`
+  // (called with the response's rate-limit budget), which fixes the deadline to the
+  // real reset window.
+  const reserveRequestSlot = useCallback((): boolean => {
+    if (secondsUntil(readDeadline()) > 0) {
+      return false; // already reserved or cooling down
+    }
+    const next = Date.now() + RESERVATION_MS;
+    writeDeadline(next);
+    setSecondsRemaining(secondsUntil(next));
+    return true;
+  }, []);
 
-  return { secondsRemaining, startCooldown, armIfSpent, isCoolingDown, isCoolingDownNow };
+  // After a reserved request completes, settle the shared deadline to the real reset
+  // window Reddit reported (extending, never shortening, an existing cooldown). A
+  // spent/unknown budget and a still-present budget both resolve here: the provisional
+  // reservation simply *becomes* the actual cooldown. We deliberately do NOT release
+  // the reservation early on "budget remained" — at ~1 request/minute the very next
+  // request should wait regardless, so holding the window is correct, and it avoids a
+  // fragile "is this deadline mine or a real cooldown?" check that could clear another
+  // command's hold. `reset` defaults to the reservation window when Reddit omits it.
+  const settleAfterRequest = useCallback((rateLimit?: RateLimit) => {
+    const reset = rateLimit?.reset ?? RESERVATION_MS / 1000;
+    const next = Math.max(readDeadline(), Date.now() + reset * 1000);
+    writeDeadline(next);
+    setSecondsRemaining(secondsUntil(next));
+  }, []);
+
+  return { secondsRemaining, startCooldown, settleAfterRequest, reserveRequestSlot, isCoolingDown };
 }


### PR DESCRIPTION
## Description

Follow-up to #29703 (merged) — three bugs a Codex review caught after approval.

### Fixed

- **Opening a favorite subreddit loaded no posts.** The URL builder turned a no-query feed request into `/r/<sub>/search.rss` (a search with an empty query → 0 results). It now builds the subreddit **listing** feed `/r/<sub>/.rss` when there's no query, and the search endpoint only for an actual query. Verified live against Reddit.
- **The "Search r/…" deeplink failed on a missing argument.** `quick-search-subreddit` declared `query` as required and immediately `.trim()`'d it, so a deeplink carrying only the subreddit errored before the user could type. `query` is now optional (subreddit-first), so the deeplink lands on a prefilled form.
- **Concurrent first requests bypassed the shared cooldown.** The gate only *checked* the shared deadline, so two commands could both read "clear" and both send, each arming the cooldown only after its response — one still got a 429. Replaced the check with a `reserveRequestSlot()` that check-and-claims the window in one step; a concurrent caller is refused. Verified: of two concurrent reservations, exactly one wins.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I ran \`npm run build\` and tested the distribution build in Raycast
- [x] I checked that files in the \`assets\` folder are used by the extension itself