### PR TITLE
Thock: add Preview Soundpack command

### DIFF
--- a/extensions/thock/CHANGELOG.md
+++ b/extensions/thock/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Thock Changelog
 
+## [Preview Soundpack] - {PR_MERGE_DATE}
+
+- Added a `Preview Soundpack` command that lists the soundpack registry and plays a few keystrokes from any pack without installing it
+- Installed packs are tagged and can be set as the active soundpack from the same list
+
 ## [Chore: Updated the README] - 2025-05-12
 
 ## [Initial Version] - 2025-05-02

--- a/extensions/thock/README.md
+++ b/extensions/thock/README.md
@@ -2,6 +2,12 @@
 
 Control Thock with Raycast
 
+## Commands
+
+- **Toggle Thock** — enable or disable Thock.
+- **Set Switch Set** — pick the active switch set.
+- **Preview Soundpack** — browse the soundpack registry and hear any pack before installing it. Packs you already have are tagged `Installed` and can be set as active from the same list.
+
 Note: 
 thock-cli is bundled automatically when you install Thock via Homebrew:
 `brew install thock`

--- a/extensions/thock/package.json
+++ b/extensions/thock/package.json
@@ -26,6 +26,13 @@
       "subtitle": "Thock",
       "description": "Sets Switch Set",
       "mode": "view"
