### PR TITLE
[WinGet] Fix stale-data failures and consolidate failure recovery

### DIFF
--- a/extensions/winget/CHANGELOG.md
+++ b/extensions/winget/CHANGELOG.md
@@ -1,5 +1,12 @@
 # WinGet Changelog
 
+## [Stale Data Fixes] - {PR_MERGE_DATE}
+
+### Fixed
+- Upgrade All refreshes stale package data before upgrading
+- Uninstalling a package that is no longer installed corrects the list instead of failing
+- A failed data refresh no longer shows an empty package list; the error toast offers Retry
+
 ## [Locale and Upgrade Fixes] - 2026-07-17
 
 ### Fixed

--- a/extensions/winget/CHANGELOG.md
+++ b/extensions/winget/CHANGELOG.md
@@ -1,6 +1,6 @@
 # WinGet Changelog
 
-## [Stale Data Fixes] - {PR_MERGE_DATE}
+## [Stale Data Fixes] - 2026-07-27
 
 ### Fixed
 - Upgrade All refreshes stale package data before upgrading

--- a/extensions/winget/src/cli/commands.test.ts
+++ b/extensions/winget/src/cli/commands.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  ensureTableQuerySucceeded,
   isElevationFailure,
   isInstallerBusyFailure,
   isModifiedPortableFailure,
+  remapUninstallNotFound,
   remapUpgradeNotFound,
 } from "./commands";
 
@@ -45,6 +47,29 @@ describe("remapUpgradeNotFound", () => {
   it("leaves successes untouched", () => {
     const ok = { success: true, exitCode: 0 };
     expect(remapUpgradeNotFound(ok)).toBe(ok);
+  });
+});
+
+describe("remapUninstallNotFound", () => {
+  it("remaps NO_APPLICATIONS_FOUND to a no-op (ghost index row self-heals)", () => {
+    const result = remapUninstallNotFound({
+      success: false,
+      message: "Package not found",
+      exitCode: -1978335212, // 0x8A150014 signed
+      errorCode: "0x8A150014",
+    });
+    expect(result).toMatchObject({
+      success: true,
+      noop: true,
+      message: "Not installed",
+    });
+  });
+
+  it("leaves genuine failures and cancellations untouched", () => {
+    const failure = { success: false, message: "Access denied", exitCode: 5 };
+    expect(remapUninstallNotFound(failure)).toBe(failure);
+    const cancelled = { success: false, cancelled: true, exitCode: -1978335212 };
+    expect(remapUninstallNotFound(cancelled)).toBe(cancelled);
   });
 });
 
@@ -158,6 +183,39 @@ describe("isInstallerBusyFailure", () => {
     expect(isInstallerBusyFailure({ success: false, cancelled: true, errorCode: "1618" })).toBe(false);
     expect(isInstallerBusyFailure({ success: false, errorCode: "1603" })).toBe(false);
     expect(isInstallerBusyFailure({ success: false, message: "Disk full" })).toBe(false);
+  });
+});
+
+describe("ensureTableQuerySucceeded", () => {
+  const emptyParse = { items: [], stats: { droppedTruncatedIds: 0 } };
+  const oneRowParse = { items: [{ id: "Foo.Bar" }], stats: { droppedTruncatedIds: 0 } };
+  const run = (exitCode: number, stdout = "") => ({ stdout, stderr: "", exitCode });
+
+  it("throws on a zero-row parse with a failure exit code", () => {
+    // Observed live: `winget list` crashed with 0x80071130 ("Fast Cache data
+    // not found") after a source package update; the empty output must not
+    // be committed as "nothing installed".
+    expect(() => ensureTableQuerySucceeded(run(-2147020496), emptyParse, "Failed to list installed packages")).toThrow(
+      "Failed to list installed packages",
+    ); // 0x80071130 signed
+  });
+
+  it("uses the curated exit-code message when one exists", () => {
+    expect(() => ensureTableQuerySucceeded(run(-1978335207), emptyParse, "fallback")).toThrow(
+      "Requires administrator, retry from an elevated terminal",
+    );
+  });
+
+  it("accepts an empty table when the query exits 0", () => {
+    expect(ensureTableQuerySucceeded(run(0), emptyParse, "fallback")).toBe(emptyParse);
+  });
+
+  it("accepts NO_APPLICATIONS_FOUND as a genuinely empty table", () => {
+    expect(ensureTableQuerySucceeded(run(-1978335212), emptyParse, "fallback")).toBe(emptyParse); // 0x8A150014 signed
+  });
+
+  it("prefers parsed rows over a failure exit code", () => {
+    expect(ensureTableQuerySucceeded(run(-2147020496), oneRowParse, "fallback")).toBe(oneRowParse);
   });
 });
 

