### PR TITLE
Update quarantine-manager extension

### DIFF
--- a/extensions/quarantine-manager/.gitignore
+++ b/extensions/quarantine-manager/.gitignore
@@ -3,6 +3,9 @@
 # dependencies
 /node_modules
 
+# build output
+dist/
+
 # Raycast specific files
 raycast-env.d.ts
 .raycast-swift-build
@@ -12,17 +15,5 @@ compiled_raycast_rust
 
 # misc
 .DS_Store
-
-node_modules/
-dist/
-.DS_Store
-
 .claude/
 CLAUDE.md
-
-# Raycast specific files
-.raycast-swift-build
-.swiftpm
-compiled_raycast_swift
-compiled_raycast_rust
-raycast-env.d.ts

--- a/extensions/quarantine-manager/CHANGELOG.md
+++ b/extensions/quarantine-manager/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Quarantine Manager
 
+## [Faster scans and correct download dates] - {PR_MERGE_DATE}
+
+### Fixed
+
+- Scanning an app installed from a DMG or zip no longer runs out of memory. Such apps carry the quarantine flag on **every** file inside them (Final Cut Pro: over 38,000), which the scan previously read one file at a time. It now reads them in a single pass — about 2.5 seconds instead of well over a minute.
+- Large scans list the first 500 quarantined items and report the full count, with **Remove Quarantine Recursively** (`⌘⇧R`) to clear everything — including the items too numerous to list individually.
+- Download dates were shown 31 years in the future (2057 instead of 2026); the quarantine timestamp was being read as Mac absolute time rather than Unix epoch seconds.
+- Source apps that escape spaces in the quarantine record now read correctly — "Free Download Manager" instead of "Free\x20Download\x20Manager".
+- A scan cut short by a size or time limit now says so, instead of reporting the item as clean.
+
 ## [Multi-target selection] - 2026-06-16
 
 ### Fixed

--- a/extensions/quarantine-manager/CHANGELOG.md
+++ b/extensions/quarantine-manager/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Quarantine Manager
 
-## [Faster scans and correct download dates] - {PR_MERGE_DATE}
+## [Faster scans and correct download dates] - 2026-07-28
 
 ### Fixed
 

--- a/extensions/quarantine-manager/src/manage-quarantine.tsx
+++ b/extensions/quarantine-manager/src/manage-quarantine.tsx
@@ -99,19 +99,26 @@ function buildGroup(paths: string[]): ScanGroup {
           ? "app · recursive scan"
           : "folder · immediate contents only";
       }
+      // The cap applies across the whole selection, so picking twenty
+      // quarantined apps at once cannot multiply into thousands of rows. Roots
+      // are checked against it too — selecting more directories than the cap
+      // would otherwise grow the list without bound. An omitted root is still
+      // cleared by the recursive removal, which acts on the selected sources.
       if (scan.rootQuarantineData) {
-        targets.push({
-          path: scan.path,
-          title: multiSource ? scan.name : `${scan.name} (itself)`,
-          quarantineData: scan.rootQuarantineData,
-          parsed: parseQuarantineData(scan.rootQuarantineData),
-          isTopLevel: true,
-          isDir: true,
-          kindLabel: scan.isApp ? "App" : "Folder",
-        });
+        if (targets.length < MAX_SCAN_ENTRIES) {
+          targets.push({
+            path: scan.path,
+            title: multiSource ? scan.name : `${scan.name} (itself)`,
+            quarantineData: scan.rootQuarantineData,
+            parsed: parseQuarantineData(scan.rootQuarantineData),
+            isTopLevel: true,
+            isDir: true,
+            kindLabel: scan.isApp ? "App" : "Folder",
+          });
+        } else {
+          omitted += 1;
+        }
       }
-      // Apply the cap across the whole selection too, so picking twenty
-      // quarantined apps at once cannot multiply into thousands of rows.
       const room = Math.max(0, MAX_SCAN_ENTRIES - targets.length);
       const listed = scan.entries.slice(0, room);
       omitted += scan.totalFound - listed.length;

