### PR TITLE
Update letterboxd extension

### DIFF
--- a/extensions/letterboxd/CHANGELOG.md
+++ b/extensions/letterboxd/CHANGELOG.md
@@ -1,6 +1,6 @@
 # letterboxd Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-07-27
 
 - Fixed movie search after Letterboxd retired the previous search endpoint
 - Use Letterboxd's JSON search response for posters, release years, and directors

--- a/extensions/letterboxd/CHANGELOG.md
+++ b/extensions/letterboxd/CHANGELOG.md
@@ -1,5 +1,11 @@
 # letterboxd Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Fixed movie search after Letterboxd retired the previous search endpoint
+- Use Letterboxd's JSON search response for posters, release years, and directors
+- Keep movie details available when optional statistics endpoints are blocked
+
 ## [Fix] - 2026-04-23
 
 - Fixed the issue with the rating histogram not working

--- a/extensions/letterboxd/src/letterboxd-api.ts
+++ b/extensions/letterboxd/src/letterboxd-api.ts
@@ -3,12 +3,11 @@ import {
   type Movie,
   type MovieDetails,
   type MovieRatingHistogram,
-  type MovieStatistics,
 } from "./types";
 import { parse } from "./parser";
 import type { Element } from "domhandler";
 import { load } from "cheerio";
-import { fetchWithRetry } from "./utils";
+import { fetchJsonWithRetry, fetchWithRetry } from "./utils";
 
 const cache = new Cache();
 
@@ -37,11 +36,6 @@ const addToCache = <T>(key: string, value: T) => {
   cache.set(key, JSON.stringify(cacheEntry));
 };
 
