### PR TITLE
Update model-context-protocol-registry: UseMyContext description

### DIFF
--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Model Context Protocol Registry Changelog
 
+## [Update UseMyContext description] - {PR_MERGE_DATE}
+
+Remove the hard-coded tool count from the UseMyContext description. The server's tool surface has grown since the original submission (now 13 tools), and a number in the listing goes stale with every addition - the description now names the capabilities without a count.
+
 ## [Add UseMyContext MCP Server] - 2026-07-28
 
 Add UseMyContext to the official registry: the personal context layer for AI - one user-owned profile plus files, read by any MCP client so you never re-introduce yourself. 8 tools (profile, file search and reads, cited answers from documents, exact table queries, suggested updates, shared contexts). Remote Streamable HTTP endpoint via mcp-remote with OAuth 2.1 sign-in; free tier, no API key.

--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Model Context Protocol Registry Changelog
 
-## [Update UseMyContext description] - {PR_MERGE_DATE}
+## [Update UseMyContext description] - 2026-07-28
 
 Remove the hard-coded tool count from the UseMyContext description. The server's tool surface has grown since the original submission (now 13 tools), and a number in the listing goes stale with every addition - the description now names the capabilities without a count.
 

--- a/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
+++ b/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
@@ -779,7 +779,7 @@ export const OFFICIAL_ENTRIES: RegistryEntry[] = [
     name: "usemycontext",
     title: "UseMyContext",
     description:
-      "The personal context layer for AI: one user-owned profile plus files, read by any MCP client so you never re-introduce yourself. 8 tools for profile, file search and reads, cited answers from your documents, and exact table queries. Connects to the remote UseMyContext server over OAuth 2.1.",
+      "The personal context layer for AI: one user-owned profile plus files, read by any MCP client so you never re-introduce yourself. Tools for profile, file search and reads, cited answers from your documents, and exact table queries. Connects to the remote UseMyContext server over OAuth 2.1.",
     icon: "usemycontext.svg",
     homepage: "https://usemycontext.ai",
     configuration: {


### PR DESCRIPTION
## Description

Removes the hard-coded tool count from the UseMyContext registry entry description (`8 tools for profile, ...` -> `Tools for profile, ...`).

The server's tool surface has grown since the original submission (13 tools today), so the listed `8` already understates it - and any number in the description goes stale again with the next addition. The capability summary (profile, file search and reads, cited answers from documents, exact table queries) stays as is.

One word changed in `entries.ts`, plus the changelog entry.

## Type of change

- [x] Existing extension update

## Checklist

- [x] The change is limited to the `model-context-protocol-registry` extension
- [x] CHANGELOG.md entry added with `{PR_MERGE_DATE}`