### PR TITLE
ccusage: add pie chart icon, pies progress style, time remaining display

### DIFF
--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Claude Code Usage (ccusage) Changelog
 
+## [Add pie chart icon, pies progress style, and time remaining display] - 2026-07-27
+
+### Added
+
+- **Menu Bar Icon Style:** 'Pie Chart' — SVG pie icon showing 5-hour utilization, filling clockwise with Claude's orange
+- **Progress Bar Style:** 'Pies' — per-row pie SVG icons on rate limit rows instead of Icon.Gauge
+- **Time Remaining Display:** Show Time Remaining toggle appends 5-hour session countdown to the menu bar title text
+- **Time Remaining Format:** Customizable template string with placeholders: `{h}h{m}m`, `{M}m`, `{h.f}h`, etc.
+
 ## [More progress bar styles] - 2026-07-12
 
 ### Added

--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Claude Code Usage (ccusage) Changelog
 
-## [Add pie chart icon, pies progress style, and time remaining display] - 2026-07-27
+## [Add pie chart icon, pies progress style, and time remaining display] - {PR_MERGE_DATE}
 
 ### Added
 

--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Claude Code Usage (ccusage) Changelog
 
-## [Add pie chart icon, pies progress style, and time remaining display] - {PR_MERGE_DATE}
+## [Add pie chart icon, pies progress style, and time remaining display] - 2026-07-28
 
 ### Added
 

--- a/extensions/ccusage/package-lock.json
+++ b/extensions/ccusage/package-lock.json
@@ -62,7 +62,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2632,7 +2631,6 @@
       "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.6.tgz",
       "integrity": "sha512-W3UnZrfh1EH9mteQQOibeUvniDnVsbRgcfSUgVWFTGuI6mzKLFzoM8mD6n5amYQM51JVvbuJbaqtfMqsTmnQCQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oclif/core": "^4.5.4",
         "@oclif/plugin-autocomplete": "^3.2.35",
@@ -2856,7 +2854,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -2946,7 +2943,6 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -3440,7 +3436,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3711,7 +3706,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4238,7 +4232,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5233,7 +5226,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -5811,7 +5803,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -6584,7 +6575,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7206,7 +7196,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7368,7 +7357,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/ccusage/package.json
+++ b/extensions/ccusage/package.json
@@ -15,7 +15,8 @@
     "pernielsentikaer",
     "raulg",
     "ridemountainpig",
-    "bendrucker"
+    "bendrucker",
+    "zeev"
   ],
   "license": "MIT",
   "commands": [
@@ -99,6 +100,10 @@
             {
               "title": "Monochrome",
               "value": "monochrome"
+            },
+            {
+              "title": "Pie Chart",
+              "value": "pie"
             }
           ]
         },
@@ -145,8 +150,29 @@
             {
               "title": "ASCII (#-)",
               "value": "ascii"
+            },
+            {
+              "title": "Pies (●)",
+              "value": "pies"
             }
           ]
+        },
+        {
+          "name": "menuBarTimeRemaining",
+          "type": "checkbox",
+          "required": false,
+          "label": "Show Time Remaining",
+          "description": "Show 5-hour session time remaining next to the menu bar title",
+          "default": false
+        },
+        {
+          "name": "menuBarTimeRemainingFormat",
+          "type": "textfield",
+          "required": false,
+          "title": "Time Remaining Format",
+          "description": "Format string for time remaining. Placeholders: {h} hours, {m} minutes, {M} total minutes, {h.f} fractional hours. Example: {h}h{m}m → 1h23m",
+          "default": "{h}h{m}m",
+          "placeholder": "e.g., {h}h{m}m or {M}m or {h.f}h"
         }
       ]
     },

