### PR TITLE
Readwise Reader: Add sorting and random shuffle to List Documents

### DIFF
--- a/extensions/readwise-reader/CHANGELOG.md
+++ b/extensions/readwise-reader/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Readwise Reader Changelog
 
-## [Add sorting and random shuffle to List Documents] - {PR_MERGE_DATE}
+## [Add sorting and random shuffle to List Documents] - 2026-08-14
 
 - Add a `Sort Documents By…` action to `List Documents` supporting Date Moved, Date Saved, Date Published, Date Last Opened, Author, Category, Length, Progress, Title, and Random
 - Add `Toggle Sort Direction` and, for Random, `Reshuffle`

--- a/extensions/readwise-reader/CHANGELOG.md
+++ b/extensions/readwise-reader/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add `Toggle Sort Direction` and, for Random, `Reshuffle`
 - Add a `Default sort` preference
 - Sort the full loaded list instead of sorting each page independently
+- Fix a crash when viewing a document whose author, website, or category is empty
 
 ## [Add Windows support] - 2026-07-07
 

--- a/extensions/readwise-reader/CHANGELOG.md
+++ b/extensions/readwise-reader/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Readwise Reader Changelog
 
+## [Add sorting and random shuffle to List Documents] - {PR_MERGE_DATE}
+
+- Add a `Sort Documents By…` action to `List Documents` supporting Date Moved, Date Saved, Date Published, Date Last Opened, Author, Category, Length, Progress, Title, and Random
+- Add `Toggle Sort Direction` and, for Random, `Reshuffle`
+- Add a `Default sort` preference
+- Sort the full loaded list instead of sorting each page independently
+
 ## [Add Windows support] - 2026-07-07
 
 - Add Windows to supported platforms

--- a/extensions/readwise-reader/CHANGELOG.md
+++ b/extensions/readwise-reader/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add a `Default sort` preference
 - Sort the full loaded list instead of sorting each page independently
 - Fix a crash when viewing a document whose author, website, or category is empty
+- Remove duplicate documents that could appear in the list after loading more pages
 
 ## [Add Windows support] - 2026-07-07
 

--- a/extensions/readwise-reader/README.md
+++ b/extensions/readwise-reader/README.md
@@ -5,3 +5,9 @@ Interacting with Readwise Reader.
 ## Setup
 
 To get your access token, log in to Readwise and [get yours](https://readwise.io/access_token).
+
+## Sorting in List Documents
+
+Use the `Sort Documents By…` action (⌘⇧S / Ctrl⇧S) to sort by date, author, category, length, progress, title, or `Random`. Toggle direction with ⌘⇧O / Ctrl⇧O; reshuffle Random with ⌘R / Ctrl R. Set a default with the `Default sort` preference.
+
+Note: sorting and Random apply to the documents currently loaded into the Raycast list (loaded page by page), not the entire Reader location.

--- a/extensions/readwise-reader/package.json
+++ b/extensions/readwise-reader/package.json
@@ -144,6 +144,56 @@
           "type": "dropdown",
           "description": "The default location to use when listing content",
           "title": "Default list location"
+        },
+        {
+          "name": "defaultSortBy",
+          "title": "Default sort",
+          "description": "The default sort to use when opening List Documents",
+          "type": "dropdown",
+          "required": false,
+          "default": "last_moved_at",
+          "data": [
+            {
+              "title": "Date Moved",
+              "value": "last_moved_at"
+            },
+            {
+              "title": "Date Saved",
+              "value": "saved_at"
+            },
+            {
+              "title": "Date Published",
+              "value": "published_date"
+            },
+            {
+              "title": "Date Last Opened",
+              "value": "last_opened_at"
+            },
+            {
+              "title": "Author",
+              "value": "author"
+            },
+            {
+              "title": "Category",
+              "value": "category"
+            },
+            {
+              "title": "Length",
+              "value": "word_count"
+            },
+            {
+              "title": "Progress",
+              "value": "reading_progress"
+            },
+            {
+              "title": "Title",
+              "value": "title"
+            },
+            {
+              "title": "Random",
+              "value": "random"
+            }
+          ]
         }
       ]
     }

