### PR TITLE
[Typefully] Expand AI tool coverage

### DIFF
--- a/extensions/typefully/CHANGELOG.md
+++ b/extensions/typefully/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Typefully Changelog
 
+## [AI Skill Parity] - 2026-07-27
+
+- Expand Raycast AI from 4 to 29 Typefully tools covering full draft CRUD, publishing, queue management, tags, media, analytics, LinkedIn mentions, comments, and X Articles
+- Add comprehensive AI instructions for account resolution, one-draft-per-post behavior, platform rules, comment-anchor safety, scheduling, publishing confirmation, and authentication failures
+- Stop silently choosing the first account when multiple social sets exist without a default
+
 ## [Cleanup] - 2026-02-04
 
 - Remove store submission checklist from README
@@ -14,4 +20,3 @@ New Raycast extension for Typefully, built on the Typefully API v2.
 - Browse unpublished, scheduled, and published drafts
 - Manage social sets and set a default for quick access
 - AI tools for Raycast AI Chat: create, list, and schedule drafts conversationally
-

--- a/extensions/typefully/package.json
+++ b/extensions/typefully/package.json
@@ -90,26 +90,151 @@
     {
       "name": "create-draft",
       "title": "Create Draft",
-      "description": "Create a new social media draft on Typefully. Provide either content (full draft text) or prompt (idea to generate). Use --- on its own line to split threads. Supports X (Twitter), LinkedIn, Threads, Bluesky, and Mastodon."
+      "description": "Create one cross-platform Typefully draft from exact text. Supports threads, media IDs, tags, scratchpad, X replies, quotes, communities, disclosures, scheduling, and publishing."
+    },
+    {
+      "name": "get-draft",
+      "title": "Get Draft",
+      "description": "Get the complete content and metadata for one Typefully draft. Use this for dropped Typefully draft URLs and before editing."
+    },
+    {
+      "name": "update-draft",
+      "title": "Update Draft",
+      "description": "Update an existing Typefully draft, including platform content, tags, scratchpad, schedule, sharing, and X-only options."
+    },
+    {
+      "name": "delete-draft",
+      "title": "Delete Draft",
+      "description": "Permanently delete a Typefully draft."
     },
     {
       "name": "list-drafts",
       "title": "List Drafts",
-      "description": "List unpublished, scheduled, or published drafts from Typefully."
-    },
-    {
-      "name": "list-social-sets",
-      "title": "List Social Sets",
-      "description": "List available Typefully social sets (accounts/profiles) the user can post to."
+      "description": "List Typefully drafts, scheduled posts, published posts, errors, or publishing posts."
     },
     {
       "name": "schedule-draft",
       "title": "Schedule Draft",
-      "description": "Schedule an existing Typefully draft for a specific date and time."
+      "description": "Schedule an existing Typefully draft for an ISO time or the next free slot."
+    },
+    {
+      "name": "publish-draft",
+      "title": "Publish Draft",
+      "description": "Publish an existing Typefully draft immediately."
+    },
+    {
+      "name": "get-current-user",
+      "title": "Get Current User",
+      "description": "Get the authenticated Typefully user and account metadata."
+    },
+    {
+      "name": "get-social-set",
+      "title": "Get Social Set",
+      "description": "Get one Typefully account, connected platforms, and publishing quota."
+    },
+    {
+      "name": "list-social-sets",
+      "title": "List Social Sets",
+      "description": "List available Typefully accounts and connected platforms. Use when no default is configured or the user asks about accounts."
+    },
+    {
+      "name": "set-default-social-set",
+      "title": "Set Default Social Set",
+      "description": "Set the default Typefully account used when social_set_id is omitted."
+    },
+    {
+      "name": "list-tags",
+      "title": "List Tags",
+      "description": "List tags for a Typefully social set."
+    },
+    {
+      "name": "create-tag",
+      "title": "Create Tag",
+      "description": "Create a tag in a Typefully social set."
+    },
+    {
+      "name": "get-queue",
+      "title": "Get Queue",
+      "description": "Get free queue slots and scheduled Typefully drafts for a date range."
+    },
+    {
+      "name": "get-queue-schedule",
+      "title": "Get Queue Schedule",
+      "description": "Get publishing queue schedule rules for a Typefully social set."
+    },
+    {
+      "name": "update-queue-schedule",
+      "title": "Update Queue Schedule",
+      "description": "Replace publishing queue schedule rules for a Typefully social set."
+    },
+    {
+      "name": "upload-media",
+      "title": "Upload Media",
+      "description": "Upload a local image, video, GIF, or PDF to Typefully and wait until it is ready."
+    },
+    {
+      "name": "get-media-status",
+      "title": "Get Media Status",
+      "description": "Check whether uploaded Typefully media is ready."
+    },
+    {
+      "name": "get-x-post-analytics",
+      "title": "Get X Post Analytics",
+      "description": "Get X post impressions and engagement metrics for an inclusive date range."
+    },
+    {
+      "name": "get-x-follower-analytics",
+      "title": "Get X Follower Analytics",
+      "description": "Get X follower totals and daily counts."
+    },
+    {
+      "name": "resolve-linkedin-organization",
+      "title": "Resolve LinkedIn Organization",
+      "description": "Resolve a LinkedIn company or school URL to Typefully mention syntax."
+    },
+    {
+      "name": "list-comments",
+      "title": "List Draft Comments",
+      "description": "List unresolved, resolved, or all comment threads on a Typefully draft."
+    },
+    {
+      "name": "create-comment",
+      "title": "Create Draft Comment",
+      "description": "Create a comment thread anchored to exact text in a Typefully draft."
+    },
+    {
+      "name": "reply-to-comment",
+      "title": "Reply to Draft Comment",
+      "description": "Reply to a Typefully draft comment thread."
+    },
+    {
+      "name": "resolve-comment",
+      "title": "Resolve Draft Comment",
+      "description": "Resolve a Typefully draft comment thread and remove its anchor."
+    },
+    {
+      "name": "update-comment",
+      "title": "Update Draft Comment",
+      "description": "Edit the text of a Typefully draft comment authored by the user."
+    },
+    {
+      "name": "delete-comment",
+      "title": "Delete Draft Comment",
+      "description": "Delete a Typefully draft comment or entire comment thread."
+    },
+    {
+      "name": "create-x-article",
+      "title": "Create X Article",
+      "description": "Create a standalone long-form X Article draft with canonical markdown and optional cover media."
+    },
+    {
+      "name": "update-x-article",
+      "title": "Update X Article",
+      "description": "Update a standalone X Article draft, cover, metadata, or schedule."
     }
   ],
   "ai": {
-    "instructions": "You help users create and manage social media drafts on Typefully. When creating a draft, always call create-draft; if you have exact draft text, pass it in content, otherwise pass the idea in prompt and let the tool generate the draft. The account and platforms are resolved automatically — do NOT call list-social-sets before creating a draft, and do NOT ask the user which platforms to target unless they explicitly mention one. For threads, separate posts with --- on its own line inside content. When scheduling, call list-drafts first to get the draft ID and social_set_id."
+    "instructions": "Use Typefully tools whenever the user asks to create, edit, schedule, publish, inspect, or analyze social media content for X, LinkedIn, Threads, Bluesky, or Mastodon, or provides a Typefully draft URL.\n\nAccount resolution:\n* Omit social_set_id to use the saved default. If the tool reports that multiple social sets exist without a default, call list-social-sets and ask the user to choose, then offer set-default-social-set. Reuse the chosen ID for the rest of the conversation.\n* A Typefully URL like https://typefully.com/?a=123&d=456 maps a to social_set_id and d to draft_id. Call get-draft rather than browsing the web UI.\n\nDraft creation:\n* Always create one draft per piece of content, even when targeting several platforms. Never create separate drafts merely to tailor copy.\n* create-draft requires final exact text. Write or adapt the copy before calling it. Separate thread posts with --- on its own line.\n* If platforms are omitted, create-draft uses every connected post platform. If the user names platforms, pass only those.\n* Tailored platform versions belong in the same draft. Create the first version, then call update-draft for each additional platform version.\n* X Articles are standalone. Use create-x-article or update-x-article and never mix x_article with post platforms.\n* Put private notes and ideas in scratchpad, not local files.\n\nPlatform rules:\n* X supports threads, replies, quote posts, communities, paid partnership, and made-with-AI labels.\n* LinkedIn supports one post. To mention a company or school, call resolve-linkedin-organization and insert the returned mention_text. Do not invent URNs.\n* Platform character limits are X 280 per post, LinkedIn 3,000, Threads 500, Bluesky 300, and Mastodon 500.\n\nEditing and comments:\n* Call get-draft before editing. Draft content can contain <typ:comment-thread> anchors. Preserve and reposition every anchor when changing text. Use exclude_comment_markers only for read-only display or export, never for content that will be patched back.\n* Use update-draft with append=true only to add posts to an existing thread. It is not supported for LinkedIn.\n* Never resolve or delete comments without explicit user instruction. After applying feedback, ask whether to resolve it.\n* force_overwrite_comments is a destructive last resort. First call list-comments with unresolved status, tell the user which threads will be resolved, and wait for explicit confirmation.\n\nScheduling and publishing:\n* If no exact time is provided, inspect recent comparable X analytics and get-queue before choosing a time. If evidence is sparse, say so. next-free-slot is available when the user wants Typefully to choose.\n* Publishing is irreversible and public. Use publish-draft or schedule=now only when the user explicitly asks to publish immediately. Otherwise create a draft or schedule it. Tool confirmation is still required.\n* Retweets, reposts, quote posts, and replies are X-only unless the user explicitly asks for separate cross-platform versions.\n* Call get-social-set when the user asks about publishing quota or when scheduling or publishing fails because of quota.\n\nAuthentication and safety:\n* On a missing, invalid, expired, or unauthorized API key error, tell the user to update the Typefully API Key in extension preferences using a key from https://typefully.com/?settings=api, then stop. Do not search for credentials, scrape Typefully, or use a localhost fallback.\n* Respect rate limits. Do not automate unsolicited replies, duplicate content across accounts, fake engagement, or trending manipulation."
   },
   "preferences": [
     {

--- a/extensions/typefully/src/lib/api.ts
+++ b/extensions/typefully/src/lib/api.ts
@@ -73,10 +73,19 @@ async function requestJson<T>(path: string, options: Omit<RequestInit, "body"> &
       ?.map((detail) => detail.message)
       .filter(Boolean)
       .join(", ");
+    if (response.status === 401) {
+      throw new Error(
+        "Authentication failed. Update the Typefully API Key in extension preferences with a valid key from https://typefully.com/?settings=api.",
+      );
+    }
     throw new Error(detailMessages ? `${message}: ${detailMessages}` : message);
   }
 
   return data as T;
+}
+
+export async function getCurrentUser() {
+  return requestJson<unknown>("/v2/me", { method: "GET" });
 }
 
 export async function listSocialSets() {
@@ -114,6 +123,7 @@ export async function listDrafts(
     tags?: string[];
     limit?: number;
     offset?: number;
+    orderBy?: string;
   } = {},
 ) {
   const searchParams = new URLSearchParams();
@@ -131,6 +141,9 @@ export async function listDrafts(
   if (params.offset !== undefined) {
     searchParams.append("offset", String(params.offset));
   }
+  if (params.orderBy) {
+    searchParams.append("order_by", params.orderBy);
+  }
 
   const path = `/v2/social-sets/${socialSetId}/drafts`;
   const queryString = searchParams.toString();
@@ -138,8 +151,9 @@ export async function listDrafts(
   return requestJson<PagedResponse<DraftListItem>>(url, { method: "GET" });
 }
 
-export async function getDraft(socialSetId: number, draftId: number) {
-  return requestJson<DraftDetail>(`/v2/social-sets/${socialSetId}/drafts/${draftId}`, { method: "GET" });
+export async function getDraft(socialSetId: number, draftId: number, excludeCommentMarkers = false) {
+  const query = excludeCommentMarkers ? "?exclude_comment_markers=true" : "";
+  return requestJson<DraftDetail>(`/v2/social-sets/${socialSetId}/drafts/${draftId}${query}`, { method: "GET" });
 }
 
 export async function createDraft(socialSetId: number, payload: DraftCreateRequest) {
@@ -184,4 +198,119 @@ export async function listTags(socialSetId: number) {
   }
 
   return results;
+}
+
+export async function getQueue(socialSetId: number, startDate: string, endDate: string) {
+  return requestJson<unknown>(
+    `/v2/social-sets/${socialSetId}/queue?start_date=${encodeURIComponent(startDate)}&end_date=${encodeURIComponent(endDate)}`,
+    { method: "GET" },
+  );
+}
+
+export async function getQueueSchedule(socialSetId: number) {
+  return requestJson<unknown>(`/v2/social-sets/${socialSetId}/queue/schedule`, { method: "GET" });
+}
+
+export async function updateQueueSchedule(socialSetId: number, rules: Array<{ h: number; m: number; days: string[] }>) {
+  return requestJson<unknown>(`/v2/social-sets/${socialSetId}/queue/schedule`, {
+    method: "PUT",
+    body: { rules },
+  });
+}
+
+export async function createTag(socialSetId: number, name: string) {
+  return requestJson<Tag>(`/v2/social-sets/${socialSetId}/tags`, { method: "POST", body: { name } });
+}
+
+export async function getXPostAnalytics(
+  socialSetId: number,
+  params: { startDate: string; endDate: string; includeReplies?: boolean; limit?: number; offset?: number },
+) {
+  const query = new URLSearchParams({ start_date: params.startDate, end_date: params.endDate });
+  if (params.includeReplies) query.set("include_replies", "true");
+  if (params.limit) query.set("limit", String(params.limit));
+  if (params.offset) query.set("offset", String(params.offset));
+  return requestJson<unknown>(`/v2/social-sets/${socialSetId}/analytics/x/posts?${query}`, { method: "GET" });
+}
+
+export async function getXFollowerAnalytics(socialSetId: number, startDate?: string, endDate?: string) {
+  const query = new URLSearchParams();
+  if (startDate) query.set("start_date", startDate);
+  if (endDate) query.set("end_date", endDate);
+  return requestJson<unknown>(`/v2/social-sets/${socialSetId}/analytics/x/followers${query.size ? `?${query}` : ""}`, {
+    method: "GET",
+  });
+}
+
+export async function resolveLinkedInOrganization(socialSetId: number, organizationUrl: string) {
+  return requestJson<unknown>(
+    `/v2/social-sets/${socialSetId}/linkedin/organizations/resolve?organization_url=${encodeURIComponent(organizationUrl)}`,
+    { method: "GET" },
+  );
+}
+
+export async function listCommentThreads(
+  socialSetId: number,
+  draftId: number,
+  params: { platform?: string; status?: string; limit?: number; offset?: number } = {},
+) {
+  const query = new URLSearchParams();
+  if (params.platform) query.set("platform", params.platform);
+  if (params.status) query.set("status", params.status);
+  query.set("limit", String(params.limit ?? 10));
+  if (params.offset) query.set("offset", String(params.offset));
+  return requestJson<unknown>(`/v2/social-sets/${socialSetId}/drafts/${draftId}/comment-threads?${query}`, {
+    method: "GET",
+  });
+}
+
+export async function createCommentThread(
+  socialSetId: number,
+  draftId: number,
+  payload: { selected_text: string; text: string; platform?: string; post_index?: number; occurrence?: number },
+) {
+  return requestJson<unknown>(`/v2/social-sets/${socialSetId}/drafts/${draftId}/comment-threads`, {
+    method: "POST",
+    body: payload,
+  });
+}
+
+export async function replyToCommentThread(socialSetId: number, draftId: number, threadId: string, text: string) {
+  return requestJson<unknown>(`/v2/social-sets/${socialSetId}/drafts/${draftId}/comment-threads/${threadId}/comments`, {
+    method: "POST",
+    body: { text },
+  });
+}
+
+export async function resolveCommentThread(socialSetId: number, draftId: number, threadId: string) {
+  return requestJson<unknown>(`/v2/social-sets/${socialSetId}/drafts/${draftId}/comment-threads/${threadId}/resolve`, {
+    method: "POST",
+  });
+}
+
+export async function updateComment(
+  socialSetId: number,
+  draftId: number,
+  threadId: string,
+  commentId: string,
+  text: string,
+) {
+  return requestJson<unknown>(
+    `/v2/social-sets/${socialSetId}/drafts/${draftId}/comment-threads/${threadId}/comments/${commentId}`,
+    { method: "PATCH", body: { text } },
+  );
+}
+
+export async function deleteComment(socialSetId: number, draftId: number, threadId: string, commentId?: string) {
+  const suffix = commentId ? `/comments/${commentId}` : "";
+  await requestJson<void>(`/v2/social-sets/${socialSetId}/drafts/${draftId}/comment-threads/${threadId}${suffix}`, {
+    method: "DELETE",
+  });
+}
+
+export async function createMediaUpload(socialSetId: number, fileName: string) {
+  return requestJson<{ media_id: string; upload_url: string }>(`/v2/social-sets/${socialSetId}/media/upload`, {
+    method: "POST",
+    body: { file_name: fileName },
+  });
 }

--- a/extensions/typefully/src/lib/resolve-social-set.ts
+++ b/extensions/typefully/src/lib/resolve-social-set.ts
@@ -1,31 +1,27 @@
 import { LocalStorage } from "@raycast/api";
 import { listSocialSets } from "./api";
-import { DEFAULT_SOCIAL_SET_STORAGE_KEY, LAST_SOCIAL_SET_STORAGE_KEY } from "./constants";
+import { DEFAULT_SOCIAL_SET_STORAGE_KEY } from "./constants";
 
-/**
- * Resolve the social set ID to use for API calls.
- * Priority: stored default → last used → only available social set → error.
- */
-export async function resolveSocialSetId(): Promise<number> {
+/** Resolve an explicit social set or the user's saved default. Never silently pick among multiple accounts. */
+export async function resolveSocialSetId(explicitId?: number): Promise<number> {
+  if (explicitId) {
+    return explicitId;
+  }
+
   const stored = await LocalStorage.getItem<string>(DEFAULT_SOCIAL_SET_STORAGE_KEY);
   if (stored) {
     return Number(stored);
-  }
-
-  const lastUsed = await LocalStorage.getItem<string>(LAST_SOCIAL_SET_STORAGE_KEY);
-  if (lastUsed) {
-    return Number(lastUsed);
   }
 
   const socialSets = await listSocialSets();
   if (socialSets.length === 1) {
     return socialSets[0].id;
   }
-
   if (socialSets.length === 0) {
-    throw new Error("No social sets found. Please set up a social set in Typefully first.");
+    throw new Error("No social sets found. Connect an account in Typefully first.");
   }
 
-  // Multiple social sets available — fall back to the first one
-  return socialSets[0].id;
+  throw new Error(
+    "Multiple social sets are available and no default is configured. Use List Social Sets, then pass social_set_id or set a default with Set Default Social Set.",
+  );
 }

--- a/extensions/typefully/src/lib/tool-helpers.ts
+++ b/extensions/typefully/src/lib/tool-helpers.ts
@@ -1,0 +1,69 @@
+import { getDraft, getSocialSetDetail } from "./api";
+import { PLATFORM_KEYS, THREAD_PLATFORMS, type PlatformKey } from "./constants";
+import { resolveSocialSetId } from "./resolve-social-set";
+import type { DraftCreatePlatforms, DraftDetail, Post } from "./types";
+import { buildPostsFromContent } from "./utils";
+
+export const POST_PLATFORMS = [...PLATFORM_KEYS] as const;
+export type ToolPlatform = PlatformKey | "x_article";
+
+export async function resolveToolSocialSetId(socialSetId?: number) {
+  return resolveSocialSetId(socialSetId);
+}
+
+export async function resolveToolPlatforms(socialSetId: number, requested?: string[]): Promise<PlatformKey[]> {
+  const detail = await getSocialSetDetail(socialSetId);
+  const enabled = PLATFORM_KEYS.filter((key) => detail.platforms[key] !== null);
+  if (!requested?.length) return enabled;
+  const selected = requested.filter((value): value is PlatformKey => enabled.includes(value as PlatformKey));
+  if (selected.length !== requested.length) {
+    throw new Error(`One or more platforms are unavailable. Connected platforms: ${enabled.join(", ")}`);
+  }
+  return selected;
+}
+
+export function buildPlatforms(content: string, platforms: PlatformKey[], mediaIds?: string[]): DraftCreatePlatforms {
+  const threadPosts = buildPostsFromContent(content, true);
+  const singlePost = buildPostsFromContent(content, false);
+  if (!threadPosts.length) throw new Error("Content is required.");
+
+  const result: DraftCreatePlatforms = {};
+  for (const platform of platforms) {
+    const posts = (THREAD_PLATFORMS.has(platform) ? threadPosts : singlePost).map((post, index) => ({
+      ...post,
+      ...(index === 0 && mediaIds?.length ? { media_ids: mediaIds } : {}),
+    }));
+    result[platform] = { enabled: true, posts };
+  }
+  return result;
+}
+
+export function sanitizePost(post: Post, platform: PlatformKey): Post {
+  const clean: Post = { text: post.text };
+  if (post.media_ids?.length) clean.media_ids = post.media_ids;
+  if (platform === "x") {
+    if (post.quote_post_url) clean.quote_post_url = post.quote_post_url;
+    if (post.paid_partnership) clean.paid_partnership = true;
+    if (post.made_with_ai) clean.made_with_ai = true;
+  }
+  return clean;
+}
+
+export function draftResult(draft: DraftDetail) {
+  return {
+    id: draft.id,
+    social_set_id: draft.social_set_id,
+    status: draft.status,
+    title: draft.draft_title,
+    preview: draft.preview,
+    url: draft.private_url,
+    share_url: draft.share_url,
+    scheduled_date: draft.scheduled_date,
+    published_at: draft.published_at,
+    tags: draft.tags,
+  };
+}
+
+export async function getDraftForTool(socialSetId: number, draftId: number) {
+  return getDraft(socialSetId, draftId);
+}

--- a/extensions/typefully/src/lib/types.ts
+++ b/extensions/typefully/src/lib/types.ts
@@ -62,6 +62,9 @@ export type Tag = {
 export type Post = {
   text: string;
   media_ids?: string[];
+  quote_post_url?: string;
+  paid_partnership?: boolean;
+  made_with_ai?: boolean;
 };
 
 export type DraftPlatform = {
@@ -70,7 +73,14 @@ export type DraftPlatform = {
   settings?: Record<string, unknown> | null;
 };
 
-export type DraftCreatePlatforms = Partial<Record<PlatformKey, DraftPlatform | { enabled: false } | null>>;
+export type XArticlePlatform = {
+  content_markdown?: string;
+  cover_media_id?: string | null;
+};
+
+export type DraftCreatePlatforms = Partial<
+  Record<PlatformKey, DraftPlatform | { enabled: false } | null> & { x_article: XArticlePlatform | null }
+>;
 
 export type DraftCreateRequest = {
   platforms: DraftCreatePlatforms;
@@ -79,6 +89,7 @@ export type DraftCreateRequest = {
   tags?: string[];
   share?: boolean;
   publish_at?: string | null;
+  force_overwrite_comments?: boolean;
 };
 
 export type DraftUpdateRequest = {
@@ -88,6 +99,7 @@ export type DraftUpdateRequest = {
   tags?: string[] | null;
   share?: boolean | null;
   publish_at?: string | null;
+  force_overwrite_comments?: boolean;
 };
 
 export type DraftDetailPlatform = {
@@ -147,3 +159,11 @@ export type DraftListItem = {
   published_at?: string | null;
   scheduled_date?: string | null;
 };
+
+export type QueueRule = {
+  h: number;
+  m: number;
+  days: string[];
+};
+
+export type CommentThread = Record<string, unknown>;

--- a/extensions/typefully/src/tools/create-comment.ts
+++ b/extensions/typefully/src/tools/create-comment.ts
@@ -1,0 +1,27 @@
+import { createCommentThread } from "../lib/api";
+import { resolveToolSocialSetId } from "../lib/tool-helpers";
+type Input = {
+  draft_id: number;
+  social_set_id?: number;
+  selected_text: string;
+  text: string;
+  platform?: string;
+  post_index?: number;
+  occurrence?: number;
+};
+export default async function tool(input: Input) {
+  if (input.platform === "x_article" && input.post_index !== undefined && input.post_index !== 0) {
+    throw new Error("post_index must be 0 or omitted for X Article comments.");
+  }
+  if (input.platform !== "x_article" && input.post_index === undefined) {
+    throw new Error("post_index is required for post comments.");
+  }
+  const socialSetId = await resolveToolSocialSetId(input.social_set_id);
+  return createCommentThread(socialSetId, input.draft_id, {
+    selected_text: input.selected_text,
+    text: input.text,
+    platform: input.platform,
+    post_index: input.platform === "x_article" ? undefined : input.post_index,
+    occurrence: input.occurrence,
+  });
+}

--- a/extensions/typefully/src/tools/create-draft.ts
+++ b/extensions/typefully/src/tools/create-draft.ts
@@ -1,109 +1,80 @@
-import { AI, Tool } from "@raycast/api";
-import { createDraft, getSocialSetDetail } from "../lib/api";
-import { PLATFORM_KEYS, THREAD_PLATFORMS, type PlatformKey } from "../lib/constants";
-import { resolveSocialSetId } from "../lib/resolve-social-set";
-import type { DraftCreatePlatforms } from "../lib/types";
-import { buildPostsFromContent } from "../lib/utils";
+import { Tool } from "@raycast/api";
+import { createDraft } from "../lib/api";
+import { buildPlatforms, draftResult, resolveToolPlatforms, resolveToolSocialSetId } from "../lib/tool-helpers";
 
 type Input = {
-  /** The full text you want to post as a social media draft. Use --- on its own line to split a thread. */
-  content?: string;
-  /** Draft prompt or idea. Required if content is omitted. */
-  prompt?: string;
-  /** Platforms to post to. Subset of: x, linkedin, threads, bluesky, mastodon. If omitted, all enabled platforms on the social set are used. */
-  platforms?: string[];
-  /** Optional title for the draft. */
+  /** Exact post text. Use --- on its own line to split a thread. */
+  content: string;
+  /** Optional social set ID. Omit to use the configured default. */
+  social_set_id?: number;
+  /** Platforms for this draft. Omit to use all connected platforms. */
+  platforms?: Array<"x" | "linkedin" | "threads" | "bluesky" | "mastodon">;
+  /** Internal draft title, never published. */
   title?: string;
-  /** Optional ISO 8601 date to schedule the draft. */
-  schedule_date?: string;
-  /** Optional tags to apply to the draft. */
+  /** Internal scratchpad notes, never published. */
+  scratchpad?: string;
+  /** ISO 8601 time, next-free-slot, or now. Use now only when the user explicitly asks to publish immediately. */
+  schedule?: string;
+  /** Existing tag slugs. */
   tags?: string[];
+  /** Existing ready media IDs to attach to the first post. */
+  media_ids?: string[];
+  /** Generate a public share URL. */
+  share?: boolean;
+  /** X post URL to reply to. X only. */
+  reply_to_url?: string;
+  /** X post URL to quote. X only. */
+  quote_post_url?: string;
+  /** X community ID. X only. */
+  community_id?: string;
+  /** Mark the X post as a paid partnership. */
+  paid_partnership?: boolean;
+  /** Mark the X post as made with AI. */
+  made_with_ai?: boolean;
 };
-
-async function resolveContent(input: Input) {
-  const content = input.content?.trim();
-  if (content) {
-    return content;
-  }
-
-  const prompt = input.prompt?.trim();
-  if (!prompt) {
-    return "";
-  }
-
-  const aiPrompt = [
-    "Write a social media draft for Typefully.",
-    "Return ONLY the draft text. Do not add quotes or commentary.",
-    "If the request is for a thread, separate posts with a line containing only ---.",
-    `User request: ${prompt}`,
-  ].join("\n");
-
-  return (await AI.ask(aiPrompt, { creativity: "medium" })).trim();
-}
 
 export const confirmation: Tool.Confirmation<Input> = async (input) => {
-  const platformLabel = input.platforms?.length ? input.platforms.join(", ") : "all enabled platforms";
-  const content = input.content?.trim();
-  const prompt = input.prompt?.trim();
-  const previewSource = content || prompt || "";
-  const preview = previewSource.length > 80 ? previewSource.slice(0, 80) + "…" : previewSource;
-  const sourceLabel = content ? "content" : prompt ? "prompt" : "content";
-  return {
-    message: `Create draft on ${platformLabel} with ${sourceLabel}: "${preview}"?`,
-  };
+  if (input.schedule !== "now") return undefined;
+  return { message: "Publish this draft immediately? This is public and cannot be undone." };
 };
 
-/**
- * Create a draft on Typefully.
- * IMPORTANT: Provide content (full draft text) or prompt (idea). Do not call without one.
- */
 export default async function tool(input: Input) {
-  const content = await resolveContent(input);
-  if (!content) {
-    throw new Error("Content is required. Provide draft text or a prompt to generate it.");
+  const socialSetId = await resolveToolSocialSetId(input.social_set_id);
+  const platformKeys = await resolveToolPlatforms(socialSetId, input.platforms);
+  if (
+    (input.reply_to_url ||
+      input.quote_post_url ||
+      input.community_id ||
+      input.paid_partnership ||
+      input.made_with_ai) &&
+    !platformKeys.includes("x")
+  ) {
+    throw new Error("Reply, quote, community, and disclosure options require X to be enabled.");
   }
 
-  const scheduleDate = input.schedule_date?.trim();
-
-  const socialSetId = await resolveSocialSetId();
-  const threadPosts = buildPostsFromContent(content, true);
-  const singlePost = buildPostsFromContent(content, false);
-
-  if (threadPosts.length === 0) {
-    throw new Error("Content is empty.");
-  }
-
-  const detail = await getSocialSetDetail(socialSetId);
-  const enabledPlatforms = PLATFORM_KEYS.filter((key) => detail.platforms[key] !== null);
-
-  const platformKeys = input.platforms?.length
-    ? (input.platforms.filter((p) => enabledPlatforms.includes(p as PlatformKey)) as PlatformKey[])
-    : enabledPlatforms;
-
-  if (platformKeys.length === 0) {
-    throw new Error(`Invalid platforms. Choose from: ${PLATFORM_KEYS.join(", ")}`);
-  }
-
-  const platforms: DraftCreatePlatforms = {};
-  for (const platform of platformKeys) {
-    platforms[platform] = {
-      enabled: true,
-      posts: THREAD_PLATFORMS.has(platform) ? threadPosts : singlePost,
-    };
+  const platforms = buildPlatforms(input.content, platformKeys, input.media_ids);
+  if (platforms.x && "posts" in platforms.x) {
+    platforms.x.posts = platforms.x.posts.map((post) => ({
+      ...post,
+      ...(input.quote_post_url ? { quote_post_url: input.quote_post_url } : {}),
+      ...(input.paid_partnership ? { paid_partnership: true } : {}),
+      ...(input.made_with_ai ? { made_with_ai: true } : {}),
+    }));
+    if (input.reply_to_url || input.community_id) {
+      platforms.x.settings = {
+        ...(input.reply_to_url ? { reply_to_url: input.reply_to_url } : {}),
+        ...(input.community_id ? { community_id: input.community_id } : {}),
+      };
+    }
   }
 
   const draft = await createDraft(socialSetId, {
     platforms,
-    draft_title: input.title ?? undefined,
-    tags: input.tags?.length ? input.tags : undefined,
-    publish_at: scheduleDate || undefined,
+    draft_title: input.title,
+    scratchpad_text: input.scratchpad,
+    tags: input.tags,
+    publish_at: input.schedule,
+    share: input.share,
   });
-
-  return {
-    id: draft.id,
-    status: draft.status,
-    url: draft.private_url,
-    share_url: draft.share_url,
-    preview: draft.preview,
-  };
+  return draftResult(draft);
 }

--- a/extensions/typefully/src/tools/create-tag.ts
+++ b/extensions/typefully/src/tools/create-tag.ts
@@ -1,0 +1,10 @@
+import { Tool } from "@raycast/api";
+import { createTag } from "../lib/api";
+import { resolveToolSocialSetId } from "../lib/tool-helpers";
+type Input = { name: string; social_set_id?: number };
+export const confirmation: Tool.Confirmation<Input> = async (input) => ({
+  message: `Create Typefully tag “${input.name}”?`,
+});
+export default async function tool(input: Input) {
+  return createTag(await resolveToolSocialSetId(input.social_set_id), input.name);
+}

--- a/extensions/typefully/src/tools/create-x-article.ts
+++ b/extensions/typefully/src/tools/create-x-article.ts
@@ -1,0 +1,32 @@
+import { Tool } from "@raycast/api";
+import { createDraft } from "../lib/api";
+import { draftResult, resolveToolSocialSetId } from "../lib/tool-helpers";
+type Input = {
+  /** Canonical article markdown. The first non-empty block must be # Title. */
+  content_markdown: string;
+  social_set_id?: number;
+  cover_media_id?: string;
+  title?: string;
+  scratchpad?: string;
+  tags?: string[];
+  share?: boolean;
+  /** ISO 8601, next-free-slot, or now. */
+  schedule?: string;
+};
+export const confirmation: Tool.Confirmation<Input> = async (input) =>
+  input.schedule === "now" ? { message: "Publish this X Article immediately?" } : undefined;
+export default async function tool(input: Input) {
+  if (!input.content_markdown.trim().startsWith("# "))
+    throw new Error("The first non-empty X Article block must be a # Title heading.");
+  const socialSetId = await resolveToolSocialSetId(input.social_set_id);
+  return draftResult(
+    await createDraft(socialSetId, {
+      platforms: { x_article: { content_markdown: input.content_markdown, cover_media_id: input.cover_media_id } },
+      draft_title: input.title,
+      scratchpad_text: input.scratchpad,
+      tags: input.tags,
+      share: input.share,
+      publish_at: input.schedule,
+    }),
+  );
+}

--- a/extensions/typefully/src/tools/delete-comment.ts
+++ b/extensions/typefully/src/tools/delete-comment.ts
@@ -1,0 +1,12 @@
+import { Tool } from "@raycast/api";
+import { deleteComment } from "../lib/api";
+import { resolveToolSocialSetId } from "../lib/tool-helpers";
+type Input = { draft_id: number; thread_id: string; comment_id?: string; social_set_id?: number };
+export const confirmation: Tool.Confirmation<Input> = async (input) => ({
+  message: input.comment_id ? "Delete this comment?" : "Delete this entire comment thread?",
+});
+export default async function tool(input: Input) {
+  const socialSetId = await resolveToolSocialSetId(input.social_set_id);
+  await deleteComment(socialSetId, input.draft_id, input.thread_id, input.comment_id);
+  return { success: true };
+}

--- a/extensions/typefully/src/tools/delete-draft.ts
+++ b/extensions/typefully/src/tools/delete-draft.ts
@@ -1,0 +1,13 @@
+import { Tool } from "@raycast/api";
+import { deleteDraft } from "../lib/api";
+import { resolveToolSocialSetId } from "../lib/tool-helpers";
+
+type Input = { draft_id: number; social_set_id?: number };
+export const confirmation: Tool.Confirmation<Input> = async (input) => ({
+  message: `Delete Typefully draft #${input.draft_id}?`,
+});
+export default async function tool(input: Input) {
+  const socialSetId = await resolveToolSocialSetId(input.social_set_id);
+  await deleteDraft(socialSetId, input.draft_id);
+  return { success: true, draft_id: input.draft_id, social_set_id: socialSetId };
+}

--- a/extensions/typefully/src/tools/get-current-user.ts
+++ b/extensions/typefully/src/tools/get-current-user.ts
@@ -1,0 +1,5 @@
+import { getCurrentUser } from "../lib/api";
+
+export default async function tool() {
+  return getCurrentUser();
+}

--- a/extensions/typefully/src/tools/get-draft.ts
+++ b/extensions/typefully/src/tools/get-draft.ts
@@ -1,0 +1,16 @@
+import { getDraft } from "../lib/api";
+import { resolveToolSocialSetId } from "../lib/tool-helpers";
+
+type Input = {
+  /** Draft ID. For a Typefully URL, d is the draft ID. */
+  draft_id: number;
+  /** Social set ID. For a Typefully URL, a is the social set ID. */
+  social_set_id?: number;
+  /** Remove comment anchors for display only. Never enable before editing the returned content. */
+  exclude_comment_markers?: boolean;
+};
+
+export default async function tool(input: Input) {
+  const socialSetId = await resolveToolSocialSetId(input.social_set_id);
+  return getDraft(socialSetId, input.draft_id, input.exclude_comment_markers);
+}

--- a/extensions/typefully/src/tools/get-media-status.ts
+++ b/extensions/typefully/src/tools/get-media-status.ts
@@ -1,0 +1,6 @@
+import { getMediaStatus } from "../lib/api";
+import { resolveToolSocialSetId } from "../lib/tool-helpers";
+type Input = { media_id: string; social_set_id?: number };
+export default async function tool(input: Input) {
+  return getMediaStatus(await resolveToolSocialSetId(input.social_set_id), input.media_id);
+}

--- a/extensions/typefully/src/tools/get-queue-schedule.ts
+++ b/extensions/typefully/src/tools/get-queue-schedule.ts
@@ -1,0 +1,6 @@
+import { getQueueSchedule } from "../lib/api";
+import { resolveToolSocialSetId } from "../lib/tool-helpers";
+type Input = { social_set_id?: number };
+export default async function tool(input: Input) {
+  return getQueueSchedule(await resolveToolSocialSetId(input.social_set_id));
+}

--- a/extensions/typefully/src/tools/get-queue.ts
+++ b/extensions/typefully/src/tools/get-queue.ts
@@ -1,0 +1,6 @@
+import { getQueue } from "../lib/api";
+import { resolveToolSocialSetId } from "../lib/tool-helpers";
+type Input = { start_date: string; end_date: string; social_set_id?: number };
+export default async function tool(input: Input) {
+  return getQueue(await resolveToolSocialSetId(input.social_set_id), input.start_date, input.end_date);
+}

--- a/extensions/typefully/src/tools/get-social-set.ts
+++ b/extensions/typefully/src/tools/get-social-set.ts
@@ -1,0 +1,7 @@
+import { getSocialSetDetail } from "../lib/api";
+import { resolveToolSocialSetId } from "../lib/tool-helpers";
+
+type Input = { social_set_id?: number };
+export default async function tool(input: Input) {
+  return getSocialSetDetail(await resolveToolSocialSetId(input.social_set_id));
+}

--- a/extensions/typefully/src/tools/get-x-follower-analytics.ts
+++ b/extensions/typefully/src/tools/get-x-follower-analytics.ts
@@ -1,0 +1,6 @@
+import { getXFollowerAnalytics } from "../lib/api";
+import { resolveToolSocialSetId } from "../lib/tool-helpers";
+type Input = { social_set_id?: number; start_date?: string; end_date?: string };
+export default async function tool(input: Input) {
+  return getXFollowerAnalytics(await resolveToolSocialSetId(input.social_set_id), input.start_date, input.end_date);
+}

--- a/extensions/typefully/src/tools/get-x-post-analytics.ts
+++ b/extensions/typefully/src/tools/get-x-post-analytics.ts
@@ -1,0 +1,19 @@
+import { getXPostAnalytics } from "../lib/api";
+import { resolveToolSocialSetId } from "../lib/tool-helpers";
+type Input = {
+  social_set_id?: number;
+  start_date: string;
+  end_date: string;
+  include_replies?: boolean;
+  limit?: number;
+  offset?: number;
+};
+export default async function tool(input: Input) {
+  return getXPostAnalytics(await resolveToolSocialSetId(input.social_set_id), {
+    startDate: input.start_date,
+    endDate: input.end_date,
+    includeReplies: input.include_replies,
+    limit: input.limit,
+    offset: input.offset,
+  });
+}

--- a/extensions/typefully/src/tools/list-comments.ts
+++ b/extensions/typefully/src/tools/list-comments.ts
@@ -1,0 +1,13 @@
+import { listCommentThreads } from "../lib/api";
+import { resolveToolSocialSetId } from "../lib/tool-helpers";
+type Input = {
+  draft_id: number;
+  social_set_id?: number;
+  platform?: string;
+  status?: "unresolved" | "resolved" | "all";
+  limit?: number;
+  offset?: number;
+};
+export default async function tool(input: Input) {
+  return listCommentThreads(await resolveToolSocialSetId(input.social_set_id), input.draft_id, input);
+}

--- a/extensions/typefully/src/tools/list-drafts.ts
+++ b/extensions/typefully/src/tools/list-drafts.ts
@@ -1,23 +1,22 @@
 import { listDrafts } from "../lib/api";
 import { DRAFT_STATUS_LABELS, type DraftStatus } from "../lib/constants";
-import { resolveSocialSetId } from "../lib/resolve-social-set";
+import { resolveToolSocialSetId } from "../lib/tool-helpers";
 import { getDraftDate, getDraftDisplayTitle, getDraftSubtitle } from "../lib/utils";
 
 type Input = {
-  /** Filter by status: draft, scheduled, published. If omitted, returns all. */
+  social_set_id?: number;
+  /** Filter: draft, scheduled, published, error, or publishing. */
   status?: string;
-  /** Maximum number of drafts to return. Defaults to 10. */
+  /** Tag slugs to filter by. */
+  tags?: string[];
   limit?: number;
+  offset?: number;
+  /** Sort field, for example -updated_at, scheduled_date, or -published_at. */
+  orderBy?: string;
 };
-
 export default async function tool(input: Input) {
-  const socialSetId = await resolveSocialSetId();
-  const limit = input.limit ?? 10;
-  const response = await listDrafts(socialSetId, {
-    status: input.status,
-    limit,
-  });
-
+  const socialSetId = await resolveToolSocialSetId(input.social_set_id);
+  const response = await listDrafts(socialSetId, input);
   return response.results.map((draft) => ({
     id: draft.id,
     social_set_id: draft.social_set_id,

--- a/extensions/typefully/src/tools/list-tags.ts
+++ b/extensions/typefully/src/tools/list-tags.ts
@@ -1,0 +1,6 @@
+import { listTags } from "../lib/api";
+import { resolveToolSocialSetId } from "../lib/tool-helpers";
+type Input = { social_set_id?: number };
+export default async function tool(input: Input) {
+  return listTags(await resolveToolSocialSetId(input.social_set_id));
+}

--- a/extensions/typefully/src/tools/publish-draft.ts
+++ b/extensions/typefully/src/tools/publish-draft.ts
@@ -2,16 +2,11 @@ import { Tool } from "@raycast/api";
 import { updateDraft } from "../lib/api";
 import { draftResult, resolveToolSocialSetId } from "../lib/tool-helpers";
 
-type Input = {
-  draft_id: number;
-  social_set_id?: number;
-  /** ISO 8601 date and time, or next-free-slot. */
-  schedule_date: string;
-};
+type Input = { draft_id: number; social_set_id?: number };
 export const confirmation: Tool.Confirmation<Input> = async (input) => ({
-  message: `Schedule draft #${input.draft_id} for ${input.schedule_date}?`,
+  message: `Publish Typefully draft #${input.draft_id} now? This is public and cannot be undone.`,
 });
 export default async function tool(input: Input) {
   const socialSetId = await resolveToolSocialSetId(input.social_set_id);
-  return draftResult(await updateDraft(socialSetId, input.draft_id, { publish_at: input.schedule_date }));
+  return draftResult(await updateDraft(socialSetId, input.draft_id, { publish_at: "now" }));
 }

--- a/extensions/typefully/src/tools/reply-to-comment.ts
+++ b/extensions/typefully/src/tools/reply-to-comment.ts
@@ -1,0 +1,11 @@
+import { replyToCommentThread } from "../lib/api";
+import { resolveToolSocialSetId } from "../lib/tool-helpers";
+type Input = { draft_id: number; thread_id: string; text: string; social_set_id?: number };
+export default async function tool(input: Input) {
+  return replyToCommentThread(
+    await resolveToolSocialSetId(input.social_set_id),
+    input.draft_id,
+    input.thread_id,
+    input.text,
+  );
+}

--- a/extensions/typefully/src/tools/resolve-comment.ts
+++ b/extensions/typefully/src/tools/resolve-comment.ts
@@ -1,0 +1,10 @@
+import { Tool } from "@raycast/api";
+import { resolveCommentThread } from "../lib/api";
+import { resolveToolSocialSetId } from "../lib/tool-helpers";
+type Input = { draft_id: number; thread_id: string; social_set_id?: number };
+export const confirmation: Tool.Confirmation<Input> = async () => ({
+  message: "Resolve this comment thread? Its anchor will be removed.",
+});
+export default async function tool(input: Input) {
+  return resolveCommentThread(await resolveToolSocialSetId(input.social_set_id), input.draft_id, input.thread_id);
+}

--- a/extensions/typefully/src/tools/resolve-linkedin-organization.ts
+++ b/extensions/typefully/src/tools/resolve-linkedin-organization.ts
@@ -1,0 +1,6 @@
+import { resolveLinkedInOrganization } from "../lib/api";
+import { resolveToolSocialSetId } from "../lib/tool-helpers";
+type Input = { organization_url: string; social_set_id?: number };
+export default async function tool(input: Input) {
+  return resolveLinkedInOrganization(await resolveToolSocialSetId(input.social_set_id), input.organization_url);
+}

--- a/extensions/typefully/src/tools/set-default-social-set.ts
+++ b/extensions/typefully/src/tools/set-default-social-set.ts
@@ -1,0 +1,13 @@
+import { LocalStorage, Tool } from "@raycast/api";
+import { getSocialSetDetail } from "../lib/api";
+import { DEFAULT_SOCIAL_SET_STORAGE_KEY } from "../lib/constants";
+
+type Input = { social_set_id: number };
+export const confirmation: Tool.Confirmation<Input> = async (input) => ({
+  message: `Use social set #${input.social_set_id} as the default Typefully account?`,
+});
+export default async function tool(input: Input) {
+  const socialSet = await getSocialSetDetail(input.social_set_id);
+  await LocalStorage.setItem(DEFAULT_SOCIAL_SET_STORAGE_KEY, String(input.social_set_id));
+  return { success: true, social_set_id: input.social_set_id, name: socialSet.name, username: socialSet.username };
+}

--- a/extensions/typefully/src/tools/update-comment.ts
+++ b/extensions/typefully/src/tools/update-comment.ts
@@ -1,0 +1,12 @@
+import { updateComment } from "../lib/api";
+import { resolveToolSocialSetId } from "../lib/tool-helpers";
+type Input = { draft_id: number; thread_id: string; comment_id: string; text: string; social_set_id?: number };
+export default async function tool(input: Input) {
+  return updateComment(
+    await resolveToolSocialSetId(input.social_set_id),
+    input.draft_id,
+    input.thread_id,
+    input.comment_id,
+    input.text,
+  );
+}

--- a/extensions/typefully/src/tools/update-draft.ts
+++ b/extensions/typefully/src/tools/update-draft.ts
@@ -1,0 +1,122 @@
+import { Tool } from "@raycast/api";
+import { THREAD_PLATFORMS, type PlatformKey } from "../lib/constants";
+import { getDraft, updateDraft } from "../lib/api";
+import {
+  buildPlatforms,
+  draftResult,
+  resolveToolPlatforms,
+  resolveToolSocialSetId,
+  sanitizePost,
+} from "../lib/tool-helpers";
+import type { DraftCreatePlatforms, DraftUpdateRequest } from "../lib/types";
+
+type Input = {
+  draft_id: number;
+  social_set_id?: number;
+  /** Replacement post text. Use --- on its own line for a thread. Omit for metadata-only updates. */
+  content?: string;
+  /** Platforms whose content should be updated. Omit to update the draft's enabled post platforms. */
+  platforms?: Array<"x" | "linkedin" | "threads" | "bluesky" | "mastodon">;
+  /** Append content as new thread posts instead of replacing existing content. Thread platforms only. */
+  append?: boolean;
+  title?: string;
+  scratchpad?: string;
+  schedule?: string;
+  tags?: string[];
+  media_ids?: string[];
+  share?: boolean;
+  quote_post_url?: string;
+  paid_partnership?: boolean;
+  made_with_ai?: boolean;
+  /** Destructive last resort. Only true after listing affected comments and receiving explicit confirmation. */
+  force_overwrite_comments?: boolean;
+};
+
+export const confirmation: Tool.Confirmation<Input> = async (input) => {
+  if (input.schedule === "now")
+    return { message: "Publish this draft immediately? This is public and cannot be undone." };
+  if (input.force_overwrite_comments) {
+    return {
+      message:
+        "Overwrite missing comment anchors? This resolves affected comment threads and cannot be undone via the API.",
+    };
+  }
+  return undefined;
+};
+
+export default async function tool(input: Input) {
+  const socialSetId = await resolveToolSocialSetId(input.social_set_id);
+  const existing = await getDraft(socialSetId, input.draft_id);
+  const payload: DraftUpdateRequest = {};
+
+  if (input.append && input.content === undefined) {
+    throw new Error("content is required when append is true.");
+  }
+
+  if (input.content !== undefined) {
+    const enabled = input.platforms
+      ? await resolveToolPlatforms(socialSetId, input.platforms)
+      : Object.entries(existing.platforms ?? {})
+          .filter(([, value]) => value?.enabled)
+          .map(([key]) => key as PlatformKey);
+
+    const newPlatforms = buildPlatforms(input.content, enabled, input.media_ids);
+    if (input.append) {
+      const unsupported = enabled.filter((platform) => !THREAD_PLATFORMS.has(platform));
+      if (unsupported.length) {
+        throw new Error(`Appending is only supported for thread platforms. Unsupported: ${unsupported.join(", ")}`);
+      }
+      payload.platforms = {};
+      for (const platform of enabled) {
+        const existingPlatform = existing.platforms?.[platform];
+        const newPlatform = newPlatforms[platform];
+        if (!existingPlatform || !newPlatform || !("posts" in newPlatform)) {
+          throw new Error(`The draft has no existing ${platform} content to append to.`);
+        }
+        payload.platforms[platform] = {
+          enabled: true,
+          posts: [...existingPlatform.posts.map((post) => sanitizePost(post, platform)), ...newPlatform.posts],
+          ...(existingPlatform.settings ? { settings: existingPlatform.settings } : {}),
+        };
+      }
+    } else {
+      payload.platforms = newPlatforms;
+    }
+
+    if (payload.platforms.x && "posts" in payload.platforms.x) {
+      payload.platforms.x.posts = payload.platforms.x.posts.map((post) => ({
+        ...post,
+        ...(input.quote_post_url ? { quote_post_url: input.quote_post_url } : {}),
+        ...(input.paid_partnership ? { paid_partnership: true } : {}),
+        ...(input.made_with_ai ? { made_with_ai: true } : {}),
+      }));
+    } else if (input.quote_post_url || input.paid_partnership || input.made_with_ai) {
+      throw new Error("Quote and disclosure options require X to be updated.");
+    }
+  } else if (input.quote_post_url || input.paid_partnership || input.made_with_ai) {
+    const xPosts = existing.platforms?.x?.posts;
+    if (!xPosts?.length) throw new Error("This draft has no X posts to update.");
+    const platforms: DraftCreatePlatforms = {
+      x: {
+        enabled: true,
+        posts: xPosts.map((post) => ({
+          ...sanitizePost(post, "x"),
+          ...(input.quote_post_url ? { quote_post_url: input.quote_post_url } : {}),
+          ...(input.paid_partnership ? { paid_partnership: true } : {}),
+          ...(input.made_with_ai ? { made_with_ai: true } : {}),
+        })),
+      },
+    };
+    payload.platforms = platforms;
+  }
+
+  if (input.title !== undefined) payload.draft_title = input.title;
+  if (input.scratchpad !== undefined) payload.scratchpad_text = input.scratchpad;
+  if (input.schedule !== undefined) payload.publish_at = input.schedule;
+  if (input.tags !== undefined) payload.tags = input.tags;
+  if (input.share !== undefined) payload.share = input.share;
+  if (input.force_overwrite_comments) payload.force_overwrite_comments = true;
+  if (!Object.keys(payload).length) throw new Error("Provide at least one field to update.");
+
+  return draftResult(await updateDraft(socialSetId, input.draft_id, payload));
+}

--- a/extensions/typefully/src/tools/update-queue-schedule.ts
+++ b/extensions/typefully/src/tools/update-queue-schedule.ts
@@ -1,0 +1,10 @@
+import { Tool } from "@raycast/api";
+import { updateQueueSchedule } from "../lib/api";
+import { resolveToolSocialSetId } from "../lib/tool-helpers";
+type Input = { social_set_id?: number; rules: Array<{ h: number; m: number; days: string[] }> };
+export const confirmation: Tool.Confirmation<Input> = async () => ({
+  message: "Replace the Typefully queue schedule with these rules?",
+});
+export default async function tool(input: Input) {
+  return updateQueueSchedule(await resolveToolSocialSetId(input.social_set_id), input.rules);
+}

--- a/extensions/typefully/src/tools/update-x-article.ts
+++ b/extensions/typefully/src/tools/update-x-article.ts
@@ -1,0 +1,45 @@
+import { Tool } from "@raycast/api";
+import { updateDraft } from "../lib/api";
+import { draftResult, resolveToolSocialSetId } from "../lib/tool-helpers";
+type Input = {
+  draft_id: number;
+  social_set_id?: number;
+  content_markdown?: string;
+  /** Ready media ID, or the literal string null to remove the cover. */
+  cover_media_id?: string;
+  title?: string;
+  scratchpad?: string;
+  tags?: string[];
+  share?: boolean;
+  schedule?: string;
+  force_overwrite_comments?: boolean;
+};
+export const confirmation: Tool.Confirmation<Input> = async (input) => {
+  if (input.schedule === "now") return { message: "Publish this X Article immediately?" };
+  if (input.force_overwrite_comments)
+    return { message: "Overwrite missing X Article comment anchors? This cannot be undone via the API." };
+  return undefined;
+};
+export default async function tool(input: Input) {
+  if (input.content_markdown !== undefined && !input.content_markdown.trim().startsWith("# ")) {
+    throw new Error("The first non-empty X Article block must be a # Title heading.");
+  }
+  const socialSetId = await resolveToolSocialSetId(input.social_set_id);
+  const platform = {
+    ...(input.content_markdown !== undefined ? { content_markdown: input.content_markdown } : {}),
+    ...(input.cover_media_id !== undefined
+      ? { cover_media_id: input.cover_media_id === "null" ? null : input.cover_media_id }
+      : {}),
+  };
+  const payload = {
+    ...(Object.keys(platform).length ? { platforms: { x_article: platform } } : {}),
+    ...(input.title !== undefined ? { draft_title: input.title } : {}),
+    ...(input.scratchpad !== undefined ? { scratchpad_text: input.scratchpad } : {}),
+    ...(input.tags !== undefined ? { tags: input.tags } : {}),
+    ...(input.share !== undefined ? { share: input.share } : {}),
+    ...(input.schedule !== undefined ? { publish_at: input.schedule } : {}),
+    ...(input.force_overwrite_comments ? { force_overwrite_comments: true } : {}),
+  };
+  if (!Object.keys(payload).length) throw new Error("Provide at least one field to update.");
+  return draftResult(await updateDraft(socialSetId, input.draft_id, payload));
+}

--- a/extensions/typefully/src/tools/upload-media.ts
+++ b/extensions/typefully/src/tools/upload-media.ts
@@ -1,0 +1,40 @@
+import { Tool } from "@raycast/api";
+import { basename } from "node:path";
+import { readFile } from "node:fs/promises";
+import { createMediaUpload, getMediaStatus } from "../lib/api";
+import { resolveToolSocialSetId } from "../lib/tool-helpers";
+
+type Input = {
+  /** Absolute local file path. */
+  file_path: string;
+  social_set_id?: number;
+};
+export const confirmation: Tool.Confirmation<Input> = async (input) => ({
+  message: `Upload ${basename(input.file_path)} to Typefully?`,
+});
+export default async function tool(input: Input) {
+  const socialSetId = await resolveToolSocialSetId(input.social_set_id);
+  let file: Buffer;
+  try {
+    file = await readFile(input.file_path);
+  } catch {
+    throw new Error(`File not found: ${input.file_path}`);
+  }
+  const originalName = basename(input.file_path);
+  const extensionIndex = originalName.lastIndexOf(".");
+  const stem = extensionIndex >= 0 ? originalName.slice(0, extensionIndex) : originalName;
+  const extension = extensionIndex >= 0 ? originalName.slice(extensionIndex).toLowerCase() : "";
+  const fileName = `${stem.replace(/[^a-zA-Z0-9_.()-]/g, "_").replace(/_+/g, "_") || "upload"}${extension}`;
+  const upload = await createMediaUpload(socialSetId, fileName);
+  const response = await fetch(upload.upload_url, { method: "PUT", body: file });
+  if (!response.ok) throw new Error(`Media upload failed with status ${response.status}`);
+
+  for (let attempt = 0; attempt < 30; attempt++) {
+    const status = await getMediaStatus(socialSetId, upload.media_id);
+    if (status.status === "ready") return status;
+    if (status.status === "error" || status.status === "failed")
+      throw new Error("Typefully failed to process the media.");
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+  }
+  return { media_id: upload.media_id, status: "processing" };
+}


### PR DESCRIPTION
## Description

Expands Typefully's Raycast AI integration from 4 to 29 tools, bringing the extension to feature parity with the Typefully CLI skill.

Adds:

* Full draft CRUD, scheduling, immediate publishing, tags, scratchpad, sharing, and thread appending
* Social-set resolution, authenticated-user lookup, default account selection, and publishing quota access
* Queue inspection and schedule management
* Media upload and processing-status checks
* X post and follower analytics
* X replies, quote posts, communities, and disclosure labels
* LinkedIn organization mention resolution
* Draft comment creation, replies, editing, resolution, deletion, and safe inline-anchor handling
* Standalone X Article creation and updates
* Comprehensive AI instructions for account selection, cross-platform drafts, comment safety, scheduling, publishing, and authentication errors

Also stops silently selecting an account when several social sets exist without a configured default.

## Verification

* `npm run lint`
* `npx ray build -e dist -o /tmp/typefully-final-build`
* Installed the production build locally and verified all 29 tools register with the expected confirmation requirements
* Successfully exercised the installed extension's `list-social-sets` tool against the live Typefully API