--- a/extensions/ccusage/src/menubar-ccusage.tsx
+++ b/extensions/ccusage/src/menubar-ccusage.tsx
@@ -113,7 +113,7 @@ export default function MenuBarccusage() {
 
   /** When pies style is selected, use a pie SVG icon for each limit row; otherwise Icon.Gauge. */
   const limitIcon = (utilization: number): string | Icon =>
-    usePies ? (pieIcon(displayUtil(utilization)) as string) : Icon.Gauge;
+    usePies ? (pieIcon(utilization) as string) : Icon.Gauge;
 
   const menuBarTitlePref = getMenuBarTitle();
   const highestUtilization = effectiveLimitsData

--- a/extensions/ccusage/src/menubar-ccusage.tsx
+++ b/extensions/ccusage/src/menubar-ccusage.tsx
@@ -112,8 +112,7 @@ export default function MenuBarccusage() {
     usePies ? label : `${label.padEnd(6)}  ${limitBar(utilization)}`;
 
   /** When pies style is selected, use a pie SVG icon for each limit row; otherwise Icon.Gauge. */
-  const limitIcon = (utilization: number): string | Icon =>
-    usePies ? (pieIcon(utilization) as string) : Icon.Gauge;
+  const limitIcon = (utilization: number): string | Icon => (usePies ? (pieIcon(utilization) as string) : Icon.Gauge);
 
   const menuBarTitlePref = getMenuBarTitle();
   const highestUtilization = effectiveLimitsData

--- a/extensions/ccusage/src/menubar-ccusage.tsx
+++ b/extensions/ccusage/src/menubar-ccusage.tsx
@@ -1,4 +1,5 @@
 import { MenuBarExtra, Icon, open, openCommandPreferences } from "@raycast/api";
+import type { Image } from "@raycast/api";
 import { useState, useEffect, useRef } from "react";
 import { useDailyUsage } from "./hooks/useDailyUsage";
 import { useWeeklyUsage } from "./hooks/useWeeklyUsage";
@@ -8,7 +9,17 @@ import { useClaudeUsageLimits } from "./hooks/useClaudeUsageLimits";
 import { useWorkingTime } from "./hooks/useWorkingTime";
 import { formatCost, formatCostDelta, formatDuration, formatTokensAsMTok } from "./utils/data-formatter";
 import { formatTimeRemaining, createProgressBar } from "./utils/usage-limits-formatter";
-import { showRemainingUsage, getMenuBarTitle, getProgressBarStyle, getMenuBarIcon } from "./preferences";
+import { pieIcon } from "./utils/pie-icon";
+import { formatTimeRemainingCustom } from "./utils/time-remaining-formatter";
+import {
+  showRemainingUsage,
+  getMenuBarTitle,
+  getProgressBarStyle,
+  getMenuBarIcon,
+  getMenuBarIconStyle,
+  getMenuBarTimeRemaining,
+  getMenuBarTimeRemainingFormat,
+} from "./preferences";
 import { TotalUsageData } from "./types/usage-types";
 
 const MOCK_LIMITS_ENABLED = false;
@@ -83,6 +94,10 @@ export default function MenuBarccusage() {
 
   const preferRemaining = showRemainingUsage();
   const progressBarStyle = getProgressBarStyle();
+  const iconStyle = getMenuBarIconStyle();
+  const showTimeRemaining = getMenuBarTimeRemaining();
+  const timeRemainingFormat = getMenuBarTimeRemainingFormat();
+  const usePies = progressBarStyle === "pies";
 
   const displayUtil = (utilization: number): number => (preferRemaining ? 100 - utilization : utilization);
 
@@ -95,6 +110,10 @@ export default function MenuBarccusage() {
 
   const limitTitle = (label: string, utilization: number): string => `${label.padEnd(6)}  ${limitBar(utilization)}`;
 
+  /** When pies style is selected, use a pie SVG icon for each limit row; otherwise Icon.Gauge. */
+  const limitIcon = (utilization: number): string | Icon =>
+    usePies ? (pieIcon(displayUtil(utilization)) as string) : Icon.Gauge;
+
   const menuBarTitlePref = getMenuBarTitle();
   const highestUtilization = effectiveLimitsData
     ? Math.max(
@@ -105,32 +124,52 @@ export default function MenuBarccusage() {
       )
     : null;
   const menuBarTitle = (() => {
-    if (menuBarTitlePref === "none") return undefined;
-    if (menuBarTitlePref === "todayUsage")
-      return todayUsage
+    let title: string | undefined;
+    if (menuBarTitlePref === "none") title = undefined;
+    else if (menuBarTitlePref === "todayUsage")
+      title = todayUsage
         ? `${formatCost(todayUsage.totalCost)} · ${formatTokensAsMTok(todayUsage.totalTokens)}`
         : undefined;
-    if (menuBarTitlePref === "todayCost") return todayUsage ? formatCost(todayUsage.totalCost) : undefined;
-    if (menuBarTitlePref === "weeklyCost") return weeklyUsage ? formatCost(weeklyUsage.totalCost) : undefined;
-    if (menuBarTitlePref === "monthlyCost") return monthlyUsage ? formatCost(monthlyUsage.totalCost) : undefined;
-    if (menuBarTitlePref === "todayTokens") return todayUsage ? formatTokensAsMTok(todayUsage.totalTokens) : undefined;
-    if (menuBarTitlePref === "fiveHour")
-      return effectiveLimitsData ? `${displayUtil(effectiveLimitsData.five_hour.utilization).toFixed(0)}%` : undefined;
-    if (menuBarTitlePref === "sevenDay")
-      return effectiveLimitsData ? `${displayUtil(effectiveLimitsData.seven_day.utilization).toFixed(0)}%` : undefined;
-    if (menuBarTitlePref === "utilization")
-      return highestUtilization !== null ? `${displayUtil(highestUtilization).toFixed(0)}%` : undefined;
-    if (menuBarTitlePref === "blockProjection") {
+    else if (menuBarTitlePref === "todayCost") title = todayUsage ? formatCost(todayUsage.totalCost) : undefined;
+    else if (menuBarTitlePref === "weeklyCost") title = weeklyUsage ? formatCost(weeklyUsage.totalCost) : undefined;
+    else if (menuBarTitlePref === "monthlyCost") title = monthlyUsage ? formatCost(monthlyUsage.totalCost) : undefined;
+    else if (menuBarTitlePref === "todayTokens")
+      title = todayUsage ? formatTokensAsMTok(todayUsage.totalTokens) : undefined;
+    else if (menuBarTitlePref === "fiveHour")
+      title = effectiveLimitsData ? `${displayUtil(effectiveLimitsData.five_hour.utilization).toFixed(0)}%` : undefined;
+    else if (menuBarTitlePref === "sevenDay")
+      title = effectiveLimitsData ? `${displayUtil(effectiveLimitsData.seven_day.utilization).toFixed(0)}%` : undefined;
+    else if (menuBarTitlePref === "utilization")
+      title = highestUtilization !== null ? `${displayUtil(highestUtilization).toFixed(0)}%` : undefined;
+    else if (menuBarTitlePref === "blockProjection") {
       const block = workingTime.activeBlock;
-      return block ? formatCost(block.projection?.totalCost ?? block.costUSD) : undefined;
+      title = block ? formatCost(block.projection?.totalCost ?? block.costUSD) : undefined;
+    } else {
+      title = todayUsage
+        ? `${formatCost(todayUsage.totalCost)} · ${formatTokensAsMTok(todayUsage.totalTokens)}`
+        : undefined;
     }
-    return todayUsage
-      ? `${formatCost(todayUsage.totalCost)} · ${formatTokensAsMTok(todayUsage.totalTokens)}`
-      : undefined;
+
+    // Append time remaining to the title when enabled
+    if (showTimeRemaining && effectiveLimitsData) {
+      const timeStr = formatTimeRemainingCustom(effectiveLimitsData.five_hour.resets_at, timeRemainingFormat);
+      if (timeStr && title) title = `${title} · ${timeStr}`;
+      else if (timeStr) title = timeStr;
+    }
+
+    return title;
+  })();
+
+  // Resolve the menu bar icon: use a pie chart SVG when that style is selected
+  const menuBarIcon: Image.Source = (() => {
+    if (iconStyle === "pie" && effectiveLimitsData) {
+      return pieIcon(effectiveLimitsData.five_hour.utilization) as string;
+    }
+    return getMenuBarIcon();
   })();
 
   return (
-    <MenuBarExtra icon={{ source: getMenuBarIcon() }} title={menuBarTitle} tooltip={getTooltip()}>
+    <MenuBarExtra icon={{ source: menuBarIcon }} title={menuBarTitle} tooltip={getTooltip()}>
       {hasError && (
         <MenuBarExtra.Section title="Error">
           <MenuBarExtra.Item
@@ -183,7 +222,7 @@ export default function MenuBarccusage() {
                       effectiveLimitsData.five_hour.utilization,
                       effectiveLimitsData.five_hour.resets_at,
                     )}
-                    icon={Icon.Gauge}
+                    icon={limitIcon(effectiveLimitsData.five_hour.utilization)}
                     onAction={revalidate}
                   />
                   <MenuBarExtra.Item
@@ -192,7 +231,7 @@ export default function MenuBarccusage() {
                       effectiveLimitsData.seven_day.utilization,
                       effectiveLimitsData.seven_day.resets_at,
                     )}
-                    icon={Icon.Gauge}
+                    icon={limitIcon(effectiveLimitsData.seven_day.utilization)}
                     onAction={revalidate}
                   />
                   {effectiveLimitsData.seven_day_sonnet && (
@@ -202,7 +241,7 @@ export default function MenuBarccusage() {
                         effectiveLimitsData.seven_day_sonnet.utilization,
                         effectiveLimitsData.seven_day_sonnet.resets_at,
                       )}
-                      icon={Icon.Gauge}
+                      icon={limitIcon(effectiveLimitsData.seven_day_sonnet.utilization)}
                       onAction={revalidate}
                     />
                   )}
@@ -213,7 +252,7 @@ export default function MenuBarccusage() {
                         effectiveLimitsData.seven_day_opus.utilization,
                         effectiveLimitsData.seven_day_opus.resets_at,
                       )}
-                      icon={Icon.Gauge}
+                      icon={limitIcon(effectiveLimitsData.seven_day_opus.utilization)}
                       onAction={revalidate}
                     />
                   )}

--- a/extensions/ccusage/src/menubar-ccusage.tsx
+++ b/extensions/ccusage/src/menubar-ccusage.tsx
@@ -108,7 +108,8 @@ export default function MenuBarccusage() {
 
   const limitBar = (utilization: number): string => createProgressBar(displayUtil(utilization), 22, progressBarStyle);
 
-  const limitTitle = (label: string, utilization: number): string => `${label.padEnd(6)}  ${limitBar(utilization)}`;
+  const limitTitle = (label: string, utilization: number): string =>
+    usePies ? label : `${label.padEnd(6)}  ${limitBar(utilization)}`;
 
   /** When pies style is selected, use a pie SVG icon for each limit row; otherwise Icon.Gauge. */
   const limitIcon = (utilization: number): string | Icon =>

--- a/extensions/ccusage/src/preferences.ts
+++ b/extensions/ccusage/src/preferences.ts
@@ -28,8 +28,23 @@ export const getMenuBarTitle = (): MenuBarTitleMode =>
 export const getProgressBarStyle = (): ProgressBarStyle =>
   (menuBarPreferences.progressBarStyle as ProgressBarStyle) ?? "solid";
 
-export const getMenuBarIcon = (): Image.Source =>
-  menuBarPreferences.menuBarIconStyle === "monochrome" ? Icon.BarChart : "extension-icon.png";
+export type MenuBarIconStyle = "color" | "monochrome" | "pie";
+
+export const getMenuBarIconStyle = (): MenuBarIconStyle =>
+  (menuBarPreferences.menuBarIconStyle as MenuBarIconStyle) ?? "color";
+
+export const getMenuBarIcon = (): Image.Source => {
+  const style = getMenuBarIconStyle();
+  if (style === "monochrome") return Icon.BarChart;
+  // "pie" is handled dynamically in the menu bar command (requires utilization data)
+  // so we return the color icon as a fallback while data loads.
+  return "extension-icon.png";
+};
+
+export const getMenuBarTimeRemaining = (): boolean => menuBarPreferences.menuBarTimeRemaining === true;
+
+export const getMenuBarTimeRemainingFormat = (): string =>
+  (menuBarPreferences.menuBarTimeRemainingFormat as string) || "{h}h{m}m";
 
 export const getCustomNpxPath = (): string | undefined => {
   const customPath = preferences.customNpxPath?.trim();

--- a/extensions/ccusage/src/utils/pie-icon.ts
+++ b/extensions/ccusage/src/utils/pie-icon.ts
@@ -1,0 +1,82 @@
+import type { Image } from "@raycast/api";
+
+// Claude's signature orange, used for the progress fill.
+const CLAUDE_ORANGE = "#D97757";
+
+// Neutral track behind the fill.
+const TRACK_GREY = "#444";
+
+// Warning color when utilization is high.
+const WARN_RED = "#D97757";
+
+const WARN_AT = 95;
+
+/** Point on the circle at `angle` degrees, measured clockwise from 12 o'clock. */
+function polarToCartesian(radius: number, angleInDegrees: number) {
+  const angleInRadians = ((angleInDegrees - 90) * Math.PI) / 180;
+  return {
+    x: (50 + radius * Math.cos(angleInRadians)).toFixed(2),
+    y: (50 + radius * Math.sin(angleInRadians)).toFixed(2),
+  };
+}
+
+/**
+ * Full disc, as a path rather than a `<circle>`.
+ *
+ * Raycast's SVG renderer draws `<path>` but ignores `<circle>` — a track drawn
+ * as a circle came out invisible, and a 100% icon (two circles, no path) came
+ * out completely blank. Two half arcs give the same shape via a path.
+ */
+function describeDisc(radius: number): string {
+  const top = 50 - radius;
+  const bottom = 50 + radius;
+  return `M 50 ${top} A ${radius} ${radius} 0 1 1 50 ${bottom} A ${radius} ${radius} 0 1 1 50 ${top} Z`;
+}
+
+/** Filled wedge from the center, sweeping clockwise from 12 o'clock. */
+function describeWedge(radius: number, sweepInDegrees: number): string {
+  const start = polarToCartesian(radius, 0);
+  const end = polarToCartesian(radius, sweepInDegrees);
+  const largeArcFlag = sweepInDegrees > 180 ? "1" : "0";
+  return `M 50 50 L ${start.x} ${start.y} A ${radius} ${radius} 0 ${largeArcFlag} 1 ${end.x} ${end.y} Z`;
+}
+
+function fillColor(percent: number): string {
+  if (percent >= WARN_AT) return WARN_RED;
+  return CLAUDE_ORANGE;
+}
+
+function progressFor(percent: number): number {
+  return Math.min(Math.max(percent / 100, 0), 1);
+}
+
+/**
+ * A grey disc that fills clockwise with an orange pie slice as usage climbs.
+ *
+ * Returns a `data:image/svg+xml,...` URI that Raycast can use as an icon.
+ * We percent-encode the payload because a hex color's `#` would open a URL
+ * fragment in a raw data URI, truncating the SVG mid-attribute.
+ */
+export function pieIcon(percent: number): Image.ImageLike {
+  const progress = progressFor(percent);
+  const color = fillColor(percent);
+  const radius = 46;
+
+  // A 360° sweep is degenerate — start and end land on the same point, drawing
+  // nothing — so a full slice is just the whole disc.
+  const slice =
+    progress >= 1
+      ? `<path d="${describeDisc(radius)}" fill="${color}" />`
+      : progress > 0
+        ? `<path d="${describeWedge(radius, progress * 360)}" fill="${color}" />`
+        : "";
+
+  const svg = [
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">`,
+    `<path d="${describeDisc(radius)}" fill="${TRACK_GREY}" />`,
+    slice,
+    `</svg>`,
+  ].join("");
+
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}

--- a/extensions/ccusage/src/utils/time-remaining-formatter.ts
+++ b/extensions/ccusage/src/utils/time-remaining-formatter.ts
@@ -20,8 +20,8 @@ export function formatTimeRemainingCustom(resetAt: string | null | undefined, fo
   const m = totalMinutes % 60;
 
   return format
-    .replace("{h.f}", (totalMinutes / 60).toFixed(2))
-    .replace("{M}", String(totalMinutes))
-    .replace("{h}", String(h))
-    .replace("{m}", String(m));
+    .replaceAll("{h.f}", (totalMinutes / 60).toFixed(2))
+    .replaceAll("{M}", String(totalMinutes))
+    .replaceAll("{h}", String(h))
+    .replaceAll("{m}", String(m));
 }

--- a/extensions/ccusage/src/utils/time-remaining-formatter.ts
+++ b/extensions/ccusage/src/utils/time-remaining-formatter.ts
@@ -1,0 +1,27 @@
+/**
+ * Format time remaining until a reset with a user-provided template string.
+ *
+ * Supported placeholders:
+ *   {h}   — whole hours (0, 1, 2, …)
+ *   {m}   — remaining minutes after whole hours (0–59)
+ *   {M}   — total minutes (62, 123, …)
+ *   {h.f} — fractional hours to 2 decimal places (1.03, 2.50, …)
+ *
+ * Returns `null` when there is no active reset time or the window has lapsed.
+ */
+export function formatTimeRemainingCustom(resetAt: string | null | undefined, format: string): string | null {
+  if (!resetAt) return null;
+
+  const diffMs = new Date(resetAt).getTime() - Date.now();
+  if (Number.isNaN(diffMs) || diffMs <= 0) return null;
+
+  const totalMinutes = Math.max(0, Math.round(diffMs / 60000));
+  const h = Math.floor(totalMinutes / 60);
+  const m = totalMinutes % 60;
+
+  return format
+    .replace("{h.f}", (totalMinutes / 60).toFixed(2))
+    .replace("{M}", String(totalMinutes))
+    .replace("{h}", String(h))
+    .replace("{m}", String(m));
+}

--- a/extensions/ccusage/src/utils/usage-limits-formatter.ts
+++ b/extensions/ccusage/src/utils/usage-limits-formatter.ts
@@ -68,7 +68,8 @@ export type ProgressBarStyle =
   | "squares"
   | "diamonds"
   | "stars"
-  | "braille";
+  | "braille"
+  | "pies";
 
 const PROGRESS_BAR_CHARS: Record<ProgressBarStyle, [string, string]> = {
   blocks: ["▰", "▱"],
@@ -80,6 +81,7 @@ const PROGRESS_BAR_CHARS: Record<ProgressBarStyle, [string, string]> = {
   diamonds: ["◆", "◇"],
   stars: ["★", "☆"],
   braille: ["⣿", "⣀"],
+  pies: ["●", "○"],
 };
 
 export const createProgressBar = (


### PR DESCRIPTION
As requested, porting my standalone `claude-usage` visualization options into the `ccusage` extension!

This adds 4 new display preferences:
1. **Menu Bar Icon Style**: 'Pie Chart' — SVG pie icon showing 5-hour utilization, filling clockwise with Claude's orange.
2. **Progress Bar Style**: 'Pies' — per-row pie SVG icons on rate limit rows instead of Icon.Gauge.
3. **Show Time Remaining** toggle — appends 5-hour session countdown to the menu bar title text.
4. **Time Remaining Format** — customizable template string with placeholders: `{h}h{m}m`, `{M}m`, `{h.f}h`, etc.