### PR TITLE
[Shottr] Add new "closeMainWindow" preference

### DIFF
--- a/extensions/shottr/CHANGELOG.md
+++ b/extensions/shottr/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Shottr Changelog
 
+## [Add Close Main Window preference] - {PR_MERGE_DATE}
+
+- Added a "Close Main Window" preference.
+
 ## [Fix didn't close Raycast main window] - 2026-07-07
 
 - Added `closeMainWindow()` to all commands so the Raycast window closes immediately when triggering a Shottr action.

--- a/extensions/shottr/CHANGELOG.md
+++ b/extensions/shottr/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Shottr Changelog
 
-## [Add Close Main Window preference] - {PR_MERGE_DATE}
+## [Add Close Main Window preference] - 2026-07-28
 
 - Added a "Close Main Window" preference.
 

--- a/extensions/shottr/README.md
+++ b/extensions/shottr/README.md
@@ -13,13 +13,14 @@ Shottr is a tiny and fast mac screenshot tool with annotations, beautiful backgr
 
 ## Table of Contents
 
-- [Introduction](#introduction)
-- [Installation and Setup](#installation-and-setup)
-- [Using Shottr](#using-shottr)
-  - [Screen Capture Features](#screen-capture-features)
-  - [Recording Features](#recording-features)
-- [Troubleshooting](#troubleshooting)
-- [Feedback and Support](#feedback-and-support)
+- [Shottr Extension User Guide](#shottr-extension-user-guide)
+  - [Table of Contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [Installation and Setup](#installation-and-setup)
+  - [Preferences](#preferences)
+    - [Close Main Window](#close-main-window)
+  - [Using Shottr](#using-shottr)
+  - [Troubleshooting](#troubleshooting)
 
 ## Introduction
 
@@ -34,6 +35,21 @@ Before using the Shottr Extension:
 3. Enable the URL Schema API in Shottr settings.
 4. Install the Shottr Extension for Raycast from the Raycast store.
 5. Once installed, you will find various commands under the Shottr Extension in Raycast.
+
+## Preferences
+
+### Close Main Window
+
+This extension provides a preference to control whether Raycast's main window is closed before executing a screenshot command.
+
+| Setting          | Behavior                                                                                                                                                                                          |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ON** (default) | Closes the Raycast main window before taking a screenshot — prevents the Raycast UI from appearing in your capture. However, you will **not** be able to screenshot Raycast's main window itself. |
+| **OFF**          | Does not close the main window — recommended if you trigger commands via **keyboard shortcuts**, since the main window won't be opened in the first place.                                        |
+
+**When to use ON:** You trigger Shottr commands by opening Raycast's main window and searching for the command.
+
+**When to use OFF:** You have keyboard shortcuts bound directly to each Shottr command.
 
 ## Using Shottr
 

--- a/extensions/shottr/package.json
+++ b/extensions/shottr/package.json
@@ -139,6 +139,17 @@
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish"
   },
+  "preferences": [
+    {
+      "name": "closeMainWindow",
+      "title": "Close Main Window",
+      "description": "If you trigger commands by opening Raycast's main window (instead of keyboard shortcuts), keep this ON to ensure the main window closes before taking a screenshot — otherwise it may appear in the capture. Note: with this ON, you cannot screenshot Raycast's main window itself. If you trigger commands via keyboard shortcuts, set this to OFF — the main window won't open, so there's no need to close it.",
+      "type": "checkbox",
+      "required": true,
+      "default": true,
+      "label": "Close Raycast Main Window before capturing"
+    }
+  ],
   "platforms": [
     "macOS"
   ]

--- a/extensions/shottr/src/ssa.tsx
+++ b/extensions/shottr/src/ssa.tsx
@@ -1,9 +1,10 @@
-import { closeMainWindow } from "@raycast/api";
 import { withShottrCheck } from "./utils/checkInstall";
+import { withCloseMainWindow } from "./utils/withCloseMainWindow";
 import { execSync } from "child_process";
 
-export default withShottrCheck(async function () {
-  const url = "shottr://grab/area";
-  await closeMainWindow();
-  execSync(`open -g ${url}`);
-});
+export default withShottrCheck(
+  withCloseMainWindow(async function () {
+    const url = "shottr://grab/area";
+    execSync(`open -g ${url}`);
+  }),
+);

--- a/extensions/shottr/src/ssap.tsx
+++ b/extensions/shottr/src/ssap.tsx
@@ -1,9 +1,10 @@
-import { closeMainWindow } from "@raycast/api";
 import { withShottrCheck } from "./utils/checkInstall";
+import { withCloseMainWindow } from "./utils/withCloseMainWindow";
 import { execSync } from "child_process";
 
-export default withShottrCheck(async function () {
-  const url = "shottr://grab/append";
-  await closeMainWindow();
-  execSync(`open -g ${url}`);
-});
+export default withShottrCheck(
+  withCloseMainWindow(async function () {
+    const url = "shottr://grab/append";
+    execSync(`open -g ${url}`);
+  }),
+);

--- a/extensions/shottr/src/ssc.tsx
+++ b/extensions/shottr/src/ssc.tsx
@@ -1,9 +1,10 @@
-import { closeMainWindow } from "@raycast/api";
 import { withShottrCheck } from "./utils/checkInstall";
+import { withCloseMainWindow } from "./utils/withCloseMainWindow";
 import { execSync } from "child_process";
 
-export default withShottrCheck(async function () {
-  const url = "shottr://load/clipboard";
-  await closeMainWindow();
-  execSync(`open -g ${url}`);
-});
+export default withShottrCheck(
+  withCloseMainWindow(async function () {
+    const url = "shottr://load/clipboard";
+    execSync(`open -g ${url}`);
+  }),
+);

--- a/extensions/shottr/src/ssds.tsx
+++ b/extensions/shottr/src/ssds.tsx
@@ -1,13 +1,15 @@
-import { LaunchProps, closeMainWindow } from "@raycast/api";
+import { LaunchProps } from "@raycast/api";
 import { withShottrCheck } from "./utils/checkInstall";
+import { withCloseMainWindow } from "./utils/withCloseMainWindow";
 import { execSync } from "child_process";
 
 interface Arguments {
   delay?: string;
 }
 
-export default withShottrCheck(async function (props: LaunchProps<{ arguments: Arguments }>) {
-  const url = "shottr://grab/delayed";
-  await closeMainWindow();
-  execSync(`open -g ${url}?t=${props?.arguments?.delay || "3"}`);
-});
+export default withShottrCheck(
+  withCloseMainWindow(async function (props: LaunchProps<{ arguments: Arguments }>) {
+    const url = "shottr://grab/delayed";
+    execSync(`open -g ${url}?t=${props?.arguments?.delay || "3"}`);
+  }),
+);

--- a/extensions/shottr/src/ssf.tsx
+++ b/extensions/shottr/src/ssf.tsx
@@ -1,9 +1,10 @@
-import { closeMainWindow } from "@raycast/api";
 import { withShottrCheck } from "./utils/checkInstall";
+import { withCloseMainWindow } from "./utils/withCloseMainWindow";
 import { execSync } from "child_process";
 
-export default withShottrCheck(async function () {
-  const url = "shottr://load/file";
-  await closeMainWindow();
-  execSync(`open -g ${url}`);
-});
+export default withShottrCheck(
+  withCloseMainWindow(async function () {
+    const url = "shottr://load/file";
+    execSync(`open -g ${url}`);
+  }),
+);

--- a/extensions/shottr/src/ssfs.tsx
+++ b/extensions/shottr/src/ssfs.tsx
@@ -1,9 +1,10 @@
-import { closeMainWindow } from "@raycast/api";
 import { withShottrCheck } from "./utils/checkInstall";
+import { withCloseMainWindow } from "./utils/withCloseMainWindow";
 import { execSync } from "child_process";
 
-export default withShottrCheck(async function () {
-  const url = "shottr://grab/fullscreen";
-  await closeMainWindow();
-  execSync(`open -g ${url}`);
-});
+export default withShottrCheck(
+  withCloseMainWindow(async function () {
+    const url = "shottr://grab/fullscreen";
+    execSync(`open -g ${url}`);
+  }),
+);

--- a/extensions/shottr/src/sso.tsx
+++ b/extensions/shottr/src/sso.tsx
@@ -1,9 +1,10 @@
-import { closeMainWindow } from "@raycast/api";
 import { withShottrCheck } from "./utils/checkInstall";
+import { withCloseMainWindow } from "./utils/withCloseMainWindow";
 import { execSync } from "child_process";
 
-export default withShottrCheck(async function () {
-  const url = "shottr://ocr";
-  await closeMainWindow();
-  execSync(`open -g ${url}`);
-});
+export default withShottrCheck(
+  withCloseMainWindow(async function () {
+    const url = "shottr://ocr";
+    execSync(`open -g ${url}`);
+  }),
+);

--- a/extensions/shottr/src/ssrg.tsx
+++ b/extensions/shottr/src/ssrg.tsx
@@ -1,9 +1,10 @@
-import { closeMainWindow } from "@raycast/api";
 import { withShottrCheck } from "./utils/checkInstall";
+import { withCloseMainWindow } from "./utils/withCloseMainWindow";
 import { execSync } from "child_process";
 
-export default withShottrCheck(async function () {
-  const url = "shottr://grab/window";
-  await closeMainWindow();
-  execSync(`open -g ${url}`);
-});
+export default withShottrCheck(
+  withCloseMainWindow(async function () {
+    const url = "shottr://grab/window";
+    execSync(`open -g ${url}`);
+  }),
+);

--- a/extensions/shottr/src/sss.tsx
+++ b/extensions/shottr/src/sss.tsx
@@ -1,9 +1,10 @@
-import { closeMainWindow } from "@raycast/api";
 import { withShottrCheck } from "./utils/checkInstall";
+import { withCloseMainWindow } from "./utils/withCloseMainWindow";
 import { execSync } from "child_process";
 
-export default withShottrCheck(async function () {
-  const url = "shottr://grab/scrolling";
-  await closeMainWindow();
-  execSync(`open -g ${url}`);
-});
+export default withShottrCheck(
+  withCloseMainWindow(async function () {
+    const url = "shottr://grab/scrolling";
+    execSync(`open -g ${url}`);
+  }),
+);

--- a/extensions/shottr/src/sssr.tsx
+++ b/extensions/shottr/src/sssr.tsx
@@ -1,9 +1,10 @@
-import { closeMainWindow } from "@raycast/api";
 import { withShottrCheck } from "./utils/checkInstall";
+import { withCloseMainWindow } from "./utils/withCloseMainWindow";
 import { execSync } from "child_process";
 
-export default withShottrCheck(async function () {
-  const url = "shottr://grab/delayed";
-  await closeMainWindow();
-  execSync(`open -g ${url}`);
-});
+export default withShottrCheck(
+  withCloseMainWindow(async function () {
+    const url = "shottr://grab/delayed";
+    execSync(`open -g ${url}`);
+  }),
+);

--- a/extensions/shottr/src/ssst.tsx
+++ b/extensions/shottr/src/ssst.tsx
@@ -1,9 +1,10 @@
-import { closeMainWindow } from "@raycast/api";
 import { withShottrCheck } from "./utils/checkInstall";
+import { withCloseMainWindow } from "./utils/withCloseMainWindow";
 import { execSync } from "child_process";
 
-export default withShottrCheck(async function () {
-  const url = "shottr://settings";
-  await closeMainWindow();
-  execSync(`open -g ${url}`);
-});
+export default withShottrCheck(
+  withCloseMainWindow(async function () {
+    const url = "shottr://settings";
+    execSync(`open -g ${url}`);
+  }),
+);

--- a/extensions/shottr/src/sstr.tsx
+++ b/extensions/shottr/src/sstr.tsx
@@ -1,9 +1,10 @@
-import { closeMainWindow } from "@raycast/api";
 import { withShottrCheck } from "./utils/checkInstall";
+import { withCloseMainWindow } from "./utils/withCloseMainWindow";
 import { execSync } from "child_process";
 
-export default withShottrCheck(async function () {
-  const url = "shottr://show";
-  await closeMainWindow();
-  execSync(`open -g ${url}`);
-});
+export default withShottrCheck(
+  withCloseMainWindow(async function () {
+    const url = "shottr://show";
+    execSync(`open -g ${url}`);
+  }),
+);

--- a/extensions/shottr/src/ssu.tsx
+++ b/extensions/shottr/src/ssu.tsx
@@ -1,9 +1,10 @@
-import { closeMainWindow } from "@raycast/api";
 import { withShottrCheck } from "./utils/checkInstall";
+import { withCloseMainWindow } from "./utils/withCloseMainWindow";
 import { execSync } from "child_process";
 
-export default withShottrCheck(async function () {
-  const url = "shottr://uploads";
-  await closeMainWindow();
-  execSync(`open -g ${url}`);
-});
+export default withShottrCheck(
+  withCloseMainWindow(async function () {
+    const url = "shottr://uploads";
+    execSync(`open -g ${url}`);
+  }),
+);

--- a/extensions/shottr/src/ssw.tsx
+++ b/extensions/shottr/src/ssw.tsx
@@ -1,9 +1,10 @@
-import { closeMainWindow } from "@raycast/api";
 import { withShottrCheck } from "./utils/checkInstall";
+import { withCloseMainWindow } from "./utils/withCloseMainWindow";
 import { execSync } from "child_process";
 
-export default withShottrCheck(async function () {
-  const url = "shottr://grab/repeat";
-  await closeMainWindow();
-  execSync(`open -g ${url}`);
-});
+export default withShottrCheck(
+  withCloseMainWindow(async function () {
+    const url = "shottr://grab/repeat";
+    execSync(`open -g ${url}`);
+  }),
+);

--- a/extensions/shottr/src/utils/withCloseMainWindow.ts
+++ b/extensions/shottr/src/utils/withCloseMainWindow.ts
@@ -1,0 +1,9 @@
+import { closeMainWindow, getPreferenceValues } from "@raycast/api";
+
+export function withCloseMainWindow<T>(fn: (props: T) => unknown) {
+  return async function (props: T) {
+    const { closeMainWindow: shouldClose } = getPreferenceValues<Preferences>();
+    if (shouldClose) await closeMainWindow();
+    return fn(props);
+  };
+}


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

Add a new "closeMainWindow" preference to allow capturing Raycast's main window.

Previously, I added the close-main-window behavior to fix the issue (https://github.com/raycast/extensions/pull/29268) where Raycast's main window would remain open when triggering commands from it (as opposed to using hotkeys). However, this made it impossible to capture Raycast's main window itself when we really want to. This PR adds a new preference to re-enable that capability.
## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

<img width="939" height="232" alt="image" src="https://github.com/user-attachments/assets/aeff3a58-b0e0-4b7e-be5b-4f932bb55142" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