-const enum SEARCH_TYPE {
-  FILMS = "films",
-  PEOPLE = "cast-crew",
-}
-
 export const enum AsyncStatus {
   Success,
   Error,
@@ -53,65 +47,88 @@ interface ApiResponse<T> {
 }
 
 const LETTERBOXD_URL_BASE = "https://letterboxd.com";
-const SEARCH_URL_BASE = `${LETTERBOXD_URL_BASE}/s/search`;
+const LETTERBOXD_API_URL_BASE = "https://api.letterboxd.com/api/v0";
 
-const getSearchPageUrl = (query: string, searchType: SEARCH_TYPE) =>
-  `${SEARCH_URL_BASE}/${searchType}/${encodeURIComponent(query)}/`;
+const getSearchUrl = (query: string) => {
+  const url = new URL(`${LETTERBOXD_API_URL_BASE}/search`);
+  url.searchParams.set("input", query);
+  url.searchParams.set("searchMethod", "Autocomplete");
+  url.searchParams.set("include", "FilmSearchItem");
+  url.searchParams.set("perPage", "20");
+  return url.toString();
+};
 
 export function getFullURL(path: string) {
   return `${LETTERBOXD_URL_BASE}${path}`;
 }
 
-export async function fetchPosterUrl(letterboxdId: string): Promise<string> {
-  const posterUrl = `${LETTERBOXD_URL_BASE}/film/${letterboxdId}/poster/std/230`;
-  const posterResponse = await fetchWithRetry(posterUrl);
-  const posterData = JSON.parse(posterResponse);
-  if (posterData.url2x) {
-    return posterData.url2x;
-  }
-  return posterData.url ?? "";
+interface LetterboxdImage {
+  sizes: Array<{
+    width: number;
+    height: number;
+    url: string;
+  }>;
+}
+
+interface LetterboxdFilmSearchItem {
+  type: "FilmSearchItem";
+  film: {
+    id: string;
+    name: string;
+    link: string;
+    releaseYear?: number;
+    rating?: number | null;
+    poster?: LetterboxdImage | null;
+    directors?: Array<{
+      name: string;
+    }>;
+  };
+}
+
+interface LetterboxdSearchResponse {
+  items: LetterboxdFilmSearchItem[];
+}
+
+function getPreferredImageUrl(
+  image?: LetterboxdImage | null,
+): string | undefined {
+  const sizes = image?.sizes ?? [];
+  return (
+    sizes.find((size) => size.width >= 300)?.url ?? sizes[sizes.length - 1]?.url
+  );
+}
+
+function getPathFromLetterboxdUrl(url: string): string {
+  return new URL(url).pathname;
 }
 
 export const fetchMoviesByTitle = async (
   title: string,
 ): Promise<ApiResponse<Movie[]>> => {
-  const url = getSearchPageUrl(title, SEARCH_TYPE.FILMS);
+  const url = getSearchUrl(title.trim());
 
   try {
-    const response = await fetchWithRetry(url);
-    const movies = extractEntitiesFromMovieSearchPage(response);
-
-    // poster pngs are loaded client side after search results page load, so we mimic that here, namely
-    // for each movie in the search results we need to:
-    // 1. make a request to https://letterboxd.com/ajax/poster/film/<filmID, e.g. aquaman-2018>/std/70x105/
-    // 2. parse the html returned in that request for img src
-    const posterUrls: string[] = await Promise.all(
-      movies.map((movie) => {
-        return fetchPosterUrl(movie.letterboxdId);
-      }),
-    );
-    movies.forEach((movie, index) => {
-      const posterUrl = posterUrls[index];
-      if (posterUrl.includes("empty-poster")) {
-        movie.thumbnail = undefined;
-      } else {
-        movie.thumbnail = posterUrl;
-      }
+    const response = await fetchJsonWithRetry<LetterboxdSearchResponse>(url);
+    const movies = response.items.map(({ film }) => {
+      const detailsPage = getPathFromLetterboxdUrl(film.link);
+      return {
+        id: film.id,
+        letterboxdId: letterboxdIdFromPath(detailsPage),
+        thumbnail: getPreferredImageUrl(film.poster),
+        title: film.name,
+        released: film.releaseYear?.toString() ?? "",
+        director: film.directors?.map(({ name }) => name).join(", ") ?? "",
+        detailsPage,
+        rating: film.rating?.toFixed(2),
+      };
     });
+
     return { status: AsyncStatus.Success, data: movies };
   } catch (error) {
     console.log(`Failed: ${error}`);
     return { status: AsyncStatus.Error, data: [] };
   }
 };
-
-interface MovieResponse {
-  thumbnail: string;
-  title: string;
-  released: string;
-  director: string;
-  detailsPage: string;
-}
 
 function letterboxdIdFromPath(path: string): string {
   // extract the letterboxd id from the details page url, e.g. https://letterboxd.com/film/aquaman-2018/ -> aquaman-2018
@@ -120,179 +137,6 @@ function letterboxdIdFromPath(path: string): string {
     throw new Error(`Failed to extract letterboxd id from path: ${path}`);
   }
   return match[1];
-}
-
-function createMovieFromResponse(data: MovieResponse, index: number): Movie {
-  const { thumbnail, title, released, director, detailsPage } = data;
-  return {
-    id: `${title}-${director}-${index}`,
-    letterboxdId: letterboxdIdFromPath(detailsPage),
-    thumbnail,
-    title,
-    released,
-    director,
-    detailsPage: detailsPage,
-  };
-}
-
-function extractEntitiesFromMovieSearchPage(html: string): Movie[] {
-  const { movies } = parse(html, {
-    movies: [
-      {
-        selector: "ul.results li",
-        value: {
-          thumbnail: {
-            selector: "img",
-            value: "src",
-          },
-          title: {
-            selector: 'span.film-title-wrapper a[href^="/film/"]',
-          },
-          released: {
-            selector: 'span.film-title-wrapper a[href^="/films/year/"]',
-          },
-          director: {
-            selector: 'a[href^="/director/"]',
-          },
-          detailsPage: {
-            selector: 'a[href^="/film/"]',
-            value: "href",
-          },
-        },
-      },
-    ],
-  });
-
-  const movieResponses: MovieResponse[] = movies.map((movie) => ({
-    thumbnail: movie.thumbnail as string,
-    title: movie.title as string,
-    released: movie.released as string,
-    director: movie.director as string,
-    detailsPage: movie.detailsPage as string,
-  }));
-
-  const result: Movie[] = movieResponses.map(createMovieFromResponse);
-  return result;
-}
-
-async function fetchMovieStats(letterboxdId: string): Promise<MovieStatistics> {
-  const statsUrl = `${LETTERBOXD_URL_BASE}/csi/film/${letterboxdId}/stats/`;
-  const statsResponse = await fetchWithRetry(statsUrl);
-  return parse(statsResponse, {
-    watches: {
-      selector: "li.filmstat-watches a",
-      value: (el: Element) => {
-        const $ = load(el);
-        // title attr is something like "Watched by 111,454 members"
-        const match = $(el)
-          .attr("title")
-          ?.trim()
-          .match(/([\d,]+)\smembers/);
-        if (match) {
-          return parseInt(match[1].replaceAll(",", ""));
-        }
-        return 0;
-      },
-    },
-    lists: {
-      selector: "li.filmstat-lists a",
-      value: (el: Element) => {
-        const $ = load(el);
-        // title attr is something like "Appears in 41,036 lists"
-        const match = $(el)
-          .attr("title")
-          ?.trim()
-          .match(/([\d,]+)\slists/);
-        if (match) {
-          return parseInt(match[1].replaceAll(",", ""));
-        }
-        return 0;
-      },
-    },
-    likes: {
-      selector: "li.filmstat-likes a",
-      value: (el: Element) => {
-        const $ = load(el);
-        // title attr is something like "Liked by 15,645 members"
-        const match = $(el)
-          .attr("title")
-          ?.trim()
-          .match(/([\d,]+)\smembers/);
-        if (match) {
-          return parseInt(match[1].replaceAll(",", ""));
-        }
-        return 0;
-      },
-    },
-  });
-}
-
-async function fetchRatingHistogram(
-  letterboxdId: string,
-): Promise<MovieRatingHistogram> {
-  const ratingUrl = `${LETTERBOXD_URL_BASE}/csi/film/${letterboxdId}/rating-histogram/`;
-  const ratingResponse = await fetchWithRetry(ratingUrl);
-  return parse(ratingResponse, {
-    histogram: [
-      {
-        selector: "ul li.rating-histogram-bar",
-        value: (el: Element) => {
-          const $ = load(el);
-          const countIsZero = $(el).attr("title")?.startsWith("No "); // e.g. "No half-★ ratings"
-          if (countIsZero) {
-            return {
-              description: $(el).attr("title")?.split(" ")[1] ?? "", // e.g. "half-★"
-              count: 0,
-              percentage: 0,
-            };
-          }
-          const ratingTooltip = $("a").attr("title") ?? "";
-          const match = ratingTooltip.match(
-            /([\d,]+)\s(.*)\sratings\s\((\d+)%\)/,
-          );
-          if (match) {
-            return {
-              count: parseInt(match[1].replaceAll(",", "")),
-              description: match[2],
-              percentage: parseInt(match[3]),
-            };
-          }
-          return { count: 0, description: "", percentage: 0 };
-        },
-      },
-    ],
-    fans: {
-      selector: "a[href*='/fans']",
-      value: (el: Element) => {
-        const $ = load(el);
-        // element inner text is something like "38 fans"
-        // extract the number from that string using a regex
-        const fansText = $(el).text();
-        const match = fansText.match(/([\d,]+)\sfan[s]*/);
-        if (match) {
-          return parseInt(match[1].replaceAll(",", ""));
-        }
-        return 0;
-      },
-    },
-    rating: {
-      selector: "span.average-rating a",
-      value: (el: Element) => {
-        const $ = load(el);
-        // title attribute is something like "Weighted average of 2.29 based on 94,717 ratings"
-        // extract the average and count from that string using a regex
-        const title = $(el).attr("title") ?? "";
-        const match = title.match(/([\d.]+)\sbased\son\s([\d,]+)\s/);
-        if (match) {
-          return {
-            average: parseFloat(match[1]),
-            count: parseInt(match[2].replaceAll(",", "")),
-          };
-        }
-        return undefined;
-      },
-    },
-  });
 }
 
 export async function fetchMovieDetails(
@@ -315,14 +159,6 @@ export async function fetchMovieDetails(
       letterboxdId,
     );
 
-    const posterUrlPromise = fetchPosterUrl(letterboxdId);
-    const ratingHistogramPromise = fetchRatingHistogram(letterboxdId);
-    const statsPromise = fetchMovieStats(letterboxdId);
-
-    data.posterUrl = await posterUrlPromise;
-    data.ratingHistogram = await ratingHistogramPromise;
-    data.stats = await statsPromise;
-
     addToCache(cacheKey, data);
 
     return { status: AsyncStatus.Success, data };
@@ -337,6 +173,57 @@ function array(str: string | string[] | undefined): string[] {
     return [];
   }
   return Array.isArray(str) ? str : [str];
+}
+
+interface StructuredMovieData {
+  "@type"?: string;
+  image?: string;
+  aggregateRating?: {
+    ratingValue?: number;
+    ratingCount?: number;
+  };
+}
+
+function extractStructuredMovieData(
+  html: string,
+): StructuredMovieData | undefined {
+  const $ = load(html);
+  const scripts = $('script[type="application/ld+json"]').toArray();
+
+  for (const script of scripts) {
+    const rawJson = $(script).text();
+    const start = rawJson.indexOf("{");
+    const end = rawJson.lastIndexOf("}");
+    if (start === -1 || end === -1) {
+      continue;
+    }
+
+    try {
+      const data = JSON.parse(
+        rawJson.slice(start, end + 1),
+      ) as StructuredMovieData;
+      if (data["@type"] === "Movie") {
+        return data;
+      }
+    } catch {
+      // Ignore malformed structured data and continue with the HTML fields.
+    }
+  }
+}
+
+function getRatingFromStructuredData(
+  data?: StructuredMovieData,
+): MovieRatingHistogram | undefined {
+  const average = data?.aggregateRating?.ratingValue;
+  const count = data?.aggregateRating?.ratingCount;
+  if (average === undefined || count === undefined) {
+    return undefined;
+  }
+
+  return {
+    histogram: [],
+    rating: { average, count },
+  };
 }
 
 function extractEntitiesFromMovieDetailsPage(
@@ -468,6 +355,8 @@ function extractEntitiesFromMovieDetailsPage(
       },
     ],
   });
+  const structuredData = extractStructuredMovieData(html);
+
   return {
     id: letterboxId,
     director: director ?? "",
@@ -483,5 +372,7 @@ function extractEntitiesFromMovieDetailsPage(
     genres: array(genres),
     reviews,
     releases,
+    posterUrl: structuredData?.image,
+    ratingHistogram: getRatingFromStructuredData(structuredData),
   };
 }

--- a/extensions/letterboxd/src/movie-details.tsx
+++ b/extensions/letterboxd/src/movie-details.tsx
@@ -13,6 +13,17 @@ interface MovieDetailsProps {
   qualifier: string;
 }
 
+const HTML_ATTRIBUTE_ESCAPES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+const escapeHtmlAttribute = (value: string): string =>
+  value.replace(/[&<>"']/g, (character) => HTML_ATTRIBUTE_ESCAPES[character]);
+
 export default function MovieDetails(props: MovieDetailsProps) {
   const { movieTitle, qualifier } = props;
   const { data, isLoading, revalidate } = useCachedPromise(
@@ -53,7 +64,7 @@ const getMarkdown = (data: MovieDetails): string => {
   ${data.ratingHistogram?.rating ? `\n\`${data.ratingHistogram.rating.average} stars\` based on \`${humanizeInteger(data.ratingHistogram.rating.count)}\` ratings ` : ""}
   ${data.ratingHistogram?.fans ? `\n\`${humanizeInteger(data.ratingHistogram.fans)}\` fans` : ""}
 
-  ${data.posterUrl ? `<img src="${data.posterUrl}" alt="${data.title}" height="230"/>` : ""}
+  ${data.posterUrl ? `<img src="${escapeHtmlAttribute(data.posterUrl)}" alt="${escapeHtmlAttribute(data.title)}" height="230"/>` : ""}
 
   ${convertHtmlToCommonMark(data.description)}
 

--- a/extensions/letterboxd/src/movie-details.tsx
+++ b/extensions/letterboxd/src/movie-details.tsx
@@ -45,30 +45,26 @@ export default function MovieDetails(props: MovieDetailsProps) {
 }
 
 const getMarkdown = (data: MovieDetails): string => {
+  const ratingHistogramMarkdown = getRatingsHistogramMarkdown(data);
+
   return `
   # ${data.title}
   by ${data.director}
-  ${data.ratingHistogram?.rating ? `\n\`${data.ratingHistogram?.rating?.average} stars\` based on \`${humanizeInteger(data.ratingHistogram?.rating?.count)}\` reviews ` : ""}
+  ${data.ratingHistogram?.rating ? `\n\`${data.ratingHistogram.rating.average} stars\` based on \`${humanizeInteger(data.ratingHistogram.rating.count)}\` ratings ` : ""}
   ${data.ratingHistogram?.fans ? `\n\`${humanizeInteger(data.ratingHistogram.fans)}\` fans` : ""}
 
-  <img src="${data.posterUrl}" alt="Image" height="230"/>
+  ${data.posterUrl ? `<img src="${data.posterUrl}" alt="${data.title}" height="230"/>` : ""}
 
   ${convertHtmlToCommonMark(data.description)}
 
-  ##
-
-  ${getRatingsHistogramMarkdown(data)}  
-
-  ##
-  ---
-  ##
+  ${ratingHistogramMarkdown ? `##\n\n${ratingHistogramMarkdown}\n\n##\n---\n##` : ""}
 
   ${data.reviews?.map((review) => getReviewsMarkdown(review)).join("")}
   `;
 };
 
 const getRatingsHistogramMarkdown = (data: MovieDetails): string => {
-  if (!data.ratingHistogram) {
+  if (!data.ratingHistogram?.histogram.length) {
     return "";
   }
   const numberWithCommas = (x: number) => {

--- a/extensions/letterboxd/src/search-movies-page.tsx
+++ b/extensions/letterboxd/src/search-movies-page.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
-import { fetchMoviesByTitle, getFullURL } from "./letterboxd-api";
+import { AsyncStatus, fetchMoviesByTitle, getFullURL } from "./letterboxd-api";
 import type { Movie } from "./types";
 import MovieDetails from "./movie-details";
 import { STRINGS } from "./strings";
@@ -14,11 +14,13 @@ interface SearchMoviesPageProps {
 
 export default function SearchMoviesPage(props: SearchMoviesPageProps) {
   const [searchQuery, setSearch] = useState(props.arguments.title);
-  const { data, isLoading } = useCachedPromise(
+  const { data, isLoading, revalidate } = useCachedPromise(
     fetchMoviesByTitle,
     [searchQuery],
-    { execute: searchQuery.length > 0 },
+    { execute: searchQuery.trim().length > 0 },
   );
+
+  const hasError = data?.status === AsyncStatus.Error && !isLoading;
 
   return (
     <List
@@ -28,9 +30,19 @@ export default function SearchMoviesPage(props: SearchMoviesPageProps) {
       searchBarPlaceholder={STRINGS.searchMoviesPlaceholder}
       onSearchTextChange={setSearch}
     >
-      {data?.data?.map((movie) => (
-        <MovieItem key={movie.id} movie={movie} />
-      ))}
+      {hasError ? (
+        <List.EmptyView
+          title={STRINGS.somethingWentWrong}
+          description={STRINGS.tryAgain}
+          actions={
+            <ActionPanel>
+              <Action title={STRINGS.retry} onAction={revalidate} />
+            </ActionPanel>
+          }
+        />
+      ) : (
+        data?.data.map((movie) => <MovieItem key={movie.id} movie={movie} />)
+      )}
     </List>
   );
 }

--- a/extensions/letterboxd/src/utils.ts
+++ b/extensions/letterboxd/src/utils.ts
@@ -5,16 +5,26 @@ export function sleep(duration: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, duration));
 }
 
-const HEADERS: Record<string, string> = {
-  accept: "text/html,application/xhtml+xml,application/xml",
+const BASE_HEADERS: Record<string, string> = {
   "cache-control": "no-cache",
   pragma: "no-cache",
   "User-Agent": `Letterboxd Extension, Raycast/${environment.raycastVersion}`,
+};
+
+const HTML_HEADERS: Record<string, string> = {
+  ...BASE_HEADERS,
+  accept: "text/html,application/xhtml+xml,application/xml",
   "sec-ch-ua":
     '"Not_A Brand";v="8", "Chromium";v="120", "Google Chrome";v="120"',
   "sec-fetch-dest": "document",
   "sec-fetch-mode": "navigate",
 };
+
+const JSON_HEADERS: Record<string, string> = {
+  ...BASE_HEADERS,
+  accept: "application/json",
+};
+
 const RETRY_BASE_DELAY = 1000;
 
 export function humanizeInteger(value: number): string {
@@ -24,17 +34,19 @@ export function humanizeInteger(value: number): string {
   return `${Math.floor(value / 1000)}k`;
 }
 
-export async function fetchWithRetry(
+async function requestWithRetry<T>(
   url: string,
+  headers: Record<string, string>,
+  transform: (response: string) => T,
   limit = 2,
   validate?: (response: string) => boolean,
-): Promise<string> {
+): Promise<T> {
   let retryCount = 0;
 
   while (retryCount < limit) {
     try {
       const response = await fetch(url, {
-        headers: HEADERS,
+        headers,
       });
 
       if (!response.ok) {
@@ -47,7 +59,7 @@ export async function fetchWithRetry(
         throw new Error("Validation failed");
       }
 
-      return result;
+      return transform(result);
     } catch (error) {
       console.log(`Failed to fetch ${url}. ${error}`);
 
@@ -59,6 +71,29 @@ export async function fetchWithRetry(
   }
 
   throw new Error(`Failed after ${limit} retries`);
+}
+
+export function fetchWithRetry(
+  url: string,
+  limit = 2,
+  validate?: (response: string) => boolean,
+): Promise<string> {
+  return requestWithRetry(
+    url,
+    HTML_HEADERS,
+    (response) => response,
+    limit,
+    validate,
+  );
+}
+
+export function fetchJsonWithRetry<T>(url: string, limit = 2): Promise<T> {
+  return requestWithRetry(
+    url,
+    JSON_HEADERS,
+    (response) => JSON.parse(response) as T,
+    limit,
+  );
 }
 
 export function convertHtmlToCommonMark(html: string): string {


### PR DESCRIPTION
## Description
- Fixed movie search after Letterboxd retired the previous search endpoint
- Use Letterboxd's JSON search response for posters, release years, and directors
- Keep movie details available when optional statistics endpoints are blocked
- Close #29191
<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast
<img width="1000" height="625" alt="letterboxd 2026-07-27 at 11 01 36" src="https://github.com/user-attachments/assets/a20671a4-0051-4908-b7dd-f0557f80064b" />
<img width="1000" height="625" alt="letterboxd 2026-07-27 at 11 01 58" src="https://github.com/user-attachments/assets/29809b78-1fd3-4f38-8705-a0fbbd561ec3" />

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