+    },
+    {
+      "name": "previewSoundpack",
+      "title": "Preview Soundpack",
+      "subtitle": "Thock",
+      "description": "Hear a soundpack before installing it",
+      "mode": "view"
     }
   ],
   "dependencies": {

--- a/extensions/thock/src/previewSoundpack.tsx
+++ b/extensions/thock/src/previewSoundpack.tsx
@@ -1,14 +1,15 @@
 import { Action, ActionPanel, Color, Icon, List, Toast, showToast } from "@raycast/api";
 import { useFetch } from "@raycast/utils";
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import fs from "fs";
 import os from "os";
 import path from "path";
 import { promisify } from "util";
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
-const THOCK_CLI_PATH = "/opt/homebrew/bin/thock-cli";
+// Apple Silicon and Intel Homebrew prefixes; falls back to whatever is on $PATH.
+const CLI_CANDIDATES = ["/opt/homebrew/bin/thock-cli", "/usr/local/bin/thock-cli"];
 const MANIFEST_URL = "https://raw.githubusercontent.com/kamillobinski/thock-soundpacks/refs/heads/main/manifest.json";
 const SOUNDPACKS_DIR = path.join(os.homedir(), "Library", "Application Support", "Thock", "Soundpacks");
 
@@ -29,6 +30,19 @@ function isInstalled(id: string): boolean {
   return fs.existsSync(path.join(SOUNDPACKS_DIR, id, "config.json"));
 }
 
+/**
+ * Runs thock-cli with the given arguments.
+ *
+ * Uses `execFile` rather than `exec` so no shell is involved: the soundpack ids come from
+ * a remote manifest, and must never be able to reach a shell as syntax.
+ */
+async function runThockCli(args: string[]) {
+  const cliPath = CLI_CANDIDATES.find((candidate) => fs.existsSync(candidate)) ?? "thock-cli";
+  await execFileAsync(cliPath, args, {
+    env: { ...process.env, PATH: [process.env.PATH, "/opt/homebrew/bin", "/usr/local/bin"].filter(Boolean).join(":") },
+  });
+}
+
 async function preview(soundpack: Soundpack) {
   const toast = await showToast({
     style: Toast.Style.Animated,
@@ -37,7 +51,7 @@ async function preview(soundpack: Soundpack) {
 
   try {
     // Plays a few keystrokes from the pack without installing it.
-    await execAsync(`${THOCK_CLI_PATH} preview "${soundpack.id}"`);
+    await runThockCli(["preview", soundpack.id]);
     toast.style = Toast.Style.Success;
     toast.title = `Previewed ${soundpack.metadata.name}`;
   } catch (err) {
@@ -49,7 +63,7 @@ async function preview(soundpack: Soundpack) {
 
 async function setSoundpack(soundpack: Soundpack) {
   try {
-    await execAsync(`${THOCK_CLI_PATH} set-soundpack "${soundpack.id}"`);
+    await runThockCli(["set-soundpack", soundpack.id]);
     await showToast({ style: Toast.Style.Success, title: `Selected ${soundpack.metadata.name}` });
   } catch (err) {
     await showToast({

--- a/extensions/thock/src/previewSoundpack.tsx
+++ b/extensions/thock/src/previewSoundpack.tsx
@@ -1,0 +1,98 @@
+import { Action, ActionPanel, Color, Icon, List, Toast, showToast } from "@raycast/api";
+import { useFetch } from "@raycast/utils";
+import { exec } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { promisify } from "util";
+
+const execAsync = promisify(exec);
+
+const THOCK_CLI_PATH = "/opt/homebrew/bin/thock-cli";
+const MANIFEST_URL = "https://raw.githubusercontent.com/kamillobinski/thock-soundpacks/refs/heads/main/manifest.json";
+const SOUNDPACKS_DIR = path.join(os.homedir(), "Library", "Application Support", "Thock", "Soundpacks");
+
+type Soundpack = {
+  id: string;
+  metadata: {
+    name: string;
+    brand: string;
+    author: string;
+  };
+};
+
+type Manifest = {
+  soundpacks: Record<string, Soundpack[]>;
+};
+
+function isInstalled(id: string): boolean {
+  return fs.existsSync(path.join(SOUNDPACKS_DIR, id, "config.json"));
+}
+
+async function preview(soundpack: Soundpack) {
+  const toast = await showToast({
+    style: Toast.Style.Animated,
+    title: `Previewing ${soundpack.metadata.name}`,
+  });
+
+  try {
+    // Plays a few keystrokes from the pack without installing it.
+    await execAsync(`${THOCK_CLI_PATH} preview "${soundpack.id}"`);
+    toast.style = Toast.Style.Success;
+    toast.title = `Previewed ${soundpack.metadata.name}`;
+  } catch (err) {
+    toast.style = Toast.Style.Failure;
+    toast.title = "Preview failed";
+    toast.message = err instanceof Error ? err.message : String(err);
+  }
+}
+
+async function setSoundpack(soundpack: Soundpack) {
+  try {
+    await execAsync(`${THOCK_CLI_PATH} set-soundpack "${soundpack.id}"`);
+    await showToast({ style: Toast.Style.Success, title: `Selected ${soundpack.metadata.name}` });
+  } catch (err) {
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "Could not select soundpack",
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+export default function Command() {
+  const { data, isLoading } = useFetch<Manifest>(MANIFEST_URL, {
+    failureToastOptions: { title: "Could not load the soundpack registry" },
+  });
+
+  const categories = Object.entries(data?.soundpacks ?? {});
+
+  return (
+    <List isLoading={isLoading} searchBarPlaceholder="Search soundpacks">
+      {categories.map(([category, soundpacks]) => (
+        <List.Section key={category} title={category.charAt(0).toUpperCase() + category.slice(1)}>
+          {soundpacks.map((soundpack) => {
+            const installed = isInstalled(soundpack.id);
+            return (
+              <List.Item
+                key={soundpack.id}
+                title={soundpack.metadata.name}
+                subtitle={`${soundpack.metadata.brand} · ${soundpack.metadata.author}`}
+                keywords={[soundpack.metadata.brand, soundpack.metadata.author]}
+                accessories={installed ? [{ tag: { value: "Installed", color: Color.Green } }] : []}
+                actions={
+                  <ActionPanel>
+                    <Action title="Preview" icon={Icon.SpeakerOn} onAction={() => preview(soundpack)} />
+                    {installed && (
+                      <Action title="Set as Active" icon={Icon.Keyboard} onAction={() => setSoundpack(soundpack)} />
+                    )}
+                  </ActionPanel>
+                }
+              />
+            );
+          })}
+        </List.Section>
+      ))}
+    </List>
+  );
+}


### PR DESCRIPTION
## Description

Adds a **Preview Soundpack** command to the Thock extension: browse the Thock soundpack registry and hear any pack played back as a few keystrokes, without installing it.

- Fetches the registry manifest live, so the list stays current instead of being hardcoded.
- Sectioned by category (Keyboard / Mouse), searchable by name, brand, or author.
- Packs already on disk are tagged `Installed` and get a secondary **Set as Active** action.
- **Preview** shells out to `thock-cli preview <uuid>`, with an animated toast while it plays.

## Dependency — please don't merge yet

The `preview` subcommand this calls is not in a released `thock-cli` yet. It's proposed upstream in kamillobinski/thock#135 (issue kamillobinski/thock#134). Keeping this as a draft until that lands and ships; happy to rebase or adjust naming if the upstream command changes.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder

`npx ray build`, `npx ray lint`, and `npx tsc --noEmit` are all clean.
