### PR TITLE
[Agent Client Protocol] Fix against current ACP agents

### DIFF
--- a/extensions/agent-client-protocol/CHANGELOG.md
+++ b/extensions/agent-client-protocol/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Agent Client Protocol Changelog
 
+## [Catch Up With the Current ACP Spec] - {PR_MERGE_DATE}
+
+### Fixed
+
+- **Agents could not reach their own credentials**: Raycast runs extensions with no `USER`/`LOGNAME` and a `PATH` that contains only the configured "Additional PATH Directories", and that environment was passed straight to the agent. On macOS the Claude CLI reads its keychain login via `/usr/bin/security -a $USER`, so it reported "not logged in" and rejected every prompt with `Authentication required` even for signed-in users. Agents now start with the system locations on `PATH` and a resolved user identity
+- **Protocol version mismatch**: Migrated from the deprecated `@zed-industries/agent-client-protocol` to its successor `@agentclientprotocol/sdk`. The old schema rejected `usage_update` notifications from current agents with `Invalid params`, and it surfaced agent errors as raw objects so every failure read `Unknown error`
+- **Streaming during the first turn**: The session is now stored and observed before the opening prompt is sent, instead of after the whole turn finished. Updates no longer land in the "session not found" buffer
+- **Authentication**: The client now advertises the `auth.terminal` capability, so agents actually offer their login methods, and an `Authentication required` rejection shows an actionable "Open Login in Terminal" error instead of a generic protocol error
+- **Switching the agent mode**: `session/set_mode` and `session/cancel` were sent through a private field of the old SDK's connection object that no longer exists; both now use the SDK's public API. The new mode is also applied locally, because agents may acknowledge the switch without sending a `current_mode_update` notification
+- **Claude Code agent**: Points at the maintained `claude-agent-acp` adapter; Zed's `claude-code-acp` was archived. Stored configurations are migrated automatically
+
+- **Message order**: Streaming chunks were merged back into the agent's first message no matter how many tool calls had been recorded behind it, so the final answer appeared above the tool calls it was based on. Chunks now only extend a message while it is still the last one
+- **Slash-command catalogue in the transcript**: The agent's `available_commands_update` was rendered as a system message right after the session opened, pushing the first answer down the list. It is stored on the session only
+
+### Added
+
+- **Agent mode before the first message**: Modes an agent reports are remembered per agent, selectable as a default in *Configure Agents* and overridable per chat in the *Ask AI Agent* form. The mode is applied between opening the session and the first prompt, so the opening turn no longer runs under the agent's default and triggers permission prompts
+- **Tool calls are hidden by default** in the conversation, with a ⌘T toggle to show them
+- Agent `stderr` is included in the extension log, so failures inside the agent are visible
+- Context-window usage and session cost reported by the agent are stored with the conversation
+
 ## [Initial Version] - 2025-11-03
 
 ### Added

--- a/extensions/agent-client-protocol/README.md
+++ b/extensions/agent-client-protocol/README.md
@@ -8,7 +8,7 @@ Connect to AI agents via Agent Client Protocol for coding assistance directly fr
 
 This extension works with any agent that supports the Agent Client Protocol:
 
