### PR TITLE
Fix OTP Inbox HTML parsing and add safe verification links

### DIFF
--- a/extensions/otp-inbox/CHANGELOG.md
+++ b/extensions/otp-inbox/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 - Add Windows support
 
+## [Update] - {PR_MERGE_DATE}
+
+- Prefer plain-text MIME content and sanitize HTML fallback before verification-method extraction.
+- Accept only one unambiguous 4–8 digit numeric OTP.
+- Prevent HTML/CSS tokens such as `font-size` from being exposed as pasteable codes.
+- Add explicit, manually invoked Open/Copy actions for high-confidence HTTPS verification CTAs.
+- Keep OTP and verification-link actions independent when emails contain both.
+- Add conservative optional local pattern learning for manually selected recurring CTAs.
+- Add deterministic link scoring, public-suffix-aware domain checks, anti-footer filtering, and readable-redirect rejection.
+- Add comprehensive unit tests for OTP, MIME, HTML sanitization, link ranking, and learned patterns.
+
 ## [Initial Version] - 2024-04-16
 
 - Automatically detects the OTP code from the email

--- a/extensions/otp-inbox/CHANGELOG.md
+++ b/extensions/otp-inbox/CHANGELOG.md
@@ -1,9 +1,5 @@
 # OTP Inbox Changelog
 
-## [Extension Improvement] - 2026-03-06
-
-- Add Windows support
-
 ## [Update] - {PR_MERGE_DATE}
 
 - Prefer plain-text MIME content and sanitize HTML fallback before verification-method extraction.

--- a/extensions/otp-inbox/README.md
+++ b/extensions/otp-inbox/README.md
@@ -6,12 +6,36 @@ The fastest way to fill in those pesky OTP codes from your email.
 
 OTP Inbox has been tested with a variety of verification emails, but it may not work with all emails. If you encounter any issues, please open an issue or submit a pull request.
 
+## Security & Privacy
+
+- **Numeric codes only:** OTP Inbox looks for exactly one unambiguous 4–8 digit numeric code. It does not transform arbitrary text, CSS, dates, or reference IDs into a pasteable code.
+- **Manual link actions:** Verification links are never opened automatically. You must explicitly choose Open or Copy.
+- **No auto-submit:** The extension never submits web forms or injects keystrokes.
+- **Domain-gated links:** A link must use HTTPS and share the sender’s registrable domain. It must also pass positive-CTA, anti-footer, and redirect checks.
+- **Fail closed:** When a link is ambiguous, the extension shows a chooser and never guesses.
+- **No sensitive storage:** Learned patterns store only the sender, hostname, normalized CTA text, and sanitized path. Full URLs, query strings, tokens, email bodies, subjects, message IDs, and OTPs are never stored.
+
+## How verification links work
+
+1. The email is parsed recursively; plain text is preferred for OTPs and HTML is retained for links.
+2. HTML is sanitized with a real parser; CSS and scripts are removed.
+3. Only HTTPS anchor tags that share the sender’s registrable domain are considered.
+4. Candidates are scored with deterministic rules:
+   - Threshold for automatic selection: **130**
+   - Required margin over the next best candidate: **30**
+   - Learned-pattern exact match bonus: **20**
+   - Learned-pattern partial match bonus: **10**
+5. If no candidate is decisive, eligible links appear in a manual chooser.
+6. You can optionally remember a minimal local pattern for recurring templates. Patterns expire after **180 days** of inactivity and cannot bypass hard security checks.
+
 ## Features
 
 - Automatically detects the OTP code from the email
-- Shows your recent email verification codes
+- Detects high-confidence HTTPS verification/magic links with explicit Open/Copy actions
+- Shows your recent email verification codes and links
 - Copy the code to your clipboard or paste directly into the active application
-- View recent emails in case the OTP code was not detected correctly
+- View recent emails in case the OTP code or link was not detected correctly
+- Optional local pattern learning for recurring verification templates
 
 ## Configuration
 

--- a/extensions/otp-inbox/docs/verification-methods.md
+++ b/extensions/otp-inbox/docs/verification-methods.md
@@ -1,0 +1,110 @@
+# OTP Inbox – Verification Methods Pipeline
+
+This document defines the safety-critical pipeline used by OTP Inbox to derive user actions from a Gmail MIME message. It is written before the implementation so that the code, tests, and README can be checked against it.
+
+## Goals
+
+1. Detect **exactly one unambiguous numeric OTP** (4–8 ASCII digits) from the visible email content.
+2. Detect and rank **high-confidence HTTPS verification CTA links** without auto-opening anything.
+3. Fail closed on ambiguity, malformed input, or missing safety signals.
+4. Store only minimal, user-confirmed local patterns. Never store full URLs, tokens, bodies, or OTPs.
+
+## Pipeline
+
+```text
+Gmail MIME payload
+  -> recursive MIME-part traversal
+  -> safe base64url decoding
+  -> choose text/plain; retain text/html
+  -> sanitize visible HTML fallback
+  -> numeric OTP extraction
+  -> structured anchor extraction from HTML
+  -> sender parsing + registrable-domain comparison
+  -> URL hard validation
+  -> deterministic candidate scoring
+  -> ambiguity resolution / abstention
+  -> optional local remembered-pattern bonus
+  -> typed result
+  -> Raycast UI actions gated by final validators
+```
+
+## OTP invariants
+
+- OTP characters: ASCII digits only.
+- OTP length: 4 through 8 inclusive.
+- Boundary-aware: never a substring of a longer digit sequence.
+- Duplicate occurrences of the same code count as one candidate.
+- Exactly one distinct candidate required; otherwise no OTP.
+- Never infer from CSS, HTML attributes, links, dates, reference IDs, phone numbers, or arbitrary words.
+- UI gate: `isValidOtp(value)` requires `^\d{4,8}$`.
+
+## MIME precedence
+
+1. Recursively traverse `multipart/*` parts.
+2. Prefer the first meaningful non-empty `text/plain` body for OTP extraction.
+3. Retain the first meaningful non-empty `text/html` body for link extraction.
+4. If `text/plain` is absent, derive visible text from sanitized `text/html`.
+5. Ignore attachments (`Content-Disposition: attachment`) for body text.
+6. Malformed/missing parts return empty safely; no crash.
+
+## HTML sanitization
+
+- Parse with a real HTML parser (`node-html-parser`).
+- Remove `head`, `style`, `script`, `noscript`, `template`, comments, SVG/math, and hidden attributes.
+- Remove inline `style` attributes.
+- Decode HTML entities and Unicode-normalize.
+- Collapse whitespace.
+- Produce clean visible text for OTP detection and the “Show Email Content” view.
+- Produce a separate structured anchor list from the same parse.
+
+## Link eligibility (hard rules)
+
+- Scheme must be exactly `https:`.
+- Reject `mailto:`, `tel:`, `javascript:`, `data:`, `file:`, custom schemes, and relative URLs.
+- Candidate hostname must share the sender’s registrable domain, using a public-suffix-aware library (`tldts`).
+- Visible anchor text must not contain strong negative/footer intent.
+- Readable cross-domain redirect parameters (`redirect`, `redirect_uri`, `return`, `return_url`, `continue`, `next`, `target`, `destination`, `callback`, `url`) must stay within the sender’s registrable domain.
+- Opaque/signed/encrypted parameters are ignored, not decoded or persisted.
+
+## Scoring
+
+| Rule | Points |
+| --- | --- |
+| Strong visible CTA phrase | +120 |
+| Generic verification/auth wording | +65 |
+| Verification intent in safe pathname or query-name | +35 |
+| Same sender registrable domain | +30 |
+| Appears before first footer marker | +15 |
+| Exact learned local-pattern match | +20 |
+| Partial learned match (same sender + host + CTA) | +10 |
+| Invalid/non-HTTPS/unrelated domain/unsafe redirect | -1000 |
+| Strong negative/footer intent | -500 |
+| No meaningful visible text | -100 |
+| Likely tracking host/path | -75 |
+| Generic “click here” without strong path intent | -40 |
+
+- Automatic selection threshold: `score >= 130`.
+- Automatic selection margin: at least `30` points above the second-best distinct eligible candidate.
+- Learned patterns add only bounded bonuses and never override hard eligibility.
+
+## Ambiguity
+
+If no candidate meets the threshold/margin, the result is ambiguous. The UI shows a “Choose Verification Link…” chooser with only eligible candidates. The default action is safe (inspect / no-op). No link is opened or remembered automatically.
+
+## Local learning
+
+- Storage: Raycast `LocalStorage`.
+- Persisted fields only: `version`, `id`, `senderAddress`, `senderRegistrableDomain`, `targetHostname`, `normalizedCtaText`, `pathSignature`, `createdAt`, `lastUsedAt`, `useCount`.
+- Never persisted: full URLs, query strings, tokens, bodies, subjects, message IDs, OTPs, sender display name.
+- Created only after explicit user confirmation via `confirmAlert`.
+- Patterns expire after 180 days of non-use.
+- A pattern matches only on exact normalized sender mailbox, sender registrable domain, target hostname, normalized CTA text, and path signature.
+- Patterns cannot bypass hard eligibility rules.
+
+## UI guarantees
+
+- Verification links are opened only by explicit `Action.OpenInBrowser` invocation.
+- OTPs are pasted/copied only when `isValidOtp` passes.
+- No form submission or keystroke automation.
+- No network requests to validate candidate links.
+- No LLM, analytics, or remote service is used.