--- a/extensions/quarantine-manager/src/manage-quarantine.tsx
+++ b/extensions/quarantine-manager/src/manage-quarantine.tsx
@@ -18,12 +18,14 @@ import {
   getFileName,
   getFinderSelections,
   getQuarantineStatus,
+  isApp,
   isDirectory,
   MAX_SCAN_ENTRIES,
   ParsedQuarantine,
   parseQuarantineData,
   parseQuarantineFlags,
   QuarantineStatus,
+  readQuarantineValue,
   removeAllAttributes,
   removeQuarantine,
   removeQuarantineFromPaths,
@@ -139,19 +141,29 @@ function buildGroup(paths: string[]): ScanGroup {
       }
     } else {
       scannedCount += 1;
-      const status = getQuarantineStatus(p);
-      if (status.hasQuarantine) {
-        targets.push({
-          path: status.path,
-          title: status.name,
-          quarantineData: status.quarantineData,
-          parsed: status.quarantineData
-            ? parseQuarantineData(status.quarantineData)
-            : null,
-          isTopLevel: true,
-          isDir: false,
-          kindLabel: status.isApp ? "App" : "File",
-        });
+      // Only the quarantine value is needed here — reading every attribute
+      // (as the single-file inspector does) would spawn several processes per
+      // file, and this branch only runs for multi-path selections.
+      // null means the attribute is absent; "" means present but empty, which
+      // still counts as quarantined.
+      const value = readQuarantineValue(p);
+      if (value !== null) {
+        // Directly selected files count against the cap as well; a selection
+        // can hold thousands of them. Omitted ones remain covered by the
+        // recursive removal, which acts on the selected sources.
+        if (targets.length < MAX_SCAN_ENTRIES) {
+          targets.push({
+            path: p,
+            title: getFileName(p),
+            quarantineData: value,
+            parsed: parseQuarantineData(value),
+            isTopLevel: true,
+            isDir: false,
+            kindLabel: isApp(p) ? "App" : "File",
+          });
+        } else {
+          omitted += 1;
+        }
       }
     }
   }

--- a/extensions/quarantine-manager/src/manage-quarantine.tsx
+++ b/extensions/quarantine-manager/src/manage-quarantine.tsx
@@ -19,12 +19,15 @@ import {
   getFinderSelections,
   getQuarantineStatus,
   isDirectory,
+  MAX_SCAN_ENTRIES,
+  ParsedQuarantine,
   parseQuarantineData,
   parseQuarantineFlags,
   QuarantineStatus,
   removeAllAttributes,
   removeQuarantine,
   removeQuarantineFromPaths,
+  removeQuarantineRecursivelyFromPaths,
   scanDirectory,
   XattrInfo,
 } from "./utils";
