### PR TITLE
Update Deepseeker to current DeepSeek API model IDs

### DIFF
--- a/extensions/deepseeker/CHANGELOG.md
+++ b/extensions/deepseeker/CHANGELOG.md
@@ -1,6 +1,6 @@
 # DeepSeeker - Quick Actions Changelog
 
-## [Fixes] - 2026-07-26
+## [Fixes] - {PR_MERGE_DATE}
 
 - Update DeepSeek API model IDs to `deepseek-v4-flash` and `deepseek-v4-pro` after the legacy model retirement.
 

--- a/extensions/deepseeker/CHANGELOG.md
+++ b/extensions/deepseeker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # DeepSeeker - Quick Actions Changelog
 
+## [Fixes] - 2026-07-26
+
+- Update DeepSeek API model IDs to `deepseek-v4-flash` and `deepseek-v4-pro` after the legacy model retirement.
+
 ## [New Features] - 2025-03-31
 
 - 🤖 Now Ask LLM command supports **search bar fallback**

--- a/extensions/deepseeker/package.json
+++ b/extensions/deepseeker/package.json
@@ -48,12 +48,12 @@
               "value": "global"
             },
             {
-              "title": "DeepSeek-V3",
-              "value": "deepseek-chat"
+              "title": "DeepSeek-V4 Flash",
+              "value": "deepseek-v4-flash"
             },
             {
-              "title": "DeepSeek-R1",
-              "value": "deepseek-reasoner"
+              "title": "DeepSeek-V4 Pro",
+              "value": "deepseek-v4-pro"
             },
             {
               "title": "GPT-4o",
@@ -106,12 +106,12 @@
               "value": "global"
             },
             {
-              "title": "DeepSeek-V3",
-              "value": "deepseek-chat"
+              "title": "DeepSeek-V4 Flash",
+              "value": "deepseek-v4-flash"
             },
             {
-              "title": "DeepSeek-R1",
-              "value": "deepseek-reasoner"
+              "title": "DeepSeek-V4 Pro",
+              "value": "deepseek-v4-pro"
             },
             {
               "title": "GPT-4o",
@@ -164,12 +164,12 @@
               "value": "global"
             },
             {
-              "title": "DeepSeek-V3",
-              "value": "deepseek-chat"
+              "title": "DeepSeek-V4 Flash",
+              "value": "deepseek-v4-flash"
             },
             {
-              "title": "DeepSeek-R1",
-              "value": "deepseek-reasoner"
+              "title": "DeepSeek-V4 Pro",
+              "value": "deepseek-v4-pro"
             },
             {
               "title": "GPT-4o",
@@ -247,12 +247,12 @@
               "value": "global"
             },
             {
-              "title": "DeepSeek-V3",
-              "value": "deepseek-chat"
+              "title": "DeepSeek-V4 Flash",
+              "value": "deepseek-v4-flash"
             },
             {
-              "title": "DeepSeek-R1",
-              "value": "deepseek-reasoner"
+              "title": "DeepSeek-V4 Pro",
+              "value": "deepseek-v4-pro"
             },
             {
               "title": "GPT-4o",
@@ -305,12 +305,12 @@
               "value": "global"
             },
             {
-              "title": "DeepSeek-V3",
-              "value": "deepseek-chat"
+              "title": "DeepSeek-V4 Flash",
+              "value": "deepseek-v4-flash"
             },
             {
-              "title": "DeepSeek-R1",
-              "value": "deepseek-reasoner"
+              "title": "DeepSeek-V4 Pro",
+              "value": "deepseek-v4-pro"
             },
             {
               "title": "GPT-4o",
@@ -363,12 +363,12 @@
               "value": "global"
             },
             {
-              "title": "DeepSeek-V3",
-              "value": "deepseek-chat"
+              "title": "DeepSeek-V4 Flash",
+              "value": "deepseek-v4-flash"
             },
             {
-              "title": "DeepSeek-R1",
-              "value": "deepseek-reasoner"
+              "title": "DeepSeek-V4 Pro",
+              "value": "deepseek-v4-pro"
             },
             {
               "title": "GPT-4o",
@@ -429,12 +429,12 @@
               "value": "global"
             },
             {
-              "title": "DeepSeek-V3",
-              "value": "deepseek-chat"
+              "title": "DeepSeek-V4 Flash",
+              "value": "deepseek-v4-flash"
             },
             {
-              "title": "DeepSeek-R1",
-              "value": "deepseek-reasoner"
+              "title": "DeepSeek-V4 Pro",
+              "value": "deepseek-v4-pro"
             },
             {
               "title": "GPT-4o",
@@ -495,12 +495,12 @@
               "value": "global"
             },
             {
-              "title": "DeepSeek-V3",
-              "value": "deepseek-chat"
+              "title": "DeepSeek-V4 Flash",
+              "value": "deepseek-v4-flash"
             },
             {
-              "title": "DeepSeek-R1",
-              "value": "deepseek-reasoner"
+              "title": "DeepSeek-V4 Pro",
+              "value": "deepseek-v4-pro"
             },
             {
               "title": "GPT-4o",
@@ -553,12 +553,12 @@
               "value": "global"
             },
             {
-              "title": "DeepSeek-V3",
-              "value": "deepseek-chat"
+              "title": "DeepSeek-V4 Flash",
+              "value": "deepseek-v4-flash"
             },
             {
-              "title": "DeepSeek-R1",
-              "value": "deepseek-reasoner"
+              "title": "DeepSeek-V4 Pro",
+              "value": "deepseek-v4-pro"
             },
             {
               "title": "GPT-4o",
@@ -611,12 +611,12 @@
               "value": "global"
             },
             {
-              "title": "DeepSeek-V3",
-              "value": "deepseek-chat"
+              "title": "DeepSeek-V4 Flash",
+              "value": "deepseek-v4-flash"
             },
             {
-              "title": "DeepSeek-R1",
-              "value": "deepseek-reasoner"
+              "title": "DeepSeek-V4 Pro",
+              "value": "deepseek-v4-pro"
             },
             {
               "title": "GPT-4o",
@@ -661,12 +661,12 @@
               "value": "global"
             },
             {
-              "title": "DeepSeek-V3",
-              "value": "deepseek-chat"
+              "title": "DeepSeek-V4 Flash",
+              "value": "deepseek-v4-flash"
             },
             {
-              "title": "DeepSeek-R1",
-              "value": "deepseek-reasoner"
+              "title": "DeepSeek-V4 Pro",
+              "value": "deepseek-v4-pro"
             },
             {
               "title": "GPT-4o",
@@ -740,12 +740,12 @@
       "type": "dropdown",
       "data": [
         {
-          "title": "deepseek-chat",
-          "value": "deepseek-chat"
+          "title": "DeepSeek-V4 Flash",
+          "value": "deepseek-v4-flash"
         },
         {
-          "title": "deepseek-reasoner",
-          "value": "deepseek-reasoner"
+          "title": "DeepSeek-V4 Pro",
+          "value": "deepseek-v4-pro"
         },
         {
           "title": "deepseek-r1",

--- a/extensions/deepseeker/src/api.ts
+++ b/extensions/deepseeker/src/api.ts
@@ -1,5 +1,6 @@
 import { getPreferenceValues } from "@raycast/api";
 import OpenAI from "openai";
+import { normalizeDeepSeekModel } from "./models";
 
 /**
  * Get preference values from Raycast API
@@ -21,7 +22,7 @@ export const openai = new OpenAI({
  */
 const customModel = preferences.custom_model;
 const isCustomModelValid = Boolean(customModel && customModel.length > 0);
-const globalModel = isCustomModelValid ? customModel : preferences.model;
+const globalModel = normalizeDeepSeekModel(isCustomModelValid ? customModel : preferences.model);
 
 // Log the selected model for debugging purposes
 console.log(`Using model: ${globalModel}`);

--- a/extensions/deepseeker/src/common.tsx
+++ b/extensions/deepseeker/src/common.tsx
@@ -11,6 +11,7 @@ import {
 } from "@raycast/api";
 import { useEffect, useState } from "react";
 import { globalModel, openai } from "./api";
+import { DEEPSEEK_FLASH_MODEL, DEEPSEEK_PRO_MODEL, normalizeDeepSeekModel } from "./models";
 import { countToken, estimatePrice, sendToSideNote } from "./util";
 
 // Define history item type
@@ -67,9 +68,10 @@ export default function ResultView(
   const [loading, setLoading] = useState(true);
   const [cumulativeTokens, setCumulativeTokens] = useState(0);
   const [cumulativeCost, setCumulativeCost] = useState(0);
-  const [model, setModel] = useState(modelOverride === "global" ? globalModel : modelOverride);
+  const [model, setModel] = useState(normalizeDeepSeekModel(modelOverride === "global" ? globalModel : modelOverride));
 
-  async function getResult() {
+  async function getResult(requestedModel = model) {
+    const activeModel = normalizeDeepSeekModel(requestedModel);
     const now = new Date();
     let duration = 0;
     const toast = await showToast(Toast.Style.Animated, toastTitle);
@@ -100,7 +102,7 @@ export default function ResultView(
 
     try {
       const stream = await openai.chat.completions.create({
-        model: model,
+        model: activeModel,
         messages: [
           { role: "system", content: prompt },
           { role: "user", content: userPrompt },
@@ -151,21 +153,21 @@ export default function ResultView(
     setModel("gpt-4o");
     setLoading(true);
     setResponse("");
-    getResult();
+    getResult("gpt-4o");
   }
 
   async function retryWithDeepSeekChat() {
-    setModel("deepseek-chat");
+    setModel(DEEPSEEK_FLASH_MODEL);
     setLoading(true);
     setResponse("");
-    getResult();
+    getResult(DEEPSEEK_FLASH_MODEL);
   }
 
   async function retryWithDeepSeekReasoner() {
-    setModel("deepseek-reasoner");
+    setModel(DEEPSEEK_PRO_MODEL);
     setLoading(true);
     setResponse("");
-    getResult();
+    getResult(DEEPSEEK_PRO_MODEL);
   }
 
   useEffect(() => {
@@ -226,17 +228,17 @@ export default function ResultView(
                 icon={Icon.ArrowNe}
               />
             )}
-            {model != "deepseek-chat" && (
+            {model != DEEPSEEK_FLASH_MODEL && (
               <Action
-                title="Retry with DeepSeek Chat"
+                title="Retry with DeepSeek-V4 Flash"
                 onAction={retryWithDeepSeekChat}
                 shortcut={{ modifiers: ["cmd", "shift"], key: "r" }}
                 icon={Icon.ArrowNe}
               />
             )}
-            {model != "deepseek-reasoner" && (
+            {model != DEEPSEEK_PRO_MODEL && (
               <Action
-                title="Retry with DeepSeek Reasoner"
+                title="Retry with DeepSeek-V4 Pro"
                 onAction={retryWithDeepSeekReasoner}
                 shortcut={{ modifiers: ["cmd", "shift"], key: "d" }}
                 icon={Icon.ArrowNe}

--- a/extensions/deepseeker/src/execute.tsx
+++ b/extensions/deepseeker/src/execute.tsx
@@ -1,9 +1,10 @@
 import { Clipboard, getPreferenceValues, getSelectedText, showHUD, showToast, Toast } from "@raycast/api";
 import { globalModel, openai } from "./api";
+import { normalizeDeepSeekModel } from "./models";
 
 export default async function Command() {
   const { model_execute } = getPreferenceValues();
-  const model = model_execute === "global" ? globalModel : model_execute;
+  const model = normalizeDeepSeekModel(model_execute === "global" ? globalModel : model_execute);
   let selectedText = "";
   try {
     selectedText = await getSelectedText();

--- a/extensions/deepseeker/src/models.ts
+++ b/extensions/deepseeker/src/models.ts
@@ -1,0 +1,11 @@
+export const DEEPSEEK_FLASH_MODEL = "deepseek-v4-flash";
+export const DEEPSEEK_PRO_MODEL = "deepseek-v4-pro";
+
+const LEGACY_MODEL_MIGRATIONS: Record<string, string> = {
+  "deepseek-chat": DEEPSEEK_FLASH_MODEL,
+  "deepseek-reasoner": DEEPSEEK_PRO_MODEL,
+};
+
+export function normalizeDeepSeekModel(model: string): string {
+  return LEGACY_MODEL_MIGRATIONS[model] ?? model;
+}

--- a/extensions/deepseeker/src/util.ts
+++ b/extensions/deepseeker/src/util.ts
@@ -1,6 +1,7 @@
 import { encode } from "@nem035/gpt-3-encoder";
 import { closeMainWindow, getPreferenceValues } from "@raycast/api";
 import { runAppleScript } from "run-applescript";
+import { DEEPSEEK_FLASH_MODEL, DEEPSEEK_PRO_MODEL, normalizeDeepSeekModel } from "./models";
 
 /**
  * Escapes special characters in a string for use in AppleScript
@@ -48,8 +49,8 @@ const prices: Record<string, { in: number; out: number }> = {
   "gpt-4": { in: 30, out: 60 },
   "gpt-4o-mini": { in: 0.15, out: 0.6 },
   "gpt-4o": { in: 5, out: 15 },
-  "deepseek-reasoner": { in: 0.55, out: 2.19 },
-  "deepseek-chat": { in: 0.27, out: 1.1 },
+  [DEEPSEEK_FLASH_MODEL]: { in: 0.14, out: 0.28 },
+  [DEEPSEEK_PRO_MODEL]: { in: 0.435, out: 0.87 },
 };
 
 /**
@@ -75,8 +76,9 @@ export function estimatePrice(promptTokens: number, outputTokens: number, model:
     return calculateCost(promptTokens, outputTokens, priceinput, priceoutput);
   }
 
-  if (model in prices) {
-    return calculateCost(promptTokens, outputTokens, prices[model].in, prices[model].out);
+  const currentModel = normalizeDeepSeekModel(model);
+  if (currentModel in prices) {
+    return calculateCost(promptTokens, outputTokens, prices[currentModel].in, prices[currentModel].out);
   }
 
   return -1;


### PR DESCRIPTION
## Description

Closes #29730.

DeepSeek retired the legacy `deepseek-chat` and `deepseek-reasoner` API model IDs. Requests from every Deepseeker command now return HTTP 400 because the API accepts only `deepseek-v4-flash` and `deepseek-v4-pro`.

This updates both model entries across all 11 command-level overrides and the global model preference:

- `DeepSeek-V3` / `deepseek-chat` → `DeepSeek-V4 Flash` / `deepseek-v4-flash`
- `DeepSeek-R1` / `deepseek-reasoner` → `DeepSeek-V4 Pro` / `deepseek-v4-pro`

Persisted command/global preferences are migrated at the request boundary, retry actions use the V4 IDs directly, and cost estimation uses the current official cache-miss input/output rates. The separate `deepseek-r1` custom-provider alias remains unchanged. The changelog documents the API migration.

Validation:

- DeepSeek's current official Models & Pricing page lists `deepseek-v4-flash` and `deepseek-v4-pro` for the OpenAI-compatible endpoint.
- A manifest assertion confirms both new IDs appear exactly 12 times and neither retired ID remains in the manifest.
- Model migration assertions cover legacy, current, custom-provider, and unrelated model IDs.
- Source audit confirms retired IDs remain only in the explicit migration table and historical changelog.
- Official pricing assertions cover V4 Flash ($0.14/$0.28) and V4 Pro ($0.435/$0.87) per 1M cache-miss input/output tokens.
- `npm run lint` passes with no issues.
- `npm run build` completes successfully and builds all 12 extension entry points.

## Screencast

N/A — model metadata/API compatibility fix with no UI layout change. A live DeepSeek credential was not used during validation.

## Checklist

- [x] I read the extension contribution guidelines
- [x] I read the documentation about publishing
- [ ] I ran `npm run build` and tested this distribution build in Raycast — build passed; manual Raycast/API-key testing was not available
- [x] I checked that files in the `assets` folder are used by the extension itself — no asset changes
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with the metadata tool — no README or metadata changes