-- **[Claude Code](https://github.com/zed-industries/claude-code-acp)** - Anthropic's official CLI (recommended)
+- **[Claude Code](https://www.npmjs.com/package/@agentclientprotocol/claude-agent-acp)** - Anthropic's official CLI (recommended), via `npm install -g @agentclientprotocol/claude-agent-acp`
 - **[Gemini CLI](https://github.com/google-gemini/gemini-cli)** - Google's AI assistant
 - **Custom agents** - Any tool implementing the [ACP specification](https://agentclientprotocol.com)
 
@@ -19,7 +19,7 @@ Follow the installation instructions from the agent's official documentation.
 1. Open **Configure Agents** command
 2. Select a built-in agent or create a custom configuration
 3. Fill in the required fields:
-   - **Command**: Path to the agent binary (e.g., `claude-code-acp`)
+   - **Command**: Path to the agent binary (e.g., `claude-agent-acp`)
    - **Arguments**: Any required arguments (e.g., `--experimental-acp` for Gemini)
    - **Environment Variables**: API keys and other variables in JSON format
    - **Additional PATH**: Add directories to PATH if needed
@@ -34,7 +34,18 @@ Use the **Ask AI Agent** command to start a conversation.
 - Use the absolute path to the binary in the **Command** field
 - Or add the binary's directory to **Additional PATH**
 
-**Connection issues**: Enable logging in extension preferences to debug.
+**"Agent is not signed in"**: The agent connected but rejected the prompt with
+`Authentication required`. Use the **Open Login in Terminal** action on the error toast,
+complete the login, then send the message again. Alternatively, put a token into the
+agent's **Environment Variables** — for `claude-agent-acp` that is
+`CLAUDE_CODE_OAUTH_TOKEN` (create one with `claude setup-token`) or `ANTHROPIC_API_KEY`.
+
+Note that **Additional PATH** only adds to the PATH the agent gets; the standard system
+directories are always included, because agents shell out to tools like `/usr/bin/security`
+to read their stored logins.
+
+**Connection issues**: Enable logging in extension preferences to debug. The agent's own
+stderr is included in the extension log.
 
 ## Commands
 

--- a/extensions/agent-client-protocol/package-lock.json
+++ b/extensions/agent-client-protocol/package-lock.json
@@ -7,10 +7,11 @@
       "name": "agent-client-protocol",
       "license": "MIT",
       "dependencies": {
+        "@agentclientprotocol/sdk": "^1.3.0",
         "@raycast/api": "^1.103.2",
         "@raycast/utils": "^1.17.0",
-        "@zed-industries/agent-client-protocol": "^0.4.5",
-        "uuid": "^13.0.0"
+        "uuid": "^13.0.0",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.0.4",
@@ -23,6 +24,15 @@
         "prettier": "^3.5.3",
         "ts-jest": "^29.4.5",
         "typescript": "^5.8.2"
+      }
+    },
+    "node_modules/@agentclientprotocol/sdk": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.3.0.tgz",
+      "integrity": "sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3124,15 +3134,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@zed-industries/agent-client-protocol": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@zed-industries/agent-client-protocol/-/agent-client-protocol-0.4.5.tgz",
-      "integrity": "sha512-OwHKfu5AiKul/GSJilHg36+kOSV9eOl2eYnjR6tenAQDdraSnt22WFk0SDFTeuAANz1Gxkv+DTf7Hq32rvX7FQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "zod": "^3.0.0"
-      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",

--- a/extensions/agent-client-protocol/package.json
+++ b/extensions/agent-client-protocol/package.json
@@ -5,6 +5,9 @@
   "description": "Connect to AI agents via Agent Client Protocol for coding assistance",
   "icon": "icon.png",
   "author": "Yukai",
+  "contributors": [
+    "torbenkeller"
+  ],
   "platforms": [
     "macOS",
     "Windows"
@@ -71,10 +74,11 @@
     }
   ],
   "dependencies": {
+    "@agentclientprotocol/sdk": "^1.3.0",
     "@raycast/api": "^1.103.2",
     "@raycast/utils": "^1.17.0",
-    "@zed-industries/agent-client-protocol": "^0.4.5",
-    "uuid": "^13.0.0"
+    "uuid": "^13.0.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.0.4",

--- a/extensions/agent-client-protocol/src/chat.tsx
+++ b/extensions/agent-client-protocol/src/chat.tsx
@@ -81,15 +81,22 @@ type ChatCommandProps = {
   initialSessionId?: string;
   initialAgentId?: string;
   initialAgent?: AgentConfig; // Pre-configured agent with working directory
+  initialModeId?: string; // Mode to open the session in, chosen before the first message
 };
 
-export default function ChatCommand({ initialSessionId, initialAgentId, initialAgent }: ChatCommandProps = {}) {
+export default function ChatCommand({
+  initialSessionId,
+  initialAgentId,
+  initialAgent,
+  initialModeId,
+}: ChatCommandProps = {}) {
   const chat = useChatSession();
   const [agents, setAgents] = useState<AgentConfig[]>([]);
   const [selectedAgentId, setSelectedAgentId] = useState<string | undefined>(undefined);
   const [isLoadingAgents, setIsLoadingAgents] = useState(true);
   const [initialLoadComplete, setInitialLoadComplete] = useState(false);
   const [searchText, setSearchText] = useState("");
+  const [showToolCalls, setShowToolCalls] = useState(false);
 
   const configService = useMemo(() => new ConfigService(), []);
   const storageService = useMemo(() => new StorageService(), []);
@@ -488,7 +495,9 @@ export default function ChatCommand({ initialSessionId, initialAgentId, initialA
       return;
     }
 
-    await chat.sendMessage(message);
+    // The mode only takes effect while the session is opened, so it is passed on
+    // the first message and ignored afterwards.
+    await chat.sendMessage(message, chat.conversation ? undefined : initialModeId);
     setSearchText("");
   }
 
@@ -660,7 +669,12 @@ export default function ChatCommand({ initialSessionId, initialAgentId, initialA
     );
   });
 
-  const messageItems = chat.messages.map((message, index) => {
+  // Tool calls are kept in the conversation but hidden by default: a single turn can
+  // produce a dozen of them, which buries the agent's actual answer.
+  const toolCallCount = chat.messages.filter((message) => message.role === "tool").length;
+  const visibleMessages = showToolCalls ? chat.messages : chat.messages.filter((message) => message.role !== "tool");
+
+  const messageItems = visibleMessages.map((message, index) => {
     const speakerLabel =
       message.role === "user"
         ? "You"
@@ -719,6 +733,14 @@ export default function ChatCommand({ initialSessionId, initialAgentId, initialA
             )}
             {renderContextActions()}
             <ActionPanel.Section>
+              {toolCallCount > 0 && (
+                <Action
+                  title={showToolCalls ? "Hide Tool Calls" : `Show Tool Calls (${toolCallCount})`}
+                  icon={showToolCalls ? Icon.EyeDisabled : Icon.Eye}
+                  shortcut={{ modifiers: ["cmd"], key: "t" }}
+                  onAction={() => setShowToolCalls((shown) => !shown)}
+                />
+              )}
               <Action
                 title="Restart Conversation"
                 icon={Icon.Repeat}
@@ -776,7 +798,13 @@ export default function ChatCommand({ initialSessionId, initialAgentId, initialA
         </List.Section>
       )}
       {chat.messages.length > 0 ? (
-        <List.Section title={conversationTitle} subtitle={conversationSubtitle || `${chat.messages.length} messages`}>
+        <List.Section
+          title={conversationTitle}
+          subtitle={
+            conversationSubtitle ||
+            `${visibleMessages.length} messages${!showToolCalls && toolCallCount > 0 ? ` · ${toolCallCount} tool calls hidden` : ""}`
+          }
+        >
           {messageItems}
         </List.Section>
       ) : chat.contexts.length === 0 ? (

--- a/extensions/agent-client-protocol/src/configure-agents.tsx
+++ b/extensions/agent-client-protocol/src/configure-agents.tsx
@@ -14,6 +14,8 @@ import { createLogger } from "@/utils/logging";
 import { getInstallationGuide, AGENT_TEMPLATES } from "@/utils/builtInAgents";
 import type { AgentConfig, AgentHealthRecord } from "@/types/extension";
 import { AddAgentForm, EditAgentForm } from "@/components/AgentConfig";
+import { AgentModeService } from "@/services/agentModeService";
+import type { AgentMode } from "@/types/entities";
 import { getAgentHealthAccessory } from "@/components/AgentSelector";
 
 const logger = createLogger("ConfigureAgentsCommand");
@@ -23,9 +25,13 @@ export default function ConfigureAgentsCommand() {
   const [defaultAgent, setDefaultAgent] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [healthMap, setHealthMap] = useState<Record<string, AgentHealthRecord>>({});
+  // Modes an agent reported in an earlier session, plus the default chosen for it.
+  const [modeMap, setModeMap] = useState<Record<string, AgentMode[]>>({});
+  const [defaultModeMap, setDefaultModeMap] = useState<Record<string, string | undefined>>({});
 
   const configService = useMemo(() => new ConfigService(), []);
   const agentConfigService = useMemo(() => new AgentConfigService(), []);
+  const agentModeService = useMemo(() => new AgentModeService(), []);
 
   useEffect(() => {
     loadAgents();
@@ -47,11 +53,41 @@ export default function ConfigureAgentsCommand() {
       setDefaultAgent(defaultAgentId);
       const healthByAgent = Object.fromEntries(healthRecords.map((record) => [record.agentId, record] as const));
       setHealthMap(healthByAgent);
+
+      const modeEntries = await Promise.all(
+        agentConfigs.map(async (agent) => {
+          const [modes, defaultModeId] = await Promise.all([
+            agentModeService.getKnownModes(agent.id),
+            agentModeService.getDefaultMode(agent.id),
+          ]);
+          return [agent.id, modes, defaultModeId] as const;
+        }),
+      );
+      setModeMap(Object.fromEntries(modeEntries.map(([id, modes]) => [id, modes])));
+      setDefaultModeMap(Object.fromEntries(modeEntries.map(([id, , defaultModeId]) => [id, defaultModeId])));
+
       logger.info("Agent configurations loaded", { count: agentConfigs.length });
     } catch (error) {
       await ErrorHandler.handleError(error, "Loading agent configurations");
     } finally {
       setIsLoading(false);
+    }
+  }
+
+  async function setDefaultMode(agent: AgentConfig, modeId: string | undefined) {
+    try {
+      await agentModeService.setDefaultMode(agent.id, modeId);
+      setDefaultModeMap((current) => ({ ...current, [agent.id]: modeId }));
+
+      const modeName = modeId ? (modeMap[agent.id]?.find((mode) => mode.id === modeId)?.name ?? modeId) : null;
+
+      await showToast({
+        style: Toast.Style.Success,
+        title: modeName ? `Default Mode: ${modeName}` : "Using the Agent's Own Default",
+        message: `New chats with ${agent.name} start in this mode.`,
+      });
+    } catch (error) {
+      await ErrorHandler.handleError(error, "Setting the default agent mode");
     }
   }
 
@@ -260,6 +296,23 @@ export default function ConfigureAgentsCommand() {
                 />
                 {agent.id !== defaultAgent && (
                   <Action title="Set as Default" icon={Icon.Star} onAction={() => setAsDefault(agent.id)} />
+                )}
+                {(modeMap[agent.id]?.length ?? 0) > 0 && (
+                  <ActionPanel.Submenu title="Set Default Mode" icon={Icon.Gauge}>
+                    <Action
+                      title="Agent Default"
+                      icon={defaultModeMap[agent.id] === undefined ? Icon.CheckCircle : Icon.Circle}
+                      onAction={() => setDefaultMode(agent, undefined)}
+                    />
+                    {modeMap[agent.id].map((mode) => (
+                      <Action
+                        key={mode.id}
+                        title={mode.name}
+                        icon={defaultModeMap[agent.id] === mode.id ? Icon.CheckCircle : Icon.Circle}
+                        onAction={() => setDefaultMode(agent, mode.id)}
+                      />
+                    ))}
+                  </ActionPanel.Submenu>
                 )}
                 {!agent.isBuiltIn && (
                   <Action

--- a/extensions/agent-client-protocol/src/hooks/useChatSession.ts
+++ b/extensions/agent-client-protocol/src/hooks/useChatSession.ts
@@ -1,12 +1,18 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { showToast, Toast } from "@raycast/api";
+import { Clipboard, showToast, Toast } from "@raycast/api";
 import { ACPClient } from "@/services/acpClient";
 import { SessionService } from "@/services/sessionService";
 import { StorageService } from "@/services/storageService";
 import type { AgentConfig, AgentConnection } from "@/types/extension";
 import type { ConversationSession, SessionMessage, ProjectContext } from "@/types/entities";
-import { ErrorHandler } from "@/utils/errors";
+import { ErrorHandler, ErrorCode, rpcErrorMessage } from "@/utils/errors";
 import { createLogger } from "@/utils/logging";
+import {
+  buildTerminalAuthCommand,
+  findTerminalAuthMethod,
+  isTerminalAuthMethod,
+  openTerminalAuth,
+} from "@/utils/agentAuth";
 import { ContextService } from "@/services/contextService";
 import { PersistenceService } from "@/services/persistenceService";
 
@@ -21,8 +27,8 @@ interface ChatSessionState {
 }
 
 interface UseChatSessionResult extends ChatSessionState {
-  startSession: (agent: AgentConfig, prompt: string) => Promise<void>;
-  sendMessage: (message: string) => Promise<void>;
+  startSession: (agent: AgentConfig, prompt: string, modeId?: string) => Promise<void>;
+  sendMessage: (message: string, modeId?: string) => Promise<void>;
   cancelMessage: () => Promise<void>;
   resetSession: () => Promise<void>;
   setActiveAgent: (agent: AgentConfig | null) => void;
@@ -83,6 +89,94 @@ export function useChatSession(): UseChatSessionResult {
   const [status, setStatus] = useState<ChatStatus>("idle");
   const isLoadingConversationRef = useRef(false);
   const activeSessionIdRef = useRef<string | null>(null);
+
+  /**
+   * Report an agent failure. When the agent asked for a login, offer to run its
+   * login command instead of showing a generic protocol error the user cannot act on.
+   */
+  const handleAgentError = useCallback(
+    async (error: unknown, context: string) => {
+      const requiresAuth = (error as { code?: unknown } | undefined)?.code === ErrorCode.AuthenticationRequired;
+      if (!requiresAuth) {
+        await ErrorHandler.handleError(error, context);
+        return;
+      }
+
+      const config = acpClient.getConnectedConfig();
+      const method = findTerminalAuthMethod(acpClient.getAuthMethods());
+      const command = config && method ? buildTerminalAuthCommand(config, method) : null;
+
+      logger.warn("Agent requires authentication", {
+        context,
+        agentId: config?.id,
+        authMethod: method?.id,
+        hasLoginCommand: !!command,
+      });
+
+      if (!command) {
+        // No terminal method: the agent either handles the login itself, or offers
+        // nothing we can drive.
+        const selfHandled = acpClient.getAuthMethods().find((candidate) => !isTerminalAuthMethod(candidate));
+
+        if (selfHandled) {
+          await showToast({
+            style: Toast.Style.Failure,
+            title: "Agent is not signed in",
+            message: `Authenticate via "${selfHandled.name}", then send your message again.`,
+            primaryAction: {
+              title: `Authenticate with ${selfHandled.name}`,
+              onAction: async (toast) => {
+                try {
+                  await acpClient.authenticate(selfHandled.id);
+                  toast.style = Toast.Style.Success;
+                  toast.title = "Authenticated";
+                  toast.message = "Send your message again.";
+                } catch (authError) {
+                  toast.title = "Authentication failed";
+                  toast.message = rpcErrorMessage(authError);
+                }
+              },
+            },
+          });
+          return;
+        }
+
+        await showToast({
+          style: Toast.Style.Failure,
+          title: "Agent is not signed in",
+          message: "Sign the agent in from a terminal, or set an API token in its environment variables.",
+        });
+        return;
+      }
+
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Agent is not signed in",
+        message: `Log in via "${command.label}", then send your message again.`,
+        primaryAction: {
+          title: "Open Login in Terminal",
+          onAction: async (toast) => {
+            const opened = await openTerminalAuth(command);
+            if (!opened) {
+              await Clipboard.copy(command.shellCommand);
+              toast.title = "Login command copied";
+              toast.message = "Run it in a terminal, then send your message again.";
+            } else {
+              toast.hide();
+            }
+          },
+        },
+        secondaryAction: {
+          title: "Copy Login Command",
+          onAction: async (toast) => {
+            await Clipboard.copy(command.shellCommand);
+            toast.title = "Login command copied";
+          },
+        },
+      });
+    },
+    [acpClient],
+  );
 
   const loadContextsForSession = useCallback(
     async (sessionId: string | null) => {
@@ -207,7 +301,7 @@ export function useChatSession(): UseChatSessionResult {
   }, [storageService]);
 
   const startSession = useCallback(
-    async (agent: AgentConfig, prompt: string) => {
+    async (agent: AgentConfig, prompt: string, modeId?: string) => {
       if (!prompt.trim()) {
         await showToast({
           style: Toast.Style.Failure,
@@ -263,6 +357,13 @@ export function useChatSession(): UseChatSessionResult {
           fallbackDir: process.cwd(),
         });
 
+        // Detach the previous session's observer up front: createSession attaches the
+        // new one itself, before the first prompt goes out, so the opening turn streams.
+        if (activeSessionIdRef.current) {
+          sessionService.offSessionMessage(activeSessionIdRef.current);
+          activeSessionIdRef.current = null;
+        }
+
         const session = await sessionService.createSession({
           agentConnectionId: agentConnection.id,
           agentConfigId: agent.id,
@@ -275,15 +376,13 @@ export function useChatSession(): UseChatSessionResult {
           metadata: {
             title: prompt.slice(0, 60),
           },
+          modeId,
+          onMessage: handleStreamingMessage,
         });
 
         setConversation(session);
         setMessages(session.messages);
-        if (activeSessionIdRef.current) {
-          sessionService.offSessionMessage(activeSessionIdRef.current);
-        }
         activeSessionIdRef.current = session.sessionId;
-        sessionService.onSessionMessage(session.sessionId, handleStreamingMessage);
 
         // Refresh conversation to ensure any streaming messages are captured
         await refreshConversation(session.sessionId);
@@ -294,14 +393,22 @@ export function useChatSession(): UseChatSessionResult {
         logger.info("Session initialized", { sessionId: session.sessionId });
       } catch (error) {
         setStatus("idle");
-        await ErrorHandler.handleError(error, "Starting chat session");
+        await handleAgentError(error, "Starting chat session");
       }
     },
-    [acpClient, sessionService, handleStreamingMessage, connection, refreshConversation, loadContextsForSession],
+    [
+      acpClient,
+      sessionService,
+      handleStreamingMessage,
+      handleAgentError,
+      connection,
+      refreshConversation,
+      loadContextsForSession,
+    ],
   );
 
   const sendMessage = useCallback(
-    async (message: string) => {
+    async (message: string, modeId?: string) => {
       if (status === "processing" || status === "connecting") {
         return;
       }
@@ -316,7 +423,9 @@ export function useChatSession(): UseChatSessionResult {
           return;
         }
 
-        await startSession(activeAgent, message);
+        // Only relevant here: the mode has to be set while the session is being
+        // opened, which is what startSession does.
+        await startSession(activeAgent, message, modeId);
         return;
       }
 
@@ -365,10 +474,20 @@ export function useChatSession(): UseChatSessionResult {
         setStatus("ready");
       } catch (error) {
         setStatus("ready");
-        await ErrorHandler.handleError(error, "Sending message to agent");
+        await handleAgentError(error, "Sending message to agent");
       }
     },
-    [status, conversation, activeAgent, sessionService, startSession, refreshConversation, connection, acpClient],
+    [
+      status,
+      conversation,
+      activeAgent,
+      sessionService,
+      startSession,
+      refreshConversation,
+      handleAgentError,
+      connection,
+      acpClient,
+    ],
   );
 
   const runSlashCommand = useCallback(

--- a/extensions/agent-client-protocol/src/services/acpClient.ts
+++ b/extensions/agent-client-protocol/src/services/acpClient.ts
@@ -7,22 +7,19 @@
 
 import { spawn, ChildProcess } from "child_process";
 import { Writable, Readable } from "stream";
-import * as acp from "@zed-industries/agent-client-protocol";
-import type { Stream } from "@zed-industries/agent-client-protocol";
+import * as acp from "@agentclientprotocol/sdk";
+import type { Stream } from "@agentclientprotocol/sdk";
 import type { SessionUpdateNotification } from "@/types/acp";
 import type { AgentConfig, AgentConnection, ExtensionError } from "@/types/extension";
 import { ErrorCode } from "@/types/extension";
 import { createLogger } from "@/utils/logging";
+import { describeRpcError, isAuthRequiredError, rpcErrorMessage } from "@/utils/errors";
+import { buildAgentEnvironment } from "@/utils/agentEnvironment";
 import { ProcessTracker } from "./processTracker";
 import { PermissionService } from "./permissionService";
 import { TerminalManager } from "./terminalManager";
 
 const logger = createLogger("ACPClient");
-
-type RpcConnection = {
-  sendNotification<TParams>(method: string, params?: TParams): Promise<void>;
-  sendRequest<TParams, TResponse>(method: string, params?: TParams): Promise<TResponse>;
-};
 
 export class ACPClient implements acp.Client {
   private connection: acp.ClientSideConnection | null = null;
@@ -34,6 +31,7 @@ export class ACPClient implements acp.Client {
   private lastError: ExtensionError | null = null;
   private updateListeners = new Set<(update: SessionUpdateNotification) => void>();
   private permissionService = new PermissionService();
+  private authMethods: acp.AuthMethod[] = [];
 
   constructor() {
     // Initialize process tracker on first instantiation
@@ -98,6 +96,13 @@ export class ACPClient implements acp.Client {
 
       // Initialize the agent
       const initResult = await this.initialize();
+      this.authMethods = initResult.authMethods ?? [];
+
+      logger.info("Agent initialized", {
+        agentId: config.id,
+        protocolVersion: initResult.protocolVersion,
+        authMethods: this.authMethods.map((method) => method.id),
+      });
 
       const connectedAt = new Date();
 
@@ -130,7 +135,7 @@ export class ACPClient implements acp.Client {
 
       const extensionError = this.createError(
         ErrorCode.AgentConnectionFailed,
-        `Failed to connect to agent: ${error instanceof Error ? error.message : "Unknown error"}`,
+        `Failed to connect to agent: ${rpcErrorMessage(error)}`,
         { originalError: error },
       );
 
@@ -164,6 +169,7 @@ export class ACPClient implements acp.Client {
     this.isConnected = false;
     this.connectionId = null;
     this.config = null;
+    this.authMethods = [];
   }
 
   /**
@@ -181,6 +187,46 @@ export class ACPClient implements acp.Client {
     if (this.isConnected) return "connected";
     if (this.lastError) return "error";
     return "disconnected";
+  }
+
+  /**
+   * Authentication methods the connected agent offered during `initialize`
+   */
+  getAuthMethods(): acp.AuthMethod[] {
+    return this.authMethods;
+  }
+
+  /**
+   * Configuration of the agent this client is currently connected to
+   */
+  getConnectedConfig(): AgentConfig | null {
+    return this.config;
+  }
+
+  /**
+   * Authenticate with the connected agent.
+   *
+   * Only for methods the agent handles itself. `terminal` methods are run by the
+   * client instead — see `buildTerminalAuthCommand` in `@/utils/agentAuth`.
+   */
+  async authenticate(methodId: string): Promise<void> {
+    this.ensureConnected();
+
+    logger.info("Authenticating with agent", { methodId });
+
+    try {
+      await this.connection!.authenticate({ methodId });
+    } catch (error) {
+      const rpcError = describeRpcError(error);
+
+      logger.error("Agent authentication failed", { methodId, error: rpcError.message });
+
+      throw this.createError(ErrorCode.AuthenticationRequired, `Authentication failed: ${rpcError.message}`, {
+        methodId,
+        rpcCode: rpcError.code,
+        originalError: error,
+      });
+    }
   }
 
   /**
@@ -225,16 +271,19 @@ export class ACPClient implements acp.Client {
 
       return response;
     } catch (error) {
+      const rpcError = describeRpcError(error);
+
       logger.error("Failed to create ACP session", {
-        error: error instanceof Error ? error.message : String(error),
+        error: rpcError.message,
+        rpcCode: rpcError.code,
         stack: error instanceof Error ? error.stack : undefined,
         request,
       });
 
       throw this.createError(
-        ErrorCode.SessionNotFound,
-        `Failed to create session: ${error instanceof Error ? error.message : "Unknown error"}`,
-        { request, originalError: error },
+        isAuthRequiredError(error) ? ErrorCode.AuthenticationRequired : ErrorCode.SessionNotFound,
+        `Failed to create session: ${rpcError.message}`,
+        { request, rpcCode: rpcError.code, originalError: error },
       );
     }
   }
@@ -272,16 +321,19 @@ export class ACPClient implements acp.Client {
 
       return response;
     } catch (error) {
+      const rpcError = describeRpcError(error);
+
       logger.error("Failed to send prompt", {
         sessionId,
-        error: error instanceof Error ? error.message : String(error),
+        error: rpcError.message,
+        rpcCode: rpcError.code,
         stack: error instanceof Error ? error.stack : undefined,
       });
 
       throw this.createError(
-        ErrorCode.ProtocolError,
-        `Failed to send prompt: ${error instanceof Error ? error.message : "Unknown error"}`,
-        { sessionId, prompt: text, originalError: error },
+        isAuthRequiredError(error) ? ErrorCode.AuthenticationRequired : ErrorCode.ProtocolError,
+        `Failed to send prompt: ${rpcError.message}`,
+        { sessionId, prompt: text, rpcCode: rpcError.code, originalError: error },
       );
     }
   }
@@ -513,6 +565,11 @@ export class ACPClient implements acp.Client {
         writeTextFile: true,
       },
       terminal: true,
+      // Without this, agents omit their terminal login methods from `authMethods`
+      // and the extension has no way to get an unauthenticated agent signed in.
+      auth: {
+        terminal: true,
+      },
     };
 
     const request: acp.InitializeRequest = {
@@ -524,11 +581,10 @@ export class ACPClient implements acp.Client {
       const response = await this.connection.initialize(request);
       return response;
     } catch (error) {
-      throw this.createError(
-        ErrorCode.SystemError,
-        `Agent initialization failed: ${error instanceof Error ? error.message : "Unknown error"}`,
-        { request, originalError: error },
-      );
+      throw this.createError(ErrorCode.SystemError, `Agent initialization failed: ${rpcErrorMessage(error)}`, {
+        request,
+        originalError: error,
+      });
     }
   }
 
@@ -589,6 +645,43 @@ export class ACPClient implements acp.Client {
   }
 
   /**
+   * Private: Surface the agent's stderr in the extension log, line by line
+   */
+  private forwardAgentStderr(child: ChildProcess, command: string): void {
+    if (!child.stderr) {
+      return;
+    }
+
+    const agentLogger = createLogger("AgentProcess");
+    let buffer = "";
+
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      buffer += chunk;
+
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        if (line.trim()) {
+          agentLogger.warn(line.trimEnd(), { command });
+        }
+      }
+    });
+
+    child.stderr.on("end", () => {
+      if (buffer.trim()) {
+        agentLogger.warn(buffer.trimEnd(), { command });
+        buffer = "";
+      }
+    });
+
+    child.stderr.on("error", (error: Error) => {
+      agentLogger.debug("Agent stderr stream error", { error: error.message });
+    });
+  }
+
+  /**
    * Private: Create subprocess connection for local agents
    */
   private async createSubprocessConnection(config: AgentConfig): Promise<Stream> {
@@ -596,40 +689,14 @@ export class ACPClient implements acp.Client {
       throw this.createError(ErrorCode.InvalidConfiguration, "Subprocess agent requires command");
     }
 
-    const baseEnv: NodeJS.ProcessEnv = { ...process.env };
-    const mergedEnv: NodeJS.ProcessEnv = { ...baseEnv, ...(config.environmentVariables ?? {}) };
-
-    if (config.appendToPath?.length) {
-      const existingPath = mergedEnv.PATH ?? mergedEnv.Path ?? mergedEnv.path ?? process.env.PATH ?? "";
-      // Use platform-specific PATH separator (: for Unix, ; for Windows)
-      const pathSeparator = process.platform === "win32" ? ";" : ":";
-
-      const currentSegments = existingPath
-        ? existingPath
-            .split(pathSeparator)
-            .map((segment) => segment.trim())
-            .filter(Boolean)
-        : [];
-
-      const appendSegments = config.appendToPath.filter(Boolean);
-      for (const segment of appendSegments) {
-        if (!currentSegments.includes(segment)) {
-          currentSegments.push(segment);
-        }
-      }
-
-      if (currentSegments.length > 0) {
-        mergedEnv.PATH = currentSegments.join(pathSeparator);
-        mergedEnv.Path = mergedEnv.PATH;
-        mergedEnv.path = mergedEnv.PATH;
-      }
-    }
+    const mergedEnv = buildAgentEnvironment(config);
 
     logger.info("Spawning ACP agent subprocess", {
       command: config.command,
       args: config.args,
       cwd: config.workingDirectory || process.cwd(),
-      path: mergedEnv.PATH ?? process.env.PATH ?? "",
+      path: mergedEnv.PATH,
+      user: mergedEnv.USER ?? mergedEnv.USERNAME,
     });
 
     // Check if there's already a running process for this agent
@@ -642,9 +709,11 @@ export class ACPClient implements acp.Client {
       ProcessTracker.killProcess(config.id);
     }
 
-    // Spawn the agent process
+    // Spawn the agent process. stderr is piped rather than inherited: agents report
+    // the real reason for protocol-level failures (missing login, bad config) there,
+    // and inheriting it drops those lines outside the extension's own log.
     this.agentProcess = spawn(config.command, config.args || [], {
-      stdio: ["pipe", "pipe", "inherit"],
+      stdio: ["pipe", "pipe", "pipe"],
       cwd: config.workingDirectory || process.cwd(),
       env: mergedEnv,
     });
@@ -652,6 +721,8 @@ export class ACPClient implements acp.Client {
     if (!this.agentProcess.stdin || !this.agentProcess.stdout) {
       throw this.createError(ErrorCode.SystemError, "Failed to create agent process streams");
     }
+
+    this.forwardAgentStderr(this.agentProcess, config.command);
 
     // Register the process with tracker
     if (this.agentProcess.pid) {
@@ -725,11 +796,6 @@ export class ACPClient implements acp.Client {
     if (!this.isConnected || !this.connection) {
       throw this.createError(ErrorCode.AgentUnavailable, "No active agent connection");
     }
-  }
-
-  private getActiveRpcConnection(): RpcConnection {
-    this.ensureConnected();
-    return this.connection as unknown as RpcConnection;
   }
 
   /**
@@ -812,26 +878,23 @@ export class ACPClient implements acp.Client {
   async cancelSession(sessionId: string): Promise<void> {
     logger.info("Cancelling session", { sessionId });
 
+    this.ensureConnected();
+
     try {
-      const connection = this.getActiveRpcConnection();
-      // Send session/cancel notification
-      // This is a notification (one-way message), not a request
-      await connection.sendNotification("session/cancel", {
-        sessionId,
-      });
+      // A notification (one-way message), not a request
+      await this.connection!.cancel({ sessionId });
 
       logger.info("Session cancel notification sent", { sessionId });
     } catch (error) {
       logger.error("Failed to send cancel notification", {
         sessionId,
-        error: error instanceof Error ? error.message : "Unknown error",
+        error: rpcErrorMessage(error),
       });
 
-      throw this.createError(
-        ErrorCode.ProtocolError,
-        `Failed to cancel session: ${error instanceof Error ? error.message : "Unknown error"}`,
-        { sessionId, originalError: error },
-      );
+      throw this.createError(ErrorCode.ProtocolError, `Failed to cancel session: ${rpcErrorMessage(error)}`, {
+        sessionId,
+        originalError: error,
+      });
     }
   }
 
@@ -844,14 +907,10 @@ export class ACPClient implements acp.Client {
       modeId: params.modeId,
     });
 
+    this.ensureConnected();
+
     try {
-      const connection = this.getActiveRpcConnection();
-      // Call the ACP session/set_mode method
-      // The connection object handles the JSON-RPC call
-      const response = await connection.sendRequest<acp.SetSessionModeRequest, acp.SetSessionModeResponse>(
-        "session/set_mode",
-        params,
-      );
+      const response = await this.connection!.setSessionMode(params);
 
       logger.info("Session mode changed successfully", {
         sessionId: params.sessionId,
@@ -863,14 +922,14 @@ export class ACPClient implements acp.Client {
       logger.error("Failed to set session mode", {
         sessionId: params.sessionId,
         modeId: params.modeId,
-        error: error instanceof Error ? error.message : "Unknown error",
+        error: rpcErrorMessage(error),
       });
 
-      throw this.createError(
-        ErrorCode.ProtocolError,
-        `Failed to set session mode: ${error instanceof Error ? error.message : "Unknown error"}`,
-        { sessionId: params.sessionId, modeId: params.modeId, originalError: error },
-      );
+      throw this.createError(ErrorCode.ProtocolError, `Failed to set session mode: ${rpcErrorMessage(error)}`, {
+        sessionId: params.sessionId,
+        modeId: params.modeId,
+        originalError: error,
+      });
     }
   }
 
@@ -988,7 +1047,7 @@ export class ACPClient implements acp.Client {
   /**
    * Kill a terminal command without releasing the terminal
    */
-  async killTerminal(params: acp.KillTerminalCommandRequest): Promise<acp.KillTerminalResponse> {
+  async killTerminal(params: acp.KillTerminalRequest): Promise<acp.KillTerminalResponse> {
     logger.info("Kill terminal request", {
       sessionId: params.sessionId,
       terminalId: params.terminalId,

--- a/extensions/agent-client-protocol/src/services/agentModeService.ts
+++ b/extensions/agent-client-protocol/src/services/agentModeService.ts
@@ -1,0 +1,90 @@
+/**
+ * Agent Mode Service
+ *
+ * An agent only reveals its modes when a session is opened, so the very first chat
+ * with an agent cannot offer a choice. This service remembers the modes each agent
+ * reported, together with the default the user picked for it, so later chats can
+ * select a mode up front instead of forcing the user to switch after the first
+ * message — by which point permission prompts have already appeared.
+ *
+ * Kept out of the agent configuration on purpose: built-in agents are read-only,
+ * but their modes should be selectable all the same.
+ */
+
+import { LocalStorage } from "@raycast/api";
+import { STORAGE_KEYS } from "@/utils/storageKeys";
+import { createLogger } from "@/utils/logging";
+import type { AgentMode } from "@/types/entities";
+
+const logger = createLogger("AgentModeService");
+
+interface AgentModeRecord {
+  modes: AgentMode[];
+  defaultModeId?: string;
+}
+
+type AgentModeStore = Record<string, AgentModeRecord>;
+
+export class AgentModeService {
+  private async readStore(): Promise<AgentModeStore> {
+    try {
+      const raw = await LocalStorage.getItem(STORAGE_KEYS.AGENT_MODES);
+      if (!raw || typeof raw !== "string") {
+        return {};
+      }
+      return JSON.parse(raw) as AgentModeStore;
+    } catch (error) {
+      logger.warn("Failed to read agent modes, starting empty", { error });
+      return {};
+    }
+  }
+
+  private async writeStore(store: AgentModeStore): Promise<void> {
+    await LocalStorage.setItem(STORAGE_KEYS.AGENT_MODES, JSON.stringify(store));
+  }
+
+  /**
+   * Modes an agent reported the last time a session was opened with it.
+   */
+  async getKnownModes(agentId: string): Promise<AgentMode[]> {
+    const store = await this.readStore();
+    return store[agentId]?.modes ?? [];
+  }
+
+  /**
+   * The mode to start new sessions with, if the user picked one.
+   */
+  async getDefaultMode(agentId: string): Promise<string | undefined> {
+    const store = await this.readStore();
+    return store[agentId]?.defaultModeId;
+  }
+
+  async setDefaultMode(agentId: string, modeId: string | undefined): Promise<void> {
+    const store = await this.readStore();
+    const record = store[agentId] ?? { modes: [] };
+
+    store[agentId] = { ...record, defaultModeId: modeId };
+    await this.writeStore(store);
+
+    logger.info("Default agent mode updated", { agentId, modeId });
+  }
+
+  /**
+   * Remember the modes an agent reported. Drops a stored default that the agent
+   * no longer offers, so a stale id cannot be sent on every new session.
+   */
+  async rememberModes(agentId: string, modes: AgentMode[]): Promise<void> {
+    if (modes.length === 0) {
+      return;
+    }
+
+    const store = await this.readStore();
+    const previousDefault = store[agentId]?.defaultModeId;
+    const defaultModeId = modes.some((mode) => mode.id === previousDefault) ? previousDefault : undefined;
+
+    store[agentId] = { modes, defaultModeId };
+    await this.writeStore(store);
+
+    logger.debug("Remembered agent modes", { agentId, modeCount: modes.length, defaultModeId });
+  }
+}

--- a/extensions/agent-client-protocol/src/services/permissionService.ts
+++ b/extensions/agent-client-protocol/src/services/permissionService.ts
@@ -8,11 +8,7 @@ import { Alert, confirmAlert, showToast, Toast } from "@raycast/api";
 import { createLogger } from "@/utils/logging";
 import { ConfigService } from "./configService";
 import type { SecuritySettings } from "@/types/extension";
-import type {
-  RequestPermissionRequest,
-  RequestPermissionResponse,
-  PermissionOption,
-} from "@zed-industries/agent-client-protocol/dist/schema";
+import type { RequestPermissionRequest, RequestPermissionResponse, PermissionOption } from "@agentclientprotocol/sdk";
 
 const logger = createLogger("PermissionService");
 

--- a/extensions/agent-client-protocol/src/services/sessionService.ts
+++ b/extensions/agent-client-protocol/src/services/sessionService.ts
@@ -227,8 +227,13 @@ export class SessionService implements SessionServiceInterface {
           error,
         });
 
-        session.status = "error";
-        await this.storageService.saveConversation(session);
+        // The session itself is fine — `session/new` succeeded and only the prompt
+        // was refused, typically because the agent still needs a login. It stays
+        // stored and active so the user can retry from the conversation list once
+        // the cause is fixed, which is exactly what the error toast asks them to do.
+        // Marking it as failed here would make it non-resumable while persistence
+        // still lists it, leaving a conversation that rejects every message.
+        this.offSessionMessage(sessionId);
 
         throw this.toAgentError(error, "Failed to send the first message to the agent", {
           sessionId,

--- a/extensions/agent-client-protocol/src/services/sessionService.ts
+++ b/extensions/agent-client-protocol/src/services/sessionService.ts
@@ -9,7 +9,7 @@
  */
 
 import { v4 as uuidv4 } from "uuid";
-import { ACPError, ErrorCode } from "@/utils/errors";
+import { ACPError, ErrorCode, rpcErrorMessage } from "@/utils/errors";
 import { createLogger, PerformanceLogger } from "@/utils/logging";
 import type {
   ConversationSession,
@@ -29,6 +29,7 @@ import type {
   PlanUpdate,
   AvailableCommandsUpdate,
   CurrentModeUpdate,
+  UsageUpdate,
   ToolCallContent,
   ContentBlock,
   ToolCallStatus,
@@ -38,6 +39,7 @@ import type { StorageService } from "./storageService";
 import type { ACPClient } from "./acpClient";
 import { ContextService } from "./contextService";
 import { PersistenceService } from "./persistenceService";
+import { AgentModeService } from "./agentModeService";
 
 const logger = createLogger("SessionService");
 
@@ -45,6 +47,8 @@ export class SessionService implements SessionServiceInterface {
   private contextService: ContextService;
 
   private persistenceService: PersistenceService;
+
+  private agentModeService = new AgentModeService();
 
   private activeStreamingMessages: Map<string, Partial<Record<"assistant" | "user", { id: string; content: string }>>> =
     new Map();
@@ -135,49 +139,13 @@ export class SessionService implements SessionServiceInterface {
         },
       };
 
-      // Send initial prompt to agent via ACP
+      // Open the ACP session first. The prompt is deliberately sent later: the agent
+      // starts streaming the answer while `session/prompt` is still pending, so the
+      // session has to be stored and observed before we ask it anything.
+      let acpSession: Awaited<ReturnType<ACPClient["createSession"]>>;
       try {
-        const acpSession = await this.acpClient.createSession({
+        acpSession = await this.acpClient.createSession({
           cwd: request.context?.workingDirectory ?? process.cwd(),
-        });
-
-        await this.acpClient.sendPrompt(acpSession.sessionId, request.prompt);
-
-        // Note: Agent responses come via sessionUpdate callbacks, not in the prompt response
-        // The prompt response just indicates the request was accepted
-
-        session.agentSessionId = acpSession.sessionId;
-        session.context = {
-          ...session.context,
-          additionalContext: {
-            ...(session.context?.additionalContext ?? {}),
-            agentSessionId: acpSession.sessionId,
-          },
-        };
-
-        // Capture mode information if provided by the agent
-        if (acpSession.modes) {
-          const currentMode = acpSession.modes.availableModes.find((m) => m.id === acpSession.modes!.currentModeId);
-
-          session.currentMode = currentMode
-            ? {
-                id: currentMode.id,
-                name: currentMode.name,
-              }
-            : undefined;
-
-          session.availableModes = acpSession.modes.availableModes;
-
-          logger.info("Agent mode information captured", {
-            sessionId,
-            currentMode: session.currentMode,
-            availableModes: session.availableModes,
-          });
-        }
-
-        logger.info("Session created successfully", {
-          sessionId,
-          messageCount: session.messages.length,
         });
       } catch (error) {
         logger.error("Failed to create ACP session", {
@@ -186,33 +154,52 @@ export class SessionService implements SessionServiceInterface {
           error,
         });
 
-        throw new ACPError(
-          ErrorCode.ProtocolError,
-          "Failed to create session with agent",
-          error instanceof Error ? error.message : "Unknown ACP error",
-          { sessionId, agentConnectionId: request.agentConnectionId },
-        );
+        throw this.toAgentError(error, "Failed to create session with agent", {
+          sessionId,
+          agentConnectionId: request.agentConnectionId,
+        });
       }
 
-      // Save session to storage BEFORE processing pending updates
-      // This ensures the session exists when processPendingUpdates tries to find it
+      session.agentSessionId = acpSession.sessionId;
+      session.context = {
+        ...session.context,
+        additionalContext: {
+          ...(session.context?.additionalContext ?? {}),
+          agentSessionId: acpSession.sessionId,
+        },
+      };
+
+      // Capture mode information if provided by the agent
+      if (acpSession.modes) {
+        const currentMode = acpSession.modes.availableModes.find((m) => m.id === acpSession.modes!.currentModeId);
+
+        session.currentMode = currentMode
+          ? {
+              id: currentMode.id,
+              name: currentMode.name,
+            }
+          : undefined;
+
+        session.availableModes = acpSession.modes.availableModes;
+
+        logger.info("Agent mode information captured", {
+          sessionId,
+          currentMode: session.currentMode,
+          availableModes: session.availableModes,
+        });
+
+        // Remember them so the next chat with this agent can pick a mode up front
+        await this.agentModeService.rememberModes(request.agentConfigId, session.availableModes);
+
+        const requestedModeId = request.modeId ?? (await this.agentModeService.getDefaultMode(request.agentConfigId));
+        await this.applyInitialMode(session, requestedModeId);
+      }
+
       try {
         await this.storageService.saveConversation(session);
         await this.persistenceService.saveSessionSnapshot(session);
 
         logger.info("Session saved to storage", { sessionId });
-
-        // Process any buffered updates that arrived while session was being created
-        // Now that the session is saved, these updates can be properly applied
-        await this.processPendingUpdates(session.agentSessionId!, sessionId);
-
-        PerformanceLogger.end(operationId, {
-          success: true,
-          sessionId,
-          messageCount: session.messages.length,
-        });
-
-        return session;
       } catch (error) {
         logger.error("Failed to save session to storage", { sessionId, error });
 
@@ -223,13 +210,105 @@ export class SessionService implements SessionServiceInterface {
           { sessionId },
         );
       }
+
+      if (request.onMessage) {
+        this.onSessionMessage(sessionId, request.onMessage);
+      }
+
+      // Anything the agent already sent (e.g. its command list) can now be applied
+      await this.processPendingUpdates(session.agentSessionId, sessionId);
+
+      try {
+        await this.acpClient.sendPrompt(acpSession.sessionId, request.prompt);
+      } catch (error) {
+        logger.error("Failed to send initial prompt", {
+          sessionId,
+          agentSessionId: acpSession.sessionId,
+          error,
+        });
+
+        session.status = "error";
+        await this.storageService.saveConversation(session);
+
+        throw this.toAgentError(error, "Failed to send the first message to the agent", {
+          sessionId,
+          agentConnectionId: request.agentConnectionId,
+        });
+      }
+
+      logger.info("Session created successfully", {
+        sessionId,
+        messageCount: session.messages.length,
+      });
+
+      PerformanceLogger.end(operationId, {
+        success: true,
+        sessionId,
+        messageCount: session.messages.length,
+      });
+
+      // Return the stored session so streamed messages that landed during the first
+      // turn are included rather than the pre-prompt snapshot.
+      return (await this.storageService.getConversation(sessionId)) ?? session;
     } catch (error) {
       PerformanceLogger.end(operationId, {
         success: false,
-        error: error instanceof Error ? error.message : "Unknown error",
+        error: rpcErrorMessage(error),
       });
       throw error;
     }
+  }
+
+  /**
+   * Put a freshly opened session into the requested mode.
+   *
+   * Failing to switch must not sink the session — the chat still works, just under
+   * the agent's own default — so this reports rather than throws.
+   */
+  private async applyInitialMode(session: ConversationSession, modeId: string | undefined): Promise<void> {
+    if (!modeId || !session.agentSessionId || modeId === session.currentMode?.id) {
+      return;
+    }
+
+    const mode = session.availableModes?.find((m) => m.id === modeId);
+    if (!mode) {
+      logger.warn("Requested mode is not offered by the agent, keeping its default", {
+        sessionId: session.sessionId,
+        modeId,
+        availableModes: session.availableModes?.map((m) => m.id),
+      });
+      return;
+    }
+
+    try {
+      await this.acpClient.setSessionMode({ sessionId: session.agentSessionId, modeId });
+      session.currentMode = { id: mode.id, name: mode.name };
+
+      logger.info("Session started in requested mode", { sessionId: session.sessionId, modeId });
+    } catch (error) {
+      logger.warn("Failed to set the initial session mode", {
+        sessionId: session.sessionId,
+        modeId,
+        error: rpcErrorMessage(error),
+      });
+    }
+  }
+
+  /**
+   * Turn a failure from the ACP client into an ACPError, keeping the agent's own
+   * message and preserving an authentication demand as its own error code so the
+   * UI can offer a login instead of a generic protocol error.
+   */
+  private toAgentError(error: unknown, message: string, context: Record<string, unknown>): ACPError {
+    const agentCode = (error as { code?: unknown } | undefined)?.code;
+    const requiresAuth = agentCode === ErrorCode.AuthenticationRequired;
+
+    return new ACPError(
+      requiresAuth ? ErrorCode.AuthenticationRequired : ErrorCode.ProtocolError,
+      requiresAuth ? "The agent requires authentication" : message,
+      rpcErrorMessage(error, "ACP communication error"),
+      context,
+    );
   }
 
   /**
@@ -307,12 +386,7 @@ export class SessionService implements SessionServiceInterface {
 
       logger.error("Failed to end session", { sessionId, error });
 
-      throw new ACPError(
-        ErrorCode.SystemError,
-        "Failed to end session",
-        error instanceof Error ? error.message : "Unknown error",
-        { sessionId },
-      );
+      throw new ACPError(ErrorCode.SystemError, "Failed to end session", rpcErrorMessage(error), { sessionId });
     }
   }
 
@@ -522,12 +596,10 @@ export class SessionService implements SessionServiceInterface {
         } else {
           logger.error("Failed to send message to agent", { sessionId, error });
 
-          throw new ACPError(
-            ErrorCode.ProtocolError,
-            "Failed to send message to agent",
-            error instanceof Error ? error.message : "ACP communication error",
-            { sessionId, messageId: userMessage.id },
-          );
+          throw this.toAgentError(error, "Failed to send message to agent", {
+            sessionId,
+            messageId: userMessage.id,
+          });
         }
       }
 
@@ -567,7 +639,7 @@ export class SessionService implements SessionServiceInterface {
     } catch (error) {
       PerformanceLogger.end(operationId, {
         success: false,
-        error: error instanceof Error ? error.message : "Unknown error",
+        error: rpcErrorMessage(error),
       });
       throw error;
     }
@@ -611,12 +683,9 @@ export class SessionService implements SessionServiceInterface {
 
       logger.error("Failed to get session messages", { sessionId, error });
 
-      throw new ACPError(
-        ErrorCode.SystemError,
-        "Failed to retrieve session messages",
-        error instanceof Error ? error.message : "Unknown error",
-        { sessionId },
-      );
+      throw new ACPError(ErrorCode.SystemError, "Failed to retrieve session messages", rpcErrorMessage(error), {
+        sessionId,
+      });
     }
   }
 
@@ -665,8 +734,16 @@ export class SessionService implements SessionServiceInterface {
         modeId,
       });
 
-      logger.info("Session mode change requested", { sessionId, modeId });
-      // Note: The actual mode update will come via current_mode_update notification
+      // Apply the switch locally. Some agents (Claude among them) acknowledge
+      // `session/set_mode` without following up with a `current_mode_update`
+      // notification, and waiting for one would leave the UI on the old mode.
+      // `handleSessionUpdate` applies the same change idempotently for agents
+      // that do send it.
+      const newMode = session.availableModes?.find((m) => m.id === modeId);
+      session.currentMode = newMode ? { id: newMode.id, name: newMode.name } : { id: modeId, name: modeId };
+      await this.storageService.saveConversation(session);
+
+      logger.info("Session mode changed", { sessionId, modeId });
     } catch (error) {
       if (error instanceof ACPError) {
         throw error;
@@ -674,12 +751,10 @@ export class SessionService implements SessionServiceInterface {
 
       logger.error("Failed to set session mode", { sessionId, modeId, error });
 
-      throw new ACPError(
-        ErrorCode.SystemError,
-        "Failed to set session mode",
-        error instanceof Error ? error.message : "Unknown error",
-        { sessionId, modeId },
-      );
+      throw new ACPError(ErrorCode.SystemError, "Failed to set session mode", rpcErrorMessage(error), {
+        sessionId,
+        modeId,
+      });
     }
   }
 
@@ -712,12 +787,7 @@ export class SessionService implements SessionServiceInterface {
 
       logger.error("Failed to get session mode", { sessionId, error });
 
-      throw new ACPError(
-        ErrorCode.SystemError,
-        "Failed to get session mode",
-        error instanceof Error ? error.message : "Unknown error",
-        { sessionId },
-      );
+      throw new ACPError(ErrorCode.SystemError, "Failed to get session mode", rpcErrorMessage(error), { sessionId });
     }
   }
 
@@ -1236,7 +1306,7 @@ export class SessionService implements SessionServiceInterface {
         return jsonString === "{}" ? null : jsonString;
       } catch (error) {
         logger.debug("JSON stringification failed, falling back to toString", {
-          error: error instanceof Error ? error.message : "Unknown error",
+          error: rpcErrorMessage(error),
         });
         // Fallback to toString or a descriptive message
         try {
@@ -1410,6 +1480,25 @@ export class SessionService implements SessionServiceInterface {
     }
   }
 
+  private async applyUsageUpdate(session: ConversationSession, usage: UsageUpdate): Promise<void> {
+    session.metadata = {
+      ...session.metadata,
+      tokenCount: usage.used,
+      contextWindowSize: usage.size,
+      estimatedCost: usage.cost?.amount ?? session.metadata?.estimatedCost,
+    };
+    session.lastActivity = new Date();
+
+    await this.storageService.saveConversation(session);
+
+    logger.debug("Session usage updated", {
+      sessionId: session.sessionId,
+      used: usage.used,
+      size: usage.size,
+      cost: usage.cost?.amount,
+    });
+  }
+
   private async handleSessionUpdate(update: SessionUpdateNotification): Promise<void> {
     const sessionId = update.sessionId;
 
@@ -1508,6 +1597,28 @@ export class SessionService implements SessionServiceInterface {
       return;
     }
 
+    // Usage updates carry context-window and cost figures rather than conversation
+    // content, so they go straight into the session metadata instead of the transcript.
+    if (update.update?.sessionUpdate === "usage_update") {
+      await this.applyUsageUpdate(session, update.update as UsageUpdate);
+      return;
+    }
+
+    // The agent's slash-command catalogue belongs on the session, not in the transcript.
+    if (update.update?.sessionUpdate === "available_commands_update") {
+      const commandsUpdate = update.update as AvailableCommandsUpdate;
+      session.availableCommands = commandsUpdate.availableCommands;
+
+      await this.storageService.saveConversation(session);
+      await this.persistenceService.saveSessionSnapshot(session);
+
+      logger.info("Available commands updated for session", {
+        sessionId,
+        commandCount: commandsUpdate.availableCommands.length,
+      });
+      return;
+    }
+
     const message = this.transformSessionUpdate(update, session.messages.length);
     if (!message) {
       logger.debug("No message produced from session update", {
@@ -1563,17 +1674,6 @@ export class SessionService implements SessionServiceInterface {
       }
     }
 
-    if (update.update?.sessionUpdate === "available_commands_update") {
-      const commandsUpdate = update.update as AvailableCommandsUpdate;
-      session.availableCommands = commandsUpdate.availableCommands;
-      forceFullSave = true;
-
-      logger.info("Available commands updated for session", {
-        sessionId,
-        commandCount: commandsUpdate.availableCommands.length,
-      });
-    }
-
     // For streaming text messages, merge content with the most recent streaming message of same role
     if (!messageUpdated && message.metadata.isStreaming) {
       let streamingIndex = -1;
@@ -1581,7 +1681,13 @@ export class SessionService implements SessionServiceInterface {
       if (roleKey) {
         const entry = streamingState[roleKey];
         if (entry) {
-          streamingIndex = session.messages.findIndex((candidate) => candidate.id === entry.id);
+          // Only keep appending while that message is still the last one. Once a
+          // tool call has been recorded behind it the turn has moved on, and
+          // merging into it would push the agent's final answer above the tool
+          // calls it is based on.
+          const isStillLast = session.messages[session.messages.length - 1]?.id === entry.id;
+          streamingIndex = isStillLast ? session.messages.length - 1 : -1;
+
           if (streamingIndex < 0) {
             delete streamingState[roleKey];
             if (!streamingState.assistant && !streamingState.user) {
@@ -1930,24 +2036,11 @@ export class SessionService implements SessionServiceInterface {
           },
         };
       }
-      case "available_commands_update": {
-        const commandsUpdate = payload as AvailableCommandsUpdate;
-        const commandText = commandsUpdate.availableCommands
-          .map((command) => `- ${command.name}${command.description ? `: ${command.description}` : ""}`)
-          .join("\n");
-
-        return {
-          id: `commands-${Date.now()}`,
-          role: "system",
-          content: `Available Commands:\n${commandText}`,
-          timestamp: new Date(),
-          metadata: {
-            source: "agent",
-            messageType: "text",
-            sequence,
-          },
-        };
-      }
+      case "available_commands_update":
+        // Not conversation content. Agents send their full slash-command catalogue
+        // right after the session opens; `handleSessionUpdate` stores it on the
+        // session, and putting it in the transcript would bury the first answer.
+        return null;
       case "current_mode_update": {
         const modeChange = payload as CurrentModeUpdate;
 

--- a/extensions/agent-client-protocol/src/start-chat-form.tsx
+++ b/extensions/agent-client-protocol/src/start-chat-form.tsx
@@ -71,10 +71,14 @@ export default function StartChatForm() {
   useEffect(() => {
     let cancelled = false;
 
+    // Drop the previous agent's modes right away. Keeping them while the new ones
+    // load would show the wrong agent's modes, and submitting in that window would
+    // send a mode the new agent does not offer — silently starting in its default.
+    setAgentModes([]);
+    setSelectedModeId("");
+
     async function loadModes() {
       if (!selectedAgentId) {
-        setAgentModes([]);
-        setSelectedModeId("");
         return;
       }
 

--- a/extensions/agent-client-protocol/src/start-chat-form.tsx
+++ b/extensions/agent-client-protocol/src/start-chat-form.tsx
@@ -14,6 +14,8 @@ import type { AgentConfig } from "@/types/extension";
 import ChatCommand from "@/chat";
 import { useNavigation } from "@raycast/api";
 import { STORAGE_KEYS } from "@/utils/storageKeys";
+import { AgentModeService } from "@/services/agentModeService";
+import type { AgentMode } from "@/types/entities";
 
 const logger = createLogger("StartChatForm");
 
@@ -37,6 +39,7 @@ interface LastChatConfig {
 interface FormValues {
   agentId: string;
   workingDirectory: string;
+  modeId?: string;
   favoriteId?: string;
   saveFavorite: boolean;
   favoriteName?: string;
@@ -52,12 +55,46 @@ export default function StartChatForm() {
   const [selectedFavoriteId, setSelectedFavoriteId] = useState<string>("");
   const [workingDirectory, setWorkingDirectory] = useState<string>("");
   const [shouldSaveFavorite, setShouldSaveFavorite] = useState(false);
+  // Modes are only known once an agent has opened a session at least once.
+  const [agentModes, setAgentModes] = useState<AgentMode[]>([]);
+  const [selectedModeId, setSelectedModeId] = useState<string>("");
 
   const configService = new ConfigService();
+  const agentModeService = new AgentModeService();
 
   useEffect(() => {
     loadInitialData();
   }, []);
+
+  // Offer the modes the selected agent reported last time, preselected with the
+  // default configured for it.
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadModes() {
+      if (!selectedAgentId) {
+        setAgentModes([]);
+        setSelectedModeId("");
+        return;
+      }
+
+      const [modes, defaultModeId] = await Promise.all([
+        agentModeService.getKnownModes(selectedAgentId),
+        agentModeService.getDefaultMode(selectedAgentId),
+      ]);
+
+      if (cancelled) return;
+
+      setAgentModes(modes);
+      setSelectedModeId(defaultModeId ?? "");
+    }
+
+    loadModes().catch((error) => logger.warn("Failed to load agent modes", { error }));
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedAgentId]);
 
   async function loadInitialData() {
     try {
@@ -252,7 +289,9 @@ export default function StartChatForm() {
       await saveLastChatConfig(agentId, cwd);
 
       // Push to chat view
-      push(<ChatCommand initialAgentId={agentId} initialAgent={agentWithCwd} />);
+      push(
+        <ChatCommand initialAgentId={agentId} initialAgent={agentWithCwd} initialModeId={values.modeId || undefined} />,
+      );
 
       await showToast({
         style: Toast.Style.Success,
@@ -309,7 +348,9 @@ export default function StartChatForm() {
               title="Configure Agents"
               icon={Icon.Gear}
               shortcut={{ modifiers: ["cmd", "shift"], key: "a" }}
-              onAction={() => open(`${process.env.RAYCAST_SCHEME ?? "raycast"}://extensions/agent-client-protocol/configure-agents`)}
+              onAction={() =>
+                open(`${process.env.RAYCAST_SCHEME ?? "raycast"}://extensions/agent-client-protocol/configure-agents`)
+              }
             />
             {selectedFavoriteId && (
               <Action
@@ -374,6 +415,22 @@ export default function StartChatForm() {
       </Form.Dropdown>
 
       {selectedAgent && selectedAgent.description && <Form.Description text={selectedAgent.description} />}
+
+      {/* Agent Mode — only offered once the agent has reported its modes at least once */}
+      {agentModes.length > 0 && (
+        <Form.Dropdown
+          id="modeId"
+          title="Agent Mode"
+          value={selectedModeId}
+          onChange={setSelectedModeId}
+          info="Applied before your first message, so the agent starts the conversation in this mode."
+        >
+          <Form.Dropdown.Item value="" title="Agent default" />
+          {agentModes.map((mode) => (
+            <Form.Dropdown.Item key={mode.id} value={mode.id} title={mode.name} />
+          ))}
+        </Form.Dropdown>
+      )}
 
       {/* Working Directory */}
       <Form.TextField

--- a/extensions/agent-client-protocol/src/types/acp.ts
+++ b/extensions/agent-client-protocol/src/types/acp.ts
@@ -144,7 +144,8 @@ export type SessionUpdate =
   | ToolCallUpdate
   | PlanUpdate
   | AvailableCommandsUpdate
-  | CurrentModeUpdate;
+  | CurrentModeUpdate
+  | UsageUpdate;
 
 export interface AgentMessageChunk {
   sessionUpdate: "agent_message_chunk";
@@ -312,6 +313,18 @@ export interface CurrentModeUpdate {
   currentModeId: string;
 }
 
+// Context window / cost reporting
+export interface UsageUpdate {
+  sessionUpdate: "usage_update";
+  /** Tokens currently in context */
+  used: number;
+  /** Total context window size in tokens */
+  size: number;
+  /** Cumulative session cost, when the agent reports it */
+  cost?: { amount: number; currency: string } | null;
+  _meta?: Record<string, unknown> | null;
+}
+
 // Permission Requests
 export interface RequestPermissionRequest {
   toolCall: {
@@ -382,7 +395,9 @@ export enum ACPErrorCode {
   InternalError = -32603,
 
   // ACP-specific errors
-  ProtocolVersionMismatch = -32000,
+  // Sent by an agent when the client has to authenticate before it may prompt.
+  // See the ACP spec and `RequestError.authRequired()` in @agentclientprotocol/sdk.
+  AuthRequired = -32000,
   SessionNotFound = -32001,
   AgentUnavailable = -32002,
   PermissionDenied = -32003,

--- a/extensions/agent-client-protocol/src/types/entities.ts
+++ b/extensions/agent-client-protocol/src/types/entities.ts
@@ -114,6 +114,35 @@ export interface SessionRequest {
     /** Priority level */
     priority?: "low" | "normal" | "high";
   };
+
+  /**
+   * Observer for streaming messages, attached before the initial prompt is sent.
+   *
+   * Registering after `createSession` resolves would miss the whole first turn,
+   * because the agent streams its answer while the prompt call is still pending.
+   */
+  onMessage?: (message: SessionMessage) => void;
+
+  /**
+   * Mode to put the session into before the first prompt is sent.
+   *
+   * Switching afterwards is too late: the opening turn already ran under the
+   * agent's own default, prompting for permissions the chosen mode would have
+   * handled on its own.
+   */
+  modeId?: string;
+}
+
+/**
+ * A working mode an agent offers for a session (permission handling, planning, …).
+ */
+export interface AgentMode {
+  /** Mode identifier */
+  id: string;
+  /** Human-readable mode name */
+  name: string;
+  /** Optional description of what this mode does */
+  description?: string | null;
 }
 
 /**
@@ -154,6 +183,8 @@ export interface ConversationSession {
     priority?: "low" | "normal" | "high";
     /** Total token count (if available) */
     tokenCount?: number;
+    /** Context window size the agent reports for this session (if available) */
+    contextWindowSize?: number;
     /** Estimated cost (if available) */
     estimatedCost?: number;
   };
@@ -177,14 +208,7 @@ export interface ConversationSession {
   };
 
   /** Available modes for this agent session */
-  availableModes?: Array<{
-    /** Mode identifier */
-    id: string;
-    /** Human-readable mode name */
-    name: string;
-    /** Optional description of what this mode does */
-    description?: string | null;
-  }>;
+  availableModes?: AgentMode[];
 
   /** Available slash commands advertised by the agent */
   availableCommands?: AvailableCommand[];

--- a/extensions/agent-client-protocol/src/types/extension.ts
+++ b/extensions/agent-client-protocol/src/types/extension.ts
@@ -41,6 +41,7 @@ export enum ErrorCode {
 
   // Protocol-related errors
   ProtocolError = "PROTOCOL_ERROR",
+  AuthenticationRequired = "AUTHENTICATION_REQUIRED",
 
   // Session-related errors
   SessionNotFound = "SESSION_NOT_FOUND",

--- a/extensions/agent-client-protocol/src/utils/agentAuth.ts
+++ b/extensions/agent-client-protocol/src/utils/agentAuth.ts
@@ -1,0 +1,116 @@
+/**
+ * Agent Authentication Helpers
+ *
+ * ACP agents that need a login advertise `authMethods` during `initialize` and
+ * reject prompts with `-32000 Authentication required` until one has been used.
+ *
+ * Methods of type `terminal` are not completed over the protocol: the agent expects
+ * the *client* to run the agent binary with the method's arguments in a real terminal,
+ * so the user can go through an interactive login. This module builds that command
+ * and hands it to the user.
+ */
+
+import { spawn } from "child_process";
+import { writeFile, chmod } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import type { AuthMethod } from "@agentclientprotocol/sdk";
+import type { AgentConfig } from "@/types/extension";
+import { createLogger } from "./logging";
+
+const logger = createLogger("AgentAuth");
+
+/** An auth method the client completes by running the agent binary itself */
+export type TerminalAuthMethod = Extract<AuthMethod, { type: "terminal" }>;
+
+export interface TerminalAuthCommand {
+  /** Label of the auth method, for display */
+  label: string;
+  /** Shell command the user has to run */
+  shellCommand: string;
+}
+
+export function isTerminalAuthMethod(method: AuthMethod): method is TerminalAuthMethod {
+  return (method as { type?: string }).type === "terminal";
+}
+
+/**
+ * Pick the auth method to offer the user: the first terminal method, if any.
+ */
+export function findTerminalAuthMethod(methods: AuthMethod[]): TerminalAuthMethod | null {
+  return methods.find(isTerminalAuthMethod) ?? null;
+}
+
+function quoteArgument(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Build the login command for a terminal auth method.
+ *
+ * Returns `null` for agents configured without a command (remote agents), which
+ * cannot be logged in this way.
+ */
+export function buildTerminalAuthCommand(config: AgentConfig, method: TerminalAuthMethod): TerminalAuthCommand | null {
+  if (!config.command) {
+    return null;
+  }
+
+  const parts: string[] = [];
+
+  // The agent binary may live outside the login shell's PATH — the same directories
+  // the extension appends when spawning it have to be available here too.
+  if (config.appendToPath?.length) {
+    const extraPath = config.appendToPath.filter(Boolean).map(quoteArgument).join(":");
+    if (extraPath) {
+      parts.push(`export PATH="$PATH:${extraPath}"`);
+    }
+  }
+
+  for (const [key, value] of Object.entries(method.env ?? {})) {
+    parts.push(`export ${key}=${quoteArgument(value)}`);
+  }
+
+  const invocation = [config.command, ...(method.args ?? [])].map(quoteArgument).join(" ");
+  parts.push(invocation);
+
+  return {
+    label: method.name || method.id,
+    shellCommand: parts.join("\n"),
+  };
+}
+
+/**
+ * Open the login command in Terminal.app.
+ *
+ * The command is written to a temporary script instead of being passed to
+ * `osascript`, which would mean quoting a shell command inside an AppleScript
+ * string inside another shell command.
+ *
+ * Returns `false` on platforms where we cannot open a terminal; callers should
+ * fall back to showing the command.
+ */
+export async function openTerminalAuth(command: TerminalAuthCommand): Promise<boolean> {
+  if (process.platform !== "darwin") {
+    return false;
+  }
+
+  try {
+    const scriptPath = join(tmpdir(), `acp-login-${Date.now()}.command`);
+    const script = ["#!/bin/sh", "", command.shellCommand, ""].join("\n");
+
+    await writeFile(scriptPath, script, "utf8");
+    await chmod(scriptPath, 0o755);
+
+    const child = spawn("open", ["-a", "Terminal", scriptPath], { stdio: "ignore", detached: true });
+    child.unref();
+
+    logger.info("Opened agent login in Terminal", { label: command.label, scriptPath });
+    return true;
+  } catch (error) {
+    logger.error("Failed to open agent login in Terminal", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}

--- a/extensions/agent-client-protocol/src/utils/agentEnvironment.ts
+++ b/extensions/agent-client-protocol/src/utils/agentEnvironment.ts
@@ -1,0 +1,105 @@
+/**
+ * Agent Process Environment
+ *
+ * Raycast runs extensions with a nearly empty environment: no `USER`, no `LOGNAME`,
+ * and a `PATH` that contains only whatever the user typed into "Additional PATH
+ * Directories". Passing that straight to an agent breaks anything it shells out to —
+ * on macOS the Claude CLI reads its credentials via `/usr/bin/security -a $USER`, so
+ * without those two it reports "not logged in" and rejects prompts with
+ * `-32000 Authentication required`, even though the user is signed in.
+ *
+ * Everything that spawns an agent goes through here so the agent starts with a usable
+ * baseline: the inherited environment first, then the user's own additions, then
+ * standard system locations as a fallback.
+ */
+
+import { userInfo, homedir } from "os";
+import type { AgentConfig } from "@/types/extension";
+
+export type AgentEnvironmentConfig = Pick<AgentConfig, "environmentVariables" | "appendToPath">;
+
+const POSIX_SYSTEM_PATHS = ["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"];
+
+/** Homebrew's prefix on Apple Silicon, where user-installed CLIs usually live. */
+const APPLE_SILICON_PATHS = ["/opt/homebrew/bin"];
+
+function pathSeparator(): string {
+  return process.platform === "win32" ? ";" : ":";
+}
+
+function systemPathDefaults(): string[] {
+  if (process.platform === "win32") {
+    const systemRoot = process.env.SystemRoot ?? process.env.SYSTEMROOT ?? "C:\\Windows";
+    return [`${systemRoot}\\system32`, systemRoot, `${systemRoot}\\system32\\Wbem`];
+  }
+
+  return process.arch === "arm64" ? [...POSIX_SYSTEM_PATHS, ...APPLE_SILICON_PATHS] : POSIX_SYSTEM_PATHS;
+}
+
+/**
+ * Build the PATH for an agent process.
+ *
+ * Order is deliberate: whatever was inherited stays in front, the user's additions
+ * follow, and the system defaults come last so they can never shadow a deliberate
+ * choice — they only fill in what Raycast left out.
+ */
+export function buildAgentPath(inheritedPath: string, appendToPath?: string[]): string {
+  const separator = pathSeparator();
+  const segments: string[] = [];
+
+  const add = (candidates: string[]) => {
+    for (const candidate of candidates) {
+      const segment = candidate?.trim();
+      if (segment && !segments.includes(segment)) {
+        segments.push(segment);
+      }
+    }
+  };
+
+  add(inheritedPath ? inheritedPath.split(separator) : []);
+  add(appendToPath ?? []);
+  add(systemPathDefaults());
+
+  return segments.join(separator);
+}
+
+/**
+ * Build the full environment for a spawned agent process.
+ */
+export function buildAgentEnvironment(config: AgentEnvironmentConfig): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env, ...(config.environmentVariables ?? {}) };
+
+  const inheritedPath = env.PATH ?? env.Path ?? env.path ?? "";
+  const resolvedPath = buildAgentPath(inheritedPath, config.appendToPath);
+  env.PATH = resolvedPath;
+  env.Path = resolvedPath;
+  env.path = resolvedPath;
+
+  // `os.userInfo()` reads the passwd database rather than the environment, so it
+  // still resolves when Raycast passes neither USER nor LOGNAME.
+  let username: string | undefined;
+  try {
+    username = userInfo().username;
+  } catch {
+    username = undefined;
+  }
+
+  if (process.platform === "win32") {
+    if (!env.USERNAME && username) {
+      env.USERNAME = username;
+    }
+  } else {
+    if (!env.USER && username) {
+      env.USER = username;
+    }
+    if (!env.LOGNAME && username) {
+      env.LOGNAME = username;
+    }
+  }
+
+  if (!env.HOME) {
+    env.HOME = homedir();
+  }
+
+  return env;
+}

--- a/extensions/agent-client-protocol/src/utils/builtInAgents.ts
+++ b/extensions/agent-client-protocol/src/utils/builtInAgents.ts
@@ -7,8 +7,15 @@
 
 import type { AgentConfig } from "@/types/extension";
 import { createLogger } from "./logging";
+import { buildAgentEnvironment } from "./agentEnvironment";
 
 const logger = createLogger("BuiltInAgents");
+
+/** The maintained Claude ACP adapter, published by the ACP project. */
+export const CLAUDE_ACP_COMMAND = "claude-agent-acp";
+
+/** Zed's original adapter — archived, superseded by {@link CLAUDE_ACP_COMMAND}. */
+export const LEGACY_CLAUDE_ACP_COMMAND = "claude-code-acp";
 
 /**
  * Built-in agent configurations
@@ -31,12 +38,12 @@ export const BUILT_IN_AGENTS: readonly AgentConfig[] = [
     id: "claude-code",
     name: "Claude Code",
     type: "subprocess",
-    command: "claude-code-acp",
+    command: CLAUDE_ACP_COMMAND,
     args: [],
     workingDirectory: process.cwd(),
     environmentVariables: {},
     isBuiltIn: true,
-    description: "Anthropic's Claude Code agent via Zed's ACP adapter. Requires claude-code-acp to be installed.",
+    description: `Anthropic's Claude Code agent via the official ACP adapter. Requires ${CLAUDE_ACP_COMMAND} to be installed.`,
     createdAt: new Date("2025-01-01T00:00:00Z"),
   },
   {
@@ -105,10 +112,11 @@ export const INSTALLATION_GUIDES: Record<
   },
   "claude-code": {
     name: "Claude Code",
-    description: "Install Anthropic's Claude Code via Zed's ACP adapter",
-    installUrl: "https://github.com/zed-industries/claude-code-acp",
-    requirements: ["Anthropic API key", "Zed editor or standalone installation", "Internet connection"],
-    verifyCommand: "claude-code --version",
+    description: "Install Anthropic's Claude Code via the official ACP adapter",
+    installCommand: "npm install -g @agentclientprotocol/claude-agent-acp",
+    installUrl: "https://www.npmjs.com/package/@agentclientprotocol/claude-agent-acp",
+    requirements: ["Node.js 18+", "A Claude subscription or an Anthropic API key", "Internet connection"],
+    verifyCommand: `${CLAUDE_ACP_COMMAND} --version`,
   },
   goose: {
     name: "Goose",
@@ -242,32 +250,9 @@ export async function checkAgentAvailability(config: AgentConfig): Promise<{
   try {
     const { spawn } = await import("child_process");
 
-    const baseEnv: NodeJS.ProcessEnv = { ...process.env };
-    const mergedEnv: NodeJS.ProcessEnv = { ...baseEnv, ...(config.environmentVariables ?? {}) };
-
-    if (config.appendToPath?.length) {
-      const currentPath = mergedEnv.PATH ?? mergedEnv.Path ?? mergedEnv.path ?? process.env.PATH ?? "";
-
-      const pathSegments = currentPath
-        ? currentPath
-            .split(":")
-            .map((segment) => segment.trim())
-            .filter(Boolean)
-        : [];
-
-      for (const segment of config.appendToPath) {
-        if (segment && !pathSegments.includes(segment)) {
-          pathSegments.push(segment);
-        }
-      }
-
-      if (pathSegments.length > 0) {
-        const finalPath = pathSegments.join(":");
-        mergedEnv.PATH = finalPath;
-        mergedEnv.Path = finalPath;
-        mergedEnv.path = finalPath;
-      }
-    }
+    // Must match how the agent is spawned for real, otherwise the connection test
+    // passes with an environment the actual session never gets.
+    const mergedEnv = buildAgentEnvironment(config);
 
     const args = config.args && config.args.length > 0 ? [...config.args] : ["--version"];
     const isLongRunningCheck = args.some((arg) => arg !== "--version");

--- a/extensions/agent-client-protocol/src/utils/errors.ts
+++ b/extensions/agent-client-protocol/src/utils/errors.ts
@@ -8,7 +8,73 @@
 import { showToast, Toast } from "@raycast/api";
 import type { ExtensionError } from "@/types/extension";
 import { ErrorCode } from "@/types/extension";
+import { ACPErrorCode } from "@/types/acp";
 export { ErrorCode } from "@/types/extension";
+
+/**
+ * A JSON-RPC error boiled down to the parts we can act on.
+ */
+export interface RpcErrorInfo {
+  /** JSON-RPC error code, when the agent sent one. */
+  code?: number;
+  message: string;
+  data?: unknown;
+}
+
+/**
+ * Describe an error that came back from an ACP agent.
+ *
+ * `@agentclientprotocol/sdk` rejects with a `RequestError` (a real `Error`), but
+ * older SDKs — and any agent talking raw JSON-RPC — reject with the bare
+ * `{ code, message, data }` payload instead. A plain `error instanceof Error`
+ * check turns those into "[object Object]" and loses the actual reason, so
+ * always funnel agent errors through here.
+ */
+export function describeRpcError(error: unknown, fallback = "Unknown error"): RpcErrorInfo {
+  if (error instanceof ACPError) {
+    return { message: error.message, data: error.details || undefined };
+  }
+
+  if (error instanceof Error) {
+    const code = (error as { code?: unknown }).code;
+    return {
+      code: typeof code === "number" ? code : undefined,
+      message: error.message || fallback,
+      data: (error as { data?: unknown }).data,
+    };
+  }
+
+  if (typeof error === "string") {
+    return { message: error || fallback };
+  }
+
+  if (error && typeof error === "object") {
+    const { code, message, data } = error as { code?: unknown; message?: unknown; data?: unknown };
+    if (typeof message === "string" && message.length > 0) {
+      return {
+        code: typeof code === "number" ? code : undefined,
+        message,
+        data,
+      };
+    }
+  }
+
+  return { message: fallback };
+}
+
+/**
+ * Message of an agent error, safe to put in front of the user.
+ */
+export function rpcErrorMessage(error: unknown, fallback = "Unknown error"): string {
+  return describeRpcError(error, fallback).message;
+}
+
+/**
+ * True when the agent refused because the client has to authenticate first.
+ */
+export function isAuthRequiredError(error: unknown): boolean {
+  return describeRpcError(error).code === ACPErrorCode.AuthRequired;
+}
 
 /**
  * Custom error class for ACP extension
@@ -148,6 +214,9 @@ export class ErrorHandler {
       case ErrorCode.ProtocolError:
         return "Communication error with the AI agent. Please try again.";
 
+      case ErrorCode.AuthenticationRequired:
+        return "The agent is not signed in. Authenticate it and try again.";
+
       case ErrorCode.SessionNotFound:
         return "Conversation session not found. It may have been deleted.";
 
@@ -207,6 +276,13 @@ export class ErrorHandler {
 
       case ErrorCode.AgentUnavailable:
         return ["Wait a moment and try again", "Check if the agent process is running", "Restart the agent"];
+
+      case ErrorCode.AuthenticationRequired:
+        return [
+          "Run the agent's login command in a terminal",
+          "Or set an API token in the agent's environment variables",
+          "Then send the message again",
+        ];
 
       case ErrorCode.NetworkError:
         return ["Check your internet connection", "Try again in a few moments", "Check firewall settings"];

--- a/extensions/agent-client-protocol/src/utils/migrations.ts
+++ b/extensions/agent-client-protocol/src/utils/migrations.ts
@@ -8,6 +8,7 @@
 import { LocalStorage } from "@raycast/api";
 import { STORAGE_VERSION, STORAGE_VERSION_KEY, STORAGE_KEYS } from "./storageKeys";
 import { createLogger } from "./logging";
+import { CLAUDE_ACP_COMMAND, LEGACY_CLAUDE_ACP_COMMAND } from "./builtInAgents";
 import type { ConversationSession } from "@/types/entities";
 
 const logger = createLogger("Migrations");
@@ -33,6 +34,7 @@ const MIGRATIONS: Record<string, MigrationFn> = {
   "1.0.0": migration_1_0_0,
   "1.1.0": migration_1_1_0,
   "1.2.0": migration_1_2_0,
+  "1.3.0": migration_1_3_0,
 };
 
 /**
@@ -265,6 +267,41 @@ async function migration_1_2_0(): Promise<void> {
     logger.info("Migration 1.2.0 completed", { conversationsUpdated: conversations.length });
   } catch (error) {
     logger.error("Migration 1.2.0 failed", { error });
+    throw error;
+  }
+}
+
+/**
+ * Migration: 1.3.0 - Point Claude agents at the maintained ACP adapter
+ *
+ * Zed's `claude-code-acp` was archived and republished by the ACP project as
+ * `@agentclientprotocol/claude-agent-acp`. Stored configurations still spawning the
+ * old binary would keep failing silently, so rewrite the command in place.
+ */
+async function migration_1_3_0(): Promise<void> {
+  logger.info("Running migration 1.3.0");
+
+  try {
+    const agentsJson = await LocalStorage.getItem(STORAGE_KEYS.AGENT_CONFIGS);
+    if (!agentsJson) return;
+
+    const agents = JSON.parse(String(agentsJson)) as Array<{ command?: string }>;
+
+    let updated = 0;
+    for (const agent of agents) {
+      if (agent.command === LEGACY_CLAUDE_ACP_COMMAND) {
+        agent.command = CLAUDE_ACP_COMMAND;
+        updated++;
+      }
+    }
+
+    if (updated > 0) {
+      await LocalStorage.setItem(STORAGE_KEYS.AGENT_CONFIGS, JSON.stringify(agents));
+    }
+
+    logger.info("Migration 1.3.0 completed", { agentsUpdated: updated });
+  } catch (error) {
+    logger.error("Migration 1.3.0 failed", { error });
     throw error;
   }
 }

--- a/extensions/agent-client-protocol/src/utils/storageKeys.ts
+++ b/extensions/agent-client-protocol/src/utils/storageKeys.ts
@@ -10,6 +10,7 @@ export const STORAGE_KEYS = {
   AGENT_CONFIGS: "acp.agents",
   DEFAULT_AGENT: "acp.defaultAgent",
   AGENT_HEALTH: "acp.agentHealth",
+  AGENT_MODES: "acp.agentModes",
 
   // Conversation and Session Storage
   CONVERSATIONS: "acp.conversations",
@@ -57,6 +58,7 @@ export const STORAGE_CATEGORIES = {
     STORAGE_KEYS.AGENT_CONFIGS,
     STORAGE_KEYS.DEFAULT_AGENT,
     STORAGE_KEYS.AGENT_HEALTH,
+    STORAGE_KEYS.AGENT_MODES,
     STORAGE_KEYS.LAST_USED_AGENT,
   ],
   SESSION: [STORAGE_KEYS.CONVERSATIONS, STORAGE_KEYS.ACTIVE_SESSIONS, STORAGE_KEYS.SESSION_HISTORY],
@@ -111,7 +113,7 @@ export const DEFAULT_VALUES = {
 } as const;
 
 // Storage migration version tracking
-export const STORAGE_VERSION = "1.0.0";
+export const STORAGE_VERSION = "1.3.0";
 export const STORAGE_VERSION_KEY = "acp.storageVersion";
 
 /**

--- a/extensions/agent-client-protocol/tests/__mocks__/@agentclientprotocol/sdk.ts
+++ b/extensions/agent-client-protocol/tests/__mocks__/@agentclientprotocol/sdk.ts
@@ -1,4 +1,4 @@
-// Mock implementation of @zed-industries/agent-client-protocol for testing
+// Mock implementation of @agentclientprotocol/sdk for testing
 
 export const Client = jest.fn();
 export const Transport = jest.fn();

--- a/extensions/agent-client-protocol/tests/integration/acpProtocol.test.ts
+++ b/extensions/agent-client-protocol/tests/integration/acpProtocol.test.ts
@@ -11,7 +11,7 @@
 import { ACPClient } from '@/services/acpClient';
 import { getBuiltInAgent } from '@/utils/builtInAgents';
 import type { AgentConfig } from '@/types/extension';
-import type * as acp from '@zed-industries/agent-client-protocol';
+import type * as acp from '@agentclientprotocol/sdk';
 
 const shouldRunAcpProtocolTests = process.env.RUN_ACP_PROTOCOL_TESTS === 'true';
 

--- a/extensions/agent-client-protocol/tests/unit/utils/agentEnvironment.test.ts
+++ b/extensions/agent-client-protocol/tests/unit/utils/agentEnvironment.test.ts
@@ -1,0 +1,79 @@
+import { buildAgentEnvironment, buildAgentPath } from '@/utils/agentEnvironment';
+
+describe('buildAgentPath', () => {
+  it('keeps inherited entries in front and appends the configured ones', () => {
+    const result = buildAgentPath('/inherited/bin', ['/configured/bin']).split(':');
+
+    expect(result.indexOf('/inherited/bin')).toBe(0);
+    expect(result.indexOf('/configured/bin')).toBe(1);
+  });
+
+  it('always adds the system locations, after everything else', () => {
+    const result = buildAgentPath('/inherited/bin', ['/configured/bin']).split(':');
+
+    expect(result).toContain('/usr/bin');
+    expect(result.indexOf('/usr/bin')).toBeGreaterThan(result.indexOf('/configured/bin'));
+  });
+
+  it('falls back to the system locations when Raycast passes an empty PATH', () => {
+    // Raycast runs extensions with no usable PATH; the agent still has to find
+    // /usr/bin/security, /bin/sh and friends.
+    const result = buildAgentPath('', ['/configured/bin']).split(':');
+
+    expect(result).toEqual(expect.arrayContaining(['/configured/bin', '/usr/bin', '/bin']));
+  });
+
+  it('does not duplicate entries', () => {
+    const result = buildAgentPath('/usr/bin:/configured/bin', ['/configured/bin']).split(':');
+
+    expect(result.filter((segment) => segment === '/configured/bin')).toHaveLength(1);
+    expect(result.filter((segment) => segment === '/usr/bin')).toHaveLength(1);
+  });
+});
+
+describe('buildAgentEnvironment', () => {
+  const originalEnv = process.env;
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('fills in the user identity Raycast omits', () => {
+    // Without USER the Claude CLI cannot look up its keychain credentials and
+    // reports "not logged in", even though the user is signed in.
+    process.env = { HOME: '/Users/someone', PATH: '' };
+
+    const env = buildAgentEnvironment({ environmentVariables: {}, appendToPath: [] });
+
+    expect(env.USER).toBeTruthy();
+    expect(env.LOGNAME).toBe(env.USER);
+  });
+
+  it('keeps an inherited user identity untouched', () => {
+    process.env = { USER: 'inherited', LOGNAME: 'inherited', PATH: '/usr/bin' };
+
+    const env = buildAgentEnvironment({ environmentVariables: {}, appendToPath: [] });
+
+    expect(env.USER).toBe('inherited');
+  });
+
+  it('lets configured environment variables win', () => {
+    process.env = { PATH: '/usr/bin', SOME_TOKEN: 'inherited' };
+
+    const env = buildAgentEnvironment({
+      environmentVariables: { SOME_TOKEN: 'configured' },
+      appendToPath: [],
+    });
+
+    expect(env.SOME_TOKEN).toBe('configured');
+  });
+
+  it('exposes the resolved PATH under every casing', () => {
+    process.env = { PATH: '' };
+
+    const env = buildAgentEnvironment({ environmentVariables: {}, appendToPath: ['/configured/bin'] });
+
+    expect(env.Path).toBe(env.PATH);
+    expect(env.path).toBe(env.PATH);
+  });
+});


### PR DESCRIPTION
# Description

Fixes #29752.

The extension was written against `@zed-industries/agent-client-protocol@0.4.5`. npm has since deprecated that package in favour of `@agentclientprotocol/sdk`, and the ACP agents it talks to have moved on with it. Against a current agent — I tested with `@agentclientprotocol/claude-agent-acp@0.62.0` — the extension connects, opens a session, and then fails on the very first message with:

```
PROTOCOL_ERROR: Failed to send prompt: Unknown error
originalError: { code: -32000, message: 'Authentication required' }
```

That turned out to be several independent problems at once, and they were hard to see because agent errors never reached the surface. Each change below is one of them.

## Agents were spawned into an unusable environment

This is the root cause of the reported bug. Raycast runs extensions with a nearly empty environment. Reading it off the live agent process:

```
HOME=/Users/…
PATH=/Users/…/.nvm/versions/node/v24.18.0/bin/
TMPDIR=…  NODE_ENV=…  NODE_PATH=…  LC_ALL=…
```

No `USER`, no `LOGNAME`, and a `PATH` that contains **only** what the user typed into *Additional PATH Directories* — the setting adds to a `PATH` that is empty to begin with, so the system directories are simply gone. The extension passed that straight to the agent.

On macOS the Claude CLI reads its stored login by shelling out to `/usr/bin/security -a $USER`. With neither on hand it reports "not logged in", and the agent turns that into `-32000 Authentication required`. The user is signed in; the agent just cannot reach the credentials. Logging in again does not help, which is what made this confusing to diagnose.

Bisected against the real agent:

| Environment | Result |
|---|---|
| as Raycast provides it | `-32000` after 35 ms |
| \+ system directories on `PATH` | `-32000` |
| \+ `USER`/`LOGNAME`, no system `PATH` | `-32000` |
| \+ both | `stopReason: end_turn` |

New `src/utils/agentEnvironment.ts` builds the environment for spawned agents: inherited entries first, the user's *Additional PATH* entries next, the standard system locations last so they can never shadow a deliberate choice, plus `USER`/`LOGNAME` from `os.userInfo()` and `HOME` from `os.homedir()` when absent. Windows gets the equivalent (`USERNAME`, `%SystemRoot%` locations).

*Test Agent Connection* now builds its environment the same way. It previously used its own copy of the merge logic, which is why it reported a healthy connection while real sessions failed.

## Migration to `@agentclientprotocol/sdk`

`@zed-industries/agent-client-protocol` is marked deprecated on npm ("renamed to `@agentclientprotocol/sdk`"). Two concrete failures came from staying on it:

- Its schema does not know the `usage_update` notification, so every one an agent sends is rejected with `-32602 Invalid params` and the context/cost figures are lost.
- It rejects RPC failures with the raw `{code, message}` payload instead of an `Error`. The extension checked `error instanceof Error ? error.message : "Unknown error"` throughout, so **every** agent-side error was reported as `Unknown error` or `[object Object]`. SDK 1.3.0 rejects with a `RequestError`.

The client interface is effectively unchanged between the two versions, so the migration is small: the import path, `KillTerminalCommandRequest` → `KillTerminalRequest`, and `zod` moving from a direct to a peer dependency.

Alongside it, a `describeRpcError` helper in `src/utils/errors.ts` understands `Error`, `RequestError` and bare `{code, message}` objects, so agents still on the old SDK stay readable too. `ACPErrorCode` also had `-32000` labelled `ProtocolVersionMismatch`; in ACP that code is `AUTH_REQUIRED`.

Agent `stderr` is now piped into the extension log rather than inherited. Without it the actual reason for a protocol-level failure is invisible.

## Authentication

`initialize` did not advertise the `auth` client capability, so agents returned `authMethods: []` — the extension had no way to sign an agent in, and never called `authenticate` anyway. With `auth: { terminal: true }` the same agent offers `claude-ai-login` and `console-login`.

A `-32000` now produces its own error state instead of a generic protocol error, with an **Open Login in Terminal** action. Note that `terminal` auth methods are not completed over the protocol: the agent expects the *client* to run the agent binary with the method's arguments so the user can log in interactively. `claude-agent-acp` throws `Method not implemented` for them. Methods the agent does handle itself go through `authenticate` as usual.

## Streaming during the first turn

`createSession` awaited the entire opening turn before storing the session and attaching the message observer. Every update from that turn therefore hit the "session not found" path and sat in the pending buffer until the turn ended — the first answer arrived in one lump, and if the prompt failed the session was never stored at all.

The ACP session is now opened, stored and observed first; the prompt goes out after. The observer is passed into `createSession` rather than attached to its return value, since attaching afterwards is inherently too late.

## `session/set_mode` and `session/cancel`

Both were sent by casting the connection object to a private interface (`sendRequest`/`sendNotification`) rather than using the public API. Those internals do not exist in the new SDK, so switching modes and cancelling both threw. They now use `connection.setSessionMode(…)` and `connection.cancel(…)`, and the private-RPC type is gone.

The new mode is also applied locally: agents may acknowledge `session/set_mode` without following up with a `current_mode_update` notification — `claude-agent-acp` does exactly this — and the UI was waiting for one that never came.

## Choosing the agent mode before the first message

Modes could only be switched after the first message had been sent, by which point the opening turn had already run under the agent's default and triggered permission prompts.

An agent only reveals its modes when a session is opened, so the modes it reports are now remembered per agent (`acp.agentModes`). *Configure Agents* gains a **Set Default Mode** submenu, and the *Ask AI Agent* form a **Agent Mode** dropdown that overrides it for a single chat. The mode is applied between opening the session and sending the first prompt. A stored default the agent no longer offers is dropped on the next session. The very first chat with a new agent still has no dropdown — the agent has not told us its modes yet.

## Conversation display

- Tool calls are hidden from the list by default (⌘T toggles them, the section subtitle says how many are hidden). They are still stored in full — a single turn can produce a dozen, which buried the answer.
- Streaming chunks were merged back into the agent's first message via a stored message id, regardless of how many tool calls had been appended behind it, so the final answer appeared *above* the tool calls it was based on. Chunks now only extend a message while it is still the last one.
- The agent's `available_commands_update` was rendered as a system message right after the session opened, pushing the first real answer to third place. It is stored on the session only.

## Built-in Claude Code agent

Zed's `claude-code-acp` is archived; the ACP project publishes the maintained successor as `@agentclientprotocol/claude-agent-acp`. The built-in agent, its installation guide and the README now point there, and a storage migration rewrites `claude-code-acp` in saved configurations.

This is a breaking change for anyone still running the old adapter — they need `npm install -g @agentclientprotocol/claude-agent-acp`. Leaving the default pointed at an archived package seemed worse.

(Bumping `STORAGE_VERSION` for that migration also revealed that it had been pinned at `1.0.0` while migrations `1.1.0` and `1.2.0` existed, so those had never run. They do now; both are idempotent.)

# Screencast

<!-- Please add a screen recording of the extension in action. -->

# Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