--- a/extensions/otp-inbox/package.json
+++ b/extensions/otp-inbox/package.json
@@ -49,7 +49,9 @@
   "dependencies": {
     "@raycast/api": "^1.104.6",
     "@raycast/utils": "^1.14.0",
-    "cross-fetch": "^4.0.0"
+    "cross-fetch": "^4.0.0",
+    "node-html-parser": "^9.0.0",
+    "tldts": "^7.4.9"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^1.0.6",
@@ -57,14 +59,17 @@
     "@types/react": "19.0.10",
     "eslint": "^8.51.0",
     "prettier": "^3.0.3",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "vitest": "^4.1.10"
   },
   "scripts": {
     "build": "ray build -e dist",
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
-    "publish": "npx @raycast/api@latest publish"
+    "publish": "npx @raycast/api@latest publish",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "platforms": [
     "macOS",

--- a/extensions/otp-inbox/src/components/email-detail.tsx
+++ b/extensions/otp-inbox/src/components/email-detail.tsx
@@ -1,0 +1,15 @@
+import { Detail } from "@raycast/api";
+import { EmailSender } from "../lib/types";
+
+interface EmailDetailProps {
+  sender: EmailSender;
+  emailText: string;
+}
+
+export function EmailDetail({ sender, emailText }: EmailDetailProps) {
+  const markdown = `### Email from ${sender.name}
+
+${emailText}`;
+
+  return <Detail markdown={markdown} />;
+}

--- a/extensions/otp-inbox/src/components/link-chooser.tsx
+++ b/extensions/otp-inbox/src/components/link-chooser.tsx
@@ -1,0 +1,87 @@
+import { Action, ActionPanel, confirmAlert, Icon, List, showToast, Toast } from "@raycast/api";
+import { LinkCandidate, EmailSender, ValidatedLink } from "../lib/types";
+import { rememberPattern } from "../lib/learning";
+import { useMemo } from "react";
+
+interface LinkChooserProps {
+  candidates: LinkCandidate[];
+  sender: EmailSender;
+  senderRegistrableDomain: string | null;
+  onSelect?: (link: ValidatedLink) => void;
+}
+
+export function LinkChooser({ candidates, sender, senderRegistrableDomain }: LinkChooserProps) {
+  const items = useMemo(() => {
+    return candidates.map((candidate, idx) => {
+      const rationale = [
+        candidate.isSameRegistrableDomain ? "Same sender domain" : null,
+        candidate.hasPositiveIntent ? "Verification CTA" : null,
+        candidate.score >= 130 ? "High confidence" : null,
+      ]
+        .filter(Boolean)
+        .join(" · ");
+
+      return { candidate, rationale, rank: idx + 1 };
+    });
+  }, [candidates]);
+
+  return (
+    <List navigationTitle="Choose Verification Link">
+      {items.map(({ candidate, rationale }) => (
+        <List.Item
+          key={`${candidate.originalIndex}-${candidate.normalizedVisibleText}`}
+          title={candidate.visibleText || "Verify"}
+          subtitle={`${candidate.hostname}${candidate.pathSignature}`}
+          accessories={[
+            {
+              tag: rationale,
+            },
+          ]}
+          actions={
+            <ActionPanel>
+              <Action.OpenInBrowser url={candidate.href} title="Open This Verification Link" />
+              <Action.CopyToClipboard
+                content={candidate.href}
+                title="Copy This Verification Link"
+                shortcut={{ modifiers: ["cmd", "shift"], key: "l" }}
+              />
+              <Action
+                title="Use and Remember This Link Pattern"
+                icon={{ source: Icon.Star }}
+                shortcut={{ modifiers: ["cmd"], key: "s" }}
+                onAction={async () => {
+                  if (!senderRegistrableDomain) return;
+                  try {
+                    const confirmed = await confirmAlert({
+                      title: "Remember this link pattern?",
+                      message: `Future emails from ${sender.email} may prefer HTTPS links with CTA "${candidate.normalizedVisibleText}" on ${candidate.hostname} and path ${candidate.pathSignature}. Links still need to match the sender’s registrable domain, pass anti-footer and redirect checks, and require explicit manual opening. No URLs, query strings, tokens, email content, or OTPs are stored.`,
+                      primaryAction: { title: "Remember", onAction: () => true },
+                    });
+                    if (confirmed) {
+                      await rememberPattern({
+                        senderAddress: sender.email,
+                        senderRegistrableDomain,
+                        targetHostname: candidate.hostname,
+                        normalizedCtaText: candidate.normalizedVisibleText,
+                        pathSignature: candidate.pathSignature,
+                      });
+                      await showToast({
+                        style: Toast.Style.Success,
+                        title: "Pattern remembered",
+                      });
+                    }
+                  } catch (error) {
+                    await showToast({
+                      style: Toast.Style.Failure,
+                      title: "Could not remember pattern",
+                    });
+                  }
+                }}
+              />
+            </ActionPanel>
+          }
+        />
+      ))}
+    </List>
+  );
+}

--- a/extensions/otp-inbox/src/lib/__tests__/extractor-nvidia.test.ts
+++ b/extensions/otp-inbox/src/lib/__tests__/extractor-nvidia.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { extractVerificationMethods } from "../extractor";
+import { Email } from "../types";
+
+function b64(str: string): string {
+  return Buffer.from(str).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+const nvidiaHtml = `<html>
+  <head>
+    <style>
+      .button { font-size: 14px; font-family: NVIDIA, Arial; font-weight: 700; }
+      @font-face { font-family: NVIDIA; src: url(https://assets.example/font.woff2); }
+    </style>
+  </head>
+  <body>
+    <p>Hello,</p>
+    <p>Your account just logged in using a Mac device we haven't seen you use recently.</p>
+    <p>Click the link below to verify this was you and continue to NVIDIA.</p>
+
+    <a href="https://accounts.nvgs.nvidia.com/api/1/message/VerifyEmail?q=synthetic-opaque-token">
+      Verify Email Address
+    </a>
+
+    <p><strong>Location:</strong> Birmingham</p>
+
+    <footer>
+      <a href="https://www.nvidia.com/en-us/about-nvidia/privacy-policy/">Privacy Policy</a>
+      <a href="https://www.nvidia.com/en-us/about-nvidia/privacy-center/">Manage My Privacy</a>
+      <a href="https://www.nvidia.com/en-us/contact/">Contact</a>
+    </footer>
+  </body>
+</html>`;
+
+function makeEmail(html: string): Email {
+  return {
+    internalDate: Date.now().toString(),
+    payload: {
+      headers: [
+        { name: "From", value: "NVIDIA Accounts <account@nvidia.com>" },
+        { name: "Subject", value: "Authenticate Your Email Address" },
+      ],
+      mimeType: "text/html",
+      body: { data: b64(html) },
+    },
+  };
+}
+
+describe("NVIDIA regression", () => {
+  it("selects verification CTA and excludes CSS from OTP", async () => {
+    const result = await extractVerificationMethods(makeEmail(nvidiaHtml));
+
+    expect(result.emailText).toContain("Verify Email Address");
+    expect(result.emailText).not.toContain("font-size");
+    expect(result.emailText).not.toContain("font-family");
+    expect(result.emailText).not.toContain("font-weight");
+    expect(result.emailText).not.toContain("@font-face");
+    expect(result.emailText).not.toContain("assets.example/font.woff2");
+
+    expect(result.otp).toBeUndefined();
+
+    expect(result.link).toBeDefined();
+    expect(result.link!.hostname).toBe("accounts.nvgs.nvidia.com");
+    expect(result.link!.pathSignature).toBe("/api/1/message/verifyemail");
+    expect(result.link!.normalizedCtaText).toBe("verify email address");
+
+    expect(result.ambiguousLinks).toHaveLength(0);
+  });
+
+  it("does not expose the opaque query token", async () => {
+    const result = await extractVerificationMethods(makeEmail(nvidiaHtml));
+    expect(result.link!.href).toContain("q=synthetic-opaque-token");
+    expect(result.emailText).not.toContain("synthetic-opaque-token");
+    expect(result.emailText).not.toContain("?q=");
+  });
+
+  it("rejects footer links", async () => {
+    const result = await extractVerificationMethods(makeEmail(nvidiaHtml));
+    const privacy = result.ambiguousLinks.find((l) => l.visibleText.toLowerCase().includes("privacy"));
+    const contact = result.ambiguousLinks.find((l) => l.visibleText.toLowerCase().includes("contact"));
+    expect(privacy).toBeUndefined();
+    expect(contact).toBeUndefined();
+  });
+});
+
+describe("generalized link tests", () => {
+  it("selects a generic transactional CTA", async () => {
+    const html = `<a href="https://auth.service.example.com/confirm">Confirm your email</a>`;
+    const email = makeEmail(html);
+    email.payload.headers = [{ name: "From", value: "security@service.example.com" }];
+    const result = await extractVerificationMethods(email);
+    expect(result.link).toBeDefined();
+    expect(result.link!.hostname).toBe("auth.service.example.com");
+  });
+
+  it("handles both OTP and link in one email", async () => {
+    const html = `Your code is 987654. <a href="https://auth.service.example.com/verify">Confirm your email</a>`;
+    const email = makeEmail(html);
+    email.payload.headers = [{ name: "From", value: "security@service.example.com" }];
+    const result = await extractVerificationMethods(email);
+    expect(result.otp).toBe("987654");
+    expect(result.link).toBeDefined();
+  });
+
+  it("rejects footer-only emails", async () => {
+    const html = `<footer><a href="https://example.com/privacy">Privacy</a><a href="https://example.com/unsubscribe">Unsubscribe</a></footer>`;
+    const email = makeEmail(html);
+    email.payload.headers = [{ name: "From", value: "no-reply@example.com" }];
+    const result = await extractVerificationMethods(email);
+    expect(result.link).toBeUndefined();
+    expect(result.ambiguousLinks).toHaveLength(0);
+  });
+});

--- a/extensions/otp-inbox/src/lib/__tests__/html.test.ts
+++ b/extensions/otp-inbox/src/lib/__tests__/html.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeHtml, getVisibleText } from "../html";
+
+describe("sanitizeHtml", () => {
+  it("removes CSS and preserves CTA text", () => {
+    const html = `
+      <html>
+        <head>
+          <style>.x { font-size: 14px; font-family: NVIDIA, Arial; font-weight: 700; }</style>
+        </head>
+        <body>
+          <p>Verify Email Address</p>
+        </body>
+      </html>
+    `;
+    const result = sanitizeHtml(html);
+    expect(result.text).toContain("Verify Email Address");
+    expect(result.text).not.toContain("font-size");
+    expect(result.text).not.toContain("font-family");
+    expect(result.text).not.toContain("font-weight");
+  });
+
+  it("extracts anchor href and visible text", () => {
+    const html = `<a href="https://example.com/verify">Verify Email</a>`;
+    const result = sanitizeHtml(html);
+    expect(result.anchors).toHaveLength(1);
+    expect(result.anchors[0].href).toBe("https://example.com/verify");
+    expect(result.anchors[0].text).toBe("Verify Email");
+  });
+
+  it("does not include script or style content", () => {
+    const html = `<style>body{color:red}</style><script>alert(1)</script><p>Hello</p>`;
+    const result = sanitizeHtml(html);
+    expect(result.text).toBe("Hello");
+  });
+
+  it("decodes HTML entities", () => {
+    const html = `<p>Hello &amp; welcome</p>`;
+    const result = sanitizeHtml(html);
+    expect(result.text).toContain("Hello & welcome");
+  });
+});
+
+describe("getVisibleText", () => {
+  it("returns plain visible text", () => {
+    expect(getVisibleText("<p>Hello world</p>")).toBe("Hello world");
+  });
+});

--- a/extensions/otp-inbox/src/lib/__tests__/learning.test.ts
+++ b/extensions/otp-inbox/src/lib/__tests__/learning.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { rememberPattern, getLearnedPatterns, forgetPattern, forgetAllPatterns } from "../learning";
+import { LearnedLinkPattern } from "../types";
+
+const storage = new Map<string, string>();
+
+vi.mock("@raycast/api", () => ({
+  LocalStorage: {
+    getItem: async () => {
+      const key = "otp-inbox-learned-link-patterns";
+      return storage.get(key) ?? null;
+    },
+    setItem: async (key: string, value: string) => {
+      storage.set(key, value);
+    },
+    removeItem: async () => {
+      storage.delete("otp-inbox-learned-link-patterns");
+    },
+  },
+}));
+
+beforeEach(async () => {
+  storage.clear();
+  await forgetAllPatterns();
+});
+
+describe("learned patterns", () => {
+  it("remembers a minimal pattern without URLs or tokens", async () => {
+    const pattern = await rememberPattern({
+      senderAddress: "account@nvidia.com",
+      senderRegistrableDomain: "nvidia.com",
+      targetHostname: "accounts.nvgs.nvidia.com",
+      normalizedCtaText: "verify email address",
+      pathSignature: "/api/1/message/verifyemail",
+    });
+
+    const patternRecord = pattern as unknown as Record<string, unknown>;
+    expect(patternRecord.href).toBeUndefined();
+    expect(patternRecord.query).toBeUndefined();
+    expect(patternRecord.token).toBeUndefined();
+    expect(patternRecord.body).toBeUndefined();
+    expect(patternRecord.subject).toBeUndefined();
+    expect(patternRecord.messageId).toBeUndefined();
+    expect(patternRecord.otp).toBeUndefined();
+
+    expect(pattern.senderAddress).toBe("account@nvidia.com");
+    expect(pattern.targetHostname).toBe("accounts.nvgs.nvidia.com");
+  });
+
+  it("increments useCount on duplicate remember", async () => {
+    const input = {
+      senderAddress: "a@example.com",
+      senderRegistrableDomain: "example.com",
+      targetHostname: "auth.example.com",
+      normalizedCtaText: "verify",
+      pathSignature: "/verify",
+    };
+    const first = await rememberPattern(input);
+    const second = await rememberPattern(input);
+    expect(second.useCount).toBe(first.useCount + 1);
+  });
+
+  it("forgets a single pattern", async () => {
+    const pattern = await rememberPattern({
+      senderAddress: "a@example.com",
+      senderRegistrableDomain: "example.com",
+      targetHostname: "auth.example.com",
+      normalizedCtaText: "verify",
+      pathSignature: "/verify",
+    });
+    await forgetPattern(pattern.id);
+    const remaining = await getLearnedPatterns();
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("prunes expired patterns", async () => {
+    const pattern = await rememberPattern({
+      senderAddress: "a@example.com",
+      senderRegistrableDomain: "example.com",
+      targetHostname: "auth.example.com",
+      normalizedCtaText: "verify",
+      pathSignature: "/verify",
+    });
+
+    const aged: LearnedLinkPattern = {
+      ...pattern,
+      lastUsedAt: new Date(Date.now() - 181 * 24 * 60 * 60 * 1000).toISOString(),
+    };
+    storage.set("otp-inbox-learned-link-patterns", JSON.stringify([aged]));
+
+    const remaining = await getLearnedPatterns();
+    expect(remaining).toHaveLength(0);
+  });
+});

--- a/extensions/otp-inbox/src/lib/__tests__/links.test.ts
+++ b/extensions/otp-inbox/src/lib/__tests__/links.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { extractLinkCandidates, selectVerificationLink, getAmbiguousLinks, normalizeCtaText } from "../links";
+import { Anchor } from "../html";
+
+function makeAnchor(text: string, href: string): Anchor {
+  return { text, href, index: 0 };
+}
+
+const nvidiaContext = {
+  senderRegistrableDomain: "nvidia.com",
+  senderAddress: "account@nvidia.com",
+  learnedPatterns: [],
+};
+
+describe("normalizeCtaText", () => {
+  it("lowercases and collapses whitespace", () => {
+    expect(normalizeCtaText("  Verify   Email  ")).toBe("verify email");
+  });
+});
+
+describe("extractLinkCandidates", () => {
+  it("selects a strong same-domain CTA", () => {
+    const anchors = [
+      makeAnchor("Verify Email Address", "https://accounts.nvgs.nvidia.com/api/1/message/VerifyEmail?q=token"),
+    ];
+    const candidates = extractLinkCandidates(anchors, nvidiaContext);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].isSameRegistrableDomain).toBe(true);
+    expect(candidates[0].hasPositiveIntent).toBe(true);
+    expect(candidates[0].hasNegativeIntent).toBe(false);
+  });
+
+  it("rejects footer privacy links", () => {
+    const anchors = [makeAnchor("Privacy Policy", "https://www.nvidia.com/en-us/about-nvidia/privacy-policy/")];
+    const candidates = extractLinkCandidates(anchors, nvidiaContext);
+    expect(candidates[0].hasNegativeIntent).toBe(true);
+  });
+
+  it("rejects cross-domain spoof", () => {
+    const anchors = [makeAnchor("Verify Email Address", "https://nvidia-login.example.com/verify")];
+    const candidates = extractLinkCandidates(anchors, nvidiaContext);
+    expect(candidates[0].rejectionReasons).toContain("domain_mismatch");
+  });
+
+  it("rejects evil lookalike", () => {
+    const anchors = [makeAnchor("Verify", "https://evilnvidia.com/verify")];
+    const candidates = extractLinkCandidates(anchors, nvidiaContext);
+    expect(candidates[0].rejectionReasons).toContain("domain_mismatch");
+  });
+
+  it("rejects HTTP", () => {
+    const anchors = [makeAnchor("Verify", "http://account.nvidia.com/verify")];
+    const candidates = extractLinkCandidates(anchors, nvidiaContext);
+    expect(candidates).toHaveLength(0);
+  });
+
+  it("rejects unsafe readable cross-domain redirect", () => {
+    const anchors = [makeAnchor("Verify", "https://accounts.nvgs.nvidia.com/verify?continue=https://evil.example/...")];
+    const candidates = extractLinkCandidates(anchors, nvidiaContext);
+    expect(candidates[0].hasUnsafeReadableRedirect).toBe(true);
+  });
+
+  it("keeps opaque same-domain token", () => {
+    const anchors = [
+      makeAnchor("Verify Email", "https://accounts.nvgs.nvidia.com/verify?q=synthetic-signed-opaque-value"),
+    ];
+    const candidates = extractLinkCandidates(anchors, nvidiaContext);
+    expect(candidates[0].rejectionReasons).not.toContain("domain_mismatch");
+    expect(candidates[0].hasUnsafeReadableRedirect).toBe(false);
+  });
+
+  it("handles co.uk public suffix correctly", () => {
+    const anchors = [makeAnchor("Confirm your email", "https://login.auth.example.co.uk/verify")];
+    const context = {
+      senderRegistrableDomain: "example.co.uk",
+      senderAddress: "no-reply@auth.example.co.uk",
+      learnedPatterns: [],
+    };
+    const candidates = extractLinkCandidates(anchors, context);
+    expect(candidates[0].isSameRegistrableDomain).toBe(true);
+  });
+
+  it("does not auto-select weak click-here without path intent", () => {
+    const anchors = [makeAnchor("Click here", "https://accounts.nvgs.nvidia.com/some/path")];
+    const candidates = extractLinkCandidates(anchors, nvidiaContext);
+    const selected = selectVerificationLink(candidates);
+    expect(selected).toBeUndefined();
+  });
+});
+
+describe("selectVerificationLink", () => {
+  it("selects a decisively strong CTA over footer links", () => {
+    const anchors = [
+      makeAnchor("Verify Email Address", "https://accounts.nvgs.nvidia.com/api/1/message/VerifyEmail?q=token"),
+      makeAnchor("Privacy Policy", "https://www.nvidia.com/en-us/about-nvidia/privacy-policy/"),
+      makeAnchor("Contact", "https://www.nvidia.com/en-us/contact/"),
+    ];
+    const candidates = extractLinkCandidates(anchors, nvidiaContext);
+    const selected = selectVerificationLink(candidates);
+    expect(selected).toBeDefined();
+    expect(selected!.link.hostname).toBe("accounts.nvgs.nvidia.com");
+    expect(selected!.link.pathSignature).toBe("/api/1/message/verifyemail");
+  });
+
+  it("returns ambiguous when two equally strong CTAs exist", () => {
+    const anchors = [
+      makeAnchor("Verify Email Address", "https://accounts.nvgs.nvidia.com/api/1/message/VerifyEmail"),
+      makeAnchor("Verify Email Address", "https://accounts.nvgs.nvidia.com/api/2/message/VerifyEmail"),
+    ];
+    const candidates = extractLinkCandidates(anchors, nvidiaContext);
+    const selected = selectVerificationLink(candidates);
+    expect(selected).toBeUndefined();
+    expect(getAmbiguousLinks(candidates).length).toBe(2);
+  });
+});

--- a/extensions/otp-inbox/src/lib/__tests__/mime.test.ts
+++ b/extensions/otp-inbox/src/lib/__tests__/mime.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { extractBodies } from "../mime";
+import { EmailPayload } from "../types";
+
+function b64url(str: string): string {
+  return Buffer.from(str).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+describe("extractBodies", () => {
+  it("prefers text/plain and retains text/html", () => {
+    const payload: EmailPayload = {
+      headers: [],
+      mimeType: "multipart/alternative",
+      parts: [
+        {
+          headers: [],
+          mimeType: "text/plain",
+          body: { data: b64url("Your code is 123456") },
+        },
+        {
+          headers: [],
+          mimeType: "text/html",
+          body: { data: b64url("<p>Your code is <b>123456</b></p>") },
+        },
+      ],
+    };
+    const result = extractBodies(payload);
+    expect(result.plainText).toContain("Your code is 123456");
+    expect(result.htmlText).toContain("<p>Your code is <b>123456</b></p>");
+  });
+
+  it("derives visible text from HTML when plain text is absent", () => {
+    const payload: EmailPayload = {
+      headers: [],
+      mimeType: "text/html",
+      body: { data: b64url("<p>Click Verify Email Address</p>") },
+    };
+    const result = extractBodies(payload);
+    expect(result.plainText).toBe("");
+    expect(result.htmlText).toContain("<p>Click Verify Email Address</p>");
+  });
+
+  it("ignores attachment parts", () => {
+    const payload: EmailPayload = {
+      headers: [],
+      mimeType: "multipart/mixed",
+      parts: [
+        {
+          headers: [{ name: "Content-Disposition", value: "attachment; filename=doc.pdf" }],
+          mimeType: "application/pdf",
+          body: { data: b64url("PDFCONTENT") },
+        },
+        {
+          headers: [],
+          mimeType: "text/plain",
+          body: { data: b64url("Your code is 654321") },
+        },
+      ],
+    };
+    const result = extractBodies(payload);
+    expect(result.plainText).toBe("Your code is 654321");
+  });
+
+  it("handles malformed base64url safely", () => {
+    const payload: EmailPayload = {
+      headers: [],
+      mimeType: "text/plain",
+      body: { data: "!!!not-base64!!!" },
+    };
+    expect(() => extractBodies(payload)).not.toThrow();
+    expect(extractBodies(payload).plainText).toBe("");
+  });
+
+  it("handles nested multipart", () => {
+    const payload: EmailPayload = {
+      headers: [],
+      mimeType: "multipart/mixed",
+      parts: [
+        {
+          headers: [],
+          mimeType: "multipart/alternative",
+          parts: [
+            {
+              headers: [],
+              mimeType: "text/plain",
+              body: { data: b64url("Plain body") },
+            },
+            {
+              headers: [],
+              mimeType: "text/html",
+              body: { data: b64url("<p>HTML body</p>") },
+            },
+          ],
+        },
+      ],
+    };
+    const result = extractBodies(payload);
+    expect(result.plainText).toBe("Plain body");
+    expect(result.htmlText).toContain("HTML body");
+  });
+});

--- a/extensions/otp-inbox/src/lib/__tests__/otp.test.ts
+++ b/extensions/otp-inbox/src/lib/__tests__/otp.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { extractOtp, isValidOtp } from "../otp";
+
+describe("extractOtp", () => {
+  it("extracts a plain numeric code", () => {
+    expect(extractOtp("Your verification code is 123456")).toBe("123456");
+  });
+
+  it("does not extract a code from CSS-like text", () => {
+    expect(extractOtp("font-size: 14px; font-family: NVIDIA;")).toBeUndefined();
+  });
+
+  it("returns no code when no number is present", () => {
+    expect(extractOtp("Click Verify Email Address to continue")).toBeUndefined();
+  });
+
+  it("returns no code when two distinct codes are present", () => {
+    expect(extractOtp("Old code 123456; new code 654321")).toBeUndefined();
+  });
+
+  it("treats duplicate occurrences as a single candidate", () => {
+    expect(extractOtp("Your code is 123456. Enter 123456 to continue.")).toBe("123456");
+  });
+
+  it("does not extract a substring of a longer digit sequence", () => {
+    expect(extractOtp("Reference 123456789 must not yield any code")).toBeUndefined();
+  });
+
+  it("rejects a code mixed with letters", () => {
+    expect(extractOtp("Your code is 1234a")).toBeUndefined();
+  });
+
+  it("handles boundary digits correctly", () => {
+    expect(extractOtp("code: 1234 end")).toBe("1234");
+    expect(extractOtp("code: 12345678 end")).toBe("12345678");
+    expect(extractOtp("code: 123 end")).toBeUndefined();
+    expect(extractOtp("code: 123456789 end")).toBeUndefined();
+  });
+});
+
+describe("isValidOtp", () => {
+  it("accepts 4-8 digit codes", () => {
+    expect(isValidOtp("1234")).toBe(true);
+    expect(isValidOtp("12345678")).toBe(true);
+    expect(isValidOtp("123456")).toBe(true);
+  });
+
+  it("rejects invalid values", () => {
+    expect(isValidOtp(undefined)).toBe(false);
+    expect(isValidOtp("font-size")).toBe(false);
+    expect(isValidOtp("1234a")).toBe(false);
+    expect(isValidOtp("123456789")).toBe(false);
+    expect(isValidOtp("123")).toBe(false);
+    expect(isValidOtp("")).toBe(false);
+  });
+});

--- a/extensions/otp-inbox/src/lib/constants.ts
+++ b/extensions/otp-inbox/src/lib/constants.ts
@@ -6,11 +6,138 @@ export const emailFilterKeywords = [
   "register",
   "sign up",
   "verify",
+  "verification",
+  "authenticate",
   "authentication",
   "otp",
-  "verification",
+  "code",
+  "confirm",
+  "activate",
+  "approve",
+  "secure",
   "2fa",
 ];
 
 // Max. age of emails in minutes
 export const maxEmailAge = 10;
+
+// Link scoring constants
+export const SCORE_STRONG_CTA = 120;
+export const SCORE_GENERIC_CTA = 65;
+export const SCORE_PATH_INTENT = 35;
+export const SCORE_SAME_DOMAIN = 30;
+export const SCORE_BEFORE_FOOTER = 15;
+export const SCORE_LEARNED_EXACT = 20;
+export const SCORE_LEARNED_PARTIAL = 10;
+
+export const PENALTY_INVALID = -1000;
+export const PENALTY_NEGATIVE_INTENT = -500;
+export const PENALTY_NO_VISIBLE_TEXT = -100;
+export const PENALTY_TRACKING = -75;
+export const PENALTY_GENERIC_CLICK = -40;
+
+export const AUTO_SELECT_THRESHOLD = 130;
+export const AUTO_SELECT_MARGIN = 30;
+
+export const LEARNED_PATTERN_MAX_AGE_DAYS = 180;
+export const LEARNED_PATTERN_VERSION = 1;
+
+// Strong positive CTA phrases (visible anchor text)
+export const STRONG_CTA_PHRASES = [
+  "verify email address",
+  "verify email",
+  "confirm email",
+  "confirm your email",
+  "authenticate your email",
+  "activate account",
+  "approve sign in",
+  "complete sign in",
+  "continue sign in",
+  "secure your account",
+];
+
+// Generic positive CTA words/phrases
+export const GENERIC_CTA_PHRASES = [
+  "verify",
+  "verification",
+  "confirm",
+  "authenticate",
+  "approve",
+  "activate",
+  "sign in",
+  "login",
+  "log in",
+  "continue",
+];
+
+// Strong negative/footer phrases
+export const NEGATIVE_CTA_PHRASES = [
+  "privacy",
+  "privacy policy",
+  "privacy center",
+  "manage privacy",
+  "manage preferences",
+  "preferences",
+  "unsubscribe",
+  "opt out",
+  "contact",
+  "help",
+  "support",
+  "terms",
+  "cookie",
+  "cookies",
+  "view in browser",
+  "web version",
+  "facebook",
+  "instagram",
+  "linkedin",
+  "youtube",
+  "twitter",
+  "x",
+  "share",
+  "download app",
+];
+
+// Path/query tokens that indicate verification intent
+export const VERIFICATION_PATH_TOKENS = [
+  "verify",
+  "verification",
+  "confirm",
+  "authenticate",
+  "auth",
+  "activate",
+  "approve",
+  "secure",
+  "login",
+  "signin",
+  "sign-in",
+  "welcome",
+];
+
+// Query parameter names that may carry readable redirects
+export const REDIRECT_PARAMETER_NAMES = [
+  "redirect",
+  "redirect_uri",
+  "return",
+  "return_url",
+  "continue",
+  "next",
+  "target",
+  "destination",
+  "callback",
+  "url",
+];
+
+// Tracking-related host or path fragments
+export const TRACKING_FRAGMENTS = [
+  "tracking",
+  "track",
+  "click",
+  "unsub",
+  "preferences",
+  "analytics",
+  "pixel",
+  "beacon",
+  "open",
+  "social",
+];

--- a/extensions/otp-inbox/src/lib/domain.ts
+++ b/extensions/otp-inbox/src/lib/domain.ts
@@ -1,0 +1,36 @@
+import { getDomain, getPublicSuffix } from "tldts";
+
+export function getRegistrableDomain(hostname: string): string | null {
+  return getDomain(hostname, { allowPrivateDomains: false }) || null;
+}
+
+export function parseSender(fromHeader: string | undefined): { name: string; email: string } {
+  if (!fromHeader) {
+    return { name: "", email: "" };
+  }
+
+  const emailMatch = fromHeader.match(/<([^>]+)>/);
+  if (emailMatch) {
+    const name = fromHeader
+      .replace(/<[^>]+>/, "")
+      .trim()
+      .replace(/^"|"$/g, "");
+    return { name, email: emailMatch[1].toLowerCase().trim() };
+  }
+
+  if (/^[^\s<>]+@[^\s<>]+$/.test(fromHeader.trim())) {
+    return { name: "", email: fromHeader.trim().toLowerCase() };
+  }
+
+  return { name: fromHeader.trim(), email: "" };
+}
+
+export function getRegistrableDomainForEmail(email: string): string | null {
+  const domain = email.split("@")[1];
+  if (!domain) return null;
+  return getRegistrableDomain(domain);
+}
+
+export function isValidPublicSuffix(hostname: string): boolean {
+  return getPublicSuffix(hostname) !== null;
+}

--- a/extensions/otp-inbox/src/lib/domain.ts
+++ b/extensions/otp-inbox/src/lib/domain.ts
@@ -1,7 +1,7 @@
 import { getDomain, getPublicSuffix } from "tldts";
 
 export function getRegistrableDomain(hostname: string): string | null {
-  return getDomain(hostname, { allowPrivateDomains: false }) || null;
+  return getDomain(hostname, { allowPrivateDomains: true }) || null;
 }
 
 export function parseSender(fromHeader: string | undefined): { name: string; email: string } {

--- a/extensions/otp-inbox/src/lib/extractor.ts
+++ b/extensions/otp-inbox/src/lib/extractor.ts
@@ -1,0 +1,67 @@
+import { Email, ProcessedEmail, LinkCandidate, ValidatedLink, LearnedLinkPattern } from "./types";
+import { extractBodies, getHeaderValue } from "./mime";
+import { sanitizeHtml } from "./html";
+import { extractOtp, isValidOtp } from "./otp";
+import { parseSender, getRegistrableDomainForEmail } from "./domain";
+import { extractLinkCandidates, selectVerificationLink, getAmbiguousLinks } from "./links";
+
+export interface ExtractionOptions {
+  learnedPatterns?: LearnedLinkPattern[];
+}
+
+export async function extractVerificationMethods(
+  email: Email,
+  options: ExtractionOptions = {},
+): Promise<ProcessedEmail> {
+  const bodies = extractBodies(email.payload);
+  const htmlResult = bodies.htmlText ? sanitizeHtml(bodies.htmlText) : { text: "", anchors: [] };
+  const plainText = bodies.plainText || "";
+  const visibleText = plainText || htmlResult.text;
+
+  const fromHeader = getHeaderValue(email.payload, "From");
+  const sender = parseSender(fromHeader);
+  const senderRegistrableDomain = getRegistrableDomainForEmail(sender.email);
+  const learnedPatterns = options.learnedPatterns ?? [];
+
+  const rawOtp = extractOtp(visibleText);
+
+  let link: ValidatedLink | undefined;
+  let ambiguousLinks: LinkCandidate[] = [];
+
+  if (senderRegistrableDomain && htmlResult.anchors.length > 0) {
+    const context = {
+      senderRegistrableDomain,
+      senderAddress: sender.email,
+      learnedPatterns,
+    };
+
+    const candidates = extractLinkCandidates(htmlResult.anchors, context);
+    const selected = selectVerificationLink(candidates);
+
+    if (selected) {
+      link = selected.link;
+      ambiguousLinks = selected.remaining;
+    } else {
+      ambiguousLinks = getAmbiguousLinks(candidates);
+    }
+  }
+
+  return {
+    otp: isValidOtp(rawOtp) ? rawOtp : undefined,
+    link,
+    ambiguousLinks,
+    sender,
+    receivedAt: new Date(parseInt(email.internalDate, 10)),
+    emailText: visibleText,
+    senderRegistrableDomain,
+    learnedPatterns,
+  };
+}
+
+export function emailMatchesKeywords(processed: ProcessedEmail, keywords: string[]): boolean {
+  const lowerText = processed.emailText.toLowerCase();
+  const senderText = `${processed.sender.name} ${processed.sender.email}`.toLowerCase();
+  return keywords.some((keyword) => lowerText.includes(keyword) || senderText.includes(keyword));
+}
+
+export { normalizeCtaText } from "./links";

--- a/extensions/otp-inbox/src/lib/html.ts
+++ b/extensions/otp-inbox/src/lib/html.ts
@@ -1,0 +1,184 @@
+import { parse, HTMLElement, Node as HtmlNode, TextNode } from "node-html-parser";
+
+export interface Anchor {
+  href: string;
+  text: string;
+  index: number;
+}
+
+export interface SanitizedHtml {
+  text: string;
+  anchors: Anchor[];
+}
+
+const SKIPPED_TAGS = new Set(["head", "style", "script", "noscript", "template", "svg", "math", "object", "embed"]);
+
+const BLOCK_TAGS = new Set([
+  "address",
+  "article",
+  "aside",
+  "blockquote",
+  "canvas",
+  "dd",
+  "div",
+  "dl",
+  "dt",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "footer",
+  "form",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "header",
+  "hr",
+  "li",
+  "main",
+  "nav",
+  "ol",
+  "p",
+  "pre",
+  "section",
+  "table",
+  "tfoot",
+  "ul",
+  "video",
+]);
+
+function removeControlCharacters(input: string): string {
+  let result = "";
+  for (const char of input) {
+    const code = char.charCodeAt(0);
+    if (code < 0x20 || code === 0x7f || (code >= 0x80 && code <= 0x9f)) {
+      result += " ";
+    } else {
+      result += char;
+    }
+  }
+  return result;
+}
+
+function isElement(node: HtmlNode): node is HTMLElement {
+  return node.nodeType === 1;
+}
+
+function isTextNode(node: HtmlNode): node is TextNode {
+  return node.nodeType === 3;
+}
+
+function isHidden(element: HTMLElement): boolean {
+  const style = element.getAttribute("style") || "";
+  const displayNone = /display\s*:\s*none/i.test(style);
+  const visibilityHidden = /visibility\s*:\s*hidden/i.test(style);
+  const ariaHidden = element.getAttribute("aria-hidden");
+  return ariaHidden === "true" || displayNone || visibilityHidden;
+}
+
+function decodeHtmlEntities(input: string): string {
+  return input
+    .replace(/&(#x[0-9a-fA-F]+|#[0-9]+|[a-zA-Z][a-zA-Z0-9]*);/g, (match, entity) => {
+      if (entity[0] === "#" && entity[1] === "x") {
+        return String.fromCodePoint(parseInt(entity.slice(2), 16));
+      } else if (entity[0] === "#") {
+        return String.fromCodePoint(parseInt(entity.slice(1), 10));
+      }
+      const entities: Record<string, string> = {
+        amp: "&",
+        lt: "<",
+        gt: ">",
+        quot: '"',
+        nbsp: " ",
+        apos: "'",
+      };
+      return entities[entity] || match;
+    })
+    .normalize("NFKC");
+}
+
+function normalizeWhitespace(input: string): string {
+  return removeControlCharacters(input).replace(/\s+/g, " ").trim();
+}
+
+function collectVisibleText(element: HTMLElement): string {
+  const parts: string[] = [];
+
+  function walk(node: HtmlNode): void {
+    if (isElement(node)) {
+      const tag = node.tagName?.toLowerCase();
+      if (SKIPPED_TAGS.has(tag || "") || isHidden(node)) {
+        return;
+      }
+
+      if (tag === "br") {
+        parts.push(" ");
+        return;
+      }
+
+      if (tag === "img") {
+        const alt = node.getAttribute("alt");
+        if (alt) parts.push(" ", alt, " ");
+        return;
+      }
+
+      for (const child of node.childNodes) {
+        walk(child);
+      }
+
+      if (BLOCK_TAGS.has(tag)) {
+        parts.push("\n");
+      }
+    } else if (isTextNode(node)) {
+      const text = node.text;
+      if (text) parts.push(text);
+    }
+  }
+
+  walk(element);
+  return normalizeWhitespace(parts.join(""));
+}
+
+function extractAnchors(root: HTMLElement): Anchor[] {
+  const anchors: Anchor[] = [];
+  let index = 0;
+
+  for (const anchor of root.querySelectorAll("a")) {
+    const href = anchor.getAttribute("href") || "";
+    const text = collectVisibleText(anchor);
+    if (href) {
+      anchors.push({
+        href: decodeHtmlEntities(href).trim(),
+        text: decodeHtmlEntities(text).trim(),
+        index,
+      });
+      index++;
+    }
+  }
+
+  return anchors;
+}
+
+export function sanitizeHtml(html: string): SanitizedHtml {
+  if (!html || typeof html !== "string") {
+    return { text: "", anchors: [] };
+  }
+
+  let root: HTMLElement;
+  try {
+    root = parse(html);
+  } catch {
+    return { text: "", anchors: [] };
+  }
+
+  const anchors = extractAnchors(root);
+  const text = collectVisibleText(root);
+
+  return { text, anchors };
+}
+
+export function getVisibleText(html: string): string {
+  return sanitizeHtml(html).text;
+}

--- a/extensions/otp-inbox/src/lib/learning.ts
+++ b/extensions/otp-inbox/src/lib/learning.ts
@@ -1,0 +1,97 @@
+import { LocalStorage } from "@raycast/api";
+import { LearnedLinkPattern } from "./types";
+import { LEARNED_PATTERN_MAX_AGE_DAYS, LEARNED_PATTERN_VERSION } from "./constants";
+
+const LEARNED_PATTERNS_KEY = "otp-inbox-learned-link-patterns";
+
+function generateId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function isExpired(pattern: LearnedLinkPattern): boolean {
+  const cutoff = Date.now() - LEARNED_PATTERN_MAX_AGE_DAYS * 24 * 60 * 60 * 1000;
+  return new Date(pattern.lastUsedAt).getTime() < cutoff;
+}
+
+export async function getLearnedPatterns(): Promise<LearnedLinkPattern[]> {
+  try {
+    const raw = await LocalStorage.getItem<string>(LEARNED_PATTERNS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+
+    const valid: LearnedLinkPattern[] = [];
+    for (const item of parsed) {
+      if (typeof item === "object" && item !== null && item.version === LEARNED_PATTERN_VERSION) {
+        valid.push(item as LearnedLinkPattern);
+      }
+    }
+
+    const pruned = valid.filter((p) => !isExpired(p));
+    if (pruned.length !== valid.length) {
+      await setLearnedPatterns(pruned);
+    }
+    return pruned;
+  } catch {
+    return [];
+  }
+}
+
+async function setLearnedPatterns(patterns: LearnedLinkPattern[]): Promise<void> {
+  await LocalStorage.setItem(LEARNED_PATTERNS_KEY, JSON.stringify(patterns));
+}
+
+export interface PatternInput {
+  senderAddress: string;
+  senderRegistrableDomain: string;
+  targetHostname: string;
+  normalizedCtaText: string;
+  pathSignature: string;
+}
+
+export async function rememberPattern(input: PatternInput): Promise<LearnedLinkPattern> {
+  const patterns = await getLearnedPatterns();
+  const now = new Date().toISOString();
+
+  const existingIndex = patterns.findIndex(
+    (p) =>
+      p.senderAddress.toLowerCase() === input.senderAddress.toLowerCase() &&
+      p.targetHostname === input.targetHostname &&
+      p.normalizedCtaText === input.normalizedCtaText &&
+      p.pathSignature === input.pathSignature,
+  );
+
+  if (existingIndex >= 0) {
+    const existing = patterns[existingIndex];
+    existing.lastUsedAt = now;
+    existing.useCount += 1;
+    await setLearnedPatterns(patterns);
+    return existing;
+  }
+
+  const pattern: LearnedLinkPattern = {
+    version: LEARNED_PATTERN_VERSION,
+    id: generateId(),
+    senderAddress: input.senderAddress.trim().toLowerCase(),
+    senderRegistrableDomain: input.senderRegistrableDomain,
+    targetHostname: input.targetHostname,
+    normalizedCtaText: input.normalizedCtaText,
+    pathSignature: input.pathSignature,
+    createdAt: now,
+    lastUsedAt: now,
+    useCount: 1,
+  };
+
+  await setLearnedPatterns([...patterns, pattern]);
+  return pattern;
+}
+
+export async function forgetPattern(id: string): Promise<void> {
+  const patterns = await getLearnedPatterns();
+  const filtered = patterns.filter((p) => p.id !== id);
+  await setLearnedPatterns(filtered);
+}
+
+export async function forgetAllPatterns(): Promise<void> {
+  await LocalStorage.removeItem(LEARNED_PATTERNS_KEY);
+}

--- a/extensions/otp-inbox/src/lib/links.ts
+++ b/extensions/otp-inbox/src/lib/links.ts
@@ -1,0 +1,311 @@
+import { LinkCandidate, ValidatedLink, LearnedLinkPattern } from "./types";
+import {
+  AUTO_SELECT_MARGIN,
+  AUTO_SELECT_THRESHOLD,
+  GENERIC_CTA_PHRASES,
+  NEGATIVE_CTA_PHRASES,
+  PENALTY_GENERIC_CLICK,
+  PENALTY_INVALID,
+  PENALTY_NEGATIVE_INTENT,
+  PENALTY_NO_VISIBLE_TEXT,
+  PENALTY_TRACKING,
+  REDIRECT_PARAMETER_NAMES,
+  SCORE_BEFORE_FOOTER,
+  SCORE_GENERIC_CTA,
+  SCORE_LEARNED_EXACT,
+  SCORE_LEARNED_PARTIAL,
+  SCORE_PATH_INTENT,
+  SCORE_SAME_DOMAIN,
+  SCORE_STRONG_CTA,
+  STRONG_CTA_PHRASES,
+  TRACKING_FRAGMENTS,
+  VERIFICATION_PATH_TOKENS,
+} from "./constants";
+import { Anchor } from "./html";
+import { getRegistrableDomain } from "./domain";
+
+const REDIRECT_PARAM_NAMES_SET = new Set(REDIRECT_PARAMETER_NAMES);
+const STRONG_CTA_SET = new Set(STRONG_CTA_PHRASES);
+const NEGATIVE_CTA_SET = new Set(NEGATIVE_CTA_PHRASES);
+
+export interface LinkExtractionContext {
+  senderRegistrableDomain: string;
+  senderAddress: string;
+  learnedPatterns: LearnedLinkPattern[];
+}
+
+export function normalizeCtaText(text: string): string {
+  return text
+    .toLowerCase()
+    .normalize("NFKC")
+    .replace(/&[a-zA-Z0-9]+;/g, " ")
+    .replace(/[^\p{L}\p{N}\s]/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function hasPhrase(normalized: string, phrases: Set<string>): boolean {
+  for (const phrase of phrases) {
+    if (normalized.includes(phrase)) return true;
+  }
+  return false;
+}
+
+function containsStrongCta(text: string): boolean {
+  return hasPhrase(normalizeCtaText(text), STRONG_CTA_SET);
+}
+
+function containsNegativeCta(text: string): boolean {
+  return hasPhrase(normalizeCtaText(text), NEGATIVE_CTA_SET);
+}
+
+function hasGenericCta(text: string): boolean {
+  return hasPhrase(normalizeCtaText(text), new Set(GENERIC_CTA_PHRASES));
+}
+
+function hasVerificationPathToken(pathname: string): boolean {
+  const normalized = pathname.toLowerCase();
+  return VERIFICATION_PATH_TOKENS.some((token) => normalized.includes(token));
+}
+
+function hasTrackingHostOrPath(hostname: string, pathname: string): boolean {
+  const combined = `${hostname} ${pathname}`.toLowerCase();
+  return TRACKING_FRAGMENTS.some((fragment) => combined.includes(fragment));
+}
+
+function hasUnsafeReadableRedirect(href: string, senderRegistrableDomain: string): boolean {
+  try {
+    const url = new URL(href);
+    for (const [name, value] of url.searchParams) {
+      if (!REDIRECT_PARAM_NAMES_SET.has(name.toLowerCase())) continue;
+      try {
+        const inner = new URL(value);
+        const innerDomain = getRegistrableDomain(inner.hostname);
+        if (innerDomain && innerDomain !== senderRegistrableDomain) {
+          return true;
+        }
+      } catch {
+        // opaque value; ignore
+      }
+    }
+  } catch {
+    // malformed; let other validation reject it
+  }
+  return false;
+}
+
+export function createPathSignature(pathname: string): string {
+  return pathname.toLowerCase().normalize("NFKC").replace(/\/+/g, "/").replace(/\/$/, "") || "/";
+}
+
+function isMeaningfulVisibleText(text: string): boolean {
+  return normalizeCtaText(text).length > 0;
+}
+
+export function extractLinkCandidates(anchors: Anchor[], context: LinkExtractionContext): LinkCandidate[] {
+  const candidates: LinkCandidate[] = [];
+  const seen = new Set<string>();
+  let footerReached = false;
+
+  for (const anchor of anchors) {
+    // Detect footer markers in surrounding visible context using simple heuristics.
+    const lowerText = anchor.text.toLowerCase();
+    if (
+      lowerText.includes("privacy") ||
+      lowerText.includes("unsubscribe") ||
+      lowerText.includes("footer") ||
+      lowerText.includes("©") ||
+      lowerText.includes("copyright")
+    ) {
+      footerReached = true;
+    }
+
+    const visibleText = anchor.text.trim();
+    const normalizedVisibleText = normalizeCtaText(visibleText);
+
+    let parsed: URL | undefined;
+    let isHttps = false;
+    let hostname = "";
+    let pathname = "";
+    let registrableDomain: string | null = null;
+    const rejectionReasons: string[] = [];
+
+    try {
+      if (!anchor.href) throw new Error("missing_href");
+      parsed = new URL(anchor.href);
+      if (parsed.protocol !== "https:") throw new Error("not_https");
+      isHttps = true;
+      hostname = parsed.hostname.toLowerCase();
+      pathname = parsed.pathname;
+      registrableDomain = getRegistrableDomain(hostname);
+      if (!registrableDomain) throw new Error("no_registrable_domain");
+    } catch {
+      // Not a valid candidate
+      continue;
+    }
+
+    if (context.senderRegistrableDomain && registrableDomain !== context.senderRegistrableDomain) {
+      rejectionReasons.push("domain_mismatch");
+    }
+
+    const hasPositiveIntent = containsStrongCta(visibleText) || hasGenericCta(visibleText);
+    const hasNegativeIntent = containsNegativeCta(visibleText);
+    const isSameRegistrableDomain =
+      !!context.senderRegistrableDomain && registrableDomain === context.senderRegistrableDomain;
+
+    const hasUnsafeRedirect = hasUnsafeReadableRedirect(anchor.href, context.senderRegistrableDomain);
+    if (hasUnsafeRedirect) {
+      rejectionReasons.push("unsafe_redirect");
+    }
+
+    const pathSignature = createPathSignature(pathname);
+
+    let score = 0;
+
+    if (containsStrongCta(visibleText)) {
+      score += SCORE_STRONG_CTA;
+    } else if (hasGenericCta(visibleText)) {
+      score += SCORE_GENERIC_CTA;
+    }
+
+    if (hasVerificationPathToken(pathname) || hasVerificationPathToken(parsed.search)) {
+      score += SCORE_PATH_INTENT;
+    }
+
+    if (isSameRegistrableDomain) {
+      score += SCORE_SAME_DOMAIN;
+    }
+
+    if (!footerReached) {
+      score += SCORE_BEFORE_FOOTER;
+    }
+
+    if (!isMeaningfulVisibleText(visibleText)) {
+      score += PENALTY_NO_VISIBLE_TEXT;
+      rejectionReasons.push("no_visible_text");
+    }
+
+    if (hasTrackingHostOrPath(hostname, pathname)) {
+      score += PENALTY_TRACKING;
+      rejectionReasons.push("tracking");
+    }
+
+    if (normalizeCtaText(visibleText) === "click here" && !hasVerificationPathToken(pathname)) {
+      score += PENALTY_GENERIC_CLICK;
+      rejectionReasons.push("generic_click");
+    }
+
+    if (hasNegativeIntent) {
+      score += PENALTY_NEGATIVE_INTENT;
+      rejectionReasons.push("negative_intent");
+    }
+
+    if (rejectionReasons.includes("domain_mismatch") || rejectionReasons.includes("unsafe_redirect")) {
+      score += PENALTY_INVALID;
+    }
+
+    const key = `${hostname}::${pathSignature}::${normalizedVisibleText}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    candidates.push({
+      href: anchor.href,
+      hostname,
+      registrableDomain: registrableDomain || "",
+      visibleText,
+      normalizedVisibleText,
+      pathSignature,
+      originalIndex: anchor.index,
+      isHttps,
+      hasPositiveIntent,
+      hasNegativeIntent,
+      isSameRegistrableDomain,
+      hasUnsafeReadableRedirect: hasUnsafeRedirect,
+      score,
+      rejectionReasons,
+    });
+  }
+
+  // Apply learned pattern bonuses after initial scoring.
+  const scored = applyLearnedPatterns(candidates, context);
+
+  // Finalize rejection state: any remaining hard rejection reasons make the candidate ineligible.
+  return scored.map((candidate) => ({
+    ...candidate,
+    score: candidate.rejectionReasons.length > 0 ? candidate.score + PENALTY_INVALID : candidate.score,
+  }));
+}
+
+function applyLearnedPatterns(candidates: LinkCandidate[], context: LinkExtractionContext): LinkCandidate[] {
+  if (!context.learnedPatterns.length) return candidates;
+
+  return candidates.map((candidate) => {
+    for (const pattern of context.learnedPatterns) {
+      const senderMatch = context.senderAddress.toLowerCase().trim() === pattern.senderAddress.toLowerCase().trim();
+      const domainMatch = context.senderRegistrableDomain === pattern.senderRegistrableDomain;
+      const hostMatch = candidate.hostname === pattern.targetHostname;
+      const ctaMatch = candidate.normalizedVisibleText === pattern.normalizedCtaText;
+      const pathMatch = candidate.pathSignature === pattern.pathSignature;
+
+      if (senderMatch && domainMatch && hostMatch && ctaMatch && pathMatch) {
+        return { ...candidate, score: candidate.score + SCORE_LEARNED_EXACT, matchedPatternId: pattern.id };
+      }
+
+      if (senderMatch && domainMatch && hostMatch && ctaMatch) {
+        return { ...candidate, score: candidate.score + SCORE_LEARNED_PARTIAL, matchedPatternId: pattern.id };
+      }
+    }
+    return candidate;
+  });
+}
+
+export function selectVerificationLink(
+  candidates: LinkCandidate[],
+): { link: ValidatedLink; remaining: LinkCandidate[] } | undefined {
+  const eligible = candidates.filter(
+    (c) =>
+      c.isHttps &&
+      c.isSameRegistrableDomain &&
+      !c.hasNegativeIntent &&
+      !c.hasUnsafeReadableRedirect &&
+      c.rejectionReasons.length === 0 &&
+      (c.hasPositiveIntent || hasVerificationPathToken(c.pathSignature)),
+  );
+
+  if (eligible.length === 0) {
+    return undefined;
+  }
+
+  const sorted = [...eligible].sort((a, b) => b.score - a.score);
+  const best = sorted[0];
+  const second = sorted[1];
+  if (best.score >= AUTO_SELECT_THRESHOLD && (!second || best.score - second.score >= AUTO_SELECT_MARGIN)) {
+    return {
+      link: {
+        href: best.href,
+        hostname: best.hostname,
+        pathSignature: best.pathSignature,
+        normalizedCtaText: best.normalizedVisibleText,
+        score: best.score,
+        selectedBy: best.matchedPatternId ? "learned-pattern" : "automatic",
+        matchedPatternId: best.matchedPatternId,
+      },
+      remaining: sorted.slice(1),
+    };
+  }
+
+  return undefined;
+}
+
+export function getAmbiguousLinks(candidates: LinkCandidate[]): LinkCandidate[] {
+  const eligible = candidates.filter(
+    (c) =>
+      c.isHttps &&
+      c.isSameRegistrableDomain &&
+      !c.hasNegativeIntent &&
+      !c.hasUnsafeReadableRedirect &&
+      c.rejectionReasons.length === 0 &&
+      (c.hasPositiveIntent || hasVerificationPathToken(c.pathSignature)),
+  );
+  return [...eligible].sort((a, b) => b.score - a.score);
+}

--- a/extensions/otp-inbox/src/lib/mime.ts
+++ b/extensions/otp-inbox/src/lib/mime.ts
@@ -1,0 +1,79 @@
+import { EmailPayload } from "./types";
+
+function tryDecodeBase64Url(input: string): string {
+  try {
+    const base64Encoded = input.replace(/-/g, "+").replace(/_/g, "/");
+    const padding = input.length % 4 === 0 ? "" : "=".repeat(4 - (input.length % 4));
+    return atob(base64Encoded + padding);
+  } catch {
+    return "";
+  }
+}
+
+function isAttachment(part: EmailPayload): boolean {
+  if (!part.headers) return false;
+  return part.headers.some(
+    (header) =>
+      header.name.toLowerCase() === "content-disposition" &&
+      (header.value.toLowerCase().startsWith("attachment") || header.value.toLowerCase().includes("filename")),
+  );
+}
+
+function isMultipart(mimeType: string | undefined): boolean {
+  return !!mimeType && mimeType.toLowerCase().startsWith("multipart/");
+}
+
+export interface EmailBodies {
+  plainText: string;
+  htmlText: string;
+}
+
+export function extractBodies(payload: EmailPayload): EmailBodies {
+  if (!payload) {
+    return { plainText: "", htmlText: "" };
+  }
+
+  const result: EmailBodies = { plainText: "", htmlText: "" };
+
+  function traverse(part: EmailPayload): void {
+    const mimeType = part.mimeType?.toLowerCase() || "";
+
+    if (isMultipart(mimeType) && Array.isArray(part.parts)) {
+      for (const child of part.parts) {
+        traverse(child);
+        if (result.plainText && result.htmlText) {
+          // We have both, stop early
+          return;
+        }
+      }
+      return;
+    }
+
+    if (isAttachment(part)) {
+      return;
+    }
+
+    const data = part.body?.data;
+    if (!data) {
+      return;
+    }
+
+    const decoded = tryDecodeBase64Url(data);
+    if (!decoded) {
+      return;
+    }
+
+    if (mimeType === "text/plain" && !result.plainText) {
+      result.plainText = decoded;
+    } else if (mimeType === "text/html" && !result.htmlText) {
+      result.htmlText = decoded;
+    }
+  }
+
+  traverse(payload);
+  return result;
+}
+
+export function getHeaderValue(payload: EmailPayload, headerName: string): string | undefined {
+  return payload.headers?.find((header) => header.name.toLowerCase() === headerName.toLowerCase())?.value;
+}

--- a/extensions/otp-inbox/src/lib/otp.ts
+++ b/extensions/otp-inbox/src/lib/otp.ts
@@ -1,0 +1,12 @@
+const OTP_PATTERN = /(?<![\d\p{L}])\d{4,8}(?![\d\p{L}])/gu;
+
+export function extractOtp(text: string): string | undefined {
+  if (!text) return undefined;
+  const candidates = text.match(OTP_PATTERN) ?? [];
+  const unique = [...new Set(candidates)];
+  return unique.length === 1 ? unique[0] : undefined;
+}
+
+export function isValidOtp(value: string | undefined): value is string {
+  return value !== undefined && /^\d{4,8}$/.test(value);
+}

--- a/extensions/otp-inbox/src/lib/types.ts
+++ b/extensions/otp-inbox/src/lib/types.ts
@@ -1,11 +1,24 @@
+export interface EmailSender {
+  name: string;
+  email: string;
+}
+
 export interface VerificationCode {
   code: string | null;
   receivedAt: Date;
-  sender: {
-    name: string;
-    email: string;
-  };
+  sender: EmailSender;
   emailText: string;
+}
+
+export interface ProcessedEmail {
+  otp: string | undefined;
+  link: ValidatedLink | undefined;
+  ambiguousLinks: LinkCandidate[];
+  sender: EmailSender;
+  receivedAt: Date;
+  emailText: string;
+  senderRegistrableDomain: string | null;
+  learnedPatterns: LearnedLinkPattern[];
 }
 
 export interface Email {
@@ -19,6 +32,47 @@ export interface EmailPayload {
     value: string;
   }[];
   mimeType: string;
-  parts: EmailPayload[];
-  body: { data: string };
+  parts?: EmailPayload[];
+  body?: { data?: string; attachmentId?: string };
+}
+
+export interface ValidatedLink {
+  href: string;
+  hostname: string;
+  pathSignature: string;
+  normalizedCtaText: string;
+  score: number;
+  selectedBy: "automatic" | "learned-pattern";
+  matchedPatternId?: string;
+}
+
+export interface LinkCandidate {
+  href: string;
+  hostname: string;
+  registrableDomain: string;
+  visibleText: string;
+  normalizedVisibleText: string;
+  pathSignature: string;
+  originalIndex: number;
+  isHttps: boolean;
+  hasPositiveIntent: boolean;
+  hasNegativeIntent: boolean;
+  isSameRegistrableDomain: boolean;
+  hasUnsafeReadableRedirect: boolean;
+  score: number;
+  rejectionReasons: string[];
+  matchedPatternId?: string;
+}
+
+export interface LearnedLinkPattern {
+  version: 1;
+  id: string;
+  senderAddress: string;
+  senderRegistrableDomain: string;
+  targetHostname: string;
+  normalizedCtaText: string;
+  pathSignature: string;
+  createdAt: string;
+  lastUsedAt: string;
+  useCount: number;
 }

--- a/extensions/otp-inbox/src/lib/utils.ts
+++ b/extensions/otp-inbox/src/lib/utils.ts
@@ -1,145 +1,50 @@
 import { getPreferenceValues } from "@raycast/api";
 import { emailFilterKeywords } from "./constants";
-import { Email, EmailPayload, VerificationCode } from "./types";
+import { Email, ProcessedEmail } from "./types";
+import { extractVerificationMethods, emailMatchesKeywords, normalizeCtaText } from "./extractor";
+import { getLearnedPatterns } from "./learning";
 
-export function extractVerificationCode(text: string): string {
-  const patterns: RegExp[] = [
-    /\b\w*(?:-\w*)+\b/g, // Pattern for codes with hyphen
-    /\b\d{6,8}\b|\b\d{3,4}\s\d{3,4}\b/g, // Pattern for 6-8 digit numeric codes with or without space
-  ];
-  const verificationCodes: string[] = [];
+export { normalizeCtaText };
 
-  // Extract the verification codes
-  for (const pattern of patterns) {
-    const matches = text.match(pattern);
-    if (matches && matches.length > 0) {
-      for (const match of matches) {
-        if (pattern.source === /\b\w*(?:-\w*)+\b/g.source) {
-          // Check if the parts on either side of the hyphen have equal length
-          const parts = match.split("-");
-          if (parts.length === 2 && parts[0].length === parts[1].length) {
-            verificationCodes.push(match);
-          }
-        } else {
-          verificationCodes.push(match);
-        }
-      }
-    }
-  }
-
-  // If theres still more than one code, prioritize digit ones
-  if (verificationCodes.length > 1) {
-    const digitCodes = verificationCodes.filter((code) => /^\d+$/.test(code));
-    if (digitCodes.length > 0) {
-      return digitCodes[0];
-    }
-  }
-
-  return verificationCodes[0] || "";
-}
-
-export function processEmails(emails: Email[]): {
-  recentEmails: VerificationCode[];
-  verificationCodes: VerificationCode[];
-} {
-  // Validate if there are any emails
+export async function processEmails(emails: Email[]): Promise<{
+  recentEmails: ProcessedEmail[];
+  verificationCodes: ProcessedEmail[];
+}> {
   if (!emails || emails.length === 0) {
-    console.log("No emails found");
     return { recentEmails: [], verificationCodes: [] };
   }
 
-  // List of verification codes
-  const recentEmails: VerificationCode[] = [];
-  const verificationCodes: VerificationCode[] = [];
+  const recentEmails: ProcessedEmail[] = [];
+  const verificationCodes: ProcessedEmail[] = [];
 
-  // Loop through the emails
-  emails.forEach((email) => {
+  const customKeywords = getPreferenceValues().emailFilterKeywords;
+  const filterKeywords = customKeywords
+    ? customKeywords
+        .split(",")
+        .map((k: string) => k.trim().toLowerCase())
+        .filter(Boolean)
+    : emailFilterKeywords;
+
+  const learnedPatterns = await getLearnedPatterns();
+
+  for (const email of emails) {
     try {
-      // Email headers
-      const headers = email["payload"]["headers"];
+      const processed = await extractVerificationMethods(email, { learnedPatterns });
 
-      // Decode body
-      const body = decodeEmailBody(email["payload"]).replace(/[^a-zA-Z0-9\s/:?.&=+-]/g, "");
-
-      // Validate if email contains keywords
-      const customKeywords = getPreferenceValues().emailFilterKeywords;
-      const filterKeywords = customKeywords ? customKeywords.split(",") : emailFilterKeywords;
-      if (
-        !filterKeywords.some(
-          (keyword: string) =>
-            body.toLowerCase().includes(keyword) ||
-            (headers.find((header) => header.name === "Subject")?.value || "").toLowerCase().includes(keyword),
-        )
-      ) {
-        return;
+      if (!emailMatchesKeywords(processed, filterKeywords)) {
+        continue;
       }
 
-      // Extract the verification code from the email
-      const verificationCode = extractVerificationCode(body);
-
-      // Extract sender & sender email (format: Sender <email@domain.com>)
-      const sender = headers
-        .find((header) => header.name === "From")
-        ?.value?.replace(/<([^>]+)>/, "")
-        .trim();
-      const senderEmail = headers.find((header) => header.name === "From")?.value?.match(/<([^>]+)>/)?.[1] || "";
-
-      // Verify if code could be extracted
-      if (!verificationCode) {
-        // Add the email to the list of recent emails
-        return recentEmails.push({
-          code: null,
-          receivedAt: new Date(parseInt(email["internalDate"], 10)),
-          sender: {
-            name: sender || "",
-            email: senderEmail,
-          },
-          emailText: body,
-        });
+      if (processed.otp || processed.link) {
+        verificationCodes.push(processed);
+      } else {
+        recentEmails.push(processed);
       }
-
-      // Add the verification code to the list
-      verificationCodes.push({
-        code: verificationCode,
-        receivedAt: new Date(parseInt(email["internalDate"], 10)),
-        sender: {
-          name: sender || "",
-          email: senderEmail,
-        },
-        emailText: body,
-      });
     } catch (error) {
-      console.log("Failed to process email", error);
+      // Fail closed: log nothing sensitive, skip this email
+      console.error("Failed to process email", error);
     }
-  });
-
-  return { recentEmails, verificationCodes };
-}
-
-export function decodeEmailBody(body: EmailPayload): string {
-  if (body["mimeType"] === "multipart/alternative") {
-    return decodeEmailBody(body["parts"][0]);
-  } else if (body["mimeType"] === "text/plain") {
-    return base64URLdecode(body["body"]["data"]).join("");
-  } else if (body["mimeType"] === "text/html") {
-    // TODO: make sure hyperlinks get detected too / eventually make it so that user has option to open link as action
-    return base64URLdecode(body["body"]["data"])
-      .join("")
-      .replace(/<[^>]+>/g, " ")
-      .replace(/\s\w+="[^"]*"/g, "")
-      .replace(/[^a-zA-Z\s\d-]/g, "")
-      .replace(/\s+/g, " ")
-      .trim();
   }
 
-  return "";
-}
-
-function base64URLdecode(str: string): string[] {
-  const base64Encoded = str.replace(/-/g, "+").replace(/_/g, "/");
-  const padding = str.length % 4 === 0 ? "" : "=".repeat(4 - (str.length % 4));
-  const base64WithPadding = base64Encoded + padding;
-  return atob(base64WithPadding)
-    .split("")
-    .map((char) => String.fromCharCode(char.charCodeAt(0)));
+  return { recentEmails, verificationCodes };
 }

--- a/extensions/otp-inbox/src/otp-inbox.tsx
+++ b/extensions/otp-inbox/src/otp-inbox.tsx
@@ -1,160 +1,188 @@
 import {
-  ActionPanel,
-  List,
   Action,
-  Color,
-  Icon,
+  ActionPanel,
   getFrontmostApplication,
-  openExtensionPreferences,
   getPreferenceValues,
-  Detail,
-  Keyboard,
+  Icon,
+  List,
+  openExtensionPreferences,
+  showHUD,
+  showToast,
+  Toast,
 } from "@raycast/api";
-import { Clipboard, showHUD } from "@raycast/api";
+import { Clipboard } from "@raycast/api";
+import React from "react";
 import { getEmails } from "./lib/gmail";
 import { processEmails } from "./lib/utils";
-import { VerificationCode } from "./lib/types";
+import { ProcessedEmail } from "./lib/types";
+import { LinkChooser } from "./components/link-chooser";
+import { EmailDetail } from "./components/email-detail";
 import AuthWrapper from "./components/auth-wrapper";
-import React from "react";
+import { forgetPattern } from "./lib/learning";
+import { isValidOtp } from "./lib/otp";
+
+function VerificationActions({
+  processed,
+  frontmostApp,
+  onForgetPattern,
+  onRefresh,
+}: {
+  processed: ProcessedEmail;
+  frontmostApp: string;
+  onForgetPattern: () => void;
+  onRefresh: () => void;
+}) {
+  const otp = isValidOtp(processed.otp) ? processed.otp : undefined;
+
+  return (
+    <ActionPanel>
+      {otp && (
+        <ActionPanel.Section title="Verification Code">
+          <Action
+            title={`Paste to ${frontmostApp}`}
+            icon={{ source: Icon.Paperclip, tintColor: "#FFFFFF" }}
+            shortcut={{ modifiers: ["cmd"], key: "return" }}
+            onAction={async () => {
+              await Clipboard.paste(otp);
+              await showHUD(`Pasted code to ${frontmostApp}`, { clearRootSearch: true });
+            }}
+          />
+          <Action
+            title="Copy Verification Code"
+            icon={{ source: Icon.Clipboard }}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+            onAction={async () => {
+              await Clipboard.copy(otp);
+              await showHUD("Copied code to clipboard", { clearRootSearch: true });
+            }}
+          />
+        </ActionPanel.Section>
+      )}
+
+      {processed.link && (
+        <ActionPanel.Section title="Verification Link">
+          <Action.OpenInBrowser
+            url={processed.link.href}
+            title="Open Verification Link"
+            shortcut={{ modifiers: ["cmd"], key: "o" }}
+          />
+          <Action.CopyToClipboard
+            content={processed.link.href}
+            title="Copy Verification Link"
+            shortcut={{ modifiers: ["cmd", "shift"], key: "l" }}
+          />
+          {processed.link.selectedBy === "learned-pattern" && processed.link.matchedPatternId && (
+            <Action
+              title="Forget Learned Link Pattern"
+              icon={{ source: Icon.Trash }}
+              shortcut={{ modifiers: ["cmd", "shift"], key: "f" }}
+              onAction={async () => {
+                await forgetPattern(processed.link!.matchedPatternId!);
+                onForgetPattern();
+                await showToast({ style: Toast.Style.Success, title: "Forgot link pattern" });
+              }}
+            />
+          )}
+        </ActionPanel.Section>
+      )}
+
+      {processed.ambiguousLinks.length > 0 && (
+        <ActionPanel.Section title="Verification Link">
+          <Action.Push
+            title="Choose Verification Link…"
+            icon={{ source: Icon.List }}
+            shortcut={{ modifiers: ["cmd"], key: "l" }}
+            target={
+              <LinkChooser
+                candidates={processed.ambiguousLinks}
+                sender={processed.sender}
+                senderRegistrableDomain={processed.senderRegistrableDomain}
+              />
+            }
+          />
+        </ActionPanel.Section>
+      )}
+
+      <ActionPanel.Section title="Email">
+        <Action.Push
+          title="Show Email Content"
+          icon={{ source: Icon.Text }}
+          shortcut={{ modifiers: ["cmd"], key: "e" }}
+          target={<EmailDetail sender={processed.sender} emailText={processed.emailText} />}
+        />
+        <Action
+          title="Refresh"
+          icon={{ source: Icon.ArrowClockwise }}
+          shortcut={{ modifiers: ["cmd"], key: "r" }}
+          onAction={onRefresh}
+        />
+        <Action title="Open Extension Preferences" icon={{ source: Icon.Gear }} onAction={openExtensionPreferences} />
+      </ActionPanel.Section>
+    </ActionPanel>
+  );
+}
 
 export default function OTPInbox() {
-  const [frontmostApp, setFrontmostApp] = React.useState<string>("");
-  const [verificationCodes, setVerificationCodes] = React.useState<VerificationCode[] | null>(null);
-  const [recentEmails, setRecentEmails] = React.useState<VerificationCode[]>([]);
+  const [frontmostApp, setFrontmostApp] = React.useState<string>("active app");
+  const [items, setItems] = React.useState<ProcessedEmail[] | null>(null);
+  const [, setForceRender] = React.useState(0);
 
-  async function getVerificationCodes() {
-    // Set states
-    setVerificationCodes(null);
-    setRecentEmails([]);
-
-    // Get the emails
-    const emails = await getEmails();
-
-    // Process emails
-    const { recentEmails, verificationCodes } = processEmails(emails);
-
-    // Set states
-    setRecentEmails(recentEmails);
-    setVerificationCodes(verificationCodes);
+  async function load() {
+    setItems(null);
+    try {
+      const app = await getFrontmostApplication();
+      setFrontmostApp(app.name);
+      const emails = await getEmails();
+      const { recentEmails, verificationCodes } = await processEmails(emails);
+      setItems([...verificationCodes, ...recentEmails]);
+    } catch (error) {
+      console.error("Failed to load OTP Inbox", error);
+      setItems([]);
+    }
   }
 
   React.useEffect(() => {
-    (async () => {
-      try {
-        // Set the frontmost app
-        setFrontmostApp((await getFrontmostApplication()).name);
-
-        // Get verification codes
-        await getVerificationCodes();
-      } catch (error) {
-        console.error("Failed to get verification codes", error);
-      }
-    })();
+    load();
   }, []);
 
   return (
     <AuthWrapper>
-      <List isLoading={verificationCodes === null}>
-        <List.Section title="Verification Codes">
-          {verificationCodes?.map((code) => (
-            <List.Item
-              key={code.receivedAt.toISOString()}
-              title={code.sender.name}
-              subtitle={code.sender.email}
-              accessories={[
-                {
-                  tag: getPreferenceValues().hideVerificationCodes
-                    ? "•".repeat(code.code?.replace(/[\s-]/g, "").length || 0)
-                    : code.code,
-                },
-                {
-                  date: code.receivedAt,
-                },
-              ]}
-              actions={
-                <ActionPanel>
-                  <Action
-                    title={`Paste to ${frontmostApp}`}
-                    icon={{ source: Icon.Paperclip, tintColor: Color.PrimaryText }}
-                    onAction={async () => {
-                      const app = await getFrontmostApplication();
-                      await Clipboard.paste(code.code!);
-                      await showHUD(`Pasted code for ${code.sender.name} to ${app.name}`, { clearRootSearch: true });
-                    }}
-                  />
-                  <Action
-                    title={`Copy to Clipboard`}
-                    icon={{ source: Icon.Clipboard }}
-                    onAction={async () => {
-                      await Clipboard.copy(code.code!);
-                      await showHUD(`Copied code for ${code.sender.name} to clipboard`, { clearRootSearch: true });
-                    }}
-                  />
-                  <Action.Push
-                    title="Show Email Content"
-                    icon={{ source: Icon.Text }}
-                    shortcut={{ macOS: { modifiers: ["cmd"], key: "e" }, Windows: { modifiers: ["ctrl"], key: "e" } }}
-                    target={<Detail markdown={`### Email from ${code.sender.name}\n\n${code.emailText}`} />}
-                  />
-                  <Action
-                    title="Refresh"
-                    icon={{ source: Icon.ArrowClockwise }}
-                    shortcut={Keyboard.Shortcut.Common.Refresh}
-                    onAction={async () => {
-                      await getVerificationCodes();
-                    }}
-                  />
-                  <Action
-                    title="Open Extension Preferences"
-                    icon={{ source: Icon.Gear }}
-                    onAction={openExtensionPreferences}
-                  />
-                </ActionPanel>
-              }
-            />
-          ))}
-        </List.Section>
-        <List.Section title="Recent Emails">
-          {recentEmails.map((email) => (
-            <List.Item
-              key={email.receivedAt.toISOString()}
-              title={email.sender.name}
-              subtitle={email.sender.email}
-              accessories={[
-                {
-                  date: email.receivedAt,
-                },
-              ]}
-              actions={
-                <ActionPanel>
-                  <Action.Push
-                    title="Show Email Content"
-                    icon={{ source: Icon.Text }}
-                    shortcut={{ macOS: { modifiers: ["cmd"], key: "e" }, Windows: { modifiers: ["ctrl"], key: "e" } }}
-                    target={<Detail markdown={`### Email from ${email.sender.name}\n\n${email.emailText}`} />}
-                  />
-                  <Action
-                    title="Open Extension Preferences"
-                    icon={{ source: Icon.Gear }}
-                    onAction={openExtensionPreferences}
-                  />
-                </ActionPanel>
-              }
-            />
-          ))}
-        </List.Section>
+      <List isLoading={items === null}>
+        {items?.map((processed, idx) => (
+          <List.Item
+            key={`${processed.receivedAt.toISOString()}-${processed.sender.email}-${idx}`}
+            title={processed.sender.name}
+            subtitle={processed.sender.email}
+            accessories={[
+              {
+                tag: processed.otp
+                  ? getPreferenceValues().hideVerificationCodes
+                    ? "•".repeat(processed.otp.length)
+                    : processed.otp
+                  : processed.link
+                    ? "Link"
+                    : processed.ambiguousLinks.length > 0
+                      ? "Choose…"
+                      : "No code/link",
+              },
+              { date: processed.receivedAt },
+            ]}
+            actions={
+              <VerificationActions
+                processed={processed}
+                frontmostApp={frontmostApp}
+                onForgetPattern={() => setForceRender((v) => v + 1)}
+                onRefresh={load}
+              />
+            }
+          />
+        ))}
         <List.EmptyView
           title="No Verification Codes Found"
           description="No verification codes found from the last 10 minutes. Try refreshing."
           actions={
             <ActionPanel>
-              <Action
-                title="Refresh"
-                icon={{ source: Icon.ArrowClockwise }}
-                onAction={async () => {
-                  await getVerificationCodes();
-                }}
-              />
+              <Action title="Refresh" icon={{ source: Icon.ArrowClockwise }} onAction={load} />
               <Action
                 title="Open Extension Preferences"
                 icon={{ source: Icon.Gear }}


### PR DESCRIPTION
## Summary
- Prefer plain-text MIME content and sanitize HTML fallback before verification-method extraction.
- Accept only one unambiguous 4–8 digit numeric OTP.
- Prevent HTML/CSS tokens such as `font-size` from being exposed as pasteable codes.
- Add explicit, manually invoked Open/Copy actions for high-confidence HTTPS verification CTAs.
- Keep OTP and verification-link actions independent when emails contain both.
- Add conservative optional local pattern learning for manually selected recurring CTAs.

## Link safety
Verification links require HTTPS, public-suffix-aware sender-domain relation, positive CTA intent, footer/tracking exclusions, readable cross-domain redirect rejection, and a decisive score margin. Ambiguous candidates fail closed.

Learned patterns store only sender, hostname, normalized CTA, and sanitized path. They cannot bypass hard checks and never auto-open links.

## Tests
- OTP extraction, duplicates, ambiguity, and numeric boundaries
- MIME and HTML sanitization behavior
- NVIDIA-shaped CSS-heavy magic-link regression
- footer/privacy/contact filtering
- public-suffix-aware domain checks
- redirect, HTTP, spoofed-host, and opaque-token handling
- OTP + link coexistence
- ambiguity chooser
- learned pattern lifecycle and expiry