### PR TITLE
Update list-by-fullforms extension

### DIFF
--- a/extensions/list-by-fullforms/.gitignore
+++ b/extensions/list-by-fullforms/.gitignore
@@ -18,9 +18,3 @@ compiled_raycast_rust
 # keeps it out of the public raycast/extensions copy. Same mechanism that keeps
 # the tracked raycast-env.d.ts out of the published tree.
 CLAUDE.md
-
-# Test suite and its runner config. Same filter mechanism as CLAUDE.md above:
-# tracked here so tests run in dev, kept out of the published raycast/extensions
-# copy. `ray build` / `ray lint` are scoped to src/ and never touch these.
-/test
-vitest.config.ts

--- a/extensions/list-by-fullforms/.gitignore
+++ b/extensions/list-by-fullforms/.gitignore
@@ -18,3 +18,9 @@ compiled_raycast_rust
 # keeps it out of the public raycast/extensions copy. Same mechanism that keeps
 # the tracked raycast-env.d.ts out of the published tree.
 CLAUDE.md
+
+# Test suite and its runner config. Same filter mechanism as CLAUDE.md above:
+# tracked here so tests run in dev, kept out of the published raycast/extensions
+# copy. `ray build` / `ray lint` are scoped to src/ and never touch these.
+/test
+vitest.config.ts

--- a/extensions/list-by-fullforms/CHANGELOG.md
+++ b/extensions/list-by-fullforms/CHANGELOG.md
@@ -1,6 +1,6 @@
 # List by FullForms Changelog
 
-## [Detail Pane Previews, Windows Shortcut Fixes, and Onboarding] - {PR_MERGE_DATE}
+## [Detail Pane Previews, Windows Shortcut Fixes, and Onboarding] - 2026-07-26
 
 - Fixed keyboard shortcuts on Windows: actions such as Open Last Added Entry (Ctrl+O), Open List / View Existing Entry (Ctrl+Shift+O), Edit Entry (Ctrl+E), Star Entry (Ctrl+S), and the note, report, and detail-toggle shortcuts now actually fire; previously their macOS Command bindings were silently ignored on Windows, so the keys did nothing even though the hints looked correct
 - Improved the Quick Add Entry and Suggest Entry empty states: they now link straight to the web app's Create a List page, a brand-new account sees a create-your-first-list prompt instead of a permissions message, and a view-only member gets a shortcut to suggest an entry instead

--- a/extensions/list-by-fullforms/CHANGELOG.md
+++ b/extensions/list-by-fullforms/CHANGELOG.md
@@ -1,5 +1,14 @@
 # List by FullForms Changelog
 
+## [Detail Pane Previews, Windows Shortcut Fixes, and Onboarding] - {PR_MERGE_DATE}
+
+- Fixed keyboard shortcuts on Windows: actions such as Open Last Added Entry (Ctrl+O), Open List / View Existing Entry (Ctrl+Shift+O), Edit Entry (Ctrl+E), Star Entry (Ctrl+S), and the note, report, and detail-toggle shortcuts now actually fire; previously their macOS Command bindings were silently ignored on Windows, so the keys did nothing even though the hints looked correct
+- Improved the Quick Add Entry and Suggest Entry empty states: they now link straight to the web app's Create a List page, a brand-new account sees a create-your-first-list prompt instead of a permissions message, and a view-only member gets a shortcut to suggest an entry instead
+- The Search Entries detail pane now previews first-party `> Image:` description callouts as inline images, matching how they render on the web (non-first-party image URLs stay as plain text)
+- The Search Entries detail pane now preserves line breaks in entry descriptions instead of collapsing them into a single paragraph
+- Show the entry's workspace avatar in the Search Entries detail pane metadata, falling back to a person or team glyph when the workspace has no avatar
+- Expanded the list-icon glyph set to match the web's category picker refresh, so lists using the newer category icons show the matching glyph in Raycast instead of the default list icon
+
 ## [Entry Actions, Single Tags Field, and AI Helpers] - 2026-07-12
 
 - The Search Entries "No matches" state now offers an Add Entry action that opens the Quick Add form pre-filled with your search term, so you can create a missing entry without leaving the search

--- a/extensions/list-by-fullforms/package-lock.json
+++ b/extensions/list-by-fullforms/package-lock.json
@@ -16,7 +16,42 @@
         "@types/react": "19.2.17",
         "eslint": "^10.4.1",
         "prettier": "^3.8.4",
-        "typescript": "~6.0.3"
+        "typescript": "~6.0.3",
+        "vitest": "^4.1.10"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -956,6 +991,32 @@
         }
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@oclif/core": {
       "version": "4.11.3",
       "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.11.3.tgz",
@@ -1025,6 +1086,16 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@raycast/api": {
@@ -1123,6 +1194,324 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -1414,6 +1803,119 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1502,6 +2004,16 @@
         "node": ">=14"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -1527,6 +2039,16 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chardet": {
@@ -1589,6 +2111,13 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1643,6 +2172,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -1662,6 +2201,13 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/esbuild": {
@@ -1901,6 +2447,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1909,6 +2465,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2029,6 +2595,21 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
@@ -2247,6 +2828,279 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -2273,6 +3127,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/minimatch": {
@@ -2305,12 +3169,45 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -2389,11 +3286,59 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -2440,6 +3385,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -2481,6 +3460,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -2492,6 +3478,30 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -2534,10 +3544,27 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -2567,16 +3594,14 @@
         }
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -2591,6 +3616,14 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -2671,6 +3704,174 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2685,6 +3886,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {

--- a/extensions/list-by-fullforms/package.json
+++ b/extensions/list-by-fullforms/package.json
@@ -65,7 +65,8 @@
     "@types/react": "19.2.17",
     "eslint": "^10.4.1",
     "prettier": "^3.8.4",
-    "typescript": "~6.0.3"
+    "typescript": "~6.0.3",
+    "vitest": "^4.1.10"
   },
   "overrides": {
     "@types/react": "19.2.17"
@@ -75,6 +76,7 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
-    "publish": "npx @raycast/api@latest publish"
+    "publish": "npx @raycast/api@latest publish",
+    "test": "vitest run"
   }
 }

--- a/extensions/list-by-fullforms/src/add-entry.tsx
+++ b/extensions/list-by-fullforms/src/add-entry.tsx
@@ -82,20 +82,33 @@ import {
   Detail,
   Form,
   Icon,
+  LaunchType,
   Toast,
   environment,
+  launchCommand,
   open,
   openExtensionPreferences,
   showToast,
 } from "@raycast/api";
 import { FormValidation, useFetch, useForm } from "@raycast/utils";
 import { useEffect, useMemo, useState } from "react";
-import { apiBase, apiFetch, authHeaders, errorMessage } from "./lib/api";
+import {
+  apiBase,
+  apiFetch,
+  authHeaders,
+  errorMessage,
+  WRITABLE_ROLES,
+} from "./lib/api";
 import { ENTRY_TYPES, entryTypeLabel } from "./lib/entryTypes";
 import { iconForList } from "./lib/listIconCatalog";
-import { shortcutHint } from "./lib/platform";
+import { crossShortcut, shortcutHint } from "./lib/platform";
 import { parseTagNames, tagsFieldInfo } from "./lib/tags";