--- a/extensions/readwise-reader/src/list-documents.tsx
+++ b/extensions/readwise-reader/src/list-documents.tsx
@@ -116,7 +116,7 @@ export default function ListDocumentsCommand() {
         category ? ` (${titlecase(category)})` : ""
       } · ${sortLabel(sortBy, sortDirection)}`}
     >
-      {displayData.length === 0 && category !== undefined ? (
+      {data?.length === 0 && category !== undefined ? (
         <List.EmptyView
           title="No documents found"
           description={`No documents found in the "${titlecase(category)}" category.`}

--- a/extensions/readwise-reader/src/list-documents.tsx
+++ b/extensions/readwise-reader/src/list-documents.tsx
@@ -7,7 +7,13 @@ import { type Document } from "./utils/document";
 import { type Category } from "./utils/category";
 import { type PaginationOptions } from "@raycast/utils/dist/types";
 import { getOpenUrlFromFullUrl } from "./utils";
-import { defaultDirectionFor, sortDocuments, type SortBy, type SortDirection } from "./utils/sort-documents";
+import {
+  dedupeById,
+  defaultDirectionFor,
+  sortDocuments,
+  type SortBy,
+  type SortDirection,
+} from "./utils/sort-documents";
 
 function getProgressIcon(readingProgress: number) {
   const asPercentage = readingProgress * 100;
@@ -91,7 +97,7 @@ export default function ListDocumentsCommand() {
   );
 
   const displayData = useMemo(
-    () => sortDocuments(data ?? [], sortBy, sortDirection, randomSeed),
+    () => sortDocuments(dedupeById(data ?? []), sortBy, sortDirection, randomSeed),
     [data, sortBy, sortDirection, randomSeed],
   );
 

--- a/extensions/readwise-reader/src/list-documents.tsx
+++ b/extensions/readwise-reader/src/list-documents.tsx
@@ -147,9 +147,9 @@ ${article.summary}
                   markdown={markdown}
                   metadata={
                     <List.Item.Detail.Metadata>
-                      <List.Item.Detail.Metadata.Label title="Author" text={article.author} />
-                      <List.Item.Detail.Metadata.Label title="Website" text={article.site_name} />
-                      <List.Item.Detail.Metadata.Label title="Category" text={article.category} />
+                      <List.Item.Detail.Metadata.Label title="Author" text={article.author ?? undefined} />
+                      <List.Item.Detail.Metadata.Label title="Website" text={article.site_name ?? undefined} />
+                      <List.Item.Detail.Metadata.Label title="Category" text={article.category ?? undefined} />
                       <List.Item.Detail.Metadata.TagList title="Tags">
                         {Object.values(article.tags ?? {}).map(({ name }) => (
                           <List.Item.Detail.Metadata.TagList.Item text={name} key={name} />

--- a/extensions/readwise-reader/src/list-documents.tsx
+++ b/extensions/readwise-reader/src/list-documents.tsx
@@ -39,13 +39,6 @@ function categoryShortcut(key: Keyboard.KeyEquivalent): Keyboard.Shortcut {
   };
 }
 
-type Preference = {
-  defaultListLocation: Document["location"];
-  token: string;
-  openInDesktopApp: boolean;
-  defaultSortBy: SortBy;
-};
-
 const SORT_LABELS: Record<SortBy, string> = {
   last_moved_at: "Date Moved",
   saved_at: "Date Saved",
@@ -67,7 +60,7 @@ function sortLabel(by: SortBy, direction: SortDirection): string {
 }
 
 export default function ListDocumentsCommand() {
-  const preferences = getPreferenceValues<Preference>();
+  const preferences = getPreferenceValues<Preferences.ListDocuments>();
   const [documentLocation, setDocumentLocation] = useState<Document["location"]>(preferences.defaultListLocation);
   const [category, setCategory] = useState<Category | undefined>();
   const [sortBy, setSortBy] = useState<SortBy>(preferences.defaultSortBy);

--- a/extensions/readwise-reader/src/list-documents.tsx
+++ b/extensions/readwise-reader/src/list-documents.tsx
@@ -1,12 +1,13 @@
 import { Action, ActionPanel, getPreferenceValues, Icon, Keyboard, List, open } from "@raycast/api";
 import { usePromise } from "@raycast/utils";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { list } from "./api/list";
 import { titlecase } from "./utils/titlecase";
 import { type Document } from "./utils/document";
 import { type Category } from "./utils/category";
 import { type PaginationOptions } from "@raycast/utils/dist/types";
 import { getOpenUrlFromFullUrl } from "./utils";
+import { defaultDirectionFor, sortDocuments, type SortBy, type SortDirection } from "./utils/sort-documents";
 
 function getProgressIcon(readingProgress: number) {
   const asPercentage = readingProgress * 100;
@@ -36,28 +37,62 @@ type Preference = {
   defaultListLocation: Document["location"];
   token: string;
   openInDesktopApp: boolean;
+  defaultSortBy: SortBy;
 };
 
+const SORT_LABELS: Record<SortBy, string> = {
+  last_moved_at: "Date Moved",
+  saved_at: "Date Saved",
+  published_date: "Date Published",
+  last_opened_at: "Date Last Opened",
+  author: "Author",
+  category: "Category",
+  word_count: "Length",
+  reading_progress: "Progress",
+  title: "Title",
+  random: "Random",
+};
+
+function sortLabel(by: SortBy, direction: SortDirection): string {
+  if (by === "random") {
+    return "Random";
+  }
+  return `${SORT_LABELS[by]} ${direction === "ascending" ? "↑" : "↓"}`;
+}
+
 export default function ListDocumentsCommand() {
-  const [documentLocation, setDocumentLocation] = useState<Document["location"]>(
-    getPreferenceValues<Preference>().defaultListLocation,
-  );
+  const preferences = getPreferenceValues<Preference>();
+  const [documentLocation, setDocumentLocation] = useState<Document["location"]>(preferences.defaultListLocation);
   const [category, setCategory] = useState<Category | undefined>();
+  const [sortBy, setSortBy] = useState<SortBy>(preferences.defaultSortBy);
+  const [sortDirection, setSortDirection] = useState<SortDirection>(defaultDirectionFor(preferences.defaultSortBy));
+  const [randomSeed, setRandomSeed] = useState(() => Date.now());
+
+  function selectSort(next: SortBy) {
+    setSortBy(next);
+    if (next === "random") {
+      setRandomSeed(Date.now());
+    } else {
+      setSortDirection(defaultDirectionFor(next));
+    }
+  }
 
   const { isLoading, data, pagination } = usePromise(
     (location, selectedCategory) => async (options: PaginationOptions<Document[]>) => {
       const { results, nextPageCursor } = await list(location, selectedCategory, options.cursor);
-      const sortedDocuments = results.sort(
-        (a, b) => new Date(b.last_moved_at).getTime() - new Date(a.last_moved_at).getTime(),
-      );
 
       return {
-        data: sortedDocuments,
+        data: results,
         hasMore: !!nextPageCursor,
         cursor: nextPageCursor,
       };
     },
     [documentLocation, category],
+  );
+
+  const displayData = useMemo(
+    () => sortDocuments(data ?? [], sortBy, sortDirection, randomSeed),
+    [data, sortBy, sortDirection, randomSeed],
   );
 
   return (
@@ -78,9 +113,11 @@ export default function ListDocumentsCommand() {
         </List.Dropdown>
       }
       pagination={pagination}
-      navigationTitle={`Documents in ${titlecase(documentLocation)}${category ? ` (${titlecase(category)})` : ""}`}
+      navigationTitle={`Documents in ${titlecase(documentLocation)}${
+        category ? ` (${titlecase(category)})` : ""
+      } · ${sortLabel(sortBy, sortDirection)}`}
     >
-      {data?.length === 0 && category !== undefined ? (
+      {displayData.length === 0 && category !== undefined ? (
         <List.EmptyView
           title="No documents found"
           description={`No documents found in the "${titlecase(category)}" category.`}
@@ -95,7 +132,7 @@ export default function ListDocumentsCommand() {
           }
         />
       ) : (
-        data?.map((article) => {
+        displayData.map((article) => {
           const markdown = `
 # ${article.title}
 
