### PR TITLE
[Safari] Restore local tabs in Search Tabs

### DIFF
--- a/extensions/safari/CHANGELOG.md
+++ b/extensions/safari/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Safari Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-08-12
 
 - Restore fast, complete local tab loading while preserving tabs with empty titles or URLs.
 - Avoid querying iCloud tabs when they are disabled.

--- a/extensions/safari/CHANGELOG.md
+++ b/extensions/safari/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Safari Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Restore fast, complete local tab loading while preserving tabs with empty titles or URLs.
+- Avoid querying iCloud tabs when they are disabled.
+- Handle `blob:` tab favicons without invalid URL errors.
+
 ## [New Command] - 2026-07-24
 
 - Add `Search Tabs, Bookmarks and History` command to search open tabs, bookmarks and history in one place.

--- a/extensions/safari/package.json
+++ b/extensions/safari/package.json
@@ -19,7 +19,8 @@
     "1weiho",
     "xmok",
     "niksite",
-    "ojowwalker77"
+    "ojowwalker77",
+    "gumadeiras"
   ],
   "pastContributors": [
     "axsuul",

--- a/extensions/safari/src/cloud-tabs.tsx
+++ b/extensions/safari/src/cloud-tabs.tsx
@@ -8,7 +8,7 @@ import { Device, Tab } from "./types";
 import { search } from "./utils";
 
 export default function Command() {
-  const { devices, permissionView, refreshDevices } = useDevices();
+  const { devices, isLoading, permissionView, refreshDevices } = useDevices();
   const [searchText, setSearchText] = useState("");
   const throttleSearchText = useThrottle(searchText, { wait: 200 });
 
@@ -17,7 +17,7 @@ export default function Command() {
   }
 
   return (
-    <List isLoading={!devices} onSearchTextChange={setSearchText}>
+    <List isLoading={isLoading} onSearchTextChange={setSearchText}>
       {_.map(devices, (device: Device) => {
         const tabs = search(
           typeof device.tabs === "undefined" ? [] : device.tabs,

--- a/extensions/safari/src/components/TabListItem.tsx
+++ b/extensions/safari/src/components/TabListItem.tsx
@@ -1,4 +1,4 @@
-import { Action, ActionPanel, List } from "@raycast/api";
+import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { getFavicon } from "@raycast/utils";
 import { Tab } from "../types";
 import { getTabUrl, getTitle, getUrlDomain } from "../utils";
@@ -7,6 +7,19 @@ import CopyMarkdownLinkAction from "./CopyMarkdownLinkAction";
 import CopyTitleAction from "./CopyTitleAction";
 import CopyUrlAction from "./CopyUrlAction";
 import OpenTabAction from "./OpenTabAction";
+
+const getTabFavicon = (url: string) => {
+  if (!url.startsWith("blob:")) {
+    return getFavicon(url);
+  }
+
+  try {
+    const origin = new URL(url).origin;
+    return origin === "null" ? Icon.Link : getFavicon(origin);
+  } catch {
+    return Icon.Link;
+  }
+};
 
 const Actions = (props: { tab: Tab; refresh: () => void }) => (
   <ActionPanel>
@@ -36,7 +49,7 @@ export default function TabListItem(props: { tab: Tab; refresh: () => void }) {
   return (
     <List.Item
       title={getTitle(props.tab)}
-      icon={getFavicon(props.tab.url)}
+      icon={getTabFavicon(props.tab.url)}
       actions={<Actions tab={props.tab} refresh={props.refresh} />}
       accessories={[
         {

--- a/extensions/safari/src/hooks/useDevices.ts
+++ b/extensions/safari/src/hooks/useDevices.ts
@@ -14,12 +14,13 @@ function fetchLocalTabs(): Promise<LocalTab[]> {
   return getLocalTabs(safariAppIdentifier) as Promise<LocalTab[]>;
 }
 
-function useRemoteTabs() {
+function useRemoteTabs(execute: boolean) {
   return useSQL<RemoteTab>(
     DATABASE_PATH,
     `SELECT t.tab_uuid as uuid, d.device_uuid, d.device_name, t.title, t.url
          FROM cloud_tabs t
          INNER JOIN cloud_tab_devices d ON t.device_uuid = d.device_uuid`,
+    { execute },
   );
 }
 
@@ -35,9 +36,10 @@ function useLocalTabs() {
 }
 
 export default function useDevices() {
+  const { areRemoteTabsUsed } = getPreferenceValues();
   const { data: deviceName } = useDeviceName();
   const localTabs = useLocalTabs();
-  const remoteTabs = useRemoteTabs();
+  const remoteTabs = useRemoteTabs(areRemoteTabsUsed);
   const [devices, setDevices] = useState<Device[]>([]);
   const permissionView = useRef<JSX.Element | null>(null);
 
@@ -51,8 +53,7 @@ export default function useDevices() {
   );
 
   useLayoutEffect(() => {
-    const preferences = getPreferenceValues();
-    if (preferences.areRemoteTabsUsed) {
+    if (areRemoteTabsUsed) {
       const remoteDevices = _.chain(remoteTabs.data)
         .groupBy("device_uuid")
         .transform((accumulator: Device[], tabs: RemoteTab[], device_uuid: string) => {
@@ -70,7 +71,7 @@ export default function useDevices() {
     } else {
       setDevices([localDevice]);
     }
-  }, [localTabs.data, remoteTabs.data, deviceName]);
+  }, [areRemoteTabsUsed, localTabs.data, remoteTabs.data, deviceName]);
 
-  return { devices, permissionView, refreshDevices: localTabs.revalidate };
+  return { devices, isLoading: localTabs.isLoading, permissionView, refreshDevices: localTabs.revalidate };
 }

--- a/extensions/safari/src/search-all.tsx
+++ b/extensions/safari/src/search-all.tsx
@@ -22,7 +22,7 @@ export default function Command() {
   const throttledSearchText = useThrottle(searchText, { wait: 200 });
   const hasSearchText = throttledSearchText.trim().length > 0;
 
-  const { devices, permissionView, refreshDevices } = useDevices();
+  const { devices, isLoading: isLoadingTabs, permissionView, refreshDevices } = useDevices();
   const { bookmarks, hasPermission } = useBookmarks(false);
   const {
     data: historyEntries,
@@ -69,7 +69,7 @@ export default function Command() {
 
   return (
     <List
-      isLoading={!devices || !bookmarks || isLoadingHistory}
+      isLoading={isLoadingTabs || !bookmarks || isLoadingHistory}
       onSearchTextChange={setSearchText}
       searchBarPlaceholder="Search tabs, bookmarks and history"
     >

--- a/extensions/safari/swift/SafariTabs/Sources/SafariTabs.swift
+++ b/extensions/safari/swift/SafariTabs/Sources/SafariTabs.swift
@@ -59,25 +59,36 @@ struct LocalTab: Codable {
       continue
     }
 
-    var tabIndex = 1
-    for tab in windowTabs {
-      guard let safariTab = tab as? SafariTab else {
-        continue
+    let tabCount = windowTabs.count
+    let batchedTitles = windowTabs.array(byApplying: #selector(getter: SafariTab.name))
+    let batchedUrls = windowTabs.array(byApplying: #selector(getter: SafariTab.URL))
+
+    // Batched selectors are fast but omit empty values, so preserve alignment
+    // with individual reads only for affected windows.
+    let tabData: [(title: String, url: String)]
+    if batchedTitles.count == tabCount && batchedUrls.count == tabCount {
+      tabData = zip(batchedTitles, batchedUrls).map { tab in
+        (tab.0 as? String ?? "", tab.1 as? String ?? "")
       }
+    } else {
+      tabData = windowTabs.compactMap {
+        guard let tab = $0 as? SafariTab else {
+          return nil
+        }
+        return (tab.name ?? "", tab.URL ?? "")
+      }
+    }
 
-      let tabTitle = safariTab.name ?? ""
-      let tabUrl = safariTab.URL ?? ""
-
+    for (tabOffset, tab) in tabData.enumerated() {
+      let tabIndex = tabOffset + 1
       tabs.append(LocalTab(
         uuid: "\(windowId)-\(tabIndex)",
-        title: tabTitle,
-        url: tabUrl,
+        title: tab.title,
+        url: tab.url,
         window_id: windowId,
         index: tabIndex,
         is_local: true
       ))
-
-      tabIndex += 1
     }
   }
 


### PR DESCRIPTION
## Description

`Search Tabs` could show only iCloud tabs while local Safari tabs were still loading. With more than 500 open tabs, loading local tabs took approximately 15 seconds.

### Cause

The Swift bridge requested each tab's title and URL separately through ScriptingBridge. This produced two Apple events per tab.

The command also checked `!devices` for its loading state. Because `devices` starts as an empty array, the loading indicator was never shown.

### Fix

- Fetch titles and URLs in one batched request per Safari window.
- Fall back to individual reads only when Safari omits empty values from a batch. This preserves tab positions and empty titles or URLs.
- Pass the actual local-tab loading state to both commands that use `useDevices`.
- Do not query the iCloud tabs database when iCloud tabs are disabled.
- Resolve `blob:` favicons through their origin, with `Icon.Link` as the fallback.

There are no command, preference, schema, dependency, or tab-identifier changes.

## Validation

Tested on macOS 27 and Safari 27 with Raycast v1 1.104.23 and Raycast v2 Beta 0.70.0.0.

- Installed Store extension with iCloud disabled: no local results.
- Patched extension with iCloud disabled: 518 local tabs.
- Patched extension with iCloud enabled: local and iCloud tabs.
- Swift and JXA returned the same 517 tabs in the comparison test.
- Local tab loading improved from approximately 14.66 seconds to 0.48 seconds.
- A blank tab retained its empty URL and correct index.
- Real `blob:` tabs rendered without invalid URL errors.
- `npm ci`
- `npm run build`
- `npm run lint`
- Distribution build with Node 22.22.2
- `git diff --check`

Related: #29296 touches the same Swift bridge and hook for multi-Safari support, but does not address this loading regression.

## Screencast

Not included because the test profile contains private tab titles.

## Checklist

- [x] I read the extension guidelines
- [x] I read the publishing documentation
- [x] I built the distribution and tested the extension in Raycast
- [x] No asset changes are required