-import { useListPicker } from "./lib/useListPicker";
+import { useDebouncedValue } from "./lib/useDebouncedValue";
+import {
+  useAutoSelectFirstList,
+  requireListId,
+  useListPicker,
+} from "./lib/useListPicker";
 
 interface CreateEntryResponse {
   entry: {
@@ -145,8 +158,6 @@ interface FormValues {
   tags: string;
 }
 
-const WRITABLE_ROLES = new Set(["owner", "admin", "editor"]);
-
 // Mirrors app/components/EntryForm.vue → TYPE_PLACEHOLDERS. Same four
 // keys, same example pairs, so the form gives the user one concrete
 // (term, definition) shape per type instead of a generic "e.g. NASA"
@@ -173,6 +184,24 @@ const TYPE_PLACEHOLDERS: Record<string, { entry: string; definition: string }> =
 
 const DUPLICATE_DEBOUNCE_MS = 350;
 
+// Keep a duplicate warning only while the debounced server match still
+// equals the live input: a slow response could otherwise ghost a warning
+// for a keystroke or two after the user kept typing. `textOf` pulls the
+// comparable field off the match (the term for an entry match, the
+// definition text for a definition match); comparison is trimmed +
+// lowercased, the same shape the server matches on. Shared by both the
+// entry and definition duplicate checks.
+function liveMatch<M>(
+  match: M | null,
+  textOf: (match: M) => string,
+  liveInput: string | undefined,
+): M | null {
+  if (!match) return null;
+  const live = (liveInput ?? "").trim().toLowerCase();
+  if (!live) return null;
+  return live === textOf(match).trim().toLowerCase() ? match : null;
+}
+
 export default function AddEntryCommand({
   initialEntry = "",
 }: {
@@ -187,6 +216,7 @@ export default function AddEntryCommand({
   const {
     buckets: writableByWorkspace,
     total: totalWritable,
+    accessibleTotal,
     lists: writableLists,
     isLoading,
   } = useListPicker((l) => WRITABLE_ROLES.has(l.effective_role));
@@ -205,14 +235,8 @@ export default function AddEntryCommand({
   const { handleSubmit, itemProps, setValue, focus, values } =
     useForm<FormValues>({
       onSubmit: async (input) => {
-        const listId = Number(input.listId);
-        if (!Number.isFinite(listId)) {
-          await showToast({
-            style: Toast.Style.Failure,
-            title: "Pick a list first",
-          });
-          return;
-        }
+        const listId = await requireListId(input.listId);
+        if (listId === null) return;
 
         const toast = await showToast({
           style: Toast.Style.Animated,
@@ -245,7 +269,7 @@ export default function AddEntryCommand({
           toast.primaryAction = {
             title: "Open Entry",
             onAction: () => open(url),
-            shortcut: { modifiers: ["cmd"], key: "o" },
+            shortcut: crossShortcut(["cmd"], "o"),
           };
           setLastAdded({
             id: res.entry.id,
@@ -292,16 +316,10 @@ export default function AddEntryCommand({
       },
     });
 
-  // Default the dropdown to the first writable list once data lands.
-  // Watching firstListId (a primitive id) keeps the effect cheap and
-  // dodges referential-equality re-fires that would happen if we
-  // watched the array.
+  // Default the dropdown to the first writable list once data lands
+  // (shared hook; see useListPicker.ts for the ordering rationale).
   const firstListId = writableByWorkspace[0]?.lists[0]?.id;
-  useEffect(() => {
-    if (firstListId !== undefined && !values.listId) {
-      setValue("listId", String(firstListId));
-    }
-  }, [firstListId, setValue, values.listId]);
+  useAutoSelectFirstList(firstListId, values.listId, setValue);
 
   // Clear the tags field when the list changes. Tag names meaningful on
   // the previous list might be brand-new on the new one and would
@@ -325,40 +343,21 @@ export default function AddEntryCommand({
   // settle) so the Entry/Definition placeholders are always concrete.
   const placeholders = TYPE_PLACEHOLDERS[values.type] ?? TYPE_PLACEHOLDERS.term;
 
-  // Debounce entry + definition so the duplicate-check fetch doesn't
-  // fire one round-trip per keystroke. 350ms is the same shape as
-  // the web's deep-search debounce on the home page; feels responsive
-  // without being chatty. Each field has its own debounce so a fast
-  // typist editing both doesn't reset the timer for the other.
-  const [debouncedEntry, setDebouncedEntry] = useState("");
-  const [debouncedDefinition, setDebouncedDefinition] = useState("");
-
-  useEffect(() => {
-    const t = setTimeout(
-      () => setDebouncedEntry(values.entry ?? ""),
-      DUPLICATE_DEBOUNCE_MS,
-    );
-    return () => clearTimeout(t);
-  }, [values.entry]);
-
-  useEffect(() => {
-    const t = setTimeout(
-      () => setDebouncedDefinition(values.definition ?? ""),
-      DUPLICATE_DEBOUNCE_MS,
-    );
-    return () => clearTimeout(t);
-  }, [values.definition]);
-
-  // Reset the debounce baselines when the user switches lists so a
-  // stale warning from the previous list doesn't linger one tick into
-  // the new selection. The useFetch URL also rebuilds when listId
-  // changes (which would invalidate keepPreviousData if it were on),
-  // but flushing the debounce state too makes the transition feel
-  // crisp.
-  useEffect(() => {
-    setDebouncedEntry("");
-    setDebouncedDefinition("");
-  }, [values.listId]);
+  // Debounce entry + definition so the duplicate-check fetch doesn't fire
+  // one round-trip per keystroke. 350ms mirrors the web's home-page deep-
+  // search debounce; each field debounces independently so a fast typist
+  // editing both doesn't reset the other's timer. When the list changes
+  // the check URL rebuilds with the new listId and, with keepPreviousData
+  // off, the in-flight refetch drops any stale warning until fresh data
+  // for the new list lands.
+  const debouncedEntry = useDebouncedValue(
+    values.entry ?? "",
+    DUPLICATE_DEBOUNCE_MS,
+  );
+  const debouncedDefinition = useDebouncedValue(
+    values.definition ?? "",
+    DUPLICATE_DEBOUNCE_MS,
+  );
 
   const checkUrl = useMemo(() => {
     if (!values.listId) return "";
@@ -382,28 +381,28 @@ export default function AddEntryCommand({
     onError: () => {},
   });
 
-  // Only surface a warning when the debounced value still matches the
-  // current input — otherwise a slow response could ghost the warning
-  // for a keystroke or two after the user keeps typing. The match
-  // payload itself has the canonical text, so the comparison is on
-  // the trimmed-lowercase form (same shape the server matches on).
-  const entryDuplicate = useMemo(() => {
-    const match = duplicateQuery.data?.entry_match ?? null;
-    if (!match) return null;
-    const live = (values.entry ?? "").trim().toLowerCase();
-    if (!live) return null;
-    const matchEntry = (match.entry ?? "").trim().toLowerCase();
-    return live === matchEntry ? match : null;
-  }, [duplicateQuery.data, values.entry]);
+  // Surface a warning only when the debounced match still equals the live
+  // input (see liveMatch for why). Entry matches compare the term,
+  // definition matches compare the definition text.
+  const entryDuplicate = useMemo(
+    () =>
+      liveMatch(
+        duplicateQuery.data?.entry_match ?? null,
+        (m) => m.entry ?? "",
+        values.entry,
+      ),
+    [duplicateQuery.data, values.entry],
+  );
 
-  const definitionDuplicate = useMemo(() => {
-    const match = duplicateQuery.data?.definition_match ?? null;
-    if (!match) return null;
-    const live = (values.definition ?? "").trim().toLowerCase();
-    if (!live) return null;
-    const matchDef = (match.definition ?? "").trim().toLowerCase();
-    return live === matchDef ? match : null;
-  }, [duplicateQuery.data, values.definition]);
+  const definitionDuplicate = useMemo(
+    () =>
+      liveMatch(
+        duplicateQuery.data?.definition_match ?? null,
+        (m) => m.definition ?? "",
+        values.definition,
+      ),
+    [duplicateQuery.data, values.definition],
+  );
 
   // Raycast AI (AI.ask) requires a Pro subscription. Gate the generate
   // actions on environment.canAccess so users without access don't see
@@ -415,9 +414,19 @@ export default function AddEntryCommand({
 
   const typeLabel = entryTypeLabel(values.type || "term");
 
-  // Fill the Definition field from the Entry term via Raycast AI. Low
-  // creativity: a glossary definition is a factual task, not open-ended.
-  const generateDefinition = async () => {
+  // Fill a field from Raycast AI. Shared by the Generate Definition /
+  // Generate Description actions: both require a non-empty term, show an
+  // animated toast, ask the AI at low creativity (glossary content is
+  // factual, not open-ended), drop the trimmed answer into the field, and
+  // toast the outcome. Only the target field, the noun in the copy, and
+  // the prompt differ; buildPrompt receives the validated term and can
+  // read other field values (the description prompt folds in the
+  // definition) off the closure.
+  const generateField = async (options: {
+    field: "definition" | "description";
+    noun: string;
+    buildPrompt: (term: string) => string;
+  }) => {
     const term = (values.entry ?? "").trim();
     if (!term) {
       await showToast({
@@ -428,71 +437,105 @@ export default function AddEntryCommand({
     }
     const toast = await showToast({
       style: Toast.Style.Animated,
-      title: "Generating definition…",
+      title: `Generating ${options.noun}…`,
     });
     try {
-      const answer = await AI.ask(
-        `Write a concise, dictionary-style definition for the ${typeLabel.toLowerCase()} "${term}". ` +
-          `One sentence, under 30 words, factual and neutral. ` +
-          `Return ONLY the definition text: no surrounding quotes, no label, no preamble.`,
-        { creativity: "low" },
-      );
-      setValue("definition", answer.trim());
+      const answer = await AI.ask(options.buildPrompt(term), {
+        creativity: "low",
+      });
+      setValue(options.field, answer.trim());
       toast.style = Toast.Style.Success;
-      toast.title = "Definition generated";
+      toast.title = `${options.noun[0].toUpperCase()}${options.noun.slice(1)} generated`;
     } catch (error) {
       toast.style = Toast.Style.Failure;
-      toast.title = "Could not generate definition";
+      toast.title = `Could not generate ${options.noun}`;
       toast.message = errorMessage(error);
     }
   };
 
-  // Fill the Description field from the term (and definition, if present)
-  // via Raycast AI. Longer than the definition; still low creativity to
-  // keep it factual and glossary-appropriate.
-  const generateDescription = async () => {
-    const term = (values.entry ?? "").trim();
-    if (!term) {
-      await showToast({
-        style: Toast.Style.Failure,
-        title: "Enter a term first",
-      });
-      return;
-    }
-    const def = (values.definition ?? "").trim();
-    const toast = await showToast({
-      style: Toast.Style.Animated,
-      title: "Generating description…",
+  const generateDefinition = () =>
+    generateField({
+      field: "definition",
+      noun: "definition",
+      buildPrompt: (term) =>
+        `Write a concise, dictionary-style definition for the ${typeLabel.toLowerCase()} "${term}". ` +
+        `One sentence, under 30 words, factual and neutral. ` +
+        `Return ONLY the definition text: no surrounding quotes, no label, no preamble.`,
     });
-    try {
-      const answer = await AI.ask(
-        `Write a short explanatory description (2 to 4 sentences) for the glossary ${typeLabel.toLowerCase()} "${term}"` +
+
+  const generateDescription = () =>
+    generateField({
+      field: "description",
+      noun: "description",
+      buildPrompt: (term) => {
+        const def = (values.definition ?? "").trim();
+        return (
+          `Write a short explanatory description (2 to 4 sentences) for the glossary ${typeLabel.toLowerCase()} "${term}"` +
           (def ? `, which is defined as: ${def}` : "") +
           `. Factual and neutral, suitable for a glossary entry. ` +
-          `Return ONLY the description text: no heading, no preamble.`,
-        { creativity: "low" },
-      );
-      setValue("description", answer.trim());
-      toast.style = Toast.Style.Success;
-      toast.title = "Description generated";
-    } catch (error) {
-      toast.style = Toast.Style.Failure;
-      toast.title = "Could not generate description";
-      toast.message = errorMessage(error);
-    }
-  };
+          `Return ONLY the description text: no heading, no preamble.`
+        );
+      },
+    });
 
   if (!isLoading && totalWritable === 0) {
+    // Two ways to land here, and they want different copy + actions:
+    //
+    //   • accessibleTotal === 0 → a brand-new account that simply hasn't
+    //     made a list yet. This isn't a permissions failure, so frame it
+    //     as onboarding ("create your first list") rather than "no edit
+    //     access to any list", which reads like something is wrong.
+    //
+    //   • accessibleTotal  >  0 → a member of one or more lists but with
+    //     only viewer access everywhere. Creating a list is still the
+    //     way to get write access, but this user ALSO has the Suggest
+    //     Entry path open to them (any role can queue a suggestion), so
+    //     surface it as a real alternative instead of a dead end.
+    const isBrandNew = accessibleTotal === 0;
+
+    // Deep-link straight to the web app's list-creation page rather than
+    // the app root; a first-time user's very next step is making a list.
+    const createUrl = `${apiBase()}/create`;
+
+    const markdown = isBrandNew
+      ? "# Create your first list\n\n" +
+        "You're signed in, but you haven't created any lists yet. " +
+        "Make one and you can start adding entries right here.\n\n" +
+        "Press Enter to create a list in the web app."
+      : "# No editable lists\n\n" +
+        "You can view lists, but the API token's account doesn't have edit access to any of them.\n\n" +
+        "Create your own list, suggest an entry to a list owner, or ask a workspace owner for an Editor role on an existing list.";
+
     return (
       <Detail
-        markdown={
-          "# No editable lists\n\n" +
-          "You're signed in, but the API token's account doesn't have edit access to any list.\n\n" +
-          "Open the web app to create a list, or ask a workspace owner for an Editor role on an existing one."
-        }
+        markdown={markdown}
         actions={
           <ActionPanel>
-            <Action.OpenInBrowser title="Open List" url={apiBase()} />
+            <Action.OpenInBrowser
+              title="Create a List"
+              icon={Icon.Plus}
+              url={createUrl}
+            />
+            {!isBrandNew && (
+              <Action
+                title="Suggest an Entry Instead"
+                icon={Icon.Envelope}
+                onAction={async () => {
+                  try {
+                    await launchCommand({
+                      name: "suggest-entry",
+                      type: LaunchType.UserInitiated,
+                    });
+                  } catch {
+                    await showToast({
+                      style: Toast.Style.Failure,
+                      title: "Could not open Suggest Entry",
+                      message: "Launch it from the Raycast root search.",
+                    });
+                  }
+                }}
+              />
+            )}
             <Action
               title="Open Preferences"
               onAction={openExtensionPreferences}
@@ -522,13 +565,13 @@ export default function AddEntryCommand({
               <Action
                 title="Generate Definition"
                 icon={Icon.Stars}
-                shortcut={{ modifiers: ["cmd"], key: "g" }}
+                shortcut={crossShortcut(["cmd"], "g")}
                 onAction={generateDefinition}
               />
               <Action
                 title="Generate Description"
                 icon={Icon.Stars}
-                shortcut={{ modifiers: ["cmd", "shift"], key: "g" }}
+                shortcut={crossShortcut(["cmd", "shift"], "g")}
                 onAction={generateDescription}
               />
             </ActionPanel.Section>
@@ -537,14 +580,14 @@ export default function AddEntryCommand({
             <Action.OpenInBrowser
               title="Open Last Added Entry"
               url={`${apiBase()}/${lastAdded.listId}#${lastAdded.id}`}
-              shortcut={{ modifiers: ["cmd"], key: "o" }}
+              shortcut={crossShortcut(["cmd"], "o")}
             />
           )}
           {entryDuplicate && (
             <Action.OpenInBrowser
               title="View Existing Entry"
               url={`${apiBase()}/${values.listId}#${entryDuplicate.id}`}
-              shortcut={{ modifiers: ["cmd", "shift"], key: "o" }}
+              shortcut={crossShortcut(["cmd", "shift"], "o")}
             />
           )}
           <Action

--- a/extensions/list-by-fullforms/src/components/EntryNoteForm.tsx
+++ b/extensions/list-by-fullforms/src/components/EntryNoteForm.tsx
@@ -24,6 +24,7 @@ import {
 } from "@raycast/api";
 import { useForm } from "@raycast/utils";
 import { apiFetch, errorMessage } from "../lib/api";
+import { crossShortcut } from "../lib/platform";
 
 interface FormValues {
   note: string;
@@ -100,7 +101,7 @@ export function EntryNoteForm({
               title="Delete Note"
               icon={Icon.Trash}
               style={Action.Style.Destructive}
-              shortcut={{ modifiers: ["cmd"], key: "backspace" }}
+              shortcut={crossShortcut(["cmd"], "backspace")}
               onAction={deleteNote}
             />
           )}

--- a/extensions/list-by-fullforms/src/components/EntrySearchRow.tsx
+++ b/extensions/list-by-fullforms/src/components/EntrySearchRow.tsx
@@ -17,8 +17,13 @@ import type { ReactNode } from "react";
 import { apiBase, apiHost } from "../lib/api";
 import type { SearchEntryResult, Tag } from "../lib/api";
 import { entryTypeLabel } from "../lib/entryTypes";
-import { iconForList, listVisibility } from "../lib/listIconCatalog";
-import { isMacOS } from "../lib/platform";
+import { renderImageCallouts } from "../lib/entryImages";
+import {
+  iconForList,
+  iconForWorkspace,
+  listVisibility,
+} from "../lib/listIconCatalog";
+import { crossShortcut, isMacOS } from "../lib/platform";
 import { composeSpeakable, speakText, stopSpeaking } from "../lib/tts";
 import { EntryEditForm } from "./EntryEditForm";
 import { EntryNoteForm } from "./EntryNoteForm";
@@ -53,6 +58,22 @@ function accessoriesForEntry(entry: SearchEntryResult) {
   return items.length > 0 ? items : undefined;
 }
 
+// Turn every single newline into a markdown hard break so multi-line
+// prose keeps one line per line, matching the web. The web renders
+// descriptions and notes inside a `white-space: pre-wrap` container
+// (EntryDetailModal.vue `.modal__description`), where each newline is a
+// visual line break; Raycast's markdown pane instead treats a lone
+// newline as a soft break and collapses it to a space, which folds the
+// emoji-bullet lists entries commonly use into one run-on paragraph.
+// The regex only touches single newlines (a non-newline followed by one
+// `\n` that isn't followed by another), so blank-line paragraph breaks,
+// and the `\n\n`-spaced image blocks renderImageCallouts emits, stay
+// intact. Two trailing spaces before the newline is CommonMark's hard
+// break.
+function hardenLineBreaks(text: string): string {
+  return text.replace(/([^\n])\n(?!\n)/g, "$1  \n");
+}
+
 // Compose the detail markdown for an entry: H2 term, definition, then
 // the long-form description (if any), then the caller's private note
 // (if any) under a "Your note" header. Plain markdown so Raycast
@@ -76,7 +97,10 @@ function entryDetailMarkdown(entry: SearchEntryResult): string {
     lines.push("");
     lines.push("---");
     lines.push("");
-    lines.push(entry.description);
+    // Rewrite any `> Image:` callout lines into markdown images so the
+    // pane shows a bounded preview instead of a blockquoted URL, then
+    // harden single newlines so the prose lines don't collapse together.
+    lines.push(hardenLineBreaks(renderImageCallouts(entry.description)));
   }
   if (entry.myNote && entry.myNote.trim()) {
     lines.push("");
@@ -84,7 +108,7 @@ function entryDetailMarkdown(entry: SearchEntryResult): string {
     lines.push("");
     lines.push("### Your note");
     lines.push("");
-    lines.push(entry.myNote);
+    lines.push(hardenLineBreaks(entry.myNote));
   }
   return lines.join("\n");
 }
@@ -93,6 +117,7 @@ export function EntrySearchRow({
   entry,
   listIcon,
   listColor,
+  workspaceAvatarUrl,
   showingDetail,
   detailToggleAction,
   canEdit,
@@ -106,6 +131,12 @@ export function EntrySearchRow({
   // call site, which renders per-bucket).
   listIcon: string | null;
   listColor: string | null;
+  // The entry's workspace avatar URL, resolved by the parent from its
+  // /api/v1/workspaces fetch (the search rows don't carry it). Feeds
+  // iconForWorkspace for the "Workspace" metadata row: the circle-masked
+  // avatar when set, else a person/team glyph by workspace type. Null
+  // while the workspaces fetch is in flight or the id doesn't resolve.
+  workspaceAvatarUrl: string | null;
   showingDetail: boolean;
   // The shared Hide/Show Detail action element owned by the parent
   // (it flips parent state, so the parent constructs it).
@@ -167,6 +198,7 @@ export function EntrySearchRow({
               <List.Item.Detail.Metadata.Label
                 title="Workspace"
                 text={entry.workspaceName}
+                icon={iconForWorkspace(workspaceAvatarUrl, entry.workspaceType)}
               />
               {Array.isArray(entry.tags) && entry.tags.length > 0 && (
                 <List.Item.Detail.Metadata.TagList title="Tags">
@@ -188,7 +220,7 @@ export function EntrySearchRow({
           <Action.OpenInBrowser
             title="Open List"
             url={`${apiBase()}/${entry.listId}`}
-            shortcut={{ modifiers: ["cmd", "shift"], key: "o" }}
+            shortcut={crossShortcut(["cmd", "shift"], "o")}
           />
           {/* Edit the entry in place. Only shown when the caller has a
               writable role on this list; the edit form PATCHes
@@ -198,7 +230,7 @@ export function EntrySearchRow({
             <Action.Push
               title="Edit Entry"
               icon={Icon.Pencil}
-              shortcut={{ modifiers: ["cmd"], key: "e" }}
+              shortcut={crossShortcut(["cmd"], "e")}
               target={
                 <EntryEditForm
                   entry={{
@@ -222,7 +254,7 @@ export function EntrySearchRow({
           <Action.Push
             title={hasNote ? "Edit Note" : "Add Note"}
             icon={Icon.Document}
-            shortcut={{ modifiers: ["cmd", "shift"], key: "n" }}
+            shortcut={crossShortcut(["cmd", "shift"], "n")}
             target={
               <EntryNoteForm
                 entryId={entry.id}
@@ -240,7 +272,7 @@ export function EntrySearchRow({
           <Action.Push
             title="Report Entry"
             icon={Icon.Flag}
-            shortcut={{ modifiers: ["cmd", "shift"], key: "r" }}
+            shortcut={crossShortcut(["cmd", "shift"], "r")}
             target={
               <EntryReportForm entryId={entry.id} entryTerm={entry.entry} />
             }
@@ -252,7 +284,7 @@ export function EntrySearchRow({
                 ? Icon.StarDisabled
                 : { source: Icon.Star, tintColor: "#f59e0b" }
             }
-            shortcut={{ modifiers: ["cmd"], key: "s" }}
+            shortcut={crossShortcut(["cmd"], "s")}
             onAction={onToggleStar}
           />
           {detailToggleAction}
@@ -260,7 +292,7 @@ export function EntrySearchRow({
           <Action.CopyToClipboard
             title="Copy Definition"
             content={entry.definition}
-            shortcut={{ modifiers: ["cmd"], key: "." }}
+            shortcut={crossShortcut(["cmd"], ".")}
           />
           {/* TTS via macOS's built-in `say`. Two granularities: Cmd+T
               speaks the full payload (term + definition + description),
@@ -277,7 +309,7 @@ export function EntrySearchRow({
               <Action
                 title="Speak Entry"
                 icon={Icon.SpeakerHigh}
-                shortcut={{ modifiers: ["cmd"], key: "t" }}
+                shortcut={crossShortcut(["cmd"], "t")}
                 onAction={() =>
                   speakText(
                     composeSpeakable(
@@ -291,13 +323,13 @@ export function EntrySearchRow({
               <Action
                 title="Speak Definition"
                 icon={Icon.SpeakerHigh}
-                shortcut={{ modifiers: ["cmd", "shift"], key: "t" }}
+                shortcut={crossShortcut(["cmd", "shift"], "t")}
                 onAction={() => speakText(entry.definition)}
               />
               <Action
                 title="Stop Speaking"
                 icon={Icon.SpeakerOff}
-                shortcut={{ modifiers: ["cmd", "opt"], key: "t" }}
+                shortcut={crossShortcut(["cmd", "opt"], "t")}
                 onAction={stopSpeaking}
               />
             </>

--- a/extensions/list-by-fullforms/src/lib/api.ts
+++ b/extensions/list-by-fullforms/src/lib/api.ts
@@ -72,6 +72,13 @@ export interface ListRow {
   tags: Tag[];
 }
 
+// Roles that grant write access to a list's entries, matching the
+// server's can_edit_list gate (owner / admin / editor; viewer is
+// read-only). Quick Add Entry filters its list picker to these, and the
+// Search command gates the per-row "Edit Entry" action on them. Shared
+// here so the set can't drift between those two call sites.
+export const WRITABLE_ROLES = new Set(["owner", "admin", "editor"]);
+
 export interface WorkspacesResponse {
   workspaces: Workspace[];
 }

--- a/extensions/list-by-fullforms/src/lib/entryImages.ts
+++ b/extensions/list-by-fullforms/src/lib/entryImages.ts
@@ -1,0 +1,73 @@
+// `> Image:` description-callout handling, mirrored from the web's
+// app/utils/imageHost.js, plus a Raycast-specific renderer that rewrites
+// those callout lines into markdown images the detail pane can preview.
+//
+// On-disk format (docs/entry-images-plan.md → "On-disk format"): an image
+// is stored inside an entry's description as a callout line
+//   > Image: <url> [caption]
+// where the first whitespace-delimited token is the URL and everything
+// after it is the caption. The Search detail pane renders the raw
+// description as markdown, so without this transform Raycast shows the
+// line as a blockquoted auto-link ("Image: https://…") instead of the
+// picture.
+//
+// Keep ENTRY_IMAGE_BASE_URL / isFirstPartyImageUrl / splitImageBody in
+// lockstep with ../list/app/utils/imageHost.js: they are the on-disk
+// contract shared with the web, and the web is the source of truth.
+
+export const ENTRY_IMAGE_BASE_URL = "https://img.list.fullforms.com";
+
+// Only first-party image URLs render as pictures. A hand-typed
+// third-party URL stays inert text (never rewritten to an image), so the
+// detail pane can't be turned into a reader-IP tracking pixel. This is
+// the same render gate the web enforces in EntryDescription.vue; the
+// defense only holds if both clients apply it.
+export function isFirstPartyImageUrl(url: string): boolean {
+  return typeof url === "string" && url.startsWith(`${ENTRY_IMAGE_BASE_URL}/`);
+}
+
+// Split an Image-callout body into { url, caption }: first
+// whitespace-delimited token is the URL, the rest is the caption.
+// Mirrors splitImageBody in the web's imageHost.js.
+export function splitImageBody(body: string): { url: string; caption: string } {
+  const source = String(body ?? "").trim();
+  if (!source) return { url: "", caption: "" };
+  const match = source.match(/^(\S+)\s*([\s\S]*)$/);
+  if (!match) return { url: "", caption: "" };
+  return { url: match[1], caption: match[2].trim() };
+}
+
+// The web's IMAGE_OPENER_RE (utils/entryMentions.js): a callout line that
+// opens with `> Image:`, case-insensitive, optional single space.
+const IMAGE_OPENER_RE = /^> Image: ?(.*)$/i;
+
+// Bounds the preview so one image never dominates the detail pane, the
+// way the web caps rendered image height at 300px. Raycast reads the
+// `raycast-width` query param on markdown image URLs and scales the
+// picture to it, preserving aspect ratio.
+const PREVIEW_WIDTH = 350;
+
+// Rewrite each `> Image:` callout line in a description into a markdown
+// image, leaving every other line untouched. First-party URLs only;
+// anything else (including a malformed body with no URL) is returned as
+// its original text. Operates line-by-line, which handles the
+// single-line form the upload modal produces; hand-authored multi-line
+// captions (continuation lines) are left as plain text below the image.
+export function renderImageCallouts(description: string): string {
+  if (!/> Image:/i.test(description)) return description;
+  return description
+    .split("\n")
+    .map((line) => {
+      const opener = line.match(IMAGE_OPENER_RE);
+      if (!opener) return line;
+      const { url, caption } = splitImageBody(opener[1]);
+      if (!url || !isFirstPartyImageUrl(url)) return line;
+      const image = `![${caption}](${url}?raycast-width=${PREVIEW_WIDTH})`;
+      const block = caption ? `${image}\n\n*${caption}*` : image;
+      // Blank lines around the block so markdown renders it standalone
+      // regardless of the surrounding description text; markdown
+      // collapses the extra blanks when the line was already spaced.
+      return `\n${block}\n`;
+    })
+    .join("\n");
+}

--- a/extensions/list-by-fullforms/src/lib/listIconCatalog.ts
+++ b/extensions/list-by-fullforms/src/lib/listIconCatalog.ts
@@ -27,11 +27,17 @@ const LIST_COLOR_HEX: Record<string, string> = {
 };
 
 // Mirrors ICON_GLYPHS in app/utils/listIconCatalog.js, mapped to
-// the closest match in Raycast's Icon enum. Three glyphs don't
-// have a 1:1 (briefcase / food / sparkle) and use a closest-fit
-// substitute (Building / MugSteam / Stars); the other 17 map
-// directly. Unknown / null glyphs fall back to Icon.List, same
-// fallback the web app's resolveListIcon uses when no glyph is set.
+// the closest match in Raycast's Icon enum, in the same order as the
+// web file: the 20 picker glyphs first (list..chart), then the legacy
+// render-only glyphs the web retired from its picker (2026-07-16/07-17)
+// but still renders for lists that stored them (star..target).
+// Seven glyphs have no 1:1 in Raycast's set and use a closest-fit
+// substitute: briefcase→Building, food→MugSteam (no cutlery icon
+// exists), school→Pencil (no graduation cap), paw→Footprints (no paw),
+// palette→Brush, bank→BankNote (no columned-building icon), and the
+// legacy sparkle→Stars. The other 23 map directly or near-exactly.
+// Unknown / null glyphs fall back to Icon.List, same fallback the web
+// app's resolveListIcon uses when no glyph is set.
 const LIST_GLYPH_ICON: Record<string, Icon> = {
   list: Icon.List,
   clipboard: Icon.Clipboard,
@@ -43,6 +49,18 @@ const LIST_GLYPH_ICON: Record<string, Icon> = {
   leaf: Icon.Leaf,
   music: Icon.Music,
   globe: Icon.Globe,
+  groups: Icon.TwoPeople,
+  memory: Icon.MemoryChip,
+  school: Icon.Pencil,
+  paw: Icon.Footprints,
+  film: Icon.FilmStrip,
+  ball: Icon.SoccerBall,
+  palette: Icon.Brush,
+  plane: Icon.Airplane,
+  bank: Icon.BankNote,
+  chart: Icon.LineChart,
+  // Legacy render-only glyphs (retired from the web picker but kept so
+  // lists that already stored them keep rendering the same in both).
   star: Icon.Star,
   heart: Icon.Heart,
   bolt: Icon.Bolt,

--- a/extensions/list-by-fullforms/src/lib/platform.ts
+++ b/extensions/list-by-fullforms/src/lib/platform.ts
@@ -1,17 +1,26 @@
-// Platform detection + platform-aware display strings. The extension
-// ships for macOS and Windows (manifest platforms), and two things vary
-// by OS:
+// Platform detection + platform-aware shortcuts and display strings. The
+// extension ships for macOS and Windows (manifest platforms), and three
+// things vary by OS:
 //
 //   1. Feature availability. TTS shells out to macOS's `say` binary, so
 //      the Speak actions render only when isMacOS (they are absent, not
 //      broken, on Windows).
-//   2. Shortcut hints baked into DISPLAY TEXT. Raycast auto-translates
-//      an Action's `shortcut` modifiers per-OS (⌘ on macOS renders as
-//      Ctrl on Windows), but a shortcut written into a plain string (the
-//      Quick Add "Last Added" banner, the duplicate-entry hint) does NOT
-//      auto-translate; shortcutHint formats those per-platform so
-//      Windows users see "Ctrl+O" instead of a Command glyph their
-//      keyboard doesn't have.
+//   2. Shortcut BINDINGS that must fire on both platforms. Raycast does
+//      NOT auto-map an "ambiguous" modifier (cmd / opt) across platforms:
+//      a bare { modifiers: ["cmd"], key: "o" } shortcut is IGNORED on
+//      Windows. Its hint still renders as Ctrl+O, so the key silently does
+//      nothing there. crossShortcut emits the { macOS, Windows } platform-
+//      object form (the shape @raycast/api requires for cross-platform
+//      shortcuts) so the same action is bound on both. cmd → ctrl,
+//      opt → alt; shift / ctrl are the same token on both.
+//   3. Shortcut hints baked into DISPLAY TEXT. A shortcut written into a
+//      plain string (the Quick Add "Last Added" banner, the duplicate-
+//      entry hint) is not a real Action `shortcut`, so nothing renders it
+//      per-OS; shortcutHint formats those with the same cmd → Ctrl /
+//      opt → Alt translation crossShortcut uses, so Windows users see
+//      "Ctrl+O" instead of a Command glyph their keyboard doesn't have.
+
+import type { Keyboard } from "@raycast/api";
 
 export const isMacOS = process.platform === "darwin";
 
@@ -31,10 +40,35 @@ const WINDOWS_NAMES: Record<HintModifier, string> = {
   ctrl: "Ctrl",
 };
 
+// Windows KeyModifier equivalents of the mac-style modifiers, for the
+// actual binding (not just display). Keep this in lockstep with
+// WINDOWS_NAMES above so a shortcut's hint and its real key agree.
+const WINDOWS_MODIFIERS: Record<HintModifier, Keyboard.KeyModifier> = {
+  cmd: "ctrl",
+  shift: "shift",
+  opt: "alt",
+  ctrl: "ctrl",
+};
+
 export function shortcutHint(modifiers: HintModifier[], key: string): string {
   const upperKey = key.toUpperCase();
   if (isMacOS) {
     return modifiers.map((m) => MAC_GLYPHS[m]).join("") + upperKey;
   }
   return [...modifiers.map((m) => WINDOWS_NAMES[m]), upperKey].join("+");
+}
+
+// Build a cross-platform Keyboard.Shortcut from a mac-style spec. Every
+// Action `shortcut` in this extension goes through here: passing a bare
+// { modifiers: ["cmd"], key } would bind on macOS but silently no-op on
+// Windows (see the header note). The { macOS, Windows } object form binds
+// on both, translating cmd → ctrl and opt → alt for the Windows variant.
+export function crossShortcut(
+  modifiers: HintModifier[],
+  key: Keyboard.KeyEquivalent,
+): Keyboard.Shortcut {
+  return {
+    macOS: { modifiers, key },
+    Windows: { modifiers: modifiers.map((m) => WINDOWS_MODIFIERS[m]), key },
+  };
 }

--- a/extensions/list-by-fullforms/src/lib/useDebouncedValue.ts
+++ b/extensions/list-by-fullforms/src/lib/useDebouncedValue.ts
@@ -1,0 +1,21 @@
+// Generic debounced-value hook: returns a copy of `value` that only
+// updates after `delayMs` has passed with no further changes. Quick Add
+// Entry uses it to throttle the duplicate-check fetch so it doesn't fire
+// one round-trip per keystroke; each debounced field is an independent
+// instance so editing one doesn't reset the other's timer.
+//
+// The debounced value initializes to the current `value` (not empty), so
+// a form pre-seeded with a term (the Search command's "add this as a new
+// entry" push) checks for duplicates on first paint rather than after an
+// idle delay.
+
+import { useEffect, useState } from "react";
+
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+  return debounced;
+}

--- a/extensions/list-by-fullforms/src/lib/useListPicker.ts
+++ b/extensions/list-by-fullforms/src/lib/useListPicker.ts
@@ -15,8 +15,10 @@
 // Empty-state rendering stays at the call site (a `Detail` with a
 // CTA when `total === 0`) because each command's copy differs:
 // "no editable lists" vs "no accessible lists". The auto-select-
-// first-list useEffect also stays at the call site because it
-// needs the caller's useForm setValue.
+// first-list effect and the "pick a list first" submit guard, which
+// both commands share verbatim, live here as useAutoSelectFirstList
+// and requireListId (parameterised on the caller's useForm setValue /
+// field value) so the two commands can't drift.
 //
 // Ordering preserved end-to-end: workspaces RPC sorts personal-
 // first then team alphabetical, lists RPC sorts updated_at desc
@@ -33,6 +35,7 @@
 
 import { Toast, showToast } from "@raycast/api";
 import { useFetch } from "@raycast/utils";
+import { useEffect } from "react";
 import { apiBase, authHeaders } from "./api";
 import type {
   ListRow,
@@ -53,6 +56,12 @@ export interface UseListPickerResult {
   // false, render the "no accessible lists" detail instead of an
   // empty Form.Dropdown.
   total: number;
+  // Count of ALL accessible lists BEFORE the role filter. Lets an
+  // empty-state branch tell "member of nothing at all" (a brand-new
+  // account that just needs to create a list) apart from "a member
+  // somewhere but view-only everywhere" (which also has the Suggest
+  // Entry path open to it). Equals `total` when no filter is passed.
+  accessibleTotal: number;
   // Flat filtered list, handy for resolving a selectedList by id
   // (selectedList = lists.find(l => String(l.id) === values.listId)).
   lists: ListRow[];
@@ -101,5 +110,39 @@ export function useListPicker(
     .filter((b) => b.lists.length > 0);
   const total = buckets.reduce((n, b) => n + b.lists.length, 0);
 
-  return { buckets, total, lists, isLoading };
+  return { buckets, total, accessibleTotal: rawLists.length, lists, isLoading };
+}
+
+// Default the list dropdown to the first list once the picker's data
+// lands. The workspaces RPC sorts personal-first then team-alphabetical
+// and the lists RPC sorts updated_at desc, so buckets[0].lists[0] is the
+// user's most recently edited list inside their primary workspace, the
+// natural default. Watching the primitive firstListId (not the array)
+// keeps the effect cheap and dodges referential-equality re-fires; the
+// `!currentListId` guard means it only fills an empty field and never
+// fights the user's manual pick. Shared by Quick Add Entry and Suggest
+// Entry, which pass their own useForm setValue + current field value.
+export function useAutoSelectFirstList(
+  firstListId: number | undefined,
+  currentListId: string,
+  setValue: (id: "listId", value: string) => void,
+): void {
+  useEffect(() => {
+    if (firstListId !== undefined && !currentListId) {
+      setValue("listId", String(firstListId));
+    }
+  }, [firstListId, currentListId, setValue]);
+}
+
+// Submit-handler guard for a list-picking form: parse the dropdown's
+// string value into a numeric list id, returning null (after a "Pick a
+// list first" toast) when it isn't a finite number. Shared so Quick Add
+// Entry and Suggest Entry validate the selection identically.
+export async function requireListId(rawListId: string): Promise<number | null> {
+  const listId = Number(rawListId);
+  if (!Number.isFinite(listId)) {
+    await showToast({ style: Toast.Style.Failure, title: "Pick a list first" });
+    return null;
+  }
+  return listId;
 }

--- a/extensions/list-by-fullforms/src/search.tsx
+++ b/extensions/list-by-fullforms/src/search.tsx
@@ -65,28 +65,26 @@ import {
   apiHost,
   authHeaders,
   errorMessage,
+  WRITABLE_ROLES,
 } from "./lib/api";
 import type {
   WorkspacesResponse,
   ListsResponse,
   ListRow,
   SearchEntryResult,
+  Workspace,
 } from "./lib/api";
 import {
   iconForList,
   iconForWorkspace,
   listVisibility,
 } from "./lib/listIconCatalog";
+import { crossShortcut } from "./lib/platform";
 import { stopSpeaking } from "./lib/tts";
 import AddEntryCommand from "./add-entry";
 import { EntrySearchRow } from "./components/EntrySearchRow";
 
 const ALL_WORKSPACES = "all";
-
-// Roles that can edit an entry, matching the server's can_edit_list
-// gate (owner/admin/editor; viewer is read-only). Used to decide
-// whether the "Edit Entry" action appears on a search result row.
-const WRITABLE_ROLES = new Set(["owner", "admin", "editor"]);
 
 interface SearchListResult {
   id: number;
@@ -146,6 +144,18 @@ export default function SearchCommand() {
   );
 
   const workspaces = workspacesQuery.data?.workspaces ?? [];
+
+  // Look up a workspace by id so each result row can show its avatar
+  // beside the workspace name in the detail pane. The /api/v1/search
+  // rows don't carry avatar_url, but the workspaces fetch above already
+  // has it for every workspace the caller belongs to (which is every
+  // workspace a result can come from), so we resolve it client-side
+  // rather than widening the search response.
+  const workspacesById = useMemo(() => {
+    const map = new Map<number, Workspace>();
+    for (const w of workspaces) map.set(w.id, w);
+    return map;
+  }, [workspaces]);
 
   // Fetch the caller's lists once so we can (a) gate the "Edit Entry"
   // action to lists the caller can write to, and (b) hand the list's
@@ -232,7 +242,7 @@ export default function SearchCommand() {
     <Action
       title={showingDetail ? "Hide Detail" : "Show Detail"}
       icon={Icon.AppWindowSidebarRight}
-      shortcut={{ modifiers: ["cmd"], key: "i" }}
+      shortcut={crossShortcut(["cmd"], "i")}
       onAction={() => setShowingDetail((v) => !v)}
     />
   );
@@ -335,6 +345,9 @@ export default function SearchCommand() {
                 entry={e}
                 listIcon={bucket.listIcon}
                 listColor={bucket.listColor}
+                workspaceAvatarUrl={
+                  workspacesById.get(e.workspaceId)?.avatar_url ?? null
+                }
                 showingDetail={showingDetail}
                 detailToggleAction={toggleDetailAction}
                 canEdit={canEdit}

--- a/extensions/list-by-fullforms/src/suggest-entry.tsx
+++ b/extensions/list-by-fullforms/src/suggest-entry.tsx
@@ -41,10 +41,13 @@ import {
   showToast,
 } from "@raycast/api";
 import { FormValidation, useForm } from "@raycast/utils";
-import { useEffect } from "react";
 import { ApiError, apiBase, apiFetch, errorMessage } from "./lib/api";
 import { iconForList } from "./lib/listIconCatalog";
-import { useListPicker } from "./lib/useListPicker";
+import {
+  useAutoSelectFirstList,
+  requireListId,
+  useListPicker,
+} from "./lib/useListPicker";
 
 interface FormValues {
   listId: string;
@@ -66,14 +69,8 @@ export default function SuggestEntryCommand() {
   const { handleSubmit, itemProps, setValue, focus, values } =
     useForm<FormValues>({
       onSubmit: async (input) => {
-        const listId = Number(input.listId);
-        if (!Number.isFinite(listId)) {
-          await showToast({
-            style: Toast.Style.Failure,
-            title: "Pick a list first",
-          });
-          return;
-        }
+        const listId = await requireListId(input.listId);
+        if (listId === null) return;
 
         const toast = await showToast({
           style: Toast.Style.Animated,
@@ -113,11 +110,7 @@ export default function SuggestEntryCommand() {
     });
 
   const firstListId = listsByWorkspace[0]?.lists[0]?.id;
-  useEffect(() => {
-    if (firstListId !== undefined && !values.listId) {
-      setValue("listId", String(firstListId));
-    }
-  }, [firstListId, setValue, values.listId]);
+  useAutoSelectFirstList(firstListId, values.listId, setValue);
 
   if (!isLoading && totalLists === 0) {
     return (
@@ -125,11 +118,15 @@ export default function SuggestEntryCommand() {
         markdown={
           "# No accessible lists\n\n" +
           "You're signed in, but the API token's account isn't a member of any list. " +
-          "Open the web app to create a list or accept an invitation."
+          "Create one in the web app, or accept a workspace invitation, then come back."
         }
         actions={
           <ActionPanel>
-            <Action.OpenInBrowser title="Open List" url={apiBase()} />
+            <Action.OpenInBrowser
+              title="Create a List"
+              icon={Icon.Plus}
+              url={`${apiBase()}/create`}
+            />
             <Action
               title="Open Preferences"
               onAction={openExtensionPreferences}

--- a/extensions/list-by-fullforms/test/entryImages.test.ts
+++ b/extensions/list-by-fullforms/test/entryImages.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import {
+  ENTRY_IMAGE_BASE_URL,
+  isFirstPartyImageUrl,
+  splitImageBody,
+  renderImageCallouts,
+} from "../src/lib/entryImages";
+
+describe("isFirstPartyImageUrl", () => {
+  it("accepts URLs under the first-party image host", () => {
+    expect(isFirstPartyImageUrl(`${ENTRY_IMAGE_BASE_URL}/abc.png`)).toBe(true);
+  });
+
+  it("rejects third-party URLs (tracking-pixel guard)", () => {
+    expect(isFirstPartyImageUrl("https://evil.example.com/x.png")).toBe(false);
+  });
+
+  it("rejects a look-alike host that isn't an exact prefix match", () => {
+    expect(
+      isFirstPartyImageUrl("https://img.list.fullforms.com.evil.com/x.png"),
+    ).toBe(false);
+  });
+
+  it("rejects the bare base URL without a path", () => {
+    expect(isFirstPartyImageUrl(ENTRY_IMAGE_BASE_URL)).toBe(false);
+  });
+});
+
+describe("splitImageBody", () => {
+  it("splits the first token as URL and the rest as caption", () => {
+    expect(
+      splitImageBody(`${ENTRY_IMAGE_BASE_URL}/a.png A nice caption`),
+    ).toEqual({ url: `${ENTRY_IMAGE_BASE_URL}/a.png`, caption: "A nice caption" });
+  });
+
+  it("returns an empty caption when only a URL is present", () => {
+    expect(splitImageBody(`${ENTRY_IMAGE_BASE_URL}/a.png`)).toEqual({
+      url: `${ENTRY_IMAGE_BASE_URL}/a.png`,
+      caption: "",
+    });
+  });
+
+  it("handles empty input", () => {
+    expect(splitImageBody("")).toEqual({ url: "", caption: "" });
+  });
+});
+
+describe("renderImageCallouts", () => {
+  it("returns the input unchanged when there is no callout", () => {
+    const text = "Just a plain description\nwith two lines.";
+    expect(renderImageCallouts(text)).toBe(text);
+  });
+
+  it("rewrites a first-party callout into a bounded markdown image", () => {
+    const out = renderImageCallouts(`> Image: ${ENTRY_IMAGE_BASE_URL}/a.png Caption`);
+    expect(out).toContain(`![Caption](${ENTRY_IMAGE_BASE_URL}/a.png?raycast-width=`);
+    expect(out).toContain("*Caption*");
+  });
+
+  it("leaves a non-first-party callout as inert text", () => {
+    const line = "> Image: https://evil.example.com/a.png Caption";
+    expect(renderImageCallouts(line)).toContain(line);
+    expect(renderImageCallouts(line)).not.toContain("![");
+  });
+
+  it("emits the image without a caption block when none is given", () => {
+    const out = renderImageCallouts(`> Image: ${ENTRY_IMAGE_BASE_URL}/a.png`);
+    expect(out).toContain(`![](${ENTRY_IMAGE_BASE_URL}/a.png?raycast-width=`);
+    expect(out).not.toContain("**");
+  });
+});

--- a/extensions/list-by-fullforms/test/entryTypes.test.ts
+++ b/extensions/list-by-fullforms/test/entryTypes.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { ENTRY_TYPES, entryTypeLabel } from "../src/lib/entryTypes";
+
+describe("ENTRY_TYPES", () => {
+  it("mirrors the server's four-value type enum", () => {
+    expect(ENTRY_TYPES.map((t) => t.value)).toEqual([
+      "term",
+      "abbreviation",
+      "word",
+      "name",
+    ]);
+  });
+});
+
+describe("entryTypeLabel", () => {
+  it("returns the display label for a known type", () => {
+    expect(entryTypeLabel("abbreviation")).toBe("Abbreviation");
+  });
+
+  it("falls back to the raw value for an unknown/future type", () => {
+    expect(entryTypeLabel("phrase")).toBe("phrase");
+  });
+});

--- a/extensions/list-by-fullforms/test/listIconCatalog.test.ts
+++ b/extensions/list-by-fullforms/test/listIconCatalog.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import {
+  iconForList,
+  iconForWorkspace,
+  listVisibility,
+} from "../src/lib/listIconCatalog";
+
+// Icon values come from the test stub (test/mocks/raycast-api.ts), where
+// Icon.Foo === "Foo". Colors are the real hex strings from the catalog.
+
+describe("iconForList", () => {
+  it("uses the explicit icon + color when both are valid", () => {
+    expect(iconForList({ icon: "book", color: "green", name: "x", id: 1 })).toEqual(
+      { source: "Book", tintColor: "#10b981" },
+    );
+  });
+
+  it("falls back to a keyword rule on the name when no icon/color is set", () => {
+    // "project" is the first KEYWORD_RULE → clipboard glyph, blue tint.
+    expect(
+      iconForList({ icon: null, color: null, name: "Project Roadmap", id: 7 }),
+    ).toEqual({ source: "Clipboard", tintColor: "#1d9bf0" });
+  });
+
+  it("honors keyword-rule ordering (first match wins)", () => {
+    // "test" appears in the medical rule; a name matching an earlier rule
+    // should still take the earlier rule. "code" → terminal/purple.
+    expect(
+      iconForList({ icon: null, color: null, name: "Code Notes", id: 1 }),
+    ).toEqual({ source: "Terminal", tintColor: "#8b5cf6" });
+  });
+
+  it("falls back to a deterministic id-based color when no keyword matches", () => {
+    // No keyword match → default "list" glyph + FALLBACK_PALETTE_KEYS[id % 7].
+    // id 3 → index 3 → "amber" (#f59e0b).
+    expect(
+      iconForList({ icon: null, color: null, name: "Zqx Miscellany", id: 3 }),
+    ).toEqual({ source: "List", tintColor: "#f59e0b" });
+  });
+
+  it("is deterministic: same id maps to the same fallback color", () => {
+    const a = iconForList({ icon: null, color: null, name: "Nope", id: 10 });
+    const b = iconForList({ icon: null, color: null, name: "Nope", id: 10 });
+    expect(a).toEqual(b);
+  });
+
+  it("maps substitute glyphs (food has no cutlery icon → MugSteam)", () => {
+    expect(
+      iconForList({ icon: "food", color: "orange", name: "x", id: 1 }),
+    ).toEqual({ source: "MugSteam", tintColor: "#fb923c" });
+  });
+
+  it("renders legacy render-only glyphs (sparkle → Stars)", () => {
+    expect(
+      iconForList({ icon: "sparkle", color: "pink", name: "x", id: 1 }),
+    ).toEqual({ source: "Stars", tintColor: "#ec4899" });
+  });
+
+  it("falls back to Icon.List for an unknown glyph key", () => {
+    const result = iconForList({
+      icon: "not-a-real-glyph",
+      color: "blue",
+      name: "Zqx",
+      id: 1,
+    });
+    // Unknown explicit icon isn't a valid glyph, so tier 1 fails and it
+    // resolves via the id fallback path, landing on the default list glyph.
+    expect(result.source).toBe("List");
+  });
+});
+
+describe("listVisibility", () => {
+  it("returns Public for a public list", () => {
+    expect(listVisibility(true, "team")).toEqual({
+      label: "Public",
+      icon: "Globe",
+    });
+  });
+
+  it("returns Shared for a private list in a team workspace", () => {
+    expect(listVisibility(false, "team")).toEqual({
+      label: "Shared",
+      icon: "TwoPeople",
+    });
+  });
+
+  it("returns Private for a private list in a personal workspace", () => {
+    expect(listVisibility(false, "personal")).toEqual({
+      label: "Private",
+      icon: "Lock",
+    });
+  });
+});
+
+describe("iconForWorkspace", () => {
+  it("uses the avatar as a circle-masked image when set", () => {
+    expect(iconForWorkspace("https://x/y.png", "team")).toEqual({
+      source: "https://x/y.png",
+      mask: "circle",
+    });
+  });
+
+  it("falls back to a single-person glyph for a personal workspace", () => {
+    expect(iconForWorkspace(null, "personal")).toBe("Person");
+  });
+
+  it("falls back to a two-people glyph for a team workspace", () => {
+    expect(iconForWorkspace(undefined, "team")).toBe("TwoPeople");
+  });
+});

--- a/extensions/list-by-fullforms/test/mocks/raycast-api.ts
+++ b/extensions/list-by-fullforms/test/mocks/raycast-api.ts
@@ -1,0 +1,18 @@
+// Minimal @raycast/api stub for unit tests. The pure lib/ modules under
+// test only touch the Icon / Image / Color values from @raycast/api, and
+// only to store or return them. Icon is a Proxy so any `Icon.Foo`
+// resolves to the string "Foo", which is enough to assert *which* glyph a
+// resolver picked without coupling the tests to Raycast's real enum
+// values. Real @raycast/api doesn't import cleanly outside the Raycast
+// runtime, which is why this alias exists (see vitest.config.ts).
+
+export const Icon: Record<string, string> = new Proxy(
+  {},
+  { get: (_target, key) => String(key) },
+) as Record<string, string>;
+
+export const Image = { Mask: { Circle: "circle" } };
+
+// Only used in a type-position cast (`hex as Color`) at runtime, so its
+// shape doesn't matter; exported so the value import resolves.
+export const Color: Record<string, string> = {};

--- a/extensions/list-by-fullforms/test/platform.test.ts
+++ b/extensions/list-by-fullforms/test/platform.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { shortcutHint, crossShortcut } from "../src/lib/platform";
+
+// The suite runs on macOS (darwin) in dev/CI, so the imported shortcutHint
+// exercises the macOS branch directly. The Windows branch is covered by
+// re-importing the module with process.platform stubbed, since isMacOS is
+// captured at module load.
+
+describe("shortcutHint on macOS", () => {
+  it("renders modifier glyphs and an uppercased key", () => {
+    expect(shortcutHint(["cmd", "shift"], "o")).toBe("⌘⇧O");
+  });
+
+  it("handles a single modifier", () => {
+    expect(shortcutHint(["cmd"], "t")).toBe("⌘T");
+  });
+});
+
+// crossShortcut always emits BOTH platform variants (it doesn't branch on
+// isMacOS), so a bare cmd shortcut binds on Windows instead of silently
+// no-opping there. The Windows variant translates cmd → ctrl / opt → alt,
+// matching shortcutHint so a shortcut's hint and its real key never drift.
+describe("crossShortcut", () => {
+  it("emits macOS + Windows variants, translating cmd → ctrl", () => {
+    expect(crossShortcut(["cmd"], "o")).toEqual({
+      macOS: { modifiers: ["cmd"], key: "o" },
+      Windows: { modifiers: ["ctrl"], key: "o" },
+    });
+  });
+
+  it("translates opt → alt and preserves shift", () => {
+    expect(crossShortcut(["cmd", "opt", "shift"], "t")).toEqual({
+      macOS: { modifiers: ["cmd", "opt", "shift"], key: "t" },
+      Windows: { modifiers: ["ctrl", "alt", "shift"], key: "t" },
+    });
+  });
+});
+
+describe("shortcutHint on Windows", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("renders '+'-joined names with Ctrl for cmd", async () => {
+    const original = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32" });
+    vi.resetModules();
+    const { shortcutHint: winHint } = await import("../src/lib/platform");
+    expect(winHint(["cmd", "shift"], "o")).toBe("Ctrl+Shift+O");
+    expect(winHint(["opt"], "t")).toBe("Alt+T");
+    Object.defineProperty(process, "platform", { value: original });
+  });
+});

--- a/extensions/list-by-fullforms/test/tags.test.ts
+++ b/extensions/list-by-fullforms/test/tags.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { parseTagNames, tagsFieldInfo } from "../src/lib/tags";
+
+describe("parseTagNames", () => {
+  it("splits on commas and trims each name", () => {
+    expect(parseTagNames("biology, physics ,math")).toEqual([
+      "biology",
+      "physics",
+      "math",
+    ]);
+  });
+
+  it("drops empty segments", () => {
+    expect(parseTagNames("foo, , bar,,")).toEqual(["foo", "bar"]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(parseTagNames("")).toEqual([]);
+  });
+
+  it("tolerates null / undefined", () => {
+    expect(parseTagNames(null)).toEqual([]);
+    expect(parseTagNames(undefined)).toEqual([]);
+  });
+});
+
+describe("tagsFieldInfo", () => {
+  it("lists existing tag names when the list has tags", () => {
+    const info = tagsFieldInfo([
+      { id: 1, name: "biology" },
+      { id: 2, name: "physics" },
+    ]);
+    expect(info).toContain("biology, physics");
+  });
+
+  it("returns the generic copy when there are no tags", () => {
+    expect(tagsFieldInfo([])).toBe(
+      "Comma-separated tag names. Any new names are created on this list.",
+    );
+  });
+
+  it("tolerates undefined (cross-deploy cache window)", () => {
+    expect(tagsFieldInfo(undefined)).toContain("Comma-separated");
+  });
+});

--- a/extensions/list-by-fullforms/vitest.config.ts
+++ b/extensions/list-by-fullforms/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+
+// Unit tests cover the pure, hand-ported lib/ logic (icon/visibility
+// resolution, image-callout rewriting, tag parsing, type labels,
+// platform-aware shortcut hints). Some of those modules import
+// @raycast/api for its Icon / Image / Color values, which don't load
+// outside the Raycast runtime, so the alias below points those imports
+// at a tiny stub (test/mocks/raycast-api.ts). Tests live outside src/
+// so `ray build` / `ray lint` (scoped to src/) never see them.
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+  },
+  resolve: {
+    alias: {
+      "@raycast/api": fileURLToPath(
+        new URL("./test/mocks/raycast-api.ts", import.meta.url),
+      ),
+    },
+  },
+});


### PR DESCRIPTION
## Description

This is an update to the already-published **List by FullForms** extension ([raycast.com/mithunmathew/list-by-fullforms](https://www.raycast.com/mithunmathew/list-by-fullforms)), a client for the FullForms List glossary service at [list.fullforms.com](https://list.fullforms.com). It authenticates with a personal API token (generated by the user at `list.fullforms.com/account` and stored as a Keychain-encrypted password preference) and ships three commands:

- **Search Entries** across every workspace you belong to, with a markdown detail pane, starring, in-place editing, private notes, and reporting to a list owner's moderation queue.
- **Quick Add Entry** with a workspace-grouped list picker, type-aware placeholders, a single comma-separated tags field, and live duplicate detection.
- **Suggest Entry** to queue an entry into a list owner's moderation queue when you only have view access.

Runs on macOS and Windows (text-to-speech is macOS-only, since it uses the built-in `say` binary).

### What's new in this release

This release, **Detail Pane Previews, Windows Shortcut Fixes, and Onboarding**:

- **Windows keyboard shortcuts now fire.** Actions such as Open Last Added Entry (Ctrl+O), Edit Entry (Ctrl+E), Star Entry (Ctrl+S), and the note, report, and detail-toggle shortcuts were previously bound only for macOS and silently ignored on Windows even though their hints rendered. They now use the platform-object shortcut form and work on both.
- **Clearer onboarding empty states.** Quick Add Entry and Suggest Entry link straight to the web app's Create a List page; a brand-new account sees a create-your-first-list prompt instead of a permissions message, and a view-only member gets a shortcut to suggest an entry instead.
- **Image callout previews in the search detail pane.** First-party `> Image:` description callouts render as inline images, matching the web (non-first-party URLs stay as plain text).
- **Line breaks preserved** in entry descriptions in the search detail pane, instead of collapsing into a single paragraph.
- **Workspace avatar in the search detail pane** metadata, falling back to a person or team glyph when the workspace has no avatar.
- **Expanded list-icon glyph set** to match the web's category picker refresh, so lists using the newer category icons show the matching glyph instead of the default.

## Screencast

Screenshots of the three commands (also in the `metadata` folder):

**Search Entries**

![Search Entries](https://raw.githubusercontent.com/mrmithunmathew/raycast-extensions/ext/list-by-fullforms/extensions/list-by-fullforms/metadata/list-by-fullforms-1.png)

**Quick Add Entry**

![Quick Add Entry](https://raw.githubusercontent.com/mrmithunmathew/raycast-extensions/ext/list-by-fullforms/extensions/list-by-fullforms/metadata/list-by-fullforms-2.png)

**Suggest Entry**

![Suggest Entry](https://raw.githubusercontent.com/mrmithunmathew/raycast-extensions/ext/list-by-fullforms/extensions/list-by-fullforms/metadata/list-by-fullforms-3.png)

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
