### PR TITLE
p00f: fix "crypto is not defined" crash on every command

### DIFF
--- a/extensions/p00f/CHANGELOG.md
+++ b/extensions/p00f/CHANGELOG.md
@@ -1,5 +1,9 @@
 # p00f Changelog
 
+## [Fix Web Crypto crash on every create] - {PR_MERGE_DATE}
+
+- Fixed every command failing with `ReferenceError: crypto is not defined`. p00f encrypts on your device using the Web Crypto API, and Raycast's extension host runs commands in a scope with no `crypto` global, so encryption threw before any Poof could be created. The extension now installs Node's Web Crypto implementation itself. No Poof content was ever at risk: the failure happened before anything left the machine.
+
 ## [Initial Version] - 2026-07-27
 
 - **Create Poof**: full form for text or one file with TTL, Reveal budget, PIN, secret kind, masked URL, reveal-anchored TTL, viewer-delete, reveal captcha, and countdown options.

--- a/extensions/p00f/CHANGELOG.md
+++ b/extensions/p00f/CHANGELOG.md
@@ -1,6 +1,6 @@
 # p00f Changelog
 
-## [Fix Web Crypto crash on every create] - {PR_MERGE_DATE}
+## [Fix Web Crypto crash on every create] - 2026-07-27
 
 - Fixed every command failing with `ReferenceError: crypto is not defined`. p00f encrypts on your device using the Web Crypto API, and Raycast's extension host runs commands in a scope with no `crypto` global, so encryption threw before any Poof could be created. The extension now installs Node's Web Crypto implementation itself. No Poof content was ever at risk: the failure happened before anything left the machine.
 

