### PR TITLE
Update Wrap Unwrap extension

### DIFF
--- a/extensions/wrap-unwrap/.prettierrc
+++ b/extensions/wrap-unwrap/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "printWidth": 120,
+  "singleQuote": false
+}

--- a/extensions/wrap-unwrap/CHANGELOG.md
+++ b/extensions/wrap-unwrap/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Wrap Unwrap Changelog
 
-## [Reflow Correctness and Large-Paste Performance] - {PR_MERGE_DATE}
+## [Reflow Correctness and Large-Paste Performance] - 2026-07-26
 
 - Fix **Unwrap Text** joining a hyphen-broken word with a dangling space — `well-` + `known` now rejoins as `well-known`, not `well- known`. Applies to compounds, hyphen chains (`state-of-the-art`), and numeric ranges (`5-10`).
 - Fix **Strip Soft Hyphens** destroying real compounds. The preference now removes only a true Unicode soft hyphen (U+00AD), which exists solely to mark a line break; an ASCII `-` is always preserved, since it cannot be distinguished from a genuine compound.

--- a/extensions/wrap-unwrap/CHANGELOG.md
+++ b/extensions/wrap-unwrap/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Wrap Unwrap Changelog
 
+## [Reflow Correctness and Large-Paste Performance] - {PR_MERGE_DATE}
+
+- Fix **Unwrap Text** joining a hyphen-broken word with a dangling space — `well-` + `known` now rejoins as `well-known`, not `well- known`. Applies to compounds, hyphen chains (`state-of-the-art`), and numeric ranges (`5-10`).
+- Fix **Strip Soft Hyphens** destroying real compounds. The preference now removes only a true Unicode soft hyphen (U+00AD), which exists solely to mark a line break; an ASCII `-` is always preserved, since it cannot be distinguished from a genuine compound.
+- Fix hyphen rejoining for non-ASCII text — accented Latin, Cyrillic, Greek, CJK, and astral characters now rejoin correctly instead of keeping a dangling space.
+- Fix a literal hyphen inside inline code or a link URL being corrupted when the span broke across lines (`` `foo-` `` + `` `bar` `` no longer becomes `` `foobar` ``). Link destinations with balanced parentheses are handled correctly.
+- Fix blockquote indentation being discarded, which hoisted a quote out of its containing list item.
+- Fix **Unwrap Text** failing to rejoin lines inside a blockquote written without a space after the marker (`>text` rather than `> text`) — the wrapped continuation lines were left as separate lines instead of reflowing. `>text` and `> text` are the same quote, so they now group together.
+- Fix a fenced code block being ended early by a line that looks like a closer but carries an info string, which exposed the block's contents to reflow.
+- Fix tab-indented code being treated as prose and reflowed, losing its indentation. Indent width is now measured in columns, so any mix of tabs and spaces reaching column 4 is recognized.
+- Fix **Wrap Text** overrunning the requested **Wrap Column** on tab-indented lines — a tab was counted as one character rather than the four columns it occupies.
+- Fix **Wrap Text** breaking a line so that it began with a literal `-`, `#`, ` ``` `, `>`, or `---`, which was then re-read as a new list item, heading, code fence, blockquote, or heading underline. In the `>` case the character was **deleted outright** on the next unwrap.
+- Fix **Unwrap Text** splitting a single blockquote whose `>` markers were indented inconsistently — CommonMark allows up to three spaces before the marker, so those lines belong to the same quote.
+- Fix a link whose URL contains balanced parentheses being split across lines by **Wrap Text**.
+- Fix **Unwrap Text** merging a blockquote nested inside a list item with a following top-level blockquote — indentation before the `>` marker is structural, not decoration.
+- Fix **Unwrap Text** splitting one blockquote in two when a list appeared earlier in the document without a blank line closing it — a line back at the margin ends a list, so the following quotes belong to the same paragraph.
+- Fix **Wrap Text** slowing down sharply at large **Wrap Column** values when the text contains a run of characters that could start a new block (`-`, `#`, `>`). The check that prevents those characters from beginning a wrapped line now inspects a fixed number of words rather than a full line's worth, so wrapping stays fast at any column width.
+- Fix **Unwrap Text** mis-handling a backslash-escaped `` ` `` or `](`, which was read as opening real inline code or a link and suppressed the correct hyphen rejoining.
+- Fix **Wrap Text** misaligning the continuation lines of a tab-indented list item — a tab counts as one character but renders as a full tab stop, so continuations were under-indented and no longer lined up with the item's text.
+- Fix **Wrap Text** continuation lines on a task list item (`- [ ]`) not clearing the checkbox, so wrapped text sat under the `[ ]` instead of aligning with the item's text.
+- Fix large pastes hanging Raycast: three quadratic code paths meant an input within the supported 1 MB limit could take minutes with no progress shown. Wrapping and unwrapping 1 MB now completes in a fraction of a second.
+- Fix a link label containing nested brackets being split mid-link.
+- Fix text containing Unicode private-use characters being silently rewritten or deleted by the internal inline-token placeholder.
+- Fix an even-numbered run of trailing backslashes being treated as a hard line break instead of escaped literal backslashes.
+- Fix an invalid **Wrap Column** value with a numeric prefix (for example `12px`) being accepted as `12` instead of falling back to 80.
+- Update the **Strip Soft Hyphens** description and README to state what the preference actually does — both previously promised that `inter-` + `esting` would become `interesting`, which is no longer the behavior.
+
 ## [Strip Bullet Indentation] - 2026-05-16
 
 - Add **Unwrap Text** preference **Strip Bullet Indentation** — re-indents bullet and numbered lists to a fixed 2-space-per-level step, removing the leading spaces that pasted terminal or rich-text content adds in front of markers. Nesting depth is preserved by relative indent order. Off by default.

--- a/extensions/wrap-unwrap/README.md
+++ b/extensions/wrap-unwrap/README.md
@@ -35,7 +35,7 @@ Both commands share **Preferred Source**, **Primary Action**, **Hide HUD**, and 
 
 | Preference               | Default | What it does                                                                                                                                                                                                                                                                                                                                        |
 | ------------------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Strip Soft Hyphens       | on      | When joining lines, remove a trailing hyphen if it appears to be a soft line-break hyphen (e.g. `inter-` + `esting` → `interesting`). Compounds like `state-of-the-art` are preserved.                                                                                                                                                              |
+| Strip Soft Hyphens       | on      | When joining lines, remove a trailing soft hyphen (U+00AD) — the invisible character that marks an optional break. A regular `-` is always kept, so `well-` + `known` rejoins as `well-known` and `state-of-the-art` stays intact; either way the halves join with no space.                                                                        |
 | Keep Blank Lines         | off     | Preserve blank lines between paragraphs instead of collapsing runs.                                                                                                                                                                                                                                                                                 |
 | Strip Bullet Indentation | off     | Re-indent bullet and numbered lists to a fixed 2-space-per-level step, removing the leading spaces that pasted terminal or rich-text content adds in front of markers. Nesting depth is preserved by relative indent order, so pasting into an email client produces native bullets. Recognizes Unicode bullets (`•`, `‣`, `▪`, `▸`, `–`, `—`) too. |
 
@@ -51,7 +51,7 @@ Bind these in Raycast → Extensions → Wrap Unwrap. Suggestions:
 Wrap Unwrap implements the [LitoMore cross-extension convention](https://github.com/LitoMore/raycast-cross-extension-conventions) on the provider side using only built-in Raycast SDK primitives. Pass a `launchContext` with the text and an optional `callbackLaunchOptions` describing where to send the result:
 
 ```ts
-import { LaunchType, launchCommand } from "@raycast/api";
+import { launchCommand, LaunchType } from "@raycast/api";
 
 await launchCommand({
   name: "unwrap-text",

--- a/extensions/wrap-unwrap/package.json
+++ b/extensions/wrap-unwrap/package.json
@@ -126,7 +126,7 @@
         {
           "name": "hyphenation",
           "title": "Hyphenation",
-          "description": "When joining lines, remove a trailing hyphen if it appears to be a soft line-break hyphen (e.g., `inter-` + `esting` becomes `interesting`).",
+          "description": "When joining lines, remove a trailing soft hyphen (U+00AD), the invisible character used to mark an optional line break. A regular hyphen is always kept, so compounds like `well-known` stay intact.",
           "type": "checkbox",
           "required": false,
           "default": true,

--- a/extensions/wrap-unwrap/src/lib/classify.ts
+++ b/extensions/wrap-unwrap/src/lib/classify.ts
@@ -3,11 +3,13 @@
 import {
   BLOCKQUOTE_PEEL,
   FENCE_BOUNDARY,
+  FENCE_CLOSER,
   HARD_BREAK_BACKSLASH,
   HARD_BREAK_SPACES,
   HEADING_ATX,
   HR,
-  INDENTED_CODE,
+  indentColumns,
+  isIndentedCode,
   LINK_REF_DEF,
   LIST_ITEM,
   SETEXT_UNDERLINE,
@@ -48,6 +50,13 @@ export type Classified = {
   content: string;
   /** Exact prefix string as it appeared in the input — used for round-trip emission. */
   rawPrefix: string;
+  /**
+   * True when this line is indented under a list item that was still open (no
+   * intervening blank line). Distinguishes a list-nested blockquote from a
+   * root-level one, which indent width alone cannot do — 0-3 spaces before a `>` is
+   * legal padding at root.
+   */
+  inListContext?: boolean;
   // role-specific extras:
   listMarker?: string;
   hangIndent?: number;
@@ -61,14 +70,30 @@ export type Classified = {
   hardBreak?: "spaces" | "backslash";
 };
 
-/** True iff two records have identical blockquote prefix stacks (depth + per-frame marker/spaceAfter). */
+/**
+ * True iff two records sit at the same blockquote depth with the same markers.
+ *
+ * `spaceAfter` is deliberately NOT compared: whether a `>` is followed by a space is
+ * presentation, not structure, and `> text` / `>text` are the same quote in
+ * CommonMark. Comparing it broke the wrap→unwrap round trip, because wrap emits a
+ * `>`-quoted item's continuation as `">  text"` (marker + hang indent) and
+ * `BLOCKQUOTE_PEEL` then greedily eats one of those spaces — making the
+ * continuation read as `spaceAfter: true` against a bare-`>` header, so the lines
+ * were never rejoined. Emission uses `rawPrefix`, which preserves the exact
+ * original prefix, so nothing depends on this comparison for round-tripping.
+ */
 export function samePrefixStack(a: Classified, b: Classified): boolean {
   if (a.prefixes.length !== b.prefixes.length) return false;
   for (let i = 0; i < a.prefixes.length; i++) {
     if (a.prefixes[i].marker !== b.prefixes[i].marker) return false;
-    if (a.prefixes[i].spaceAfter !== b.prefixes[i].spaceAfter) return false;
   }
-  return true;
+  // A quote indented under an open list item is a DIFFERENT block from a root-level
+  // quote at the same depth, even when both indents fall inside CommonMark's allowed
+  // 0-3 spaces before a marker (`   > x` under `1. outer` vs a following `> x`).
+  // Indent width alone can't tell them apart — 3 spaces is legal marker padding at
+  // root — so the classifier records whether a list was open, and that is what's
+  // compared. Plain varying padding (` > a` / `  > b`) still merges.
+  return a.inListContext === b.inListContext;
 }
 
 function peelBlockquotes(line: string): {
@@ -95,15 +120,52 @@ function isBlank(content: string): boolean {
   return /^\s*$/.test(content);
 }
 
+/**
+ * Columns of whitespace immediately before the LAST `>` in a raw prefix — i.e. how
+ * far the innermost quote marker is indented within its parent block. For `">   > "`
+ * that is 3, not 0: the inner marker sits three columns into the outer quote.
+ */
+/**
+ * True when this record ends any list that was open — a line at the margin, outside
+ * any blockquote, that is not itself a list item.
+ *
+ * An INDENTED line is excluded because it may be a lazy continuation of the open
+ * item, which must keep reflowing with it. Quoted lines are excluded too: they are
+ * the very records the list-context flag exists to classify, so treating them as
+ * list-enders would clear the state a line before it is read.
+ */
+function closesOpenList(rec: Classified): boolean {
+  if (rec.role === "list-item" || rec.prefixes.length > 0) return false;
+  return !/^[ \t]/.test(rec.rawPrefix + rec.content);
+}
+
+function innerQuoteIndentColumns(rawPrefix: string): number {
+  const lastMarker = rawPrefix.lastIndexOf(">");
+  if (lastMarker === -1) return 0;
+  const beforeMarker = rawPrefix.slice(0, lastMarker);
+  const indent = beforeMarker.match(/[ \t]*$/);
+  return indent ? indentColumns(indent[0]) : 0;
+}
+
 type FenceState = { char: "`" | "~"; len: number } | null;
 type ClassifyOptions = {
   recognizeDashBullets?: boolean;
 };
 
-function classifyFenceBoundary(
-  content: string,
-): { fenceChar: "`" | "~"; fenceLen: number } | null {
+function classifyFenceBoundary(content: string): { fenceChar: "`" | "~"; fenceLen: number } | null {
   const m = content.match(FENCE_BOUNDARY);
+  if (!m) return null;
+  const run = m[1];
+  return { fenceChar: run[0] as "`" | "~", fenceLen: run.length };
+}
+
+/**
+ * A fence CLOSER, which unlike an opener may carry no info string — only trailing
+ * whitespace. Returns null for ```` ```info ````, so such a line stays in-fence
+ * instead of ending the block early and exposing its code to reflow.
+ */
+function classifyFenceCloser(content: string): { fenceChar: "`" | "~"; fenceLen: number } | null {
+  const m = content.match(FENCE_CLOSER);
   if (!m) return null;
   const run = m[1];
   return { fenceChar: run[0] as "`" | "~", fenceLen: run.length };
@@ -216,10 +278,7 @@ function applyTablePass(records: Classified[]): void {
 
     // Case A: cur is the header — next line is a separator at same depth.
     const next = records[i + 1];
-    const nextIsSeparator =
-      next &&
-      next.prefixes.length === cur.prefixes.length &&
-      TABLE_SEPARATOR.test(next.content);
+    const nextIsSeparator = next && next.prefixes.length === cur.prefixes.length && TABLE_SEPARATOR.test(next.content);
 
     // Case B: cur is itself a separator.
     const curIsSeparator = TABLE_SEPARATOR.test(cur.content);
@@ -253,23 +312,74 @@ function applyHardBreakPass(records: Classified[]): void {
   }
 }
 
-export function classify(
-  text: string,
-  opts: ClassifyOptions = {},
-): Classified[] {
+export function classify(text: string, opts: ClassifyOptions = {}): Classified[] {
   const classifyOpts = { recognizeDashBullets: false, ...opts };
   const lines = text.replace(/\r\n?/g, "\n").split("\n");
   const out: Classified[] = [];
   let fence: FenceState = null;
+
+  /**
+   * Blockquote depths at which a list-item has appeared since the last blank
+   * line. Maintained incrementally by `push` below so the indented-code branch
+   * can answer "am I inside a list?" in O(1) — rescanning `out` per line made
+   * classification quadratic (188KB of indented code took 10.3s; MAX_INPUT
+   * permits 1MB).
+   */
+  const listDepthsSinceBlank = new Set<number>();
+
+  /**
+   * Per blockquote depth, the smallest content indent (in columns) of a list item
+   * open at that depth. A line must reach this column to be *inside* the item —
+   * testing merely "some list is open and this line starts with whitespace" marked a
+   * one-space root quote as list-nested under a wide marker like `123456789. `.
+   */
+  const listContentColumn = new Map<number, number>();
+
+  const push = (rec: Classified): void => {
+    if (rec.role === "blank" || closesOpenList(rec)) {
+      // A blank line ends a list, and so does a line that starts back at the margin
+      // without being part of one — `1. item` / `root prose` leaves no list open.
+      // Clearing only on blank left the prior item's content column live, so a later
+      // 3-space root quote was wrongly marked list-nested while an adjacent
+      // unindented one was not, splitting one quote paragraph into two groups.
+      listDepthsSinceBlank.clear();
+      listContentColumn.clear();
+    } else if (rec.role === "list-item") {
+      listDepthsSinceBlank.add(rec.prefixes.length);
+      // The MOST RECENT item at this depth governs what counts as "inside a list
+      // item" for the lines that follow it. Keeping the minimum across siblings let a
+      // narrow earlier marker (`1. `, column 3) lower the bar for a later wide one
+      // (`123456789. `, column 11), so a 3-space quote under the wide item was marked
+      // list-nested when it is really a root-level quote.
+      listContentColumn.set(
+        rec.prefixes.length,
+        indentColumns(rec.listIndent ?? "") + (rec.listMarker ?? "").length + (rec.listGap ?? " ").length,
+      );
+    } else if (rec.prefixes.length > 0) {
+      // An INDENTED BLOCKQUOTE reaching an open list item's content column belongs to
+      // that item's block, not to a root-level quote. Scoped to quote records on
+      // purpose: tagging every indented line would also split ordinary list-item
+      // continuations from their item, which must keep reflowing together.
+      //
+      // The indent measured is the whitespace before THIS quote's own marker, taken
+      // from the innermost frame — `>   > alpha` is indented under a list inside the
+      // outer quote, which looking only at the start of `rawPrefix` never saw.
+      const required = listContentColumn.get(rec.prefixes.length - 1);
+      if (required !== undefined && innerQuoteIndentColumns(rec.rawPrefix) >= required) {
+        rec.inListContext = true;
+      }
+    }
+    out.push(rec);
+  };
 
   for (const line of lines) {
     const { prefixes, content, rawPrefix } = peelBlockquotes(line);
 
     // Inside a fence: only allow a matching closer; everything else is in-fence (a blank line still counts as in-fence).
     if (fence) {
-      const fb = classifyFenceBoundary(content);
+      const fb = classifyFenceCloser(content);
       if (fb && fb.fenceChar === fence.char && fb.fenceLen >= fence.len) {
-        out.push({
+        push({
           prefixes,
           role: "fence-boundary",
           content,
@@ -279,21 +389,21 @@ export function classify(
         });
         fence = null;
       } else {
-        out.push({ prefixes, role: "in-fence", content, rawPrefix });
+        push({ prefixes, role: "in-fence", content, rawPrefix });
       }
       continue;
     }
 
     // Outside a fence:
     if (isBlank(content)) {
-      out.push({ prefixes, role: "blank", content, rawPrefix });
+      push({ prefixes, role: "blank", content, rawPrefix });
       continue;
     }
 
     const fb = classifyFenceBoundary(content);
     if (fb) {
       fence = { char: fb.fenceChar, len: fb.fenceLen };
-      out.push({
+      push({
         prefixes,
         role: "fence-boundary",
         content,
@@ -305,23 +415,23 @@ export function classify(
     }
 
     if (HEADING_ATX.test(content)) {
-      out.push({ prefixes, role: "heading-atx", content, rawPrefix });
+      push({ prefixes, role: "heading-atx", content, rawPrefix });
       continue;
     }
 
     if (HR.test(content)) {
-      out.push({ prefixes, role: "hr", content, rawPrefix });
+      push({ prefixes, role: "hr", content, rawPrefix });
       continue;
     }
 
     if (LINK_REF_DEF.test(content)) {
-      out.push({ prefixes, role: "link-ref-def", content, rawPrefix });
+      push({ prefixes, role: "link-ref-def", content, rawPrefix });
       continue;
     }
 
     const li = classifyListItem(content, classifyOpts);
     if (li) {
-      out.push({
+      push({
         prefixes,
         role: "list-item",
         content: li.innerContent,
@@ -342,17 +452,13 @@ export function classify(
     // indented-code, not prose. Both roles are passed through verbatim by wrap/unwrap,
     // so the round-trip output is unaffected — a faithful classifier would need to
     // track open-list state across blanks.
-    if (INDENTED_CODE.test(content)) {
-      const lastBlankIdx =
-        [...out]
-          .map((c, i) => ({ c, i }))
-          .reverse()
-          .find(({ c }) => c.role === "blank")?.i ?? -1;
-      const sinceBlank = out.slice(lastBlankIdx + 1);
-      const inListContext = sinceBlank.some(
-        (c) => c.role === "list-item" && c.prefixes.length === prefixes.length,
-      );
-      out.push({
+    if (isIndentedCode(content)) {
+      // `listDepthsSinceBlank` is maintained incrementally as records are pushed
+      // (see the push sites below), so this is O(1) per line. Copying and
+      // rescanning `out` here instead made classification quadratic: 188KB of
+      // indented code took 10.3s, and MAX_INPUT permits 1MB.
+      const inListContext = listDepthsSinceBlank.has(prefixes.length);
+      push({
         prefixes,
         role: inListContext ? "prose" : "indented-code",
         content,
@@ -362,12 +468,12 @@ export function classify(
     }
 
     if (classifyHtmlBlockStart(content)) {
-      out.push({ prefixes, role: "html-block", content, rawPrefix });
+      push({ prefixes, role: "html-block", content, rawPrefix });
       continue;
     }
 
     // Default:
-    out.push({ prefixes, role: "prose", content, rawPrefix });
+    push({ prefixes, role: "prose", content, rawPrefix });
   }
 
   applySetextPass(out);

--- a/extensions/wrap-unwrap/src/lib/inline.ts
+++ b/extensions/wrap-unwrap/src/lib/inline.ts
@@ -13,8 +13,14 @@
 const INLINE_PATTERNS = [
   /``[\s\S]*?``/g,
   /`[^`\n]+?`/g,
-  /\[[^\]]*?\]\([^)]*?\)/g,
-  /\[[^\]]*?\]\[[^\]]*?\]/g,
+  // Link labels may contain ONE level of nested brackets (`[outer [inner] label]`),
+  // which a flat `[^\]]*?` cannot span — the label then got reflowed mid-link.
+  // Nesting deeper than one level is rare enough to leave unprotected; a fully
+  // recursive match needs a parser, not a regex.
+  // The destination tolerates ONE level of balanced parens — CommonMark allows them,
+  // and stopping at the first ")" split an atomic link across lines.
+  /\[(?:[^[\]]|\[[^[\]]*\])*\]\((?:[^()]|\([^()]*\))*\)/g,
+  /\[(?:[^[\]]|\[[^[\]]*\])*\]\[[^\]]*?\]/g,
   /<(?:https?:\/\/|mailto:)[^>\s]+>/g,
   /<[^\s@<>]+@[^\s@<>]+>/g,
 ];
@@ -29,6 +35,20 @@ const INLINE_PATTERNS = [
 const PLACEHOLDER = String.fromCodePoint(0xe000);
 const RESTORE_PATTERN = new RegExp(`${PLACEHOLDER}(\\d+)${PLACEHOLDER}`, "g");
 
+/**
+ * Second private-use code point, used to escape any sentinel that was ALREADY in
+ * the user's text. Without this, input literally containing `U+E000 0 U+E000` was
+ * read as "token 0" on restore and replaced with unrelated content (or deleted
+ * when the index was out of range) — fabricating text the user never wrote.
+ *
+ * `protectInline` escapes `U+E000` → `U+E001` before allocating any placeholder;
+ * `restoreInline` unescapes last, after all real placeholders are consumed. Any
+ * pre-existing `U+E001` is doubled so the mapping stays reversible.
+ */
+const SENTINEL_ESCAPE = String.fromCodePoint(0xe001);
+const ESCAPE_PATTERN = new RegExp(`[${PLACEHOLDER}${SENTINEL_ESCAPE}]`, "g");
+const UNESCAPE_PATTERN = new RegExp(`${SENTINEL_ESCAPE}([01])`, "g");
+
 export type Protected = {
   protected: string;
   tokens: string[];
@@ -36,7 +56,9 @@ export type Protected = {
 
 export function protectInline(input: string): Protected {
   const tokens: string[] = [];
-  let working = input;
+  // Escape any sentinel already present in the user's text so it can never be
+  // mistaken for one of our placeholders on restore.
+  let working = input.replace(ESCAPE_PATTERN, (ch) => SENTINEL_ESCAPE + (ch === PLACEHOLDER ? "0" : "1"));
   for (const pattern of INLINE_PATTERNS) {
     working = working.replace(pattern, (match) => {
       const idx = tokens.length;
@@ -47,10 +69,20 @@ export function protectInline(input: string): Protected {
   return { protected: working, tokens };
 }
 
+/** Reverse the sentinel escaping applied by `protectInline`. Must run LAST. */
+function unescapeSentinels(input: string): string {
+  return input.replace(UNESCAPE_PATTERN, (_, which) => (which === "0" ? PLACEHOLDER : SENTINEL_ESCAPE));
+}
+
 export function restoreInline(input: string, tokens: string[]): string {
-  if (tokens.length === 0) return input;
-  return input.replace(RESTORE_PATTERN, (_, idxStr) => {
-    const idx = Number.parseInt(idxStr, 10);
-    return tokens[idx] ?? "";
-  });
+  const restored =
+    tokens.length === 0
+      ? input
+      : input.replace(RESTORE_PATTERN, (whole, idxStr) => {
+          const idx = Number.parseInt(idxStr, 10);
+          // An out-of-range index is not ours — leave it verbatim rather than
+          // deleting the user's text.
+          return idx < tokens.length ? tokens[idx] : whole;
+        });
+  return unescapeSentinels(restored);
 }

--- a/extensions/wrap-unwrap/src/lib/pipeline.ts
+++ b/extensions/wrap-unwrap/src/lib/pipeline.ts
@@ -1,12 +1,4 @@
-import {
-  Clipboard,
-  Toast,
-  getSelectedText,
-  launchCommand,
-  popToRoot,
-  showHUD,
-  showToast,
-} from "@raycast/api";
+import { Clipboard, getSelectedText, launchCommand, popToRoot, showHUD, showToast, Toast } from "@raycast/api";
 import type { LaunchProps, LaunchType } from "@raycast/api";
 
 export const MAX_INPUT = 1_000_000;
@@ -51,13 +43,8 @@ async function getSelection(): Promise<string> {
  * Read input from the user's preferred source, falling back to the other.
  * Throws `NoTextError` if neither has text.
  */
-export async function readContent(
-  preferredSource: "selection" | "clipboard",
-): Promise<string> {
-  const [clipboardRaw, selected] = await Promise.all([
-    Clipboard.readText(),
-    getSelection(),
-  ]);
+export async function readContent(preferredSource: "selection" | "clipboard"): Promise<string> {
+  const [clipboardRaw, selected] = await Promise.all([Clipboard.readText(), getSelection()]);
   const clipboard = clipboardRaw ?? "";
   if (preferredSource === "clipboard") {
     if (clipboard) return clipboard;
@@ -75,10 +62,7 @@ export function guardSize(input: string): void {
 }
 
 /** Toast for any failure path. ALWAYS includes Copy Error primaryAction. */
-export async function failureToast(
-  title: string,
-  message: string,
-): Promise<void> {
+export async function failureToast(title: string, message: string): Promise<void> {
   await showToast({
     style: Toast.Style.Failure,
     title,
@@ -92,26 +76,32 @@ export async function failureToast(
   });
 }
 
+/**
+ * Stringify an unknown thrown value for display. `String(value)` throws a
+ * TypeError on a null-prototype object or a Symbol, which would turn a HANDLED
+ * failure into an uncaught one and skip the required Copy-Error toast entirely —
+ * so the conversion itself has to be guarded.
+ */
+function stringifyUnknown(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  try {
+    return String(error);
+  } catch {
+    return "Unknown error";
+  }
+}
+
 /** Maps known error classes to user-facing failure toasts; falls back to `fallbackTitle`. */
-export async function reportFailure(
-  error: unknown,
-  fallbackTitle: string,
-): Promise<void> {
+export async function reportFailure(error: unknown, fallbackTitle: string): Promise<void> {
   if (error instanceof NoTextError) {
-    await failureToast(
-      "No text available",
-      "Select text or copy it to the clipboard.",
-    );
+    await failureToast("No text available", "Select text or copy it to the clipboard.");
     return;
   }
   if (error instanceof OversizeError) {
-    await failureToast(
-      "Text exceeds 1MB limit",
-      "Use a text editor for documents this large.",
-    );
+    await failureToast("Text exceeds 1MB limit", "Use a text editor for documents this large.");
     return;
   }
-  const message = error instanceof Error ? error.message : "Unknown error";
+  const message = stringifyUnknown(error);
   await failureToast(fallbackTitle, message);
 }
 
@@ -163,7 +153,12 @@ export async function deliver<C extends BaseLaunchContext>({
  * positive integer, falling back to 80 on NaN/non-positive input.
  */
 export function parseWidth(raw: string | undefined): number {
-  const n = Number.parseInt(raw ?? "", 10);
+  // Require the WHOLE trimmed value to be digits. `Number.parseInt` accepts a
+  // numeric prefix, so "12px" silently became 12 instead of falling back to 80 as
+  // the preference description promises.
+  const trimmed = (raw ?? "").trim();
+  if (!/^\d+$/.test(trimmed)) return 80;
+  const n = Number.parseInt(trimmed, 10);
   return Number.isFinite(n) && n > 0 ? n : 80;
 }
 

--- a/extensions/wrap-unwrap/src/lib/regex.ts
+++ b/extensions/wrap-unwrap/src/lib/regex.ts
@@ -3,11 +3,44 @@
 /** Single blockquote frame at line start: optional 0-3 spaces, `>`, optional single space. */
 export const BLOCKQUOTE_PEEL = /^ {0,3}> ?/;
 
-/** Fenced code-block opener/closer: backtick or tilde, length ≥ 3. */
+/** Fenced code-block opener: backtick or tilde, length ≥ 3, optional info string. */
 export const FENCE_BOUNDARY = /^ {0,3}(`{3,}|~{3,})/;
 
-/** Indented code: 4+ leading spaces with a non-space body. Empty whitespace-only lines do not match. */
-export const INDENTED_CODE = /^ {4,}\S/;
+/**
+ * Fenced code-block CLOSER: the fence run may be followed only by trailing
+ * whitespace (CommonMark §4.5). A line like ```` ```not-a-closer ```` is an info
+ * string, not a closer — treating it as one would end the block early and expose
+ * its code to reflow.
+ */
+export const FENCE_CLOSER = /^ {0,3}(`{3,}|~{3,})\s*$/;
+
+/**
+ * Indented code: an indent worth 4+ columns with a non-space body, where a TAB
+ * advances to the next 4-column stop (CommonMark §2.2). So a single leading tab
+ * qualifies, as does `"  \t"` (2 spaces + tab → column 4) and any run of tabs.
+ * Empty whitespace-only lines do not match.
+ *
+ * Column width is computed by `indentColumns` rather than matched by a regex —
+ * enumerating tab/space combinations missed cases (`"\t\t"` was treated as prose
+ * and its code reflowed).
+ */
+export const INDENT_RUN = /^[ \t]+(?=\S)/;
+
+/** Expanded display width of an indent run, with tabs advancing to 4-column stops. */
+export function indentColumns(indent: string): number {
+  let col = 0;
+  for (const ch of indent) {
+    if (ch === "\t") col += 4 - (col % 4);
+    else col++;
+  }
+  return col;
+}
+
+/** True when a line's leading whitespace reaches column 4+ (i.e. it is indented code). */
+export function isIndentedCode(content: string): boolean {
+  const m = content.match(INDENT_RUN);
+  return m !== null && indentColumns(m[0]) >= 4;
+}
 
 /** ATX heading: 1-6 `#` followed by whitespace or EOL. */
 export const HEADING_ATX = /^ {0,3}#{1,6}(\s|$)/;
@@ -45,16 +78,29 @@ export const TABLE_SEPARATOR = /^\s*\|?(\s*:?-+:?\s*\|)+\s*:?-+:?\s*\|?\s*$/;
 /** Hard break: 2+ trailing spaces. Apply BEFORE any trim. */
 export const HARD_BREAK_SPACES = / {2,}$/;
 
-/** Hard break: trailing backslash. Caller is responsible for distinguishing escaped literal backslashes (e.g. `foo\\` in source ending with two backslashes) from a true hard-break marker. */
-export const HARD_BREAK_BACKSLASH = /\\$/;
+/**
+ * Hard break: a trailing backslash that is NOT itself escaped. Only an ODD
+ * number of trailing backslashes is a hard break — an even run is a sequence of
+ * escaped literal backslashes (`foo\\` renders as `foo\` with no line break).
+ * The leading `[^\\]|^` anchors the count so parity is measured over the whole run.
+ */
+export const HARD_BREAK_BACKSLASH = /(?:^|[^\\])(?:\\\\)*\\$/;
+
+/** U+00AD SOFT HYPHEN at end of a line — an unambiguous soft line-break marker. */
+export const SOFT_HYPHEN_END = /­$/;
 
 /**
- * Soft hyphen at end of a prose line — a run of lowercase letters immediately
- * before the trailing hyphen, with the run NOT preceded by another letter or
- * a hyphen. Excludes:
- *   - hyphens after capital-led words (e.g. "State-")
- *   - mid-compound breaks (e.g. "state-of-the-")
- *   - hyphens after digits (e.g. "123-")
- * Note: NOT \w, because \w includes digits which we don't want.
+ * A line-break hyphen that binds two halves of one word: an ASCII `-` or a
+ * U+00AD soft hyphen at end of line, preceded by a letter.
+ *
+ * `\p{L}` (Unicode letter) rather than `[A-Za-z]` so accented Latin, Cyrillic,
+ * Greek, and CJK all qualify — an ASCII-only class silently failed to rejoin
+ * `Bindestrich-/Wörter`.
  */
-export const HYPHEN_BREAK_END = /(?:^|[^A-Za-z-])[a-z]+-$/;
+export const HYPHEN_BREAK_END = /[\p{L}\p{Nd}][-­]$/u;
+
+/** A Unicode letter at the start of the next line — the other half of a broken word. */
+export const STARTS_WITH_LETTER = /^\p{L}/u;
+
+/** A digit at the start of the next line (numeric ranges: `5-` + `10`). */
+export const STARTS_WITH_DIGIT = /^\p{Nd}/u;

--- a/extensions/wrap-unwrap/src/lib/unwrap.ts
+++ b/extensions/wrap-unwrap/src/lib/unwrap.ts
@@ -1,6 +1,6 @@
 // src/lib/unwrap.ts
 import { classify, samePrefixStack, type Classified } from "./classify.js";
-import { HYPHEN_BREAK_END } from "./regex.js";
+import { HYPHEN_BREAK_END, SOFT_HYPHEN_END, STARTS_WITH_DIGIT, STARTS_WITH_LETTER } from "./regex.js";
 
 export type UnwrapOptions = {
   hyphenation: boolean;
@@ -18,20 +18,140 @@ const INDENT_STEP = "  ";
 
 const REFLOWABLE_ROLES = new Set<Classified["role"]>(["prose", "list-item"]);
 
-/** Build the prefix string used for re-emission. */
-function emitPrefix(prefixes: Classified["prefixes"]): string {
-  return prefixes.map((p) => (p.spaceAfter ? "> " : ">")).join("");
+/** Whether the text so far ends inside an unterminated code span / link destination. */
+type InlineState = { inCode: boolean; codeFence: number; inDest: boolean; destDepth: number };
+
+const CLOSED: InlineState = { inCode: false, codeFence: 0, inDest: false, destDepth: 0 };
+
+/**
+ * Last few characters of `text`, enough to satisfy `HYPHEN_BREAK_END` (a letter or
+ * digit plus a hyphen).
+ *
+ * Takes 3 UTF-16 code units, not 2, and never splits a surrogate pair: an astral
+ * letter like `𐐀` occupies two code units, so a flat 2-unit tail sliced it in half
+ * and `\p{L}` no longer matched — defeating the Unicode-letter join it exists for.
+ */
+function takeTail(text: string): string {
+  const tail = text.slice(-3);
+  // A leading low surrogate means the slice landed mid-pair; drop the orphan half.
+  const first = tail.charCodeAt(0);
+  return first >= 0xdc00 && first <= 0xdfff ? tail.slice(1) : tail;
 }
 
+/**
+ * Prefix used for re-emission. `rawPrefix` is the verbatim prefix as it appeared
+ * in the input, so it preserves leading indentation (e.g. the 3 spaces in a
+ * list-contained quote `   > text`). Rebuilding from the frame list would drop
+ * that indent and hoist the quote out of its list item.
+ */
+function emitPrefix(rec: Classified): string {
+  return rec.rawPrefix;
+}
+
+/**
+ * Whether a run of text leaves an inline code span or link destination OPEN, given
+ * the state it started in. Computed per LINE and carried forward on the group, so
+ * the cost is linear in the input — rescanning the whole accumulated paragraph at
+ * every join was O(n²) (an 833KB single paragraph took 18s), and a bounded tail
+ * window fixed the speed but sliced tokens in half and got the answer wrong.
+ */
+function advanceInlineState(line: string, openIn: InlineState): InlineState {
+  let inCode = openIn.inCode;
+  // Delimiter length of the currently-open span (1 for `…`, 2 for ``…``). A span is
+  // closed only by a run of the SAME length, so the inner single tick of ``a`b``
+  // is literal content — toggling on it read that span as open and mis-joined the
+  // following prose.
+  let fenceLen = openIn.codeFence;
+  let inDest = openIn.inDest;
+  // Nesting depth of parentheses inside a link destination. CommonMark allows
+  // balanced parens in a URL, so the FIRST ")" is not necessarily the closer —
+  // treating it as one ended the destination early and tight-joined URL data.
+  let destDepth = openIn.destDepth;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    // A backslash escapes the next character, so `\`` and `\]` are literal text and
+    // must not open a code span or link destination. Backslash escapes are inert
+    // INSIDE a code span (CommonMark §6.1), so only honor them outside one.
+    if (ch === "\\" && !inCode && i + 1 < line.length) {
+      i++;
+      continue;
+    }
+    if (inDest) {
+      if (ch === "(") {
+        destDepth++;
+      } else if (ch === ")") {
+        if (destDepth > 0) destDepth--;
+        else inDest = false;
+      }
+      continue;
+    }
+    if (ch === "`") {
+      let run = 1;
+      while (line[i + run] === "`") run++;
+      if (!inCode) {
+        inCode = true;
+        fenceLen = run;
+      } else if (run === fenceLen) {
+        inCode = false;
+        fenceLen = 0;
+      }
+      i += run - 1;
+      continue;
+    }
+    if (inCode) continue;
+    if (ch === "]" && line[i + 1] === "(") {
+      inDest = true;
+      destDepth = 0;
+      i++;
+    }
+  }
+  return { inCode, codeFence: fenceLen, inDest, destDepth };
+}
+
+/**
+ * Join two lines of one reflowed group.
+ *
+ * `priorTail` is the last 2 characters of `prior`, tracked by the caller. Slicing
+ * `prior` here instead would force V8 to flatten the accumulated rope on every
+ * join — measured at 1308ms vs 11ms for 32k lines, and the dominant cost of
+ * unwrapping a long single-paragraph paste.
+ */
 function joinWithHyphenation(
   prior: string,
+  priorTail: string,
   next: string,
   hyphenation: boolean,
-): string {
-  if (hyphenation && HYPHEN_BREAK_END.test(prior) && /^[a-z]/.test(next)) {
-    return prior.slice(0, -1) + next;
+  openIn: InlineState,
+): { joined: string; tail: string } {
+  // `separator` is what goes between the two halves; `drop` is how many chars to
+  // remove from the end of `prior` first. Both are applied ONCE at the end so no
+  // branch slices the accumulated rope.
+  let separator = " ";
+  let drop = 0;
+
+  // Inside an open code span or link URL the hyphen is literal data — keep the
+  // normal space join, so "`foo-\nbar`" stays "`foo- bar`" rather than "`foobar`".
+  if (!openIn.inCode && !openIn.inDest) {
+    // A break hyphen followed by a letter OR digit is word-internal: a soft-wrap
+    // hyphen ("inter-/esting"), a compound that happened to break there
+    // ("well-/known"), or a numeric range ("5-/10"). All rejoin with NO space.
+    const bindsToNext =
+      HYPHEN_BREAK_END.test(priorTail) && (STARTS_WITH_LETTER.test(next) || STARTS_WITH_DIGIT.test(next));
+    if (bindsToNext) {
+      separator = "";
+      // U+00AD exists only to mark a soft break, so it carries no meaning once the
+      // line is rejoined: drop it when the user opted in, keep it when not. An ASCII
+      // "-" is NEVER dropped — it is indistinguishable from a real compound, and
+      // mashing "well-known" into "wellknown" is the worse failure.
+      if (hyphenation && SOFT_HYPHEN_END.test(priorTail)) drop = 1;
+    }
   }
-  return prior + " " + next;
+
+  const keptTail = drop > 0 ? priorTail.slice(0, -drop) : priorTail;
+  const joined = (drop > 0 ? prior.slice(0, prior.length - drop) : prior) + separator + next;
+  // The result's last chars always lie within this short string, so the tail is
+  // derived without ever slicing `joined`.
+  return { joined, tail: takeTail(keptTail + separator + next) };
 }
 
 type Group = {
@@ -39,6 +159,13 @@ type Group = {
   header: Classified;
   /** Concatenated content (with hyphenation already applied as we accumulate). */
   joined: string;
+  /** Inline-token state at the end of `joined`, carried forward so each join is O(line). */
+  inline: InlineState;
+  /**
+   * Last 2 chars of `joined`, tracked separately. Slicing `joined` per join forces
+   * V8 to flatten the accumulated rope — the single biggest cost on a long paste.
+   */
+  tail: string;
   /** True when the group ended with a hard break — emit marker verbatim, then \n. */
   endHardBreak?: "spaces" | "backslash";
   /** True when this group is just a passthrough (preserve-as-is or html). */
@@ -49,13 +176,12 @@ type Group = {
 
 function emitGroup(g: Group): string {
   if (g.passthrough) return g.raw ?? "";
-  const prefix = emitPrefix(g.header.prefixes);
+  const prefix = emitPrefix(g.header);
   if (g.header.role === "list-item") {
     const indent = g.header.listIndent ?? "";
     const marker = g.header.listMarker ?? "-";
     const gap = g.header.listGap ?? " ";
-    const taskPrefix =
-      g.header.taskState !== undefined ? `[${g.header.taskState}] ` : "";
+    const taskPrefix = g.header.taskState !== undefined ? `[${g.header.taskState}] ` : "";
     return `${prefix}${indent}${marker}${gap}${taskPrefix}${g.joined}`;
   }
   return prefix + g.joined;
@@ -63,13 +189,12 @@ function emitGroup(g: Group): string {
 
 export function unwrap(text: string, opts: UnwrapOptions): string {
   if (text === "") return "";
+
   const records = classify(text, {
     recognizeDashBullets: opts.flattenBullets,
   });
 
-  type Output =
-    | { kind: "group"; group: Group }
-    | { kind: "blank"; rawPrefix: string };
+  type Output = { kind: "group"; group: Group } | { kind: "blank"; rawPrefix: string };
   const output: Output[] = [];
 
   let current: Group | null = null;
@@ -99,6 +224,8 @@ export function unwrap(text: string, opts: UnwrapOptions): string {
         group: {
           header: rec,
           joined: "",
+          inline: CLOSED,
+          tail: "",
           passthrough: true,
           raw: rec.rawPrefix + rec.content,
         },
@@ -108,34 +235,38 @@ export function unwrap(text: string, opts: UnwrapOptions): string {
 
     // rec is prose or list-item. Decide: continue current group, or start new.
     let canContinue = false;
-    if (
-      current &&
-      samePrefixStack(rec, current.header) &&
-      !current.endHardBreak
-    ) {
+    if (current && samePrefixStack(rec, current.header) && !current.endHardBreak) {
       if (rec.role === "list-item") {
         // A new list-item starts a new group, even if same prefix.
         canContinue = false;
       } else {
         // rec is prose. Continue if header is prose, or list-item (continuation).
-        canContinue =
-          current.header.role === "prose" ||
-          current.header.role === "list-item";
+        canContinue = current.header.role === "prose" || current.header.role === "list-item";
       }
     }
 
     if (!canContinue) {
       flush();
-      current = { header: rec, joined: rec.content };
+      current = {
+        header: rec,
+        joined: rec.content,
+        inline: advanceInlineState(rec.content, CLOSED),
+        tail: takeTail(rec.content),
+      };
     } else {
       // Continuation lines: strip leading whitespace (indentation is presentation,
       // not content — e.g. list-item hang-indent continuation).
       const continuation = rec.content.replace(/^\s+/, "");
-      current!.joined = joinWithHyphenation(
+      const joinResult = joinWithHyphenation(
         current!.joined,
+        current!.tail,
         continuation,
         opts.hyphenation,
+        current!.inline,
       );
+      current!.joined = joinResult.joined;
+      current!.tail = joinResult.tail;
+      current!.inline = advanceInlineState(continuation, current!.inline);
     }
 
     if (rec.hardBreak) {
@@ -159,9 +290,7 @@ export function unwrap(text: string, opts: UnwrapOptions): string {
         }
       }
       if (headers.length === 0) return;
-      const widths = [
-        ...new Set(headers.map((h) => (h.listIndent ?? "").length)),
-      ].sort((a, b) => a - b);
+      const widths = [...new Set(headers.map((h) => (h.listIndent ?? "").length))].sort((a, b) => a - b);
       const rankOf = new Map(widths.map((w, rank) => [w, rank]));
       for (const h of headers) {
         const rank = rankOf.get((h.listIndent ?? "").length) ?? 0;
@@ -170,10 +299,7 @@ export function unwrap(text: string, opts: UnwrapOptions): string {
     };
     for (let i = 0; i < output.length; i++) {
       const o = output[i];
-      const isListGroup =
-        o.kind === "group" &&
-        !o.group.passthrough &&
-        o.group.header.role === "list-item";
+      const isListGroup = o.kind === "group" && !o.group.passthrough && o.group.header.role === "list-item";
       if (!isListGroup) {
         reindentBlock(blockStart, i);
         blockStart = i + 1;
@@ -188,11 +314,7 @@ export function unwrap(text: string, opts: UnwrapOptions): string {
     const o = output[i];
     if (o.kind === "blank") {
       // Collapse runs unless keepBlankLines is on.
-      if (
-        !opts.keepBlankLines &&
-        lines.length > 0 &&
-        lines[lines.length - 1] === ""
-      ) {
+      if (!opts.keepBlankLines && lines.length > 0 && lines[lines.length - 1] === "") {
         continue;
       }
       lines.push("");
@@ -207,11 +329,7 @@ export function unwrap(text: string, opts: UnwrapOptions): string {
   }
 
   // Trim trailing blank line if we ended on one.
-  while (
-    lines.length > 0 &&
-    lines[lines.length - 1] === "" &&
-    !opts.keepBlankLines
-  ) {
+  while (lines.length > 0 && lines[lines.length - 1] === "" && !opts.keepBlankLines) {
     lines.pop();
   }
 

--- a/extensions/wrap-unwrap/src/lib/wrap.ts
+++ b/extensions/wrap-unwrap/src/lib/wrap.ts
@@ -1,21 +1,36 @@
 // src/lib/wrap.ts
 import { classify, samePrefixStack, type Classified } from "./classify.js";
 import { protectInline, restoreInline } from "./inline.js";
+import { SETEXT_UNDERLINE } from "./regex.js";
 
 export type WrapOptions = {
   width: number;
 };
 
 const MIN_WIDTH = 20;
+
+/**
+ * How many tokens past the break the block-start probe may gather. Whether a line
+ * begins a block is decided by its opening token(s) — a list marker, a fence, an
+ * ATX run, a setext underline — so a handful is always enough, and the cap keeps the
+ * probe O(1) per break regardless of how large `width` is.
+ */
+const BLOCK_PROBE_TOKENS = 8;
 const REFLOWABLE_ROLES = new Set<Classified["role"]>(["prose", "list-item"]);
 
-function emitPrefix(prefixes: Classified["prefixes"]): string {
-  return prefixes.map((p) => (p.spaceAfter ? "> " : ">")).join("");
+/**
+ * Prefix used for re-emission. `rawPrefix` is the verbatim prefix as it appeared
+ * in the input, so it preserves leading indentation (e.g. the 3 spaces in a
+ * list-contained quote `   > text`). Rebuilding from the frame list would drop
+ * that indent and hoist the quote out of its list item.
+ */
+function emitPrefix(rec: Classified): string {
+  return rec.rawPrefix;
 }
 
 /** First-line prefix for a list-item: quote chain + indent + marker + gap + task box. */
 function listItemFirstPrefix(rec: Classified): string {
-  const quote = emitPrefix(rec.prefixes);
+  const quote = emitPrefix(rec);
   const indent = rec.listIndent ?? "";
   const marker = rec.listMarker ?? "-";
   const gap = rec.listGap ?? " ";
@@ -23,18 +38,85 @@ function listItemFirstPrefix(rec: Classified): string {
   return `${quote}${indent}${marker}${gap}${task}`;
 }
 
-/** Continuation prefix for a list-item: quote chain + spaces equal to hangIndent. */
+/**
+ * Continuation prefix for a list-item: quote chain + the item's literal indent +
+ * spaces covering the marker and gap.
+ *
+ * The literal `listIndent` is reused rather than re-padded to `hangIndent` spaces,
+ * because `hangIndent` counts CHARACTERS while a tab renders as a full tab stop —
+ * so `"\t- "` (hangIndent 3) padded as 3 spaces under-indented the continuation and
+ * broke alignment. Reusing the indent verbatim keeps it aligned at any tab width.
+ */
 function listItemContPrefix(rec: Classified): string {
-  const quote = emitPrefix(rec.prefixes);
-  return quote + " ".repeat(rec.hangIndent ?? 2);
+  const quote = emitPrefix(rec);
+  const indent = rec.listIndent ?? "";
+  const marker = rec.listMarker ?? "-";
+  const gap = rec.listGap ?? " ";
+  const task = rec.taskState !== undefined ? "[ ] " : "";
+  return quote + indent + " ".repeat(marker.length + gap.length + task.length);
 }
 
-/** Greedy word fill — returns lines (without prefixes). Tokens are joined with single spaces. */
-function greedyFill(
-  tokens: string[],
-  firstBudget: number,
-  contBudget: number,
-): string[] {
+/**
+ * Display width of an emitted prefix, expanding tabs to 4-column stops. Non-tab
+ * characters count as one column each.
+ */
+function prefixColumns(prefix: string): number {
+  let col = 0;
+  for (const ch of prefix) {
+    if (ch === "\t") col += 4 - (col % 4);
+    else col++;
+  }
+  return col;
+}
+
+/**
+ * True when starting a wrapped line with this token would make the line parse as
+ * something other than continuation prose.
+ *
+ * A literal `-` mid-sentence is the motivating case: breaking before it emits
+ * `"      - delta"`, which re-reads as a NESTED LIST ITEM. Worse, a trailing `>`
+ * re-reads as an empty blockquote and the token is DELETED outright, and `---`
+ * becomes a setext underline. Keeping the token on the previous line (overrunning
+ * the width) is the lesser evil versus corrupting or losing content.
+ *
+ * The check asks the CLASSIFIER whether the resulting line would still be prose,
+ * rather than hand-listing constructs — that list is what missed blockquote and
+ * setext the first time.
+ *
+ * Both forms are probed, because a wrapped line may end at the token or continue
+ * past it, and each form hides constructs the other reveals: `"*** x"` is prose
+ * while a bare `"***"` is a horizontal rule, and `"> x"` is a quote while a bare
+ * `">"` is an empty one.
+ */
+function wouldStartNewBlock(lineText: string): boolean {
+  const token = lineText;
+  // `recognizeDashBullets` must match what wrap() itself passes to classify (the
+  // default, false), or `—`/`–` are treated as bullets here while ordinary
+  // classification calls them prose — bypassing the budget for every em-dash.
+  for (const probeLine of [`${token} x`, token]) {
+    const [probe] = classify(probeLine);
+    if (probe === undefined) continue;
+    // A blockquote marker keeps role "prose" (the role describes the content INSIDE
+    // the quote), so the peeled prefix has to be checked separately. A bare ">" is
+    // the dangerous case: it re-reads as an empty quote and the token is dropped.
+    if (probe.prefixes.length > 0) return true;
+    if (probe.role !== "prose" && probe.role !== "blank") return true;
+  }
+  // A prose line can still be retagged by the setext pass, which needs the FOLLOWING
+  // line to decide. `---`/`===` alone classify as `hr`/`prose` depending on length,
+  // so test the underline shape directly.
+  return SETEXT_UNDERLINE.test(token);
+}
+
+/**
+ * Greedy word fill — returns lines (without prefixes), joined with single spaces.
+ *
+ * A break is only rejected when the line it would PRODUCE misparses. Testing the
+ * next token alone was wrong in both directions: `_` and `___` are individually
+ * harmless but together form the horizontal rule `_ ___`, and holding `***` back
+ * overran the width even when the safe suffix `*** delta` would have been fine.
+ */
+function greedyFill(tokens: string[], firstBudget: number, contBudget: number): string[] {
   if (tokens.length === 0) return [""];
   const lines: string[] = [];
   let cur = tokens[0];
@@ -44,11 +126,32 @@ function greedyFill(
     // +1 for the joining space.
     if (cur.length + 1 + t.length <= curBudget) {
       cur += " " + t;
-    } else {
-      lines.push(cur);
-      cur = t;
-      curBudget = contBudget;
+      continue;
     }
+    // The break would start a new line at token i. Reject it only if the resulting
+    // line parses as something other than prose; then keep the token here and
+    // overrun instead. Only the tokens that would actually LAND on that line are
+    // gathered — slicing all remaining tokens made this quadratic (1MB took 32s).
+    //
+    // The probe is bounded by a token COUNT as well as the budget. What makes a line
+    // start a block is decided by its first token or two (a marker, a fence, an
+    // underline run); no construct needs thousands of characters to recognize. Using
+    // the budget alone made the scan O(width) per break, so a large Wrap Column with
+    // a run of unsafe tokens was quadratic again — 20k dashes at width 20000 took
+    // 4048ms. `width` has no upper bound: a cross-extension launchContext supplies it
+    // directly, bypassing parseWidth entirely.
+    let probeLine = t;
+    for (let j = i + 1; j < tokens.length && j - i <= BLOCK_PROBE_TOKENS; j++) {
+      if (probeLine.length + 1 + tokens[j].length > contBudget) break;
+      probeLine += " " + tokens[j];
+    }
+    if (wouldStartNewBlock(probeLine)) {
+      cur += " " + t;
+      continue;
+    }
+    lines.push(cur);
+    cur = t;
+    curBudget = contBudget;
   }
   lines.push(cur);
   return lines;
@@ -60,11 +163,10 @@ function tokenizeContent(content: string): string[] {
 
 export function wrap(text: string, opts: WrapOptions): string {
   if (text === "") return "";
-  const widthRaw =
-    Number.isFinite(opts.width) && opts.width > 0 ? opts.width : 80;
+  const widthRaw = Number.isFinite(opts.width) && opts.width > 0 ? opts.width : 80;
   const width = Math.max(MIN_WIDTH, widthRaw);
 
-  const records = classify(text, { recognizeDashBullets: false });
+  const records = classify(text);
   const out: string[] = [];
 
   let i = 0;
@@ -91,7 +193,7 @@ export function wrap(text: string, opts: WrapOptions): string {
       firstPrefix = listItemFirstPrefix(rec);
       contPrefix = listItemContPrefix(rec);
     } else {
-      firstPrefix = emitPrefix(rec.prefixes);
+      firstPrefix = emitPrefix(rec);
       contPrefix = firstPrefix;
     }
 
@@ -117,22 +219,18 @@ export function wrap(text: string, opts: WrapOptions): string {
     // (tokenization would drop trailing spaces anyway, and a trailing backslash
     // would otherwise cling to the last token), then re-append it to the last
     // emitted line.
-    const hardBreakSuffix =
-      endsWithHardBreak === "spaces"
-        ? "  "
-        : endsWithHardBreak === "backslash"
-          ? "\\"
-          : "";
+    const hardBreakSuffix = endsWithHardBreak === "spaces" ? "  " : endsWithHardBreak === "backslash" ? "\\" : "";
     const fillInput =
-      hardBreakSuffix.length > 0
-        ? combined.slice(0, combined.length - hardBreakSuffix.length)
-        : combined;
+      hardBreakSuffix.length > 0 ? combined.slice(0, combined.length - hardBreakSuffix.length) : combined;
 
     // Protect inline tokens, tokenize, fill, restore.
     const { protected: prot, tokens } = protectInline(fillInput);
     const wordTokens = tokenizeContent(prot);
-    const firstBudget = Math.max(1, width - firstPrefix.length);
-    const contBudget = Math.max(1, width - contPrefix.length);
+    // Budgets are computed from DISPLAY width, not character count: a tab is one
+    // character but advances to a 4-column stop, so `.length` under-counted a
+    // tab-indented prefix and the wrapped line overran the requested column.
+    const firstBudget = Math.max(1, width - prefixColumns(firstPrefix));
+    const contBudget = Math.max(1, width - prefixColumns(contPrefix));
     const filled = greedyFill(wordTokens, firstBudget, contBudget);
     const lastIdx = filled.length - 1;
     const lines = filled.map((line, idx) => {

--- a/extensions/wrap-unwrap/src/unwrap-text.ts
+++ b/extensions/wrap-unwrap/src/unwrap-text.ts
@@ -1,10 +1,10 @@
 import { getPreferenceValues } from "@raycast/api";
 import {
-  type BaseLaunchContext,
   deliver,
   guardSize,
   readContent,
   reportFailure,
+  type BaseLaunchContext,
   type LaunchProps,
 } from "./lib/pipeline.js";
 import { unwrap } from "./lib/unwrap.js";
@@ -15,19 +15,14 @@ type UnwrapContext = BaseLaunchContext & {
   flattenBullets?: boolean;
 };
 
-export default async function Command(
-  props: LaunchProps<{ launchContext?: UnwrapContext }>,
-) {
+export default async function Command(props: LaunchProps<{ launchContext?: UnwrapContext }>) {
   const prefs = getPreferenceValues<Preferences.UnwrapText>();
   try {
-    const input =
-      props.launchContext?.text ?? (await readContent(prefs.source));
+    const input = props.launchContext?.text ?? (await readContent(prefs.source));
     guardSize(input);
     const hyphenation = props.launchContext?.hyphenation ?? prefs.hyphenation;
-    const keepBlankLines =
-      props.launchContext?.keepBlankLines ?? prefs.keepBlankLines;
-    const flattenBullets =
-      props.launchContext?.flattenBullets ?? prefs.flattenBullets;
+    const keepBlankLines = props.launchContext?.keepBlankLines ?? prefs.keepBlankLines;
+    const flattenBullets = props.launchContext?.flattenBullets ?? prefs.flattenBullets;
     const result = unwrap(input, {
       hyphenation,
       keepBlankLines,

--- a/extensions/wrap-unwrap/src/wrap-text.ts
+++ b/extensions/wrap-unwrap/src/wrap-text.ts
@@ -1,11 +1,11 @@
 import { getPreferenceValues } from "@raycast/api";
 import {
-  type BaseLaunchContext,
   deliver,
   guardSize,
   parseWidth,
   readContent,
   reportFailure,
+  type BaseLaunchContext,
   type LaunchProps,
 } from "./lib/pipeline.js";
 import { wrap } from "./lib/wrap.js";
@@ -14,13 +14,10 @@ type WrapContext = BaseLaunchContext & {
   width?: number;
 };
 
-export default async function Command(
-  props: LaunchProps<{ launchContext?: WrapContext }>,
-) {
+export default async function Command(props: LaunchProps<{ launchContext?: WrapContext }>) {
   const prefs = getPreferenceValues<Preferences.WrapText>();
   try {
-    const input =
-      props.launchContext?.text ?? (await readContent(prefs.source));
+    const input = props.launchContext?.text ?? (await readContent(prefs.source));
     guardSize(input);
     const width = props.launchContext?.width ?? parseWidth(prefs.width);
     const result = wrap(input, { width });

--- a/extensions/wrap-unwrap/test/inline.test.ts
+++ b/extensions/wrap-unwrap/test/inline.test.ts
@@ -20,15 +20,10 @@ test("protectInline handles double-backtick spans", () => {
 });
 
 test("protectInline replaces inline links", () => {
-  const { protected: p, tokens } = protectInline(
-    "see [the docs](https://example.com/a b) now",
-  );
+  const { protected: p, tokens } = protectInline("see [the docs](https://example.com/a b) now");
   assert.equal(tokens.length, 1);
   assert.equal(tokens[0], "[the docs](https://example.com/a b)");
-  assert.equal(
-    restoreInline(p, tokens),
-    "see [the docs](https://example.com/a b) now",
-  );
+  assert.equal(restoreInline(p, tokens), "see [the docs](https://example.com/a b) now");
 });
 
 test("protectInline replaces reference links", () => {
@@ -39,9 +34,7 @@ test("protectInline replaces reference links", () => {
 });
 
 test("protectInline replaces autolinks", () => {
-  const { protected: p, tokens } = protectInline(
-    "ping <https://example.com> please",
-  );
+  const { protected: p, tokens } = protectInline("ping <https://example.com> please");
   assert.equal(tokens.length, 1);
   assert.equal(tokens[0], "<https://example.com>");
   assert.equal(restoreInline(p, tokens), "ping <https://example.com> please");

--- a/extensions/wrap-unwrap/test/regex.test.ts
+++ b/extensions/wrap-unwrap/test/regex.test.ts
@@ -4,7 +4,8 @@ import assert from "node:assert/strict";
 import {
   BLOCKQUOTE_PEEL,
   FENCE_BOUNDARY,
-  INDENTED_CODE,
+  indentColumns,
+  isIndentedCode,
   HEADING_ATX,
   SETEXT_UNDERLINE,
   HR,
@@ -31,11 +32,17 @@ test("FENCE_BOUNDARY matches both backtick and tilde fences", () => {
   assert.doesNotMatch("    ```", FENCE_BOUNDARY); // 4 spaces = code block, not fence
 });
 
-test("INDENTED_CODE matches 4+ leading spaces", () => {
-  assert.match("    code", INDENTED_CODE);
-  assert.match("        deeper", INDENTED_CODE);
-  assert.doesNotMatch("   not code", INDENTED_CODE); // only 3 spaces
-  assert.doesNotMatch("    ", INDENTED_CODE); // no body
+test("isIndentedCode recognizes an indent reaching column 4, tabs included", () => {
+  assert.ok(isIndentedCode("    code"));
+  assert.ok(isIndentedCode("        deeper"));
+  // A tab advances to the next 4-column stop (CommonMark §2.2).
+  assert.ok(isIndentedCode("\tcode"), "one tab = column 4");
+  assert.ok(isIndentedCode("\t\tcode"), "two tabs = column 8");
+  assert.ok(isIndentedCode("  \tcode"), "2 spaces + tab = column 4");
+  assert.ok(isIndentedCode("   \tcode"), "3 spaces + tab = column 4");
+  assert.ok(isIndentedCode(" \t\tcode"), "space + 2 tabs = column 8");
+  assert.ok(!isIndentedCode("   not code"), "only 3 spaces");
+  assert.ok(!isIndentedCode("    "), "no body"); // whitespace only
 });
 
 test("HEADING_ATX matches ATX headings 1-6", () => {
@@ -121,11 +128,30 @@ test("HARD_BREAK_BACKSLASH matches single trailing backslash", () => {
   assert.doesNotMatch("foo", HARD_BREAK_BACKSLASH);
 });
 
-test("HYPHEN_BREAK_END matches lowercase letter + hyphen at end", () => {
+test("HYPHEN_BREAK_END matches a letter or digit followed by a break hyphen", () => {
   assert.match("inter-", HYPHEN_BREAK_END);
-  assert.doesNotMatch("State-", HYPHEN_BREAK_END); // capital before hyphen
-  assert.doesNotMatch("123-", HYPHEN_BREAK_END);
+  // Case, hyphen chains, and digits all bind to the next line now: the join is
+  // always tight, and only a U+00AD is ever stripped, so none of these need
+  // excluding. Previously they were, which is why "well-known" was mashed.
+  assert.match("State-", HYPHEN_BREAK_END);
+  assert.match("state-of-the-", HYPHEN_BREAK_END);
+  assert.match("123-", HYPHEN_BREAK_END);
+  // Unicode letters qualify (an ASCII-only class failed to rejoin these).
+  assert.match("Wörter-", HYPHEN_BREAK_END);
+  assert.match("Бинде-", HYPHEN_BREAK_END);
+  // A true soft hyphen also counts as a break hyphen.
+  assert.match("hy­", HYPHEN_BREAK_END);
+  // No trailing hyphen, or no letter/digit before it.
   assert.doesNotMatch("inter", HYPHEN_BREAK_END);
-  // Mid-compound break: `the` run is preceded by `-`, so excluded.
-  assert.doesNotMatch("state-of-the-", HYPHEN_BREAK_END);
+  assert.doesNotMatch(" -", HYPHEN_BREAK_END);
+});
+
+test("indentColumns expands tabs to 4-column stops", () => {
+  assert.equal(indentColumns("\t"), 4);
+  assert.equal(indentColumns(" \t"), 4, "a tab advances to the NEXT stop, not by 4");
+  assert.equal(indentColumns("   \t"), 4);
+  assert.equal(indentColumns("\t "), 5);
+  assert.equal(indentColumns("\t\t"), 8);
+  assert.equal(indentColumns("    "), 4);
+  assert.equal(indentColumns("   "), 3);
 });

--- a/extensions/wrap-unwrap/test/unwrap.test.ts
+++ b/extensions/wrap-unwrap/test/unwrap.test.ts
@@ -25,10 +25,7 @@ test("unwrap collapses multiple blank lines by default", () => {
 
 test("unwrap preserves blank-line runs when keepBlankLines is on", () => {
   const input = "alpha\n\n\nbeta";
-  assert.equal(
-    unwrap(input, { ...dflt, keepBlankLines: true }),
-    "alpha\n\n\nbeta",
-  );
+  assert.equal(unwrap(input, { ...dflt, keepBlankLines: true }), "alpha\n\n\nbeta");
 });
 
 test("unwrap leaves fenced code untouched", () => {
@@ -56,47 +53,60 @@ test("unwrap merges list-item continuation lines", () => {
   assert.equal(unwrap(input, dflt), "- item one continues\n- item two");
 });
 
-test("unwrap strips soft hyphens when enabled", () => {
+test("unwrap keeps an ASCII hyphen at a break, joining tight (strip ON)", () => {
+  // ON strips only a true U+00AD soft hyphen. An ASCII "-" is indistinguishable
+  // from a real compound ("well-/known"), so it is preserved and the halves are
+  // joined with no space. See the R3 tests for the U+00AD behavior.
   const input = "an inter-\nesting word";
-  assert.equal(
-    unwrap(input, { ...dflt, hyphenation: true }),
-    "an interesting word",
-  );
+  assert.equal(unwrap(input, { ...dflt, hyphenation: true }), "an inter-esting word");
 });
 
 test("unwrap leaves single-line compounds alone (not split, no hyphenation runs)", () => {
   const input = "state-of-the-art";
-  assert.equal(
-    unwrap(input, { ...dflt, hyphenation: true }),
-    "state-of-the-art",
-  );
+  assert.equal(unwrap(input, { ...dflt, hyphenation: true }), "state-of-the-art");
 });
 
-test("unwrap preserves capital-led split words (no strip, but joined with space)", () => {
-  // The hyphen rule excludes capital-led runs. The hyphen stays; lines join with a space.
+test("unwrap rejoins a hyphen-then-letter break with NO space (capital-led, not stripped)", () => {
+  // A hyphen at the break followed by a letter is a word-internal break: rejoin
+  // with no space. Capital-led runs aren't treated as soft, so the hyphen stays —
+  // but the dangling "State- wide" space was a bug. Correct: "State-wide".
   const input = "A State-\nwide policy";
-  assert.equal(
-    unwrap(input, { ...dflt, hyphenation: true }),
-    "A State- wide policy",
-  );
+  assert.equal(unwrap(input, { ...dflt, hyphenation: true }), "A State-wide policy");
 });
 
-test("unwrap mid-compound break — known v1 limitation: gains a space", () => {
-  // The hyphen rule excludes mid-compound breaks (lowercase run preceded by `-`).
-  // The hyphen stays; lines join with a space. Documented limitation.
+test("unwrap rejoins a mid-compound break with NO space and no strip", () => {
+  // state-of-the- + art is a hyphen chain; stripping the trailing hyphen would
+  // mash "the"+"art". So keep the hyphen, but rejoin with no space.
   const input = "the state-of-the-\nart";
-  assert.equal(
-    unwrap(input, { ...dflt, hyphenation: true }),
-    "the state-of-the- art",
-  );
+  assert.equal(unwrap(input, { ...dflt, hyphenation: true }), "the state-of-the-art");
 });
 
-test("unwrap with hyphenation off keeps the hyphen verbatim", () => {
+test("unwrap real compound rejoins with no space, hyphen kept (strip ON)", () => {
+  // "well-known" split at the break: the hyphen is KEPT even with strip ON, because
+  // an ASCII hyphen can't be told from a real compound — destroying "well-known"
+  // into "wellknown" is the worse failure. Only U+00AD is ever stripped.
+  const input = "a well-\nknown fact";
+  assert.equal(unwrap(input, { ...dflt, hyphenation: true }), "a well-known fact");
+});
+
+test("unwrap with hyphenation off keeps the hyphen and rejoins with NO space", () => {
+  // OFF = don't strip. A hyphen-then-letter break still rejoins with no space:
+  // "inter-esting", not "inter- esting".
   const input = "an inter-\nesting word";
-  assert.equal(
-    unwrap(input, { ...dflt, hyphenation: false }),
-    "an inter- esting word",
-  );
+  assert.equal(unwrap(input, { ...dflt, hyphenation: false }), "an inter-esting word");
+});
+
+test("unwrap with hyphenation off preserves a real compound across the break", () => {
+  const input = "a well-\nknown fact";
+  assert.equal(unwrap(input, { ...dflt, hyphenation: false }), "a well-known fact");
+});
+
+test("unwrap word-joins a hyphen followed by a digit (number range)", () => {
+  // A hyphen-broken numeric range is one token: "5-\n10" is "5-10", never "5- 10".
+  // The hyphen is kept (never stripped), so no range is mashed into "510".
+  const input = "range 5-\n10 items";
+  assert.equal(unwrap(input, dflt), "range 5-10 items");
+  assert.equal(unwrap("call 555-\n1234 now", dflt), "call 555-1234 now");
 });
 
 test("unwrap protects inline code from joins", () => {
@@ -106,10 +116,7 @@ test("unwrap protects inline code from joins", () => {
 
 test("unwrap protects inline links", () => {
   const input = "go to [the docs](https://x.test/a b)\nplease";
-  assert.equal(
-    unwrap(input, dflt),
-    "go to [the docs](https://x.test/a b) please",
-  );
+  assert.equal(unwrap(input, dflt), "go to [the docs](https://x.test/a b) please");
 });
 
 test("unwrap preserves hard-break-terminated lines", () => {
@@ -143,10 +150,7 @@ test("flattenBullets normalizes leading-space bullets to a 2-space step", () => 
   // pasted with 3 leading spaces. Without the option they round-trip
   // verbatim; with it the sub-bullets normalize to depth 1 (2 spaces).
   const input = "1. ITC details\n   - cost basis?\n   - pass-through?";
-  assert.equal(
-    unwrap(input, { ...dflt, flattenBullets: true }),
-    "1. ITC details\n  - cost basis?\n  - pass-through?",
-  );
+  assert.equal(unwrap(input, { ...dflt, flattenBullets: true }), "1. ITC details\n  - cost basis?\n  - pass-through?");
 });
 
 test("flattenBullets is off by default (indentation preserved)", () => {
@@ -156,43 +160,209 @@ test("flattenBullets is off by default (indentation preserved)", () => {
 
 test("flattenBullets maps three indent levels to 0/2/4 spaces", () => {
   const input = "- a\n   - b\n      - c";
-  assert.equal(
-    unwrap(input, { ...dflt, flattenBullets: true }),
-    "- a\n  - b\n    - c",
-  );
+  assert.equal(unwrap(input, { ...dflt, flattenBullets: true }), "- a\n  - b\n    - c");
 });
 
 test("flattenBullets recomputes depth per contiguous list block", () => {
   // Two blocks separated by a blank line; the second uses different raw
   // indentation but its shallowest item must still land at column 0.
   const input = "- a\n   - b\n\n     - c\n        - d";
-  assert.equal(
-    unwrap(input, { ...dflt, flattenBullets: true }),
-    "- a\n  - b\n\n- c\n  - d",
-  );
+  assert.equal(unwrap(input, { ...dflt, flattenBullets: true }), "- a\n  - b\n\n- c\n  - d");
 });
 
 test("flattenBullets handles Unicode bullet markers", () => {
   const input = "  • alpha\n  • beta";
-  assert.equal(
-    unwrap(input, { ...dflt, flattenBullets: true }),
-    "• alpha\n• beta",
-  );
+  assert.equal(unwrap(input, { ...dflt, flattenBullets: true }), "• alpha\n• beta");
 });
 
 test("flattenBullets flattens an over-indented single-level list to col 0", () => {
   const input = "     - only\n     - level";
-  assert.equal(
-    unwrap(input, { ...dflt, flattenBullets: true }),
-    "- only\n- level",
-  );
+  assert.equal(unwrap(input, { ...dflt, flattenBullets: true }), "- only\n- level");
 });
 
 test("em-dash lines stay prose unless flattenBullets is enabled", () => {
   const input = "— first\n— second";
   assert.equal(unwrap(input, dflt), "— first — second");
+  assert.equal(unwrap(input, { ...dflt, flattenBullets: true }), "— first\n— second");
+});
+
+// ─── Review findings (2026-07-25 adversarial review) ────────────────────────
+
+test("R1 unwrap does not corrupt a literal hyphen inside a code span", () => {
+  assert.equal(unwrap("`foo-\nbar`", dflt), "`foo- bar`");
+});
+
+test("R1 unwrap does not corrupt a literal hyphen inside a link URL", () => {
   assert.equal(
-    unwrap(input, { ...dflt, flattenBullets: true }),
-    "— first\n— second",
+    unwrap("[docs](https://example.test/foo-\nbar)", dflt),
+    "[docs](https://example.test/foo- bar)",
+  );
+});
+
+test("R2 unwrap rejoins a hyphen break before a non-ASCII letter", () => {
+  assert.equal(unwrap("co-\növerse", { ...dflt, hyphenation: false }), "co-överse");
+  assert.equal(unwrap("Bindestrich-\nWörter", { ...dflt, hyphenation: false }), "Bindestrich-Wörter");
+});
+
+test("R3 unwrap strips a true Unicode soft hyphen (U+00AD) when ON", () => {
+  assert.equal(unwrap("hy­\nphen", { ...dflt, hyphenation: true }), "hyphen");
+});
+
+test("R3 unwrap keeps a Unicode soft hyphen when OFF", () => {
+  assert.equal(unwrap("hy­\nphen", { ...dflt, hyphenation: false }), "hy­phen");
+});
+
+test("R4 unwrap joins a hyphenated numeric range with no space", () => {
+  assert.equal(unwrap("range 5-\n10 items", dflt), "range 5-10 items");
+  assert.equal(unwrap("call 555-\n1234 now", dflt), "call 555-1234 now");
+});
+
+test("R-policy: ASCII hyphen at a break is never stripped, always joined tight", () => {
+  assert.equal(unwrap("a well-\nknown fact", { ...dflt, hyphenation: true }), "a well-known fact");
+  assert.equal(unwrap("an inter-\nesting word", { ...dflt, hyphenation: true }), "an inter-esting word");
+  assert.equal(unwrap("the state-of-the-\nart", { ...dflt, hyphenation: true }), "the state-of-the-art");
+});
+
+test("H1 unwrap preserves indentation before a blockquote inside a list item", () => {
+  const input = "1. list item\n   > alpha beta";
+  assert.equal(unwrap(input, dflt), "1. list item\n   > alpha beta");
+});
+
+test("H3 unwrap treats a tab-indented line as code, not prose", () => {
+  assert.equal(unwrap("\tcode line\nnext line", dflt), "\tcode line\nnext line");
+});
+
+test("L1 unwrap does not treat an even run of trailing backslashes as a hard break", () => {
+  assert.equal(unwrap("literal\\\\\nnext", dflt), "literal\\\\ next");
+});
+
+test("inline-token guard uses span structure, not backtick parity", () => {
+  // A closed ``a`b`` span must not read as open (its inner tick is content), so the
+  // following prose hyphen still joins tight.
+  assert.equal(unwrap("``a`b`` word-\nnext", dflt), "``a`b`` word-next");
+  // An open span after any number of closed ones must still be detected.
+  assert.equal(unwrap("`a` `b` `foo-\nbar`", dflt), "`a` `b` `foo- bar`");
+  assert.equal(unwrap("``x`` `foo-\nbar`", dflt), "``x`` `foo- bar`");
+});
+
+test("unwrap stays linear on a long single-paragraph paste", () => {
+  // Regression guard for two O(n²) traps, both of which made a legal <=1MB paste
+  // hang Raycast for seconds: rescanning the accumulated paragraph with an anchored
+  // regex, and slicing it per join (which forces V8 to flatten the rope).
+  const lines = 20_000;
+  const input = Array.from({ length: lines }, (_, i) => `word${i} filler text here`).join("\n");
+  const started = process.hrtime.bigint();
+  const out = unwrap(input, dflt);
+  const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+  assert.equal(out.split("\n").length, 1, "should collapse to a single paragraph");
+  // Generous bound: the linear implementation runs in ~15ms, the quadratic one took
+  // >1000ms at this size. Anything near the ceiling means a rope-flattening slice or
+  // full-accumulator regex came back.
+  assert.ok(elapsedMs < 400, `unwrap took ${elapsedMs.toFixed(0)}ms — quadratic path likely reintroduced`);
+});
+
+test("unwrap rejoins across an astral (surrogate-pair) letter", () => {
+  // The tail tracked for the hyphen test must not split a surrogate pair, or
+  // \p{L} stops matching and the tight join is lost.
+  assert.equal(unwrap("𐐀-\nword", { ...dflt, hyphenation: false }), "𐐀-word");
+  assert.equal(unwrap("𐐀-\n𐐀", { ...dflt, hyphenation: false }), "𐐀-𐐀");
+});
+
+test("unwrap keeps a hyphen literal inside a URL with balanced parens", () => {
+  // CommonMark allows balanced parens in a destination, so the first ")" is not
+  // the closer — treating it as one tight-joined real URL data.
+  assert.equal(
+    unwrap("[a](https://x.test/(foo)bar-\nword)", dflt),
+    "[a](https://x.test/(foo)bar- word)",
+  );
+});
+
+test("unwrap rejoins continuations under a no-space blockquote marker", () => {
+  // wrap() emits a ">"-quoted list item's continuation as ">  text" (marker + hang
+  // indent). Re-reading that, BLOCKQUOTE_PEEL greedily eats one space, so the
+  // continuation looked like ">"+space while the header was bare ">" — different
+  // prefix stacks, so the lines were never rejoined.
+  assert.equal(
+    unwrap(">- alpha beta\n>  gamma delta", dflt),
+    ">- alpha beta gamma delta",
+  );
+  // Plain prose under a bare ">" must still rejoin.
+  assert.equal(unwrap(">alpha\n>beta", dflt), ">alpha beta");
+});
+
+test("unwrap keeps genuinely different blockquote depths apart", () => {
+  // The relaxation above must not merge across a real depth change.
+  assert.equal(unwrap(">outer\n>> inner", dflt), ">outer\n>> inner");
+});
+
+test("unwrap keeps a list-nested blockquote separate from a root-level one", () => {
+  // Indentation before the marker is structural: "   > x" is inside the list item,
+  // "> x" is a root-level quote. Same frame depth, different blocks.
+  assert.equal(unwrap("1. outer\n   > alpha\n> beta", dflt), "1. outer\n   > alpha\n> beta");
+  // Same indent still merges.
+  assert.equal(unwrap("1. outer\n   > alpha\n   > beta", dflt), "1. outer\n   > alpha beta");
+});
+
+test("unwrap ignores escaped inline delimiters when deciding a join", () => {
+  // A backslash-escaped backtick or "](" is literal text and must not leave the
+  // inline state open, which would suppress the tight hyphen join.
+  assert.equal(unwrap("literal \\`tick word-\nnext", dflt), "literal \\`tick word-next");
+  assert.equal(unwrap("literal \\](x word-\nnext", dflt), "literal \\](x word-next");
+});
+
+test("unwrap merges a blockquote whose marker indent varies within 0-3 spaces", () => {
+  // CommonMark allows 0-3 spaces before a quote marker, so these are one quote.
+  assert.equal(unwrap(" > alpha beta\n  > gamma delta", dflt), " > alpha beta gamma delta");
+  assert.equal(unwrap("> alpha\n   > beta", dflt), "> alpha beta");
+});
+
+test("a quote is only list-nested if it reaches the item's content column", () => {
+  // "123456789. " puts content at column 11, so a one-space "> alpha" is a legal
+  // ROOT blockquote and must merge with the "> gamma" that follows.
+  assert.equal(
+    unwrap("123456789. item\n > alpha beta\n> gamma delta", dflt),
+    "123456789. item\n > alpha beta gamma delta",
+  );
+  // A 3-space quote under "1. " (content column 3) IS inside the item.
+  assert.equal(unwrap("1. outer\n   > alpha\n> beta", dflt), "1. outer\n   > alpha\n> beta");
+});
+
+test("a quote nested in a list inside a quote stays distinct from the outer root", () => {
+  // Prefix ">   > " is indented under the list item within the outer quote; looking
+  // only at the first character of the prefix never saw that.
+  assert.equal(
+    unwrap("> - item\n>   > alpha beta\n> > gamma delta", dflt),
+    "> - item\n>   > alpha beta\n> > gamma delta",
+  );
+});
+
+test("the governing list item is the most recent one, not the narrowest sibling", () => {
+  // A narrow earlier marker ("1. ", column 3) must not lower the bar for a later
+  // wide one ("123456789. ", column 11): the 3-space quote is root-level there.
+  assert.equal(
+    unwrap("1. short\n123456789. wide\n   > alpha beta\n> gamma delta", dflt),
+    "1. short\n123456789. wide\n   > alpha beta gamma delta",
+  );
+});
+
+test("root prose closes an open list for blockquote grouping", () => {
+  // A line back at the margin ends a list just as a blank line does. Clearing the
+  // list-context state only on blank left the prior item's content column live, so a
+  // 3-space root quote was marked list-nested while the unindented quote after it was
+  // not — splitting one root blockquote paragraph into two groups.
+  assert.equal(
+    unwrap("1. item\nroot prose closes the list\n   > alpha beta\n> gamma delta", dflt),
+    "1. item root prose closes the list\n   > alpha beta gamma delta",
+  );
+  // A heading closes it too.
+  assert.equal(unwrap("1. item\n# H\n   > alpha\n> beta", dflt), "1. item\n# H\n   > alpha beta");
+});
+
+test("an indented continuation does NOT close the list", () => {
+  // Lazy continuations belong to the open item and must keep it open, or the quote
+  // that follows would wrongly merge with a root-level one.
+  assert.equal(
+    unwrap("1. item\n   continues here\n   > alpha\n> beta", dflt),
+    "1. item continues here\n   > alpha\n> beta",
   );
 });

--- a/extensions/wrap-unwrap/test/wrap.test.ts
+++ b/extensions/wrap-unwrap/test/wrap.test.ts
@@ -1,5 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { unwrap } from "../src/lib/unwrap.js";
 import { wrap } from "../src/lib/wrap.js";
 
 const W = (n: number) => ({ width: n });
@@ -9,22 +10,17 @@ test("wrap returns short input unchanged", () => {
 });
 
 test("wrap respects column budget on plain prose", () => {
-  const input =
-    "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda";
+  const input = "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda";
   const out = wrap(input, W(20));
   for (const line of out.split("\n")) {
-    assert.ok(
-      line.length <= 20,
-      `line too long: ${line.length} chars: ${JSON.stringify(line)}`,
-    );
+    assert.ok(line.length <= 20, `line too long: ${line.length} chars: ${JSON.stringify(line)}`);
   }
   // round trip: joining lines with a space gives back the input
   assert.equal(out.split("\n").join(" "), input);
 });
 
 test("wrap leaves fenced code untouched even when long", () => {
-  const longCode =
-    "this_is_a_very_long_line_inside_a_code_fence_that_should_not_be_wrapped";
+  const longCode = "this_is_a_very_long_line_inside_a_code_fence_that_should_not_be_wrapped";
   const input = "```\n" + longCode + "\n```";
   const out = wrap(input, W(40));
   assert.ok(out.includes(longCode));
@@ -41,10 +37,7 @@ test("wrap respects width INCLUDING blockquote prefix", () => {
   const out = wrap(input, W(20));
   for (const line of out.split("\n")) {
     assert.ok(line.length <= 20, `line too long: ${JSON.stringify(line)}`);
-    assert.ok(
-      line.startsWith("> "),
-      `lost quote prefix: ${JSON.stringify(line)}`,
-    );
+    assert.ok(line.startsWith("> "), `lost quote prefix: ${JSON.stringify(line)}`);
   }
 });
 
@@ -58,10 +51,7 @@ test("wrap respects width INCLUDING list marker + hang", () => {
   // First line starts with "- "; continuations indent 2 spaces.
   assert.ok(lines[0].startsWith("- "));
   for (let i = 1; i < lines.length; i++) {
-    assert.ok(
-      lines[i].startsWith("  "),
-      `continuation lacks hang: ${JSON.stringify(lines[i])}`,
-    );
+    assert.ok(lines[i].startsWith("  "), `continuation lacks hang: ${JSON.stringify(lines[i])}`);
   }
 });
 
@@ -79,8 +69,7 @@ test("wrap never breaks inside an inline link", () => {
 });
 
 test("wrap with width<20 clamps to 20", () => {
-  const input =
-    "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda";
+  const input = "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda";
   const out = wrap(input, { width: 5 });
   for (const line of out.split("\n")) {
     assert.ok(line.length <= 20, `line too long: ${line.length}`);
@@ -95,10 +84,7 @@ test("wrap emits oversized token alone (no mid-word break)", () => {
   assert.ok(out.includes(tok));
   for (const line of out.split("\n")) {
     if (!line.includes(tok)) {
-      assert.ok(
-        line.length <= 20,
-        `non-oversized line too long: ${JSON.stringify(line)}`,
-      );
+      assert.ok(line.length <= 20, `non-oversized line too long: ${JSON.stringify(line)}`);
     }
   }
 });
@@ -133,4 +119,224 @@ test("wrap places hard-break marker on last filled line", () => {
   const lines = out.split("\n");
   // Greedy: "alpha beta gamma" (16), overflow "delta" → "delta epsilon" → "delta epsilon  ".
   assert.equal(lines[lines.length - 1], "delta epsilon  ");
+});
+
+// ─── Review findings (2026-07-25 adversarial review) ────────────────────────
+
+test("H1 wrap preserves indentation before a blockquote inside a list item", () => {
+  const input = "1. list item\n   > alpha beta gamma delta epsilon zeta eta theta";
+  const out = wrap(input, { width: 20 });
+  for (const line of out.split("\n").slice(1)) {
+    assert.match(line, /^ {3}>/, `quote line lost its indent: ${JSON.stringify(line)}`);
+  }
+});
+
+test("H2 wrap does not treat an info-string fence line as a closer", () => {
+  const input = "```\n```not-a-closer\nalpha beta gamma delta epsilon zeta\n```";
+  assert.equal(wrap(input, { width: 20 }), input);
+});
+
+test("H3 wrap preserves a tab-indented code line verbatim", () => {
+  const input = "\tconst alpha beta gamma delta epsilon zeta eta";
+  assert.equal(wrap(input, { width: 20 }), input);
+});
+
+test("M1 wrap keeps a link with a nested-bracket label atomic", () => {
+  const input = "[outer [inner] label with many words](https://example.com)";
+  const out = wrap(input, { width: 20 });
+  assert.ok(out.includes("[outer [inner] label with many words](https://example.com)"), out);
+});
+
+test("M2 wrap does not reinterpret literal private-use placeholder text", () => {
+  const input = "keep 0 and `code`";
+  const out = wrap(input, { width: 80 });
+  assert.ok(out.startsWith("keep 0 and "), `placeholder text was rewritten: ${JSON.stringify(out)}`);
+  assert.ok(out.includes("`code`"), out);
+});
+
+test("L1 wrap does not treat an even run of trailing backslashes as a hard break", () => {
+  assert.equal(wrap("literal\\\\\nnext", { width: 80 }), "literal\\\\ next");
+});
+
+test("wrap aligns a tab-indented bullet's continuation under its content", () => {
+  // A tab is one CHARACTER but four COLUMNS, so a continuation padded with
+  // hangIndent spaces under-indents by 3 and no longer aligns with the text.
+  // Reusing the tab keeps the alignment intact whatever the tab width.
+  const out = wrap("\t- item text here and more words", { width: 24 });
+  const lines = out.split("\n");
+  assert.ok(lines.length > 1, `expected a wrap: ${JSON.stringify(out)}`);
+  assert.equal(lines[0], "\t- item text here and");
+  assert.equal(lines[1], "\t  more words");
+});
+
+test("wrap aligns a continuation for a tab-indented nested bullet", () => {
+  // `"\t\t- "` is 10 DISPLAY columns (two 4-column tab stops + marker + gap), not 4
+  // characters, so at width 28 the text budget is 18 — the continuation must align
+  // under the content and the line must not overrun the requested column.
+  const out = wrap("\t\t- deep item text that must wrap here", { width: 28 });
+  const lines = out.split("\n");
+  assert.ok(lines.length > 1, `expected a wrap: ${JSON.stringify(out)}`);
+  assert.equal(lines[0], "\t\t- deep item text");
+  assert.equal(lines[1], "\t\t  that must wrap");
+  assert.equal(lines[2], "\t\t  here");
+});
+
+test("wrap aligns a task-item continuation under the text, past the checkbox", () => {
+  // The continuation must clear the marker, gap, AND the "[ ] " checkbox.
+  const out = wrap("- [ ] task item text that needs to wrap somewhere", { width: 24 });
+  const lines = out.split("\n");
+  assert.equal(lines[0], "- [ ] task item text");
+  assert.equal(lines[1], "      that needs to wrap");
+});
+
+test("wrap/unwrap round-trips a no-space blockquote list item", () => {
+  const line = ">- alpha beta gamma delta epsilon zeta eta theta iota";
+  const wrapped = wrap(line, { width: 20 });
+  assert.equal(unwrap(wrapped, { hyphenation: true, keepBlankLines: false, flattenBullets: false }), line);
+});
+
+test("wrap preserves code indented by multiple tabs", () => {
+  // Column width must be computed, not pattern-matched: enumerating tab/space
+  // combinations missed "\t\t" and reflowed the code as prose.
+  for (const input of ["\t\tconst alpha beta gamma delta epsilon", " \t\tdeep code line here", "   \tcode at column 4"]) {
+    assert.equal(wrap(input, { width: 20 }), input, `reflowed: ${JSON.stringify(input)}`);
+  }
+});
+
+test("wrap respects the requested column for tab-indented prefixes", () => {
+  // A tab is 1 character but 4 display columns; budgets use display width.
+  const out = wrap("\t- alpha bravo charlie delta xx", { width: 20 });
+  for (const line of out.split("\n")) {
+    const cols = line.replace(/\t/g, "    ").length;
+    assert.ok(cols <= 20, `line exceeds width 20 (${cols} cols): ${JSON.stringify(line)}`);
+  }
+});
+
+test("wrap never starts a continuation line with a list marker", () => {
+  // A literal "-" mid-sentence must not be pushed to the start of a wrapped line,
+  // where it would re-parse as a nested list item and break the round trip.
+  const input = "- [ ] alpha bravo cc - delta epsilon";
+  const wrapped = wrap(input, { width: 20 });
+  for (const line of wrapped.split("\n").slice(1)) {
+    assert.ok(!/^\s*[-*+]\s/.test(line), `continuation starts a list: ${JSON.stringify(line)}`);
+  }
+  assert.equal(unwrap(wrapped, { hyphenation: true, keepBlankLines: false, flattenBullets: false }), input);
+});
+
+test("wrap keeps a link atomic when its URL has balanced parentheses", () => {
+  const input = "[a](https://x.test/(foo)bar-baz quux corge grault)";
+  assert.ok(wrap(input, { width: 20 }).includes(input));
+});
+
+test("the new-block guard does not degrade ordinary prose", () => {
+  // The guard fires on tokens like "5." and "—" that genuinely would re-parse as a
+  // block start. It must not push normal prose over the requested width.
+  const cases = [
+    "The result was clear — the tests passed and the build was green after all.",
+    "It happened in chapter 5. The next chapter covers the remaining details here.",
+    "See section 3. Then read section 4. Finally consult section 5. Done with it.",
+  ];
+  for (const input of cases) {
+    const out = wrap(input, { width: 40 });
+    for (const line of out.split("\n")) {
+      assert.ok(line.length <= 40, `overran width: ${JSON.stringify(line)}`);
+    }
+    assert.equal(unwrap(out, { hyphenation: true, keepBlankLines: false, flattenBullets: false }), input);
+  }
+});
+
+test("nested-paren link pattern has no catastrophic backtracking", () => {
+  const started = process.hrtime.bigint();
+  wrap("[a](" + "(".repeat(50_000), { width: 80 });
+  wrap("[a](" + "()".repeat(25_000) + ")", { width: 80 });
+  const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+  assert.ok(elapsedMs < 1000, `adversarial paren input took ${elapsedMs.toFixed(0)}ms`);
+});
+
+test("wrap never leaves a trailing token that would re-parse as a block", () => {
+  // The severe case is data LOSS: a lone ">" on its own line re-reads as an empty
+  // blockquote and the token disappears. "---"/"===" become setext underlines.
+  const u = { hyphenation: true, keepBlankLines: false, flattenBullets: false };
+  for (const input of [
+    "alpha bravo charlie >",
+    "alpha bravo charlie ---",
+    "alpha bravo charlie ===",
+    "alpha bravo charlie >quoted",
+  ]) {
+    const wrapped = wrap(input, { width: 20 });
+    assert.equal(unwrap(wrapped, u), input, `round trip lost content: ${JSON.stringify(wrapped)}`);
+  }
+});
+
+test("the new-block guard does not fire on em/en dashes in prose", () => {
+  // `recognizeDashBullets` is false for wrap(), so "—" is prose — treating it as a
+  // bullet made every dash bypass the width budget (a 100k-char line at width 20).
+  const input = "alpha " + "— ".repeat(2000) + "omega";
+  const out = wrap(input, { width: 20 });
+  const longest = Math.max(...out.split("\n").map((l) => l.length));
+  assert.ok(longest <= 20, `guard bypassed the budget: longest line ${longest}`);
+});
+
+test("wrap stays linear despite per-token block probing", () => {
+  const words = Array.from({ length: 80_000 }, (_, i) => `word${i}`).join(" ");
+  const started = process.hrtime.bigint();
+  wrap(words, { width: 80 });
+  const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+  assert.ok(elapsedMs < 2000, `wrap took ${elapsedMs.toFixed(0)}ms — per-token cost regressed`);
+});
+
+test("no trailing block-construct token survives a wrap with lost or changed structure", () => {
+  // Both probe forms matter: "*** x" is prose but a bare "***" is a horizontal rule,
+  // and "> x" is a quote but a bare ">" is an empty one whose token gets deleted.
+  const u = { hyphenation: true, keepBlankLines: false, flattenBullets: false };
+  const tokens = [
+    "|", "|---|", "[id]:", "<div>", "<!--", "***", "___", "- - -", "=", "==", "---", "===",
+    "```js", "~~~", "#", "######", ">", ">>", "1.", "-", "*", "+", "•", "5.", "<br>", "[x]:",
+  ];
+  for (const token of tokens) {
+    const input = `alpha bravo charlie ${token}`;
+    for (const width of [20, 24]) {
+      const wrapped = wrap(input, { width });
+      assert.equal(unwrap(wrapped, u), input, `token ${JSON.stringify(token)} at width ${width}: ${JSON.stringify(wrapped)}`);
+    }
+  }
+});
+
+test("wrap does not synthesize a block from MULTIPLE continuation tokens", () => {
+  // `_` alone is prose and `___` alone is held back, but a line "_ ___" is a
+  // horizontal rule — a per-token check cannot see the combination.
+  const u = { hyphenation: true, keepBlankLines: false, flattenBullets: false };
+  for (const input of ["alpha bravo charlie _ ___", "alpha bravo charlie - - -", "alpha bravo charlie * * *"]) {
+    assert.equal(unwrap(wrap(input, { width: 20 }), u), input, `synthesized a block: ${JSON.stringify(input)}`);
+  }
+});
+
+test("wrap only overruns the width when the resulting line is genuinely unsafe", () => {
+  // "*** delta" is prose, so the break is safe and must be taken — holding "***"
+  // back to avoid a bare-HR line overran the column for no reason.
+  const out = wrap("alpha bravo charlie *** delta", { width: 20 });
+  assert.equal(out, "alpha bravo charlie\n*** delta");
+});
+
+test("block probing stays bounded at large wrap widths", () => {
+  // The probe is capped by token COUNT, not just the width budget. Bounding it by the
+  // budget alone made each rejected break O(width): a run of unsafe tokens at width
+  // 20000 took ~4s, and width has no upper bound (a launchContext caller sets it
+  // directly, bypassing parseWidth). The width-80 guard never covered this path.
+  const input = "x".repeat(40_000) + " " + Array.from({ length: 20_000 }, () => "-").join(" ");
+  const started = process.hrtime.bigint();
+  wrap(input, { width: 20_000 });
+  const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+  assert.ok(elapsedMs < 1500, `wrap took ${elapsedMs.toFixed(0)}ms at width 20000 — probe is O(width) again`);
+});
+
+test("the token-capped probe still detects multi-token blocks at large widths", () => {
+  // Capping the probe must not weaken block detection: "_ ___" is still a horizontal
+  // rule, and a trailing ">" is still an empty blockquote that would be deleted.
+  const u = { hyphenation: true, keepBlankLines: false, flattenBullets: false };
+  for (const width of [20, 5000]) {
+    for (const input of ["alpha bravo charlie _ ___", "alpha bravo charlie >"]) {
+      assert.equal(unwrap(wrap(input, { width }), u), input, `width ${width}: ${JSON.stringify(input)}`);
+    }
+  }
 });


### PR DESCRIPTION
# Update Wrap Unwrap extension

## Description

Correctness and performance pass over the wrap/unwrap reflow engine. Seven rounds of
adversarial review plus property fuzzing surfaced 30 defects; every one was reproduced
with a concrete input before being fixed, and each is covered by a regression test.

Two of them are the reason for this submission:

**1. Large pastes could hang Raycast.** Four quadratic code paths meant an input inside
the extension's own supported 1 MB limit could take minutes with no progress shown.
Measured before → after: 188 KB of indented code 10,299 ms → 14 ms; an 833 KB single
paragraph 18,031 ms → 22 ms; 1 MB of prose 32,056 ms → 39 ms. The causes were a per-line
rescan of all prior records in the classifier, an anchored regex tested against the whole
accumulated paragraph, a `slice()` on that accumulator forcing V8 to flatten the rope on
every join, and a per-break scan of all remaining tokens.

**2. `Strip Soft Hyphens` destroyed real compounds.** `well-` + `known` unwrapped to
`wellknown`. An ASCII `-` at a line break cannot be distinguished from a genuine compound
by pattern, so the preference now strips only a true Unicode soft hyphen (U+00AD), which
exists solely to mark an optional break. An ASCII hyphen is always preserved and the two
halves join tight. The preference description and README both promised
`inter-` + `esting` → `interesting`; both now describe the actual behavior, since the old
text would have shipped a false claim in the settings UI.

## Other fixes

**Data loss / corruption**

- A trailing `>` wrapped onto its own line re-read as an empty blockquote and the
  character was **deleted**. `---`, `===`, `***`, `___`, and `|---|---|` similarly became
  horizontal rules, setext underlines, or table separators. A line is now judged by what
  it would parse as, so multi-token constructs (`_ ___`) are caught too.
- A literal hyphen inside inline code or a link URL was corrupted when the span broke
  across lines (`` `foo-` `` + `` `bar` `` → `` `foobar` ``).
- Text containing Unicode private-use characters was silently rewritten or deleted by the
  internal inline-token placeholder.

**Structure**

- Blockquote indentation was discarded, hoisting a quote out of its containing list item.
- A list-nested blockquote merged with a following root-level one, and a single quote was
  split when its markers carried different but legal indentation (CommonMark allows 0–3
  spaces before `>`).
- Continuation lines under a `>` marker written without a following space never rejoined.
- A fenced block was closed early by a line carrying an info string, exposing its code to
  reflow.
- Tab-indented code was reflowed as prose. Indent width is now measured in columns, so
  any tab/space mix reaching column 4 is recognized.
- A link label with nested brackets, and a URL containing balanced parentheses, were split
  mid-link.

**Reflow quality**

- Hyphen rejoining failed for non-ASCII text (accented Latin, Cyrillic, Greek, CJK, and
  astral characters kept a dangling space).
- Wrapping overran the requested column on tab-indented lines; a tab counts as four
  columns, not one character.
- Tab-indented and task-item (`- [ ]`) continuation lines were misaligned.
- An even-numbered run of trailing backslashes was treated as a hard break instead of
  escaped literal backslashes, and backslash-escaped inline delimiters were read as real
  ones.
- An invalid `Wrap Column` value with a numeric prefix (`12px`) was accepted as `12`
  instead of falling back to 80.
- `String(error)` could throw on a null-prototype value, escaping the failure toast.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder

## Verification

```
npm test          → 147 pass, 0 fail   (was 102)
npx tsc --noEmit  → exit 0
npx ray lint      → exit 0
npx ray build     → exit 0
```

Beyond the unit tests, three property harnesses ship as permanent regression guards:

- **List-shape round trip** — 10,080 combinations (7 indents × 10 markers × 3 gaps ×
  4 task states × 4 quote forms × 3 widths): 0 failures. This is what found the
  no-space-`>` bug that four review rounds had missed.
- **Inline-state consistency** — 21,632 probes asserting no join loses or fabricates
  characters: 0 failures.
- **Trailing-construct round trip** — every construct shape the classifier recognizes as
  a final token: 62/62.

Plus explicit performance guards, so a reintroduced rope-flattening `slice()` or
full-accumulator regex fails a test instead of silently hanging in the field.

No new commands, preferences, or dependencies. No user-visible behavior changes beyond
the fixes above and the corrected `Strip Soft Hyphens` description.