--- a/extensions/winget/src/cli/commands.ts
+++ b/extensions/winget/src/cli/commands.ts
@@ -47,6 +47,7 @@ import {
 import { WingetProgressDetector } from "./progress";
 import { runWinget, runWingetElevated, UAC_DECLINED_EXIT_CODE, withQuerySlot } from "./spawn";
 import {
+  type ExecutorResult,
   type WingetExecutorOptions,
   type WingetInstalledPackage,
   type WingetOperationResult,
@@ -255,6 +256,29 @@ async function isWingetAvailable(): Promise<boolean> {
 }
 
 /**
+ * A zero-row parse plus a nonzero exit means the query itself failed (source
+ * update error, cache corruption) — not that the table was empty. Throw so
+ * callers keep their previous data instead of caching the failure as absence;
+ * same contract as the showPackage* transient-failure guards.
+ * NO_APPLICATIONS_FOUND is winget's own "nothing matched" answer, the one
+ * legitimate empty-table exit (empty `pin list` and no-upgrades exit 0).
+ */
+function ensureTableQuerySucceeded<T>(
+  result: ExecutorResult,
+  parsed: TableParseResult<T>,
+  fallbackMessage: string,
+): TableParseResult<T> {
+  if (
+    parsed.items.length === 0 &&
+    result.exitCode !== 0 &&
+    toUnsignedHResult(result.exitCode) !== NO_APPLICATIONS_FOUND
+  ) {
+    throw new Error(getExitCodeMessage(result.exitCode) ?? fallbackMessage);
+  }
+  return parsed;
+}
+
+/**
  * The full catalog. Requires an explicit empty query — winget lists the whole
  * source only for `search -q ""` (and cmd.exe would drop the empty arg, which
  * is one reason we spawn winget directly).
@@ -265,7 +289,7 @@ async function searchAllPackages(signal?: AbortSignal): Promise<TableParseResult
       timeout: CATALOG_TIMEOUT_MS,
       signal,
     });
-    return parseSearchResults(result.stdout);
+    return ensureTableQuerySucceeded(result, parseSearchResults(result.stdout), "Failed to load the package catalog");
   });
 }
 
@@ -275,7 +299,11 @@ async function listInstalledPackages(signal?: AbortSignal): Promise<TableParseRe
       timeout: QUERY_TIMEOUT_MS,
       signal,
     });
-    return parseInstalledPackages(result.stdout);
+    return ensureTableQuerySucceeded(
+      result,
+      parseInstalledPackages(result.stdout),
+      "Failed to list installed packages",
+    );
   });
 }
 
@@ -285,7 +313,7 @@ async function listUpgradePackages(signal?: AbortSignal): Promise<TableParseResu
       timeout: QUERY_TIMEOUT_MS,
       signal,
     });
-    return parseUpgradePackages(result.stdout);
+    return ensureTableQuerySucceeded(result, parseUpgradePackages(result.stdout), "Failed to list available updates");
   });
 }
 
@@ -295,7 +323,7 @@ async function listPinnedPackages(signal?: AbortSignal): Promise<TableParseResul
       timeout: QUERY_TIMEOUT_MS,
       signal,
     });
-    return parsePinnedPackages(result.stdout);
+    return ensureTableQuerySucceeded(result, parsePinnedPackages(result.stdout), "Failed to list pinned packages");
   });
 }
 
@@ -440,66 +468,130 @@ function delay(ms: number, signal?: AbortSignal): Promise<"elapsed" | "aborted">
   });
 }
 
-/**
- * Retry once when the installer failed only because the Windows Installer
- * mutex was busy — a transient collision, not a package problem. The wait
- * gives the other installation time to finish; a cancel during the wait
- * returns the original failure immediately.
- */
-async function executeWithBusyRetry(
-  run: () => Promise<WingetOperationResult>,
-  options: WingetExecutorOptions,
-): Promise<WingetOperationResult> {
-  const result = await run();
-  if (!isInstallerBusyFailure(result)) {
-    return result;
-  }
-  if ((await delay(INSTALLER_BUSY_RETRY_DELAY_MS, options.signal)) === "aborted") {
-    return result;
-  }
-  return run();
+/** One winget invocation: argv, plus whether winget itself runs elevated. */
+interface Attempt {
+  args: string[];
+  elevated?: boolean;
 }
 
 /**
- * Last-resort retry for the requires-administrator class: relaunch winget
- * itself elevated. The UAC prompt is the confirmation — no dialog precedes
- * it — and a decline surfaces as a normal per-package failure, so bulk runs
- * carry on with the next package. `elevatedArgs` is a thunk resolved after
- * `run` settles, so retry chains can elevate with the arguments of whichever
- * attempt ran last (e.g. upgrade's --force retry).
+ * One failure class and its remedy. Rules are consulted in order after every
+ * failed attempt; the first unspent match yields the next attempt, and each
+ * rule fires at most once per operation. `disclose` annotates the eventual
+ * success so overrides (e.g. --force) stay visible to the user.
  */
-async function executeWithElevatedFallback(
-  run: () => Promise<WingetOperationResult>,
-  elevatedArgs: () => string[],
-  options: WingetExecutorOptions,
-): Promise<WingetOperationResult> {
-  const result = await run();
-  if (!isElevationFailure(result)) {
-    return result;
-  }
-  return executeElevatedOperation(elevatedArgs(), options);
+interface RecoveryRule {
+  matches(result: WingetOperationResult): boolean;
+  /** Wait before retrying (cancellable; a cancelled wait keeps the failure). */
+  waitMs?: number;
+  next(current: Attempt): Attempt;
+  disclose?: string;
 }
 
 /**
- * Run an install/repair invocation silent-first; when it fails with the
- * requires-administrator class, retry once without --silent so the installer
- * can raise its own UAC prompt, then fall back to relaunching winget itself
- * elevated (machine-scope MSIX packages accept nothing less).
+ * The recovery engine: execute, and while the failure matches an unspent
+ * rule, escalate to the rule's next attempt. Attempt state threads through
+ * rules, so a later retry keeps what an earlier rule established — flags
+ * (an elevated retry after --force keeps --force) and PRIVILEGE (a retry
+ * after an elevated attempt stays elevated; the runner suspends cancellation
+ * for the rest of the package once elevation starts, so a demoted attempt
+ * would run uncancellable). Elevated attempts have no observable output —
+ * their result comes from the exit code alone.
  */
-async function executeWithElevationRetry(
-  argsFor: (flags: string[]) => string[],
-  silentFlags: string[],
+async function executeWithRecovery(
+  first: Attempt,
+  rules: RecoveryRule[],
   options: WingetExecutorOptions,
 ): Promise<WingetOperationResult> {
-  const result = await executeOperation(argsFor(silentFlags), options);
-  if (!isElevationFailure(result)) {
-    return result;
+  const run = (attempt: Attempt) =>
+    attempt.elevated ? executeElevatedOperation(attempt.args, options) : executeOperation(attempt.args, options);
+
+  const spent = new Set<RecoveryRule>();
+  const disclosures: string[] = [];
+  let attempt = first;
+  let result = await run(attempt);
+  for (;;) {
+    if (result.success) {
+      if (disclosures.length === 0 || result.noop) {
+        return result;
+      }
+      const note = disclosures.join("; ");
+      return {
+        ...result,
+        message: result.message ? `${result.message} (${note})` : note.charAt(0).toUpperCase() + note.slice(1),
+      };
+    }
+    if (result.cancelled) {
+      return result;
+    }
+    const rule = rules.find((r) => !spent.has(r) && r.matches(result));
+    if (!rule) {
+      return result;
+    }
+    spent.add(rule);
+    if (rule.waitMs && (await delay(rule.waitMs, options.signal)) === "aborted") {
+      return result;
+    }
+    if (rule.disclose) {
+      disclosures.push(rule.disclose);
+    }
+    attempt = rule.next(attempt);
+    result = await run(attempt);
   }
-  return executeWithElevatedFallback(
-    () => executeOperation(argsFor(ELEVATION_RETRY_FLAGS), options),
-    () => argsFor(silentFlags),
-    options,
-  );
+}
+
+// The failure classes and their remedies. Adding a class = one classifier
+// predicate + one rule here + the rule's slot in the operations' policies.
+
+/**
+ * ERROR_INSTALL_ALREADY_RUNNING (1618): the Windows Installer mutex was held
+ * by another installation — a transient collision, not a package problem.
+ * Wait it out and retry the same attempt.
+ */
+const installerBusyRule: RecoveryRule = {
+  matches: isInstallerBusyFailure,
+  waitMs: INSTALLER_BUSY_RETRY_DELAY_MS,
+  next: (current) => current,
+};
+
+/**
+ * Silent mode suppressed the installer's own UAC prompt (the root cause
+ * behind upgrade's no---silent policy): retry without --silent.
+ */
+function unsilencedRetryRule(argsFor: (flags: string[]) => string[]): RecoveryRule {
+  return {
+    matches: isElevationFailure,
+    next: (current) => ({ ...current, args: argsFor(ELEVATION_RETRY_FLAGS) }),
+  };
+}
+
+/**
+ * Nothing unelevated can install this package (machine-scope MSIX): relaunch
+ * winget itself elevated — the UAC prompt is the confirmation, and a decline
+ * is a normal per-package failure so bulk runs carry on. `args` overrides the
+ * attempt (install/repair re-elevate their SILENT argv: the installer needs
+ * no prompt of its own once winget is elevated); by default the current
+ * attempt's argv is kept (upgrade's --force retry must survive elevation).
+ */
+function elevatedRetryRule(args?: () => string[]): RecoveryRule {
+  return {
+    matches: isElevationFailure,
+    next: (current) => ({ args: args?.() ?? current.args, elevated: true }),
+  };
+}
+
+/**
+ * A modified portable package refuses removal during upgrade; winget's
+ * printed remedy is --force (an upgrade replaces the package either way).
+ * Uninstall deliberately has no such rule — forced removal deletes the
+ * user's modifications, so it runs only after an explicit confirmation.
+ */
+function forceRetryRule(argsFor: (extra: string[]) => string[]): RecoveryRule {
+  return {
+    matches: isModifiedPortableFailure,
+    next: (current) => ({ ...current, args: argsFor(["--force"]) }),
+    disclose: "modified portable package, used --force",
+  };
 }
 
 async function installPackage(
@@ -507,13 +599,10 @@ async function installPackage(
   source: WingetSource,
   options: WingetExecutorOptions = {},
 ): Promise<WingetOperationResult> {
-  return executeWithBusyRetry(
-    () =>
-      executeWithElevationRetry(
-        (flags) => withSource(["install", ...EXACT_ID_FLAGS, id, ...flags], source),
-        INSTALL_FLAGS,
-        options,
-      ),
+  const argsFor = (flags: string[]) => withSource(["install", ...EXACT_ID_FLAGS, id, ...flags], source);
+  return executeWithRecovery(
+    { args: argsFor(INSTALL_FLAGS) },
+    [installerBusyRule, unsilencedRetryRule(argsFor), elevatedRetryRule(() => argsFor(INSTALL_FLAGS))],
     options,
   );
 }
@@ -529,13 +618,11 @@ async function installPackageVersion(
   source: WingetSource,
   options: WingetExecutorOptions = {},
 ): Promise<WingetOperationResult> {
-  const result = await executeWithBusyRetry(
-    () =>
-      executeWithElevationRetry(
-        (flags) => withSource(["install", ...EXACT_ID_FLAGS, id, "--version", version, ...flags], source),
-        INSTALL_FLAGS,
-        options,
-      ),
+  const argsFor = (flags: string[]) =>
+    withSource(["install", ...EXACT_ID_FLAGS, id, "--version", version, ...flags], source);
+  const result = await executeWithRecovery(
+    { args: argsFor(INSTALL_FLAGS) },
+    [installerBusyRule, unsilencedRetryRule(argsFor), elevatedRetryRule(() => argsFor(INSTALL_FLAGS))],
     options,
   );
   if (!result.success) {
@@ -563,30 +650,27 @@ async function installPackageVersion(
   return result;
 }
 
-/**
- * Upgrade-specific exit-code remap: with a `--source` filter, winget reports
- * an installed-but-up-to-date package as NO_APPLICATIONS_FOUND ("No installed
- * package found matching input criteria") instead of UPDATE_NOT_APPLICABLE —
- * verified live (winget 1.28: 0x8A15002B without --source, 0x8A150014 with).
- * For an upgrade that is a no-op, not a failure. (For uninstall the same code
- * genuinely means "not installed" and stays a failure.)
- */
-function remapUpgradeNotFound(result: WingetOperationResult): WingetOperationResult {
+/** NO_APPLICATIONS_FOUND as a no-op — the meaning differs per operation. */
+function remapNotFoundAsNoop(result: WingetOperationResult, message: string): WingetOperationResult {
   if (
     !result.success &&
     !result.cancelled &&
     result.exitCode !== undefined &&
     toUnsignedHResult(result.exitCode) === NO_APPLICATIONS_FOUND
   ) {
-    return {
-      ...result,
-      success: true,
-      noop: true,
-      message: "No applicable update",
-      errorCode: undefined,
-    };
+    return { ...result, success: true, noop: true, message, errorCode: undefined };
   }
   return result;
+}
+
+/**
+ * Upgrade-specific: with a `--source` filter, winget reports an
+ * installed-but-up-to-date package as NO_APPLICATIONS_FOUND ("No installed
+ * package found matching input criteria") instead of UPDATE_NOT_APPLICABLE —
+ * verified live (winget 1.28: 0x8A15002B without --source, 0x8A150014 with).
+ */
+function remapUpgradeNotFound(result: WingetOperationResult): WingetOperationResult {
+  return remapNotFoundAsNoop(result, "No applicable update");
 }
 
 /**
@@ -605,55 +689,30 @@ function isModifiedPortableFailure(result: WingetOperationResult): boolean {
   return /portable package/i.test(message) && /modified/i.test(message);
 }
 
-/**
- * Run an upgrade invocation normally; when it fails because a portable
- * package was modified after install, retry once with --force (the remedy
- * winget itself prints — an upgrade replaces the package either way). The
- * success message discloses the override. Uninstall deliberately does NOT
- * auto-force: forced removal deletes the user's modifications, so it runs
- * only after the runner's explicit confirmation prompt.
- */
-async function executeWithForceRetry(
-  argsFor: (extra: string[]) => string[],
-  options: WingetExecutorOptions,
-): Promise<WingetOperationResult> {
-  const result = await executeOperation(argsFor([]), options);
-  if (!isModifiedPortableFailure(result)) {
-    return result;
-  }
-  const retried = await executeOperation(argsFor(["--force"]), options);
-  if (retried.success && !retried.noop) {
-    // Append rather than replace: a successful retry can carry its own
-    // message (e.g. "Restart your PC to finish") that must stay visible.
-    const disclosure = "modified portable package, used --force";
-    return {
-      ...retried,
-      message: retried.message ? `${retried.message} (${disclosure})` : "Modified portable package, used --force",
-    };
-  }
-  return retried;
-}
-
 async function upgradePackage(
   id: string,
   source: WingetSource,
   options: WingetExecutorOptions = {},
 ): Promise<WingetOperationResult> {
-  // Track the last attempt's arguments so an elevated retry keeps the
-  // --force flag when the force retry is what hit the administrator wall.
-  let lastAttemptArgs = withSource(["upgrade", ...EXACT_ID_FLAGS, id, ...UPGRADE_FLAGS], source);
   const argsFor = (extra: string[]) =>
-    (lastAttemptArgs = withSource(["upgrade", ...EXACT_ID_FLAGS, id, ...UPGRADE_FLAGS, ...extra], source));
-  const result = await executeWithBusyRetry(
-    () =>
-      executeWithElevatedFallback(
-        () => executeWithForceRetry(argsFor, options),
-        () => lastAttemptArgs,
-        options,
-      ),
+    withSource(["upgrade", ...EXACT_ID_FLAGS, id, ...UPGRADE_FLAGS, ...extra], source);
+  const result = await executeWithRecovery(
+    { args: argsFor([]) },
+    [installerBusyRule, forceRetryRule(argsFor), elevatedRetryRule()],
     options,
   );
   return remapUpgradeNotFound(result);
+}
+
+/**
+ * Uninstall-specific exit-code remap: NO_APPLICATIONS_FOUND means winget has
+ * no such installed package — the index row that offered the uninstall was a
+ * ghost (the package was removed outside this extension, or a prior uninstall
+ * finished without the index catching up). Not a failure: report a no-op so
+ * the optimistic patch drops the row and the index self-heals.
+ */
+function remapUninstallNotFound(result: WingetOperationResult): WingetOperationResult {
+  return remapNotFoundAsNoop(result, "Not installed");
 }
 
 /**
@@ -676,15 +735,8 @@ async function uninstallPackage(
     ["uninstall", ...EXACT_ID_FLAGS, id, ...versionFlags, ...UNINSTALL_FLAGS, ...forceFlags],
     source,
   );
-  return executeWithBusyRetry(
-    () =>
-      executeWithElevatedFallback(
-        () => executeOperation(args, options),
-        () => args,
-        options,
-      ),
-    options,
-  );
+  const result = await executeWithRecovery({ args }, [installerBusyRule, elevatedRetryRule()], options);
+  return remapUninstallNotFound(result);
 }
 
 async function repairPackage(
@@ -692,13 +744,10 @@ async function repairPackage(
   source: WingetSource,
   options: WingetExecutorOptions = {},
 ): Promise<WingetOperationResult> {
-  return executeWithBusyRetry(
-    () =>
-      executeWithElevationRetry(
-        (flags) => withSource(["repair", ...EXACT_ID_FLAGS, id, ...flags], source),
-        REPAIR_FLAGS,
-        options,
-      ),
+  const argsFor = (flags: string[]) => withSource(["repair", ...EXACT_ID_FLAGS, id, ...flags], source);
+  return executeWithRecovery(
+    { args: argsFor(REPAIR_FLAGS) },
+    [installerBusyRule, unsilencedRetryRule(argsFor), elevatedRetryRule(() => argsFor(REPAIR_FLAGS))],
     options,
   );
 }
@@ -758,9 +807,11 @@ async function importPackages(
 }
 
 export {
+  ensureTableQuerySucceeded,
   isElevationFailure,
   isInstallerBusyFailure,
   isModifiedPortableFailure,
+  remapUninstallNotFound,
   remapUpgradeNotFound,
   downloadInstaller,
   exportPackages,

--- a/extensions/winget/src/cli/recovery.test.ts
+++ b/extensions/winget/src/cli/recovery.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Recovery-policy sequences, driven through the real executors with the spawn
+ * layer mocked: each test scripts the exit codes winget would return and
+ * asserts which invocations (argv, elevation) the policy escalates through.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./spawn", () => ({
+  runWinget: vi.fn(),
+  runWingetElevated: vi.fn(),
+  UAC_DECLINED_EXIT_CODE: 1223,
+  withQuerySlot: (fn: () => unknown) => fn(),
+  configureWingetPath: vi.fn(),
+}));
+
+import { runWinget, runWingetElevated } from "./spawn";
+
+import { installPackage, upgradePackage } from "./commands";
+
+const COMMAND_REQUIRES_ADMIN_SIGNED = -1978335207; // 0x8A150019
+const PORTABLE_UNINSTALL_FAILED_SIGNED = -1978335145; // 0x8A150057
+
+type SpawnOptions = { onStdout?: (chunk: string) => void };
+
+/** Queue winget responses; each entry is [exitCode, stdout]. */
+function scriptRuns(entries: Array<[number, string?]>) {
+  for (const [exitCode, stdout = ""] of entries) {
+    vi.mocked(runWinget).mockImplementationOnce(async (_args: string[], options?: SpawnOptions) => {
+      if (stdout) {
+        options?.onStdout?.(stdout);
+      }
+      return { stdout, stderr: "", exitCode };
+    });
+  }
+}
+
+beforeEach(() => {
+  vi.mocked(runWinget).mockReset();
+  vi.mocked(runWingetElevated).mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("recovery policy sequences", () => {
+  it("install escalates silent → unsilenced → elevated on the requires-admin class", async () => {
+    scriptRuns([[COMMAND_REQUIRES_ADMIN_SIGNED], [COMMAND_REQUIRES_ADMIN_SIGNED]]);
+    vi.mocked(runWingetElevated).mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 });
+
+    const result = await installPackage("Foo.Bar", "winget");
+
+    expect(result.success).toBe(true);
+    const attempts = vi.mocked(runWinget).mock.calls.map((c) => c[0] as string[]);
+    expect(attempts[0]).toContain("--silent");
+    expect(attempts[1]).not.toContain("--silent");
+    // The elevated relaunch goes back to the silent argv: once winget itself
+    // is elevated the installer needs no prompt of its own.
+    const elevatedArgs = vi.mocked(runWingetElevated).mock.calls[0]![0] as string[];
+    expect(elevatedArgs).toContain("--silent");
+  });
+
+  it("upgrade keeps --force when the force retry hits the administrator wall", async () => {
+    scriptRuns([[PORTABLE_UNINSTALL_FAILED_SIGNED], [COMMAND_REQUIRES_ADMIN_SIGNED]]);
+    vi.mocked(runWingetElevated).mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 });
+
+    const result = await upgradePackage("Foo.Bar", "winget");
+
+    expect(result.success).toBe(true);
+    const attempts = vi.mocked(runWinget).mock.calls.map((c) => c[0] as string[]);
+    expect(attempts[0]).not.toContain("--force");
+    expect(attempts[1]).toContain("--force");
+    const elevatedArgs = vi.mocked(runWingetElevated).mock.calls[0]![0] as string[];
+    expect(elevatedArgs).toContain("--force");
+    // The override survives into the terminal message even though the success
+    // came from the elevated attempt.
+    expect(result.message).toMatch(/--force/);
+  });
+
+  it("waits out an installer-mutex collision and retries the same attempt once", async () => {
+    vi.useFakeTimers();
+    scriptRuns([
+      [43, "Installer failed with exit code: 1618"],
+      [0, "Successfully installed"],
+    ]);
+
+    const pending = installPackage("Foo.Bar", "winget");
+    await vi.advanceTimersByTimeAsync(30_000);
+    const result = await pending;
+
+    expect(result.success).toBe(true);
+    expect(vi.mocked(runWinget).mock.calls).toHaveLength(2);
+    expect(vi.mocked(runWinget).mock.calls[1]![0]).toEqual(vi.mocked(runWinget).mock.calls[0]![0]);
+    expect(vi.mocked(runWingetElevated)).not.toHaveBeenCalled();
+  });
+
+  it("never demotes privilege: a force retry after an elevated attempt stays elevated", async () => {
+    scriptRuns([[COMMAND_REQUIRES_ADMIN_SIGNED]]);
+    vi.mocked(runWingetElevated)
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: PORTABLE_UNINSTALL_FAILED_SIGNED })
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 });
+
+    const result = await upgradePackage("Foo.Bar", "winget");
+
+    expect(result.success).toBe(true);
+    // Exactly one unelevated attempt; the force retry runs through the
+    // elevated lane (a demoted attempt would run with cancellation
+    // suspended and terminate with the wrong failure class).
+    expect(vi.mocked(runWinget).mock.calls).toHaveLength(1);
+    const elevatedCalls = vi.mocked(runWingetElevated).mock.calls.map((c) => c[0] as string[]);
+    expect(elevatedCalls).toHaveLength(2);
+    expect(elevatedCalls[0]).not.toContain("--force");
+    expect(elevatedCalls[1]).toContain("--force");
+    expect(result.message).toMatch(/--force/);
+  });
+
+  it("returns the failure untouched when no rule matches", async () => {
+    scriptRuns([[-1978334971]]); // DISK_FULL-class: no recovery rule
+    const result = await upgradePackage("Foo.Bar", "winget");
+    expect(result.success).toBe(false);
+    expect(vi.mocked(runWinget).mock.calls).toHaveLength(1);
+    expect(vi.mocked(runWingetElevated)).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/winget/src/core/feedback.ts
+++ b/extensions/winget/src/core/feedback.ts
@@ -116,7 +116,8 @@ function noopTitle(state: OperationState): string {
   const name = state.target?.name ?? "Package";
   if (state.bulk && state.bulk.skipped > 0) {
     // Everything was skipped: winget had no applicable action for any target.
-    return `Nothing ${bulkVerb(state)}, ${state.bulk.skipped} skipped (no applicable update)`;
+    const reason = state.kind === "uninstall-all" ? "not installed" : "no applicable update";
+    return `Nothing ${bulkVerb(state)}, ${state.bulk.skipped} skipped (${reason})`;
   }
   switch (state.kind) {
     case "install":
@@ -126,6 +127,8 @@ function noopTitle(state: OperationState): string {
       return `${name} is already up to date`;
     case "upgrade-all":
       return "All packages are up to date";
+    case "uninstall":
+      return `${name} was not installed`;
     case "pin":
       return `${name} is already pinned`;
     case "unpin":

--- a/extensions/winget/src/core/index-patches.test.ts
+++ b/extensions/winget/src/core/index-patches.test.ts
@@ -108,4 +108,12 @@ describe("applyOperationPatch", () => {
     expect(applyOperationPatch("repair", target, undefined, ok, slices())).toBeNull();
     expect(applyOperationPatch("download", target, undefined, ok, slices())).toBeNull();
   });
+
+  it("uninstall no-op: removes the ghost row (winget reported the package not installed)", () => {
+    const notInstalled: WingetOperationResult = { success: true, noop: true, message: "Not installed" };
+    const next = applyOperationPatch("uninstall", target, undefined, notInstalled, slices())!;
+    expect(next).not.toBeNull();
+    expect(next.installed).toHaveLength(0);
+    expect(next.upgradable).toHaveLength(0);
+  });
 });

--- a/extensions/winget/src/core/index-patches.ts
+++ b/extensions/winget/src/core/index-patches.ts
@@ -17,7 +17,9 @@ function sameKey(a: { id: string; source: string }, b: { id: string; source: str
 /**
  * Returns the patched slices, or null when there is nothing to patch (no-ops,
  * failures other than completed-with-reboot, kinds without per-package
- * effects like import/export/download/repair).
+ * effects like import/export/download/repair). Exception: an uninstall no-op
+ * means winget reported the package NOT installed — the index row that
+ * offered the action was a ghost, and removing it is exactly the patch.
  */
 function applyOperationPatch(
   kind: OperationKind,
@@ -26,7 +28,7 @@ function applyOperationPatch(
   result: WingetOperationResult,
   slices: MutableSlices,
 ): MutableSlices | null {
-  if (!result.success || result.noop || !target) {
+  if (!result.success || (result.noop && kind !== "uninstall") || !target) {
     return null;
   }
 

--- a/extensions/winget/src/core/refresh.ts
+++ b/extensions/winget/src/core/refresh.ts
@@ -29,6 +29,7 @@ import {
   patchMutable,
   type IndexPaths,
   type MutableSlices,
+  type PackageIndex,
 } from "./index-store";
 import { acquireLock, heartbeatLock, inspectLock, releaseLock, DEFAULT_ENV } from "./lock";
 import { inspectOperationGate } from "./operations";
@@ -45,6 +46,11 @@ type RefreshOutcome = "refreshed" | "refreshed-elsewhere" | "skipped-busy" | "sk
 
 /** How stale the mutable slices may get before a view mount refreshes them. */
 const MUTABLE_STALENESS_MS = 10 * 60 * 1000;
+
+/** True when the index's mutable slices are due a refresh (or absent). */
+function isMutableDataStale(index: PackageIndex | null): boolean {
+  return !index?.mutableAt || Date.now() - index.mutableAt > MUTABLE_STALENESS_MS;
+}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -103,6 +109,8 @@ interface SliceRefreshGuards {
   startEpoch?: number;
   /** Ownership check for the op-lock holder; false fences the commit. */
   stillOwned?: () => boolean;
+  /** Aborts the queries (a failed refresh rolls back and rethrows). */
+  signal?: AbortSignal;
 }
 
 interface SliceRefreshResult {
@@ -155,15 +163,15 @@ async function refreshSlicesIncrementally(paths: IndexPaths, guards: SliceRefres
   let installed: WingetInstalledPackage[] = [];
   let upgradable: WingetUpgradePackage[] = [];
   const settled = await Promise.allSettled([
-    listInstalledPackages().then((r) => {
+    listInstalledPackages(guards.signal).then((r) => {
       installed = r.items;
       committed.installed = commit({}, (s) => ({ ...s, installed: r.items }));
     }),
-    listUpgradePackages().then((r) => {
+    listUpgradePackages(guards.signal).then((r) => {
       upgradable = r.items;
       committed.upgradable = commit({}, (s) => ({ ...s, upgradable: r.items }));
     }),
-    listPinnedPackages().then((r) => {
+    listPinnedPackages(guards.signal).then((r) => {
       committed.pinned = commit({}, (s) => ({ ...s, pinned: r.items }));
     }),
   ]);
@@ -232,8 +240,7 @@ async function rebuildFullIndex(paths: IndexPaths, stillNeeded: () => boolean = 
 
     // Skip the mutable stage when those slices are already fresh — e.g. the
     // mount policy refreshed them moments ago and only the catalog was stale.
-    const current = loadIndex(paths);
-    if (current?.mutableAt && Date.now() - current.mutableAt < MUTABLE_STALENESS_MS) {
+    if (!isMutableDataStale(loadIndex(paths))) {
       return "refreshed";
     }
 
@@ -251,6 +258,7 @@ async function rebuildFullIndex(paths: IndexPaths, stillNeeded: () => boolean = 
 }
 
 export {
+  isMutableDataStale,
   MUTABLE_STALENESS_MS,
   rebuildFullIndex,
   refreshMutableSlices,

--- a/extensions/winget/src/core/runner.ts
+++ b/extensions/winget/src/core/runner.ts
@@ -82,7 +82,7 @@ import {
   writeOperationState,
 } from "./operations";
 import { supportPath } from "./paths";
-import { refreshSlicesIncrementally } from "./refresh";
+import { isMutableDataStale, refreshSlicesIncrementally } from "./refresh";
 
 const CANCEL_POLL_MS = 500;
 const STATE_WRITE_THROTTLE_MS = 250;
@@ -143,6 +143,22 @@ function statusFromResult(result: WingetOperationResult): OperationStatus {
   if (result.cancelled) return "cancelled";
   if (!result.success) return "failed";
   return result.noop ? "noop" : "succeeded";
+}
+
+/**
+ * Upgrade All's target list, derived from the index: every upgradable package
+ * that is not pinned and whose offered version is not marked not-applicable —
+ * the same exclusions the upgradable view applies.
+ */
+function upgradableTargets(indexPaths: IndexPaths): PackageTarget[] {
+  const index = loadIndex(indexPaths);
+  if (!index) {
+    return [];
+  }
+  const pinnedKeys = new Set(index.pinned.map((p) => packageKey(p)));
+  return index.upgradable
+    .filter((u) => !pinnedKeys.has(packageKey(u)) && index.notApplicable[packageKey(u)] !== u.available)
+    .map((u) => ({ id: u.id, name: u.name, source: u.source }));
 }
 
 /**
@@ -334,6 +350,31 @@ async function runOperation(request: OperationRequest): Promise<OperationState |
     try {
       switch (request.kind) {
         case "upgrade-all":
+          // View-launched bulk targets are an index snapshot; when the
+          // mutable slices are stale, packages upgraded or removed outside
+          // this extension turn into per-package failures. Refresh under the
+          // held lock (same ownership guard as the post-operation refresh)
+          // and re-derive the targets. The view's Upgrade All has no
+          // confirmation dialog, so a fresher target list breaks no promise.
+          if (isMutableDataStale(loadIndex(indexPaths))) {
+            publish({ stage: "refreshing", message: "Checking for updates…" });
+            try {
+              const refreshed = await refreshSlicesIncrementally(indexPaths, {
+                stillOwned: () => heartbeatLock(lockPath, opId) !== "fenced",
+                // Cancellation must not wait out a slow preflight; the failed
+                // refresh rolls back and the bulk loop exits as cancelled.
+                signal: controller.signal,
+              });
+              if (refreshed.outcome !== "fenced") {
+                request.targets = upgradableTargets(indexPaths);
+              }
+            } catch (error) {
+              // Preflight is an upgrade in accuracy, not a gate: proceed with
+              // the snapshot targets (stale rows fail per-package, honestly).
+              console.error("upgrade-all preflight refresh failed", error);
+            }
+          }
+        // fall through
         case "uninstall-all":
           result = await runBulkOperation(
             request,
@@ -683,12 +724,9 @@ async function runDirectUpgradeAll(): Promise<void> {
       return;
     }
 
-    // Markers were reconciled against this snapshot by the commit above.
-    const notApplicable = loadIndex(indexPaths)?.notApplicable ?? {};
-    const pinnedKeys = new Set(data.pinned.map((p) => packageKey(p)));
-    targets = data.upgradable
-      .filter((u) => !pinnedKeys.has(packageKey(u)) && notApplicable[packageKey(u)] !== u.available)
-      .map((u) => ({ id: u.id, name: u.name, source: u.source }));
+    // The commit above published this snapshot (markers reconciled), so the
+    // index is now the single derivation source for both preflight paths.
+    targets = upgradableTargets(indexPaths);
   } catch (error) {
     toast.style = Toast.Style.Failure;
     toast.title = "Could not check for updates";

--- a/extensions/winget/src/hooks/useIndex.ts
+++ b/extensions/winget/src/hooks/useIndex.ts
@@ -19,7 +19,7 @@ import { indexMtime, isCatalogFresh, loadIndex, migrateLegacyIndex, type Package
 import { DEFAULT_ENV } from "../core/lock";
 import { supportPath } from "../core/paths";
 import { getCatalogValidityMs } from "../core/prefs";
-import { MUTABLE_STALENESS_MS, rebuildFullIndex, refreshMutableSlices } from "../core/refresh";
+import { isMutableDataStale, rebuildFullIndex, refreshMutableSlices } from "../core/refresh";
 import { getIndexPaths } from "../core/runner";
 
 const TICK_MS = 1_000;
@@ -86,7 +86,7 @@ function useIndex(options: UseIndexOptions = {}): UseIndexResult {
       const stillStale = () => {
         const current = loadIndex(paths);
         if (mode === "mutable") {
-          return !current || current.mutableAt === null || Date.now() - current.mutableAt > MUTABLE_STALENESS_MS;
+          return isMutableDataStale(current);
         }
         return !isCatalogFresh(current, getCatalogValidityMs(), Date.now());
       };
@@ -127,6 +127,10 @@ function useIndex(options: UseIndexOptions = {}): UseIndexResult {
           style: Toast.Style.Failure,
           title: "Failed to refresh package data",
           message,
+          primaryAction: {
+            title: "Retry",
+            onAction: () => void runRefresh(mode, runOptions),
+          },
         });
       }
     } finally {
@@ -146,9 +150,8 @@ function useIndex(options: UseIndexOptions = {}): UseIndexResult {
       if (!available) return;
 
       const current = loadIndex(paths);
-      const now = Date.now();
-      const catalogStale = !isCatalogFresh(current, getCatalogValidityMs(), now);
-      const mutableStale = !current || current.mutableAt === null || now - current.mutableAt > MUTABLE_STALENESS_MS;
+      const catalogStale = !isCatalogFresh(current, getCatalogValidityMs(), Date.now());
+      const mutableStale = isMutableDataStale(current);
 
       if (needsCatalog) {
         if (catalogStale) {


### PR DESCRIPTION
## Description

Three user-facing fixes for the WinGet extension around stale or wrong package data, plus an internal consolidation of the operation retry logic.

- **Upgrade All refreshes stale data before upgrading.** When launched from a view, Upgrade All acted on the cached index snapshot; packages upgraded or removed outside the extension turned into per-package failures. The runner now refreshes installed/upgradable/pinned data before the bulk run when the cache is older than the staleness policy and re-derives the target list (a failed refresh falls back to the snapshot). If everything turns out to be already up to date, the run reports exactly that instead of a list of failures.
- **Uninstalling a ghost row self-heals the list.** Uninstalling a package winget no longer has (removed outside the extension) reported a failure and left the row in place. Winget's "not found" exit is now treated as "was not installed" and the row is removed immediately.
- **A failed data refresh no longer empties the lists.** Queries that fail with zero parsed rows (observed live: winget crashing with "Fast Cache data not found" right after a source update) now surface as a refresh error with a Retry action, instead of being cached as "0 installed packages / everything up to date" for the staleness window.
- **Internal: one recovery engine for operation retries.** The accreted retry wrappers (installer-mutex busy wait, silent/unsilenced ladder, elevated relaunch, --force retry for modified portable packages) are consolidated into a single rule-based engine with the same behavior, and the escalation sequences are now pinned by unit tests against a mocked spawn layer.

## Screencast

Straightforward fixes to existing behavior; no UI changes beyond the new Retry action on the refresh-failure toast.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

Made with [Cursor](https://cursor.com)