@@ -45,6 +48,8 @@ interface Target {
   path: string;
   title: string;
   quarantineData: string | null;
+  /** Parsed once at scan time — re-parsing per row and per sort comparison is what made large scans crawl */
+  parsed: ParsedQuarantine | null;
   /** Directly selected (sorts to top, gets a kind tag) vs. found inside a scan */
   isTopLevel: boolean;
   /** Directory/bundle — controls recursive "remove all" and the kind tag */
@@ -58,6 +63,10 @@ interface ScanGroup {
   sources: string[];
   targets: Target[];
   scannedCount: number;
+  /** Quarantined items found but not listed, because a source exceeded the display cap */
+  omitted: number;
+  /** Human-readable reasons a scan could not complete (buffer/timeout) */
+  issues: string[];
   /** Short label for the navigation title (a name, or "N items") */
   label: string;
   /** Context line for the section header, e.g. "app · recursive scan" */
@@ -73,13 +82,18 @@ interface ScanGroup {
 function buildGroup(paths: string[]): ScanGroup {
   const multiSource = paths.length > 1;
   const targets: Target[] = [];
+  const issues: string[] = [];
   let scannedCount = 0;
+  let omitted = 0;
   let contextNote = multiSource ? `across ${paths.length} selected items` : "";
 
   for (const p of paths) {
     if (isDirectory(p)) {
       const scan = scanDirectory(p);
-      scannedCount += scan.scannedCount;
+      // scannedCount is null once a scan has findings; it is only ever shown
+      // when nothing was found anywhere, so treating null as 0 is safe.
+      scannedCount += scan.scannedCount ?? 0;
+      if (scan.scanError) issues.push(`${scan.name}: ${scan.scanError}`);
       if (!multiSource) {
         contextNote = scan.isApp
           ? "app · recursive scan"
@@ -90,18 +104,27 @@ function buildGroup(paths: string[]): ScanGroup {
           path: scan.path,
           title: multiSource ? scan.name : `${scan.name} (itself)`,
           quarantineData: scan.rootQuarantineData,
+          parsed: parseQuarantineData(scan.rootQuarantineData),
           isTopLevel: true,
           isDir: true,
           kindLabel: scan.isApp ? "App" : "Folder",
         });
       }
-      for (const entry of scan.entries) {
+      // Apply the cap across the whole selection too, so picking twenty
+      // quarantined apps at once cannot multiply into thousands of rows.
+      const room = Math.max(0, MAX_SCAN_ENTRIES - targets.length);
+      const listed = scan.entries.slice(0, room);
+      omitted += scan.totalFound - listed.length;
+      for (const entry of listed) {
         targets.push({
           path: entry.path,
           title: multiSource
             ? `${scan.name} › ${entry.relativePath}`
             : entry.relativePath,
           quarantineData: entry.quarantineData,
+          parsed: entry.quarantineData
+            ? parseQuarantineData(entry.quarantineData)
+            : null,
           isTopLevel: false,
           isDir: isDirectory(entry.path),
           kindLabel: "File",
@@ -115,6 +138,9 @@ function buildGroup(paths: string[]): ScanGroup {
           path: status.path,
           title: status.name,
           quarantineData: status.quarantineData,
+          parsed: status.quarantineData
+            ? parseQuarantineData(status.quarantineData)
+            : null,
           isTopLevel: true,
           isDir: false,
           kindLabel: status.isApp ? "App" : "File",
@@ -127,6 +153,8 @@ function buildGroup(paths: string[]): ScanGroup {
     sources: paths,
     targets,
     scannedCount,
+    omitted,
+    issues,
     label: paths.length === 1 ? getFileName(paths[0]) : `${paths.length} items`,
     contextNote,
     multiSource,
@@ -508,6 +536,48 @@ export default function ManageQuarantine() {
     }
   }
 
+  /**
+   * Clears quarantine from the selected sources and everything inside them.
+   * This is the escape hatch when a scan finds more items than the list can
+   * show — per-item removal would silently leave the unlisted ones behind.
+   */
+  async function handleRemoveRecursive(group: ScanGroup) {
+    const affected = group.targets.length + group.omitted;
+    const confirmed = await confirmAlert({
+      title: "Remove Quarantine Recursively",
+      message: `Clear the quarantine flag from ${group.label} and everything inside — ${affected} item${affected !== 1 ? "s" : ""} in total?\n\nThis includes the items that are too numerous to list individually.`,
+      primaryAction: {
+        title: "Remove All",
+        style: Alert.ActionStyle.Destructive,
+      },
+    });
+    if (!confirmed) return;
+
+    const toast = await showToast({
+      style: Toast.Style.Animated,
+      title: `Removing quarantine from ${affected} item${affected !== 1 ? "s" : ""}…`,
+    });
+    const result = removeQuarantineRecursivelyFromPaths(group.sources);
+    await toast.hide();
+
+    if (result.success) {
+      await showToast({
+        style: Toast.Style.Success,
+        title: "Quarantine removed",
+        message: result.usedAdmin
+          ? `${group.label} and contents (required admin)`
+          : `${group.label} and contents`,
+      });
+      void loadFiles(group.sources);
+    } else {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Could not remove quarantine",
+        message: result.error ?? "Unknown error",
+      });
+    }
+  }
+
   async function handleRemoveAll(
     filePath: string,
     name: string,
@@ -640,6 +710,7 @@ export default function ManageQuarantine() {
         onRemoveSelected={handleRemoveSelected}
         onRemoveOne={handleRemoveOne}
         onRemoveAll={handleRemoveAll}
+        onRemoveRecursive={handleRemoveRecursive}
         onSelectDifferent={() => selectFile(true)}
       />
     );
@@ -837,6 +908,7 @@ function SelectionList({
   onRemoveSelected,
   onRemoveOne,
   onRemoveAll,
+  onRemoveRecursive,
   onSelectDifferent,
 }: {
   group: ScanGroup;
@@ -853,6 +925,7 @@ function SelectionList({
     recursive: boolean,
     sources: string[],
   ) => void;
+  onRemoveRecursive: (group: ScanGroup) => void;
   onSelectDifferent: () => void;
 }) {
   const targets = useMemo<Target[]>(
@@ -863,18 +936,28 @@ function SelectionList({
   const allPaths = targets.map((t) => t.path);
   const selectedCount = allPaths.filter((p) => selected.has(p)).length;
   const total = targets.length;
+  const incomplete = group.issues.length > 0;
 
   if (total === 0) {
     return (
       <List searchBarPlaceholder="Filter quarantined items…">
         <List.EmptyView
           title={
-            group.multiSource
-              ? "No quarantine found in the selection"
-              : `No quarantine found in ${group.label}`
+            incomplete
+              ? "Scan did not complete"
+              : group.multiSource
+                ? "No quarantine found in the selection"
+                : `No quarantine found in ${group.label}`
           }
-          description={cleanGroupSummary(group)}
-          icon={{ source: Icon.Checkmark, tintColor: Color.Green }}
+          description={
+            // Never present a truncated or timed-out scan as a clean result.
+            incomplete ? group.issues.join(" ") : cleanGroupSummary(group)
+          }
+          icon={
+            incomplete
+              ? { source: Icon.ExclamationMark, tintColor: Color.Orange }
+              : { source: Icon.Checkmark, tintColor: Color.Green }
+          }
           actions={
             <ActionPanel>
               <Action
@@ -888,6 +971,17 @@ function SelectionList({
       </List>
     );
   }
+
+  // Shared element instance — referenced from the notice row and from every
+  // item's panel without allocating a copy per row.
+  const recursiveAction = (
+    <Action
+      title={`Remove Quarantine Recursively (${total + group.omitted})`}
+      icon={{ source: Icon.LockUnlocked, tintColor: Color.Green }}
+      shortcut={{ modifiers: ["cmd", "shift"], key: "r" }}
+      onAction={() => onRemoveRecursive(group)}
+    />
+  );
 
   return (
     <List
@@ -905,14 +999,44 @@ function SelectionList({
         </List.Dropdown>
       }
     >
+      {(group.omitted > 0 || incomplete) && (
+        <List.Section title="Scan Notice">
+          <List.Item
+            title={
+              group.omitted > 0
+                ? `Showing ${total} of ${total + group.omitted} quarantined items`
+                : "Scan did not complete"
+            }
+            subtitle={
+              group.omitted > 0
+                ? "Remove recursively to clear every item, including those not listed"
+                : group.issues.join(" ")
+            }
+            icon={{ source: Icon.ExclamationMark, tintColor: Color.Orange }}
+            accessories={[
+              { tag: { value: "Large scan", color: Color.Orange } },
+            ]}
+            actions={
+              <ActionPanel>
+                {recursiveAction}
+                <Action
+                  title="Select Different File"
+                  icon={Icon.Folder}
+                  shortcut={{ modifiers: ["cmd"], key: "o" }}
+                  onAction={onSelectDifferent}
+                />
+              </ActionPanel>
+            }
+          />
+        </List.Section>
+      )}
+
       <List.Section
         title={`${selectedCount} of ${total} selected · ${group.contextNote}`}
       >
         {targets.map((target) => {
           const isSelected = selected.has(target.path);
-          const parsed = target.quarantineData
-            ? parseQuarantineData(target.quarantineData)
-            : null;
+          const parsed = target.parsed;
           return (
             <List.Item
               key={target.path}
@@ -946,6 +1070,9 @@ function SelectionList({
                     icon={{ source: Icon.LockUnlocked, tintColor: Color.Green }}
                     onAction={() => onRemoveSelected(targets, group.sources)}
                   />
+                  {/* With items left unlisted, per-item removal is incomplete —
+                      keep the recursive sweep one keystroke away. */}
+                  {group.omitted > 0 && recursiveAction}
                   <Action
                     title={isSelected ? "Deselect" : "Select"}
                     icon={isSelected ? Icon.Circle : Icon.CheckCircle}
@@ -1049,8 +1176,10 @@ function sortTargets(targets: Target[], key: SortKey): Target[] {
     if (key === "path") {
       return a.title.localeCompare(b.title);
     }
-    const pa = a.quarantineData ? parseQuarantineData(a.quarantineData) : null;
-    const pb = b.quarantineData ? parseQuarantineData(b.quarantineData) : null;
+    // Pre-parsed at scan time — parsing inside the comparator meant a Date and a
+    // locale-formatted string per comparison, i.e. O(n log n) allocations.
+    const pa = a.parsed;
+    const pb = b.parsed;
     if (key === "source") {
       return (pa?.source ?? "").localeCompare(pb?.source ?? "");
     }

--- a/extensions/quarantine-manager/src/utils.ts
+++ b/extensions/quarantine-manager/src/utils.ts
@@ -539,7 +539,7 @@ function countEntries(dirPath: string, recursive: boolean): number {
  * Reads the value of com.apple.quarantine for a single path.
  * Returns the raw value, or null if the attribute is absent.
  */
-function readQuarantineValue(filePath: string): string | null {
+export function readQuarantineValue(filePath: string): string | null {
   const res = spawnSync("xattr", ["-p", QUARANTINE_ATTR, filePath], {
     encoding: "utf8",
     timeout: 5000,

--- a/extensions/quarantine-manager/src/utils.ts
+++ b/extensions/quarantine-manager/src/utils.ts
@@ -218,6 +218,45 @@ export function removeQuarantine(filePath: string): {
 }
 
 /**
+ * Runs `xattr <flags> com.apple.quarantine <paths…>` behind ONE administrator
+ * prompt, quoting each path safely inside AppleScript. `flags` is always an
+ * internal literal, never user input.
+ */
+function removeWithAdmin(
+  flags: string,
+  paths: string[],
+): { success: boolean; usedAdmin: boolean; error?: string } {
+  try {
+    execFileSync(
+      "osascript",
+      [
+        "-e",
+        "on run argv",
+        "-e",
+        `set cmd to "xattr ${flags} com.apple.quarantine"`,
+        "-e",
+        "repeat with p in argv",
+        "-e",
+        'set cmd to cmd & " " & quoted form of (contents of p)',
+        "-e",
+        "end repeat",
+        "-e",
+        "do shell script cmd with administrator privileges",
+        "-e",
+        "end run",
+        ...paths,
+      ],
+      { timeout: 120000 },
+    );
+    return { success: true, usedAdmin: true };
+  } catch (adminErr) {
+    const error =
+      adminErr instanceof Error ? adminErr.message : String(adminErr);
+    return { success: false, usedAdmin: false, error };
+  }
+}
+
+/**
  * Removes com.apple.quarantine from a specific set of paths in a single pass
  * (non-recursive `xattr -d`, so only the named paths are touched). Tries without
  * elevated privileges first, then falls back to ONE administrator prompt that
@@ -255,36 +294,32 @@ export function removeQuarantineFromPaths(paths: string[]): {
 
     if (needsAdmin.length === 0) return { success: true, usedAdmin: false };
 
-    // One admin prompt covering only the paths that were genuinely blocked,
-    // quoting each one safely inside AppleScript.
-    try {
-      execFileSync(
-        "osascript",
-        [
-          "-e",
-          "on run argv",
-          "-e",
-          'set cmd to "xattr -d com.apple.quarantine"',
-          "-e",
-          "repeat with p in argv",
-          "-e",
-          'set cmd to cmd & " " & quoted form of (contents of p)',
-          "-e",
-          "end repeat",
-          "-e",
-          "do shell script cmd with administrator privileges",
-          "-e",
-          "end run",
-          ...needsAdmin,
-        ],
-        { timeout: 60000 },
-      );
-      return { success: true, usedAdmin: true };
-    } catch (adminErr) {
-      const error =
-        adminErr instanceof Error ? adminErr.message : String(adminErr);
-      return { success: false, usedAdmin: false, error };
-    }
+    // One admin prompt covering only the paths that were genuinely blocked.
+    return removeWithAdmin("-d", needsAdmin);
+  }
+}
+
+/**
+ * Clears com.apple.quarantine from the given paths AND everything inside them
+ * (`xattr -dr`). Unlike the non-recursive form, `xattr -dr` succeeds on paths
+ * that lack the attribute, so no per-path retry pass is needed. Used when a
+ * scan finds more quarantined items than the list shows — the recursive sweep
+ * clears the whole tree, including the items that were never listed.
+ */
+export function removeQuarantineRecursivelyFromPaths(paths: string[]): {
+  success: boolean;
+  usedAdmin: boolean;
+  error?: string;
+} {
+  if (paths.length === 0) return { success: true, usedAdmin: false };
+
+  try {
+    execFileSync("xattr", ["-dr", "com.apple.quarantine", ...paths], {
+      timeout: 120000,
+    });
+    return { success: true, usedAdmin: false };
+  } catch {
+    return removeWithAdmin("-dr", paths);
   }
 }
 
@@ -373,6 +408,22 @@ export interface ParsedQuarantine {
   epoch: number | null;
 }
 
+/**
+ * Expands `\xNN` escapes that some downloaders write into the quarantine record
+ * — Free Download Manager stores its name as `Free\x20Download\x20Manager`, and
+ * the escape is in the stored attribute itself, not an artifact of reading it.
+ * Only printable results are substituted, so a decoded control byte can never
+ * end up in a list title. Applied per field AFTER splitting on ";" so a decoded
+ * `\x3b` cannot fabricate an extra field.
+ */
+function decodeXattrEscapes(value: string): string {
+  if (!value.includes("\\x")) return value;
+  return value.replace(/\\x([0-9a-fA-F]{2})/g, (match, hex) => {
+    const code = parseInt(hex, 16);
+    return code >= 0x20 && code !== 0x7f ? String.fromCharCode(code) : match;
+  });
+}
+
 export function parseQuarantineData(rawValue: string): ParsedQuarantine | null {
   // Format: FLAGHEX;TIMESTAMP_HEX;APPNAME;UUID
   const parts = rawValue.split(";");
@@ -380,7 +431,7 @@ export function parseQuarantineData(rawValue: string): ParsedQuarantine | null {
 
   const flagHex = parts[0] ?? "";
   const timestamp = parts[1] ?? "";
-  const appName = parts[2] ?? "";
+  const appName = decodeXattrEscapes(parts[2] ?? "");
   const uuid = parts[3] ?? "";
 
   const flagInt = parseInt(flagHex, 16);
@@ -394,10 +445,12 @@ export function parseQuarantineData(rawValue: string): ParsedQuarantine | null {
   let dateStr = "Unknown";
   let epoch: number | null = null;
   if (timestamp.length === 8) {
-    const mac2001Epoch = 978307200;
+    // Hex seconds since the Unix epoch — NOT Mac absolute time (2001-01-01).
+    // Verified against real records: Free Download Manager's stamp on Final Cut
+    // Pro reads 2026-06-28 as Unix seconds, and 2057 if the 2001 offset is added.
     const ts = parseInt(timestamp, 16);
     if (!isNaN(ts)) {
-      epoch = ts + mac2001Epoch;
+      epoch = ts;
       dateStr = new Date(epoch * 1000).toLocaleString("en-US");
     }
   }
@@ -418,7 +471,17 @@ export function parseQuarantineFlags(rawValue: string): string {
   return `Source: ${parsed.source} | Date: ${parsed.date} | Flags: ${parsed.flags.join(", ")}`;
 }
 
-const QUARANTINE_SUFFIX = ": com.apple.quarantine";
+const QUARANTINE_ATTR = "com.apple.quarantine";
+
+/**
+ * Upper bound on how many quarantined items are listed — applied per directory
+ * here, and again across the whole selection by the caller. A .app installed
+ * from a DMG or zip carries the flag on EVERY file inside it (Final Cut Pro:
+ * ~38k), and rendering one row — each with its own action panel and detail
+ * view — per file exhausts the extension's heap. Items past the cap are
+ * reported as a count and cleared via recursive removal.
+ */
+export const MAX_SCAN_ENTRIES = 500;
 
 export interface DirEntry {
   path: string;
@@ -435,10 +498,18 @@ export interface DirectoryScan {
   scanMode: "recursive" | "shallow";
   /** The directory's own com.apple.quarantine attribute, if any */
   rootQuarantineData: string | null;
-  /** Quarantined items found inside the directory (excludes the root itself) */
+  /** Quarantined items found inside the directory (excludes the root itself), capped at MAX_SCAN_ENTRIES */
   entries: DirEntry[];
-  /** How many items were examined for quarantine (immediate for shallow, all descendants for recursive) */
-  scannedCount: number;
+  /** Quarantined items found before the cap was applied */
+  totalFound: number;
+  /**
+   * How many items were examined for quarantine. Only computed when nothing was
+   * found (the sole place it is displayed); null otherwise, so a large tree is
+   * never walked twice just to produce a number no one sees.
+   */
+  scannedCount: number | null;
+  /** Set when the scan could not run to completion, so partial output is never presented as a clean result */
+  scanError: string | null;
   lastModified: string;
 }
 
@@ -469,7 +540,7 @@ function countEntries(dirPath: string, recursive: boolean): number {
  * Returns the raw value, or null if the attribute is absent.
  */
 function readQuarantineValue(filePath: string): string | null {
-  const res = spawnSync("xattr", ["-p", "com.apple.quarantine", filePath], {
+  const res = spawnSync("xattr", ["-p", QUARANTINE_ATTR, filePath], {
     encoding: "utf8",
     timeout: 5000,
   });
@@ -479,22 +550,72 @@ function readQuarantineValue(filePath: string): string | null {
   return null;
 }
 
+const QUARANTINE_LINE = /^(.*): ([0-9a-fA-F]*;[0-9a-fA-F]*;.*)$/;
+
 /**
- * Parses `xattr` listing output (one `<path>: <attr>` line per attribute) and
- * returns the paths that carry com.apple.quarantine. Matching on the exact
- * suffix keeps paths containing ": " intact.
+ * Splits one `xattr -p` output line into its path and value. A path can itself
+ * contain ": " (a file may legitimately be named "a: b"), so the split is
+ * anchored on the quarantine value's shape — `<flags>;<timestamp>;` — with a
+ * greedy path match, which lands on the last viable separator.
  */
-function collectQuarantinedPaths(
+function parseQuarantineLine(
+  line: string,
+): { path: string; value: string } | null {
+  const match = QUARANTINE_LINE.exec(line);
+  if (match) return { path: match[1], value: match[2] };
+  // A value that doesn't follow the documented shape still carries a path
+  // prefix; fall back to the first separator rather than dropping the entry.
+  const idx = line.indexOf(": ");
+  if (idx <= 0) return null;
+  return { path: line.slice(0, idx), value: line.slice(idx + 2) };
+}
+
+/**
+ * Turns `xattr -p com.apple.quarantine` output (one `<path>: <value>` line per
+ * match) into entries appended to `entries`, skipping `dirPath` itself — it is
+ * reported separately as the root, and in shallow mode it is also passed as a
+ * sentinel argument. Stops collecting at MAX_SCAN_ENTRIES but keeps counting,
+ * so the caller can report how much was left out. Returns the count found.
+ */
+function collectEntries(
   stdout: string,
-  excludePath?: string,
-): string[] {
-  const paths: string[] = [];
+  dirPath: string,
+  entries: DirEntry[],
+): number {
+  let found = 0;
   for (const line of stdout.split("\n")) {
-    if (!line.endsWith(QUARANTINE_SUFFIX)) continue;
-    const p = line.slice(0, -QUARANTINE_SUFFIX.length);
-    if (p && p !== excludePath) paths.push(p);
+    if (!line) continue;
+    const parsed = parseQuarantineLine(line);
+    if (!parsed || !parsed.path || parsed.path === dirPath) continue;
+    found++;
+    if (entries.length >= MAX_SCAN_ENTRIES) continue;
+    entries.push({
+      path: parsed.path,
+      name: getFileName(parsed.path),
+      relativePath:
+        path.relative(dirPath, parsed.path) || getFileName(parsed.path),
+      quarantineData: parsed.value.trim(),
+    });
   }
-  return paths;
+  return found;
+}
+
+/**
+ * Describes why a spawned scan could not complete. `status` is deliberately
+ * ignored: `xattr -p` exits non-zero whenever ANY path lacks the attribute,
+ * which is the normal case, so only a spawn-level error (ENOBUFS from a
+ * truncated buffer, ETIMEDOUT from the timeout) means the output is incomplete.
+ */
+function scanFailure(error: Error | undefined, what: string): string | null {
+  if (!error) return null;
+  const code = (error as NodeJS.ErrnoException).code;
+  if (code === "ENOBUFS") {
+    return `${what} produced more output than could be read — results are incomplete.`;
+  }
+  if (code === "ETIMEDOUT") {
+    return `${what} timed out — results are incomplete.`;
+  }
+  return `${what} failed: ${error.message}`;
 }
 
 /**
@@ -510,17 +631,22 @@ export function scanDirectory(dirPath: string): DirectoryScan {
   // The directory's own quarantine flag.
   const rootQuarantineData = readQuarantineValue(dirPath);
 
-  // List candidate paths in a single batched call.
-  let quarantinedPaths: string[] = [];
-  let scannedCount = 0;
+  // Read paths AND values in one pass. Asking xattr for the quarantine
+  // attribute directly (rather than listing every attribute and then reading
+  // each match back individually) turns a 1 + N process storm — one `xattr -p`
+  // per quarantined file, ~2ms each — into a single call per batch.
+  const entries: DirEntry[] = [];
+  let totalFound = 0;
+  let scanError: string | null = null;
+
   if (scanMode === "recursive") {
-    scannedCount = countEntries(dirPath, true);
-    const res = spawnSync("xattr", ["-r", dirPath], {
+    const res = spawnSync("xattr", ["-p", QUARANTINE_ATTR, "-r", dirPath], {
       encoding: "utf8",
-      timeout: 60000,
-      maxBuffer: 64 * 1024 * 1024,
+      timeout: 120000,
+      maxBuffer: 32 * 1024 * 1024,
     });
-    quarantinedPaths = collectQuarantinedPaths(res.stdout ?? "", dirPath);
+    scanError = scanFailure(res.error, "Scanning this bundle");
+    totalFound = collectEntries(res.stdout ?? "", dirPath, entries);
   } else {
     let children: string[] = [];
     try {
@@ -528,32 +654,31 @@ export function scanDirectory(dirPath: string): DirectoryScan {
     } catch {
       children = [];
     }
-    scannedCount = children.length;
     // Process children in chunks to stay well under ARG_MAX, and append dirPath
     // as a sentinel so every call has >= 2 path arguments. With a single path,
-    // xattr prints bare attribute names (no "<path>: " prefix); the extra arg
-    // forces the prefixed format so a lone quarantined child is never missed.
+    // xattr prints the bare value (no "<path>: " prefix); the extra arg forces
+    // the prefixed format so a lone quarantined child is never missed.
     const CHUNK = 256;
     for (let i = 0; i < children.length; i += CHUNK) {
       const batch = children.slice(i, i + CHUNK);
-      const res = spawnSync("xattr", [...batch, dirPath], {
-        encoding: "utf8",
-        timeout: 30000,
-        maxBuffer: 64 * 1024 * 1024,
-      });
-      quarantinedPaths.push(
-        ...collectQuarantinedPaths(res.stdout ?? "", dirPath),
+      const res = spawnSync(
+        "xattr",
+        ["-p", QUARANTINE_ATTR, ...batch, dirPath],
+        {
+          encoding: "utf8",
+          timeout: 30000,
+          maxBuffer: 32 * 1024 * 1024,
+        },
       );
+      scanError = scanError ?? scanFailure(res.error, "Scanning this folder");
+      totalFound += collectEntries(res.stdout ?? "", dirPath, entries);
     }
   }
 
-  // Fetch values only for the (typically small) set of quarantined paths.
-  const entries: DirEntry[] = quarantinedPaths.map((p) => ({
-    path: p,
-    name: getFileName(p),
-    relativePath: path.relative(dirPath, p) || getFileName(p),
-    quarantineData: readQuarantineValue(p),
-  }));
+  // Only worth walking the tree for a scope number when there is nothing to
+  // show — with findings present, the count is never displayed.
+  const scannedCount =
+    totalFound === 0 ? countEntries(dirPath, scanMode === "recursive") : null;
 
   let lastModified = "unknown";
   try {
@@ -569,7 +694,9 @@ export function scanDirectory(dirPath: string): DirectoryScan {
     scanMode,
     rootQuarantineData,
     entries,
+    totalFound,
     scannedCount,
+    scanError,
     lastModified,
   };
 }


### PR DESCRIPTION
## Description

Fixes an out-of-memory crash reported through Raycast's error reporting for the `manage-quarantine` command (`Worker terminated due to reaching memory limit: JS heap out of memory`), plus two data-correctness bugs found while tracing it.

**The crash.** An app installed from a DMG or zip carries `com.apple.quarantine` on *every* file inside the bundle, not just the bundle root — `Final Cut Pro.app` on my machine has 38,114 of them. The scan then did two unbounded things: it read each match back with its own `xattr -p` child process (~2ms each, so ~75s of blocking `spawnSync` calls), and it rendered one `List.Item` per file, each with an 11-action panel and an eagerly-constructed `Detail` subtree. That is what exhausted the worker heap.

- Paths and values now come from a single `xattr -p com.apple.quarantine -r` pass instead of a listing pass plus one process per match — **2.5s and one process**, down from ~75s and 38k processes. Line parsing is anchored on the quarantine value's shape so paths containing `": "` still parse correctly.
- Listings are capped at 500 items (per directory and across the whole selection). The true count is reported in a notice row, and a new **Remove Quarantine Recursively** action (`⌘⇧R`) clears everything including the unlisted items — without it, per-item removal would silently leave them quarantined.
- Quarantine data is parsed once per target instead of inside the sort comparator (which built a `Date` and a locale-formatted string per comparison) and again per render.
- `spawnSync` failures are now surfaced. `ENOBUFS`/`ETIMEDOUT` produce a visible "scan did not complete" state; previously the truncated output was reported as "No quarantine found", i.e. a failed scan looked like a clean file. Exit status is deliberately still ignored, since `xattr -p` exits non-zero whenever any path simply lacks the attribute.
- The tree is only walked for a scope count when nothing was found, since that count is displayed solely in the empty state.

**Download dates were 31 years in the future.** The quarantine timestamp is hex seconds since the Unix epoch, but it was being read as Mac absolute time (adding the 2001-01-01 offset). Verified against real records: Free Download Manager's stamp on Final Cut Pro reads `2026-06-28` correctly and `2057-06-28` under the old code. Sort order was unaffected — the offset was uniform — so only the displayed dates change.

**Escaped source names.** Some downloaders write `\xNN` escapes into the quarantine record (`Free\x20Download\x20Manager`). These are now decoded for display. Decoding happens per field *after* splitting on `;`, so a decoded `\x3b` cannot fabricate an extra field, and non-printable results are left escaped.

### Measured on `/Applications/Final Cut Pro.app` (38,114 quarantined files)

| | before | after |
|---|---|---|
| scan | ~75s, 38,114 child processes | 2.5s, 1 process |
| rows rendered | 38,114 | 500 + notice row |
| result | JS heap out of memory | 17 MB heap |

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