--- a/extensions/p00f/src/create-poof.tsx
+++ b/extensions/p00f/src/create-poof.tsx
@@ -1,3 +1,6 @@
+// Must stay the first import: guarantees the Web Crypto global that @p00f/core
+// encrypts with before anything else in the command is evaluated.
+import "./lib/webcrypto";
 import {
   Action,
   ActionPanel,

--- a/extensions/p00f/src/lib/webcrypto.ts
+++ b/extensions/p00f/src/lib/webcrypto.ts
@@ -1,0 +1,45 @@
+// @p00f/core is written against the ambient Web Crypto global so the same code
+// runs unchanged in browsers, in workerd, and under Node (ADR-0010, one core
+// many shells). Raycast's extension host does not guarantee that global: it
+// runs each command in a worker_threads Worker whose scope has been observed on
+// multiple machines to have no binding for `crypto`, so the first encrypt threw
+// "ReferenceError: crypto is not defined" before any request left the machine.
+//
+// Node always exposes the same implementation as `webcrypto` from node:crypto,
+// so the shell installs it on globalThis before core touches it. Core reads
+// `crypto` lazily inside its functions, never at module scope, so importing
+// this module first in every entry point is sufficient.
+import { webcrypto } from "node:crypto";
+
+/**
+ * True when `candidate` cannot serve as Web Crypto for core's needs: core uses
+ * `crypto.getRandomValues` for IVs and salts, and `crypto.subtle` for HKDF and
+ * AES-GCM. A partial global (present but missing `subtle`) is as unusable as an
+ * absent one, so both are treated the same.
+ */
+export function needsWebCryptoPolyfill(candidate: unknown): boolean {
+  if (typeof candidate !== "object" || candidate === null) return true;
+  const c = candidate as Partial<Crypto>;
+  return typeof c.getRandomValues !== "function" || !c.subtle;
+}
+
+/**
+ * Guarantee a usable Web Crypto on `target`. Idempotent, and a no-op on hosts
+ * that already provide a working global, so this never shadows a real
+ * implementation with the Node one.
+ */
+export function ensureWebCrypto(target: object = globalThis): void {
+  const holder = target as Record<string, unknown>;
+  if (!needsWebCryptoPolyfill(holder.crypto)) return;
+  // defineProperty rather than assignment: on some hosts `crypto` is an
+  // accessor with no setter, where a plain assignment silently no-ops (or
+  // throws under strict mode) and leaves the broken value in place.
+  Object.defineProperty(holder, "crypto", {
+    value: webcrypto,
+    configurable: true,
+    enumerable: false,
+    writable: false,
+  });
+}
+
+ensureWebCrypto();

--- a/extensions/p00f/src/poof-clipboard.ts
+++ b/extensions/p00f/src/poof-clipboard.ts
@@ -1,3 +1,6 @@
+// Must stay the first import: guarantees the Web Crypto global that @p00f/core
+// encrypts with before anything else in the command is evaluated.
+import "./lib/webcrypto";
 import { Clipboard, Toast, getPreferenceValues, showToast } from "@raycast/api";
 import { execFile } from "node:child_process";
 import { readFile, stat, unlink } from "node:fs/promises";

--- a/extensions/p00f/src/poof-selection.ts
+++ b/extensions/p00f/src/poof-selection.ts
@@ -1,3 +1,6 @@
+// Must stay the first import: guarantees the Web Crypto global that @p00f/core
+// encrypts with before anything else in the command is evaluated.
+import "./lib/webcrypto";
 import {
   Clipboard,
   Toast,


### PR DESCRIPTION
## Description

Hotfix for `p00f`, which I submitted in #28989 and which merged earlier today. **Every command in the published extension fails**, so the extension is currently unusable in the Store.

Running any of the three commands throws:

```
ReferenceError: crypto is not defined
```

Reproduced on two separate machines, using the Store build (not a dev build).

## Root cause

p00f encrypts on-device before anything is uploaded. The crypto lives in `@p00f/core`, which is deliberately written against the **ambient Web Crypto global** so one implementation runs unchanged in browsers, in `workerd`, and under Node:

```js
crypto.getRandomValues(iv);
await crypto.subtle.importKey("raw", ikm, "HKDF", false, ["deriveKey"]);
```

Raycast's extension host runs each command in a worker scope that has **no binding for `crypto`**. So the very first `getRandomValues` throws, before any request leaves the machine.

I missed this because every environment I tested in resolves the global fine. A plain `node` process, a plain `worker_threads` Worker, and Raycast's own bundled Node runtime (`v22.22.2`) all expose `globalThis.crypto`. Only the actual extension-host scope does not, so `ray build` and `ray lint` both stayed green and the bug reached the Store.

## Fix

Fixed in the shell, not in core. Core keeps its browser and `workerd` compatibility, and importing `node:crypto` there would break both.

New `src/lib/webcrypto.ts` installs Node's `webcrypto` on `globalThis` when the host provides nothing usable, and is imported first in all three entry points. Two deliberate details:

- **It no-ops when a working global already exists**, so a genuine host implementation is never shadowed by the Node one. It also treats a *partial* global (present but missing `subtle`) as needing the polyfill, since that is just as unusable for HKDF and AES-GCM.
- **`defineProperty` rather than assignment.** Where `crypto` is a getter-only accessor, a plain assignment silently no-ops and leaves the broken value in place.

Core reads `crypto` lazily inside its functions and never at module scope, so importing the shim first is sufficient.

## Verification

Confirmed the mechanism rather than guessing at it. Deleting `globalThis.crypto` to emulate the host scope reproduces the reported error exactly, and the shim repairs it:

```
precondition: crypto global present initially = true | after delete = undefined
  [REPRO] ReferenceError: crypto is not defined
  [SHIM] applied. typeof crypto = object | subtle = object
  [VERIFY] encrypt+upload OK: https://p00f.me/c/XsuQD0UG5T0DWJEQ...
  [VERIFY] reveal ok: true | plaintext matches: true
```

Also verified:

- The shim **survives bundling** in all three built commands, and is ordered before the first `crypto` use (byte offset 497 vs 913).
- Clean `npm ci` then `ray build` and `ray lint`, all green.
- 7 new regression tests upstream, 192 green overall.

## Note on user data

No user content was ever at risk. The failure is local and happens *before* anything is transmitted, so no Poof was created, uploaded, or partially encrypted. The zero-knowledge model is unchanged: the server still only ever receives ciphertext.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