@@ -204,6 +241,57 @@ ${article.summary}
                       shortcut={categoryShortcut("0")}
                     />
                   </ActionPanel.Submenu>
+                  <ActionPanel.Submenu
+                    title="Sort Documents By…"
+                    icon={Icon.ChevronUpDown}
+                    shortcut={{
+                      macOS: { modifiers: ["cmd", "shift"], key: "s" },
+                      Windows: { modifiers: ["ctrl", "shift"], key: "s" },
+                    }}
+                  >
+                    <Action title="Date Moved" icon={Icon.Calendar} onAction={() => selectSort("last_moved_at")} />
+                    <Action title="Date Saved" icon={Icon.Calendar} onAction={() => selectSort("saved_at")} />
+                    <Action title="Date Published" icon={Icon.Calendar} onAction={() => selectSort("published_date")} />
+                    <Action
+                      title="Date Last Opened"
+                      icon={Icon.Calendar}
+                      onAction={() => selectSort("last_opened_at")}
+                    />
+                    <Action title="Author" icon={Icon.Person} onAction={() => selectSort("author")} />
+                    <Action title="Category" icon={Icon.Tag} onAction={() => selectSort("category")} />
+                    <Action title="Length" icon={Icon.Text} onAction={() => selectSort("word_count")} />
+                    <Action
+                      title="Progress"
+                      icon={Icon.CircleProgress}
+                      onAction={() => selectSort("reading_progress")}
+                    />
+                    <Action title="Title" icon={Icon.Uppercase} onAction={() => selectSort("title")} />
+                    <Action title="Random" icon={Icon.Shuffle} onAction={() => selectSort("random")} />
+                  </ActionPanel.Submenu>
+                  {sortBy !== "random" && (
+                    <Action
+                      title="Toggle Sort Direction"
+                      icon={Icon.ChevronUpDown}
+                      shortcut={{
+                        macOS: { modifiers: ["cmd", "shift"], key: "o" },
+                        Windows: { modifiers: ["ctrl", "shift"], key: "o" },
+                      }}
+                      onAction={() =>
+                        setSortDirection((current) => (current === "ascending" ? "descending" : "ascending"))
+                      }
+                    />
+                  )}
+                  {sortBy === "random" && (
+                    <Action
+                      title="Reshuffle"
+                      icon={Icon.Shuffle}
+                      shortcut={{
+                        macOS: { modifiers: ["cmd"], key: "r" },
+                        Windows: { modifiers: ["ctrl"], key: "r" },
+                      }}
+                      onAction={() => setRandomSeed(Date.now())}
+                    />
+                  )}
                 </ActionPanel>
               }
             />

--- a/extensions/readwise-reader/src/utils/sort-documents.ts
+++ b/extensions/readwise-reader/src/utils/sort-documents.ts
@@ -61,6 +61,18 @@ function compareValue(a: Document, b: Document, sortBy: FieldSortBy): number {
   return (a[sortBy] as number) - (b[sortBy] as number);
 }
 
+export function dedupeById(docs: readonly Document[]): Document[] {
+  const seen = new Set<string>();
+  const result: Document[] = [];
+  for (const doc of docs) {
+    if (!seen.has(doc.id)) {
+      seen.add(doc.id);
+      result.push(doc);
+    }
+  }
+  return result;
+}
+
 export function sortDocuments(
   docs: readonly Document[],
   sortBy: SortBy,

--- a/extensions/readwise-reader/src/utils/sort-documents.ts
+++ b/extensions/readwise-reader/src/utils/sort-documents.ts
@@ -1,0 +1,96 @@
+import { type Document } from "./document";
+
+export type SortBy =
+  | "last_moved_at"
+  | "saved_at"
+  | "published_date"
+  | "last_opened_at"
+  | "author"
+  | "category"
+  | "word_count"
+  | "reading_progress"
+  | "title"
+  | "random";
+
+export type SortDirection = "ascending" | "descending";
+
+type FieldSortBy = Exclude<SortBy, "random">;
+
+const DATE_FIELDS: readonly FieldSortBy[] = ["last_moved_at", "saved_at", "published_date", "last_opened_at"];
+const TEXT_FIELDS: readonly FieldSortBy[] = ["author", "category", "title"];
+
+function fnv1a(input: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+function randomRank(documentId: string, seed: number): number {
+  return fnv1a(`${seed}:${documentId}`);
+}
+
+export function defaultDirectionFor(sortBy: SortBy): SortDirection {
+  return TEXT_FIELDS.includes(sortBy as FieldSortBy) ? "ascending" : "descending";
+}
+
+function isMissing(doc: Document, sortBy: FieldSortBy): boolean {
+  const value = doc[sortBy];
+  if (value === null || value === undefined || value === "") {
+    return true;
+  }
+  if (DATE_FIELDS.includes(sortBy)) {
+    return Number.isNaN(Date.parse(value as string));
+  }
+  return false;
+}
+
+function compareValue(a: Document, b: Document, sortBy: FieldSortBy): number {
+  if (TEXT_FIELDS.includes(sortBy)) {
+    return String(a[sortBy]).localeCompare(String(b[sortBy]), undefined, {
+      sensitivity: "base",
+      numeric: true,
+    });
+  }
+  if (DATE_FIELDS.includes(sortBy)) {
+    return Date.parse(a[sortBy] as string) - Date.parse(b[sortBy] as string);
+  }
+  // numeric fields: word_count, reading_progress
+  return (a[sortBy] as number) - (b[sortBy] as number);
+}
+
+export function sortDocuments(
+  docs: readonly Document[],
+  sortBy: SortBy,
+  direction: SortDirection,
+  seed: number,
+): Document[] {
+  const result = [...docs];
+
+  // direction is not meaningful for random order; ignore it
+  if (sortBy === "random") {
+    return result.sort((a, b) => randomRank(a.id, seed) - randomRank(b.id, seed));
+  }
+
+  return result.sort((a, b) => {
+    const aMissing = isMissing(a, sortBy);
+    const bMissing = isMissing(b, sortBy);
+
+    // Missing values always sort last, independent of direction.
+    if (aMissing && bMissing) {
+      return a.id.localeCompare(b.id);
+    }
+    if (aMissing) {
+      return 1;
+    }
+    if (bMissing) {
+      return -1;
+    }
+
+    const base = compareValue(a, b, sortBy);
+    const directed = direction === "ascending" ? base : -base;
+    return directed || a.id.localeCompare(b.id);
+  });
+}


### PR DESCRIPTION
## Description

This PR adds **sorting** and a seeded **Random** shuffle to the **List Documents** command.

- New **Sort Documents By…** action (`⌘⇧S` / `Ctrl⇧S`): Date Moved, Date Saved, Date Published, Date Last Opened, Author, Category, Length, Progress, Title, and **Random**.
- **Toggle Sort Direction** (`⌘⇧O` / `Ctrl⇧O`) for field sorts; **Reshuffle** (`⌘R` / `Ctrl R`) for Random. Random uses a stable seed so ordinary re-renders don't reshuffle.
- New **Default sort** preference for List Documents.
- Sorting is applied to the whole loaded list (previously each page was sorted independently).

Missing values (e.g. an empty author) always sort last regardless of direction, and equal values fall back to a stable tie-break so the order doesn't jump around.

### Note for reviewers — current display-side scope

Sorting and Random apply to the documents **currently loaded** into the Raycast list (loaded page-by-page via `usePromise` pagination), **not the entire Reader location**. The Reader Document List API has no server-side sort parameter, so a true whole-library sort would require a local index/cache. I've intentionally scoped that out as a follow-up (and say so in the README) to keep this PR focused. Happy to discuss if you'd prefer a different approach here.

### Pre-existing fixes included

While testing I hit two pre-existing issues in List Documents that this feature makes easier to trigger, so I fixed them here:

1. **Crash on a document with an empty author / website / category.** `Metadata.Label`'s `text` accepts `string | { value: string }`, and `typeof null === "object"`, so passing `null` made Raycast read `null.value` and throw. Guarded the three labels with `?? undefined`. (Sorting by Author groups such documents together, making the crash easy to reach.)
2. **Duplicate rows near the bottom of short lists.** Raycast's `pagination` re-fetches and appends the initial page on scroll-to-bottom even when `hasMore` is `false`, producing duplicate document ids (and duplicate React keys). Fixed by de-duplicating accumulated documents by `id` before rendering. (The new global sort just made the duplicates adjacent and obvious.)

Both were reproducible on `main` before this change.

## Screencast

https://github.com/user-attachments/assets/2954836d-2de7-4e98-a08b-b74447b6089b


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our metadata tool
