### PR TITLE
Twenty: fix metadata API parsing for current Twenty versions

### DIFF
--- a/extensions/twenty/CHANGELOG.md
+++ b/extensions/twenty/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Twenty Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Fixed "Invalid input: expected object, received array" on newer Twenty versions, which changed the metadata API response shape
+- Objects beyond the first page are no longer silently dropped — the metadata API now paginates at 60 objects by default
+- Objects and fields no longer disappear when optional metadata flags are absent
+- API errors now show the message returned by Twenty instead of a raw validation dump
+
 ## [Fix Bug] - 2025-11-27
 
 - Fixed issue when adding API Key, it would not work

--- a/extensions/twenty/CHANGELOG.md
+++ b/extensions/twenty/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Twenty Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-07-28
 
 - Fixed "Invalid input: expected object, received array" on newer Twenty versions, which changed the metadata API response shape
 - Objects beyond the first page are no longer silently dropped — the metadata API now paginates at 60 objects by default

--- a/extensions/twenty/src/create-object-record.tsx
+++ b/extensions/twenty/src/create-object-record.tsx
@@ -1,11 +1,11 @@
 import { Action, ActionPanel, Detail, Icon, List, showToast, Toast, useNavigation } from "@raycast/api";
-import { randomUUID } from "crypto";
 
 import twenty from "./services/TwentySDK";
 import { ObjectIcons } from "./enum/icons";
 import { OpenCreateObjectRecordForm } from "./pages";
 import { usePromise } from "@raycast/utils";
 import { useState } from "react";
+import { DataModelItem } from "./services/zod/schema/dataModelSchema";
 
 export default function CreateObjectRecord() {
   const {
@@ -29,8 +29,55 @@ export default function CreateObjectRecord() {
     return <Detail markdown={` # ERROR \n\n ${error.message}`} />;
   }
 
-  const standardActiveModel = activeDataModels?.filter((model) => !model.isCustom);
-  const customActiveModel = activeDataModels?.filter((model) => model.isCustom);
+  // `isCustom` was removed from the metadata API in Twenty 2.12. Without it we
+  // cannot tell standard and custom objects apart, so they share one section.
+  const canSplitByCustom = activeDataModels?.some((model) => typeof model.isCustom === "boolean") ?? false;
+  const standardActiveModel = canSplitByCustom
+    ? activeDataModels?.filter((model) => !model.isCustom)
+    : activeDataModels;
+  const customActiveModel = canSplitByCustom ? activeDataModels?.filter((model) => model.isCustom) : [];
+
+  function renderModel(model: DataModelItem) {
+    const { id, description, labelPlural, icon } = model;
+
+    return (
+      <List.Item
+        id={id}
+        key={id}
+        title={labelPlural}
+        subtitle={description ?? ""}
+        icon={icon ? (ObjectIcons[icon] ?? Icon.BulletPoints) : Icon.BulletPoints}
+        actions={
+          !isOpenView ? (
+            <ActionPanel>
+              <Action
+                title="Create Record"
+                icon={Icon.List}
+                onAction={async () => {
+                  try {
+                    setIsOpenView(true);
+                    const objectRecordMetadata = await twenty.getRecordFieldsForDataModel(id);
+                    if (typeof objectRecordMetadata === "string") {
+                      await showToast({
+                        style: Toast.Style.Failure,
+                        title: objectRecordMetadata,
+                      });
+                    } else {
+                      push(OpenCreateObjectRecordForm({ objectRecordMetadata }));
+                    }
+                  } finally {
+                    setIsOpenView(false);
+                  }
+                }}
+              />
+            </ActionPanel>
+          ) : (
+            <></>
+          )
+        }
+      />
+    );
+  }
 
   return (
     <List
@@ -38,90 +85,10 @@ export default function CreateObjectRecord() {
       navigationTitle="Create Object Record"
       searchBarPlaceholder="Search Object Record"
     >
-      <List.Section title="Standard Objects">
-        {standardActiveModel?.map((model) => {
-          const { id, description, labelPlural, icon } = model;
-          return (
-            <List.Item
-              id={id}
-              title={labelPlural}
-              subtitle={description ?? ""}
-              actions={
-                !isOpenView ? (
-                  <ActionPanel>
-                    <Action
-                      title="Create Record"
-                      icon={Icon.List}
-                      onAction={async () => {
-                        try {
-                          setIsOpenView(true);
-                          const objectRecordMetadata = await twenty.getRecordFieldsForDataModel(id);
-                          if (typeof objectRecordMetadata === "string") {
-                            await showToast({
-                              style: Toast.Style.Failure,
-                              title: objectRecordMetadata,
-                            });
-                          } else {
-                            push(OpenCreateObjectRecordForm({ objectRecordMetadata }));
-                          }
-                        } finally {
-                          setIsOpenView(false);
-                        }
-                      }}
-                    />
-                  </ActionPanel>
-                ) : (
-                  <></>
-                )
-              }
-              icon={icon ? (ObjectIcons[icon] ?? Icon.BulletPoints) : Icon.BulletPoints}
-              key={randomUUID().toString()}
-            />
-          );
-        })}
+      <List.Section title={canSplitByCustom ? "Standard Objects" : "Objects"}>
+        {standardActiveModel?.map(renderModel)}
       </List.Section>
-      <List.Section title="Custom Objects">
-        {customActiveModel?.map((model) => {
-          const { id, description, labelPlural } = model;
-          return (
-            <List.Item
-              id={id}
-              title={labelPlural}
-              subtitle={description ?? ""}
-              icon={Icon.BulletPoints}
-              actions={
-                !isOpenView ? (
-                  <ActionPanel>
-                    <Action
-                      title="Create Record"
-                      icon={Icon.List}
-                      onAction={async () => {
-                        try {
-                          setIsOpenView(true);
-                          const objectRecordMetadata = await twenty.getRecordFieldsForDataModel(id);
-                          if (typeof objectRecordMetadata === "string") {
-                            await showToast({
-                              style: Toast.Style.Failure,
-                              title: objectRecordMetadata,
-                            });
-                          } else {
-                            push(OpenCreateObjectRecordForm({ objectRecordMetadata }));
-                          }
-                        } finally {
-                          setIsOpenView(false);
-                        }
-                      }}
-                    />
-                  </ActionPanel>
-                ) : (
-                  <></>
-                )
-              }
-              key={randomUUID().toString()}
-            />
-          );
-        })}
-      </List.Section>
+      <List.Section title="Custom Objects">{customActiveModel?.map(renderModel)}</List.Section>
     </List>
   );
 }

--- a/extensions/twenty/src/services/TwentySDK.ts
+++ b/extensions/twenty/src/services/TwentySDK.ts
@@ -1,11 +1,27 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { getPreferenceValues } from "@raycast/api";
 import { Api } from "../enum/api";
-import fetch from "node-fetch";
-import { getActiveDataModelsSchema } from "./zod/schema/dataModelSchema";
-import { getDataModelWithFieldsSchema } from "./zod/schema/recordFieldSchema";
+import fetch, { Response } from "node-fetch";
+import { z } from "zod";
+import { DataModelItem, extractDataModels, getActiveDataModelsSchema } from "./zod/schema/dataModelSchema";
+import { extractDataModelWithFields, getDataModelWithFieldsSchema } from "./zod/schema/recordFieldSchema";
 import { removeTrailingSlash } from "../helper/removeTrailingSlash";
 import { isUrl } from "../helper/isUrl";
+
+// `QUERY_MAX_RECORDS` on the Twenty API — larger values are clamped server side.
+const METADATA_PAGE_SIZE = 200;
+// Safety net so a server that never clears `hasNextPage` cannot loop forever.
+const MAX_METADATA_PAGES = 25;
+
+function describeError(err: unknown) {
+  if (err instanceof z.ZodError) {
+    const [issue] = err.issues;
+    const path = issue?.path.join(".") || "response";
+    return `Unexpected response from the Twenty API at "${path}": ${issue?.message ?? "invalid data"}`;
+  }
+
+  return err instanceof Error ? err.message : String(err);
+}
 
 class TwentySDK {
   private url!: string;
@@ -18,26 +34,60 @@ class TwentySDK {
     this.url = isUrl(url) ? `${url}/rest` : `https://api.twenty.com/rest`;
   }
 
+  private get headers() {
+    return {
+      "Content-Type": "application/json",
+      [Api.KEY]: this.token,
+    };
+  }
+
+  private async describeResponseError(response: Response) {
+    const body = await response.text().catch(() => "");
+
+    try {
+      const parsed = JSON.parse(body);
+      const detail = parsed?.messages ?? parsed?.message ?? parsed?.error;
+
+      if (Array.isArray(detail) && detail.length > 0) return detail.join(", ");
+      if (typeof detail === "string" && detail.length > 0) return detail;
+    } catch {
+      // Body was not JSON, fall through to the status text.
+    }
+
+    return response.statusText || `Request failed with status ${response.status}`;
+  }
+
   async getActiveDataModels() {
     try {
-      const response = await fetch(this.url + "/metadata/objects", {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          [Api.KEY]: this.token,
-        },
-      });
+      const dataModels: DataModelItem[] = [];
+      let startingAfter: string | undefined;
 
-      if (response.ok) {
-        const rawData = await response.json();
-        const data = getActiveDataModelsSchema.parse(rawData);
-        const activeDataModel = data.data.objects.filter((model) => !model.isSystem && model.isActive);
-        return activeDataModel;
+      for (let page = 0; page < MAX_METADATA_PAGES; page++) {
+        const query = new URLSearchParams({ limit: String(METADATA_PAGE_SIZE) });
+        if (startingAfter) query.set("starting_after", startingAfter);
+
+        const response = await fetch(`${this.url}/metadata/objects?${query.toString()}`, {
+          method: "GET",
+          headers: this.headers,
+        });
+
+        if (!response.ok) {
+          return await this.describeResponseError(response);
+        }
+
+        const parsed = getActiveDataModelsSchema.parse(await response.json());
+        dataModels.push(...extractDataModels(parsed));
+
+        const { pageInfo } = parsed;
+        if (!pageInfo?.hasNextPage || !pageInfo.endCursor) break;
+        startingAfter = pageInfo.endCursor;
       }
 
-      return response.statusText;
+      // `isSystem` / `isActive` are optional on newer servers, so only exclude
+      // models that explicitly opt out.
+      return dataModels.filter((model) => model.isSystem !== true && model.isActive !== false);
     } catch (err) {
-      return err instanceof Error ? err.message : String(err);
+      return describeError(err);
     }
   }
 
@@ -45,28 +95,28 @@ class TwentySDK {
     try {
       const response = await fetch(this.url + `/metadata/objects/${id}`, {
         method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          [Api.KEY]: this.token,
-        },
+        headers: this.headers,
       });
 
-      if (response.ok) {
-        const rawData = await response.json();
-        const objectRecordWithFieldsMetadata = getDataModelWithFieldsSchema.parse(rawData);
-        const excludeFieldsWithName = ["updatedAt", "deletedAt"];
-        objectRecordWithFieldsMetadata.data.object.fields = objectRecordWithFieldsMetadata.data.object.fields
-          .filter((object) => !object.isSystem)
-          .filter((object) => object.isActive)
-          .filter((object) => object.type !== "RELATION" && object.type !== "ACTOR") // handle relation later
-          .filter((object) => !excludeFieldsWithName.includes(object.name));
-
-        return objectRecordWithFieldsMetadata.data.object;
+      if (!response.ok) {
+        return await this.describeResponseError(response);
       }
 
-      return response.statusText;
+      const objectRecordMetadata = extractDataModelWithFields(
+        getDataModelWithFieldsSchema.parse(await response.json()),
+      );
+      const excludeFieldsWithName = ["updatedAt", "deletedAt"];
+
+      return {
+        ...objectRecordMetadata,
+        fields: objectRecordMetadata.fields
+          .filter((field) => field.isSystem !== true)
+          .filter((field) => field.isActive !== false)
+          .filter((field) => field.type !== "RELATION" && field.type !== "ACTOR") // handle relation later
+          .filter((field) => !excludeFieldsWithName.includes(field.name)),
+      };
     } catch (err) {
-      return err instanceof Error ? err.message : String(err);
+      return describeError(err);
     }
   }
 
@@ -74,10 +124,7 @@ class TwentySDK {
     try {
       const response = await fetch(this.url + `/${namePlural}`, {
         method: "POST",
-        headers: {
-          "Content-type": "application/json",
-          [Api.KEY]: this.token,
-        },
+        headers: this.headers,
         body: JSON.stringify({
           ...bodyParam,
         }),

--- a/extensions/twenty/src/services/zod/schema/dataModelSchema.ts
+++ b/extensions/twenty/src/services/zod/schema/dataModelSchema.ts
@@ -3,23 +3,36 @@ import { z } from "zod";
 export const dataModelSchema = z.array(
   z.object({
     id: z.string(),
-    dataSourceId: z.string().optional(),
+    dataSourceId: z.string().nullish(),
     nameSingular: z.string(),
     namePlural: z.string(),
     labelSingular: z.string(),
     labelPlural: z.string(),
-    description: z.string().nullable(),
-    icon: z.string().nullable(),
-    isCustom: z.boolean(),
-    isActive: z.boolean(),
-    isSystem: z.boolean(),
+    description: z.string().nullish(),
+    icon: z.string().nullish(),
+    // Dropped from the metadata API in Twenty 2.12, so it is absent on newer servers.
+    isCustom: z.boolean().nullish(),
+    isActive: z.boolean().nullish(),
+    isSystem: z.boolean().nullish(),
   }),
 );
 
+export const restCursorPageInfoSchema = z.object({
+  hasNextPage: z.boolean().nullish(),
+  startCursor: z.string().nullish(),
+  endCursor: z.string().nullish(),
+});
+
+// Newer Twenty servers return `{ data: [...] }`, older ones wrap the list as
+// `{ data: { objects: [...] } }`. Both are paginated by an id cursor.
 export const getActiveDataModelsSchema = z.object({
-  data: z.object({
-    objects: dataModelSchema,
-  }),
+  data: z.union([dataModelSchema, z.object({ objects: dataModelSchema })]),
+  pageInfo: restCursorPageInfoSchema.nullish(),
 });
 
 export type DataModel = z.infer<typeof dataModelSchema>;
+export type DataModelItem = DataModel[number];
+
+export function extractDataModels(response: z.infer<typeof getActiveDataModelsSchema>): DataModel {
+  return Array.isArray(response.data) ? response.data : response.data.objects;
+}

--- a/extensions/twenty/src/services/zod/schema/recordFieldSchema.ts
+++ b/extensions/twenty/src/services/zod/schema/recordFieldSchema.ts
@@ -1,52 +1,62 @@
 import { z } from "zod";
 
-export const getDataModelWithFieldsSchema = z.object({
-  data: z.object({
-    object: z.object({
-      id: z.string(),
-      dataSourceId: z.string().optional(),
-      nameSingular: z.string(),
-      namePlural: z.string(),
-      labelSingular: z.string(),
-      labelPlural: z.string(),
-      description: z.string().nullable(),
-      isCustom: z.boolean(),
-      isActive: z.boolean(),
-      isSystem: z.boolean(),
-      fields: z.array(
-        z.object({
-          id: z.string(),
-          type: z.string(),
-          name: z.string(),
-          label: z.string(),
-          description: z.string().nullable(),
-          isCustom: z.boolean(),
-          isActive: z.boolean(),
-          isSystem: z.boolean(),
-          isNullable: z.boolean(),
-          defaultValue: z.any().nullable(),
-          options: z
-            .array(
-              z.object({
-                id: z.string().nullish(),
-                color: z.string().nullish(),
-                label: z.string().nullish(),
-                value: z.string().nullish(),
-                position: z.number().nullish(),
-              }),
-            )
-            .nonempty()
-            .nullish(),
-        }),
-      ),
-    }),
-  }),
+export const dataModelFieldSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  name: z.string(),
+  label: z.string(),
+  description: z.string().nullish(),
+  // Dropped from the metadata API in Twenty 2.12, so it is absent on newer servers.
+  isCustom: z.boolean().nullish(),
+  isActive: z.boolean().nullish(),
+  isSystem: z.boolean().nullish(),
+  isNullable: z.boolean().nullish(),
+  defaultValue: z.any().nullish(),
+  options: z
+    .array(
+      z.object({
+        id: z.string().nullish(),
+        color: z.string().nullish(),
+        label: z.string().nullish(),
+        value: z.string().nullish(),
+        position: z.number().nullish(),
+      }),
+    )
+    .nonempty()
+    .nullish(),
 });
 
-export type DataModelWithFields = z.infer<typeof getDataModelWithFieldsSchema>["data"]["object"];
+export const dataModelWithFieldsSchema = z.object({
+  id: z.string(),
+  dataSourceId: z.string().nullish(),
+  nameSingular: z.string(),
+  namePlural: z.string(),
+  labelSingular: z.string(),
+  labelPlural: z.string(),
+  description: z.string().nullish(),
+  isCustom: z.boolean().nullish(),
+  isActive: z.boolean().nullish(),
+  isSystem: z.boolean().nullish(),
+  fields: z.array(dataModelFieldSchema),
+});
+
+// Older Twenty servers wrap the object as `{ data: { object: {...} } }`, newer
+// ones return the object metadata directly.
+export const getDataModelWithFieldsSchema = z.union([
+  z.object({ data: z.object({ object: dataModelWithFieldsSchema }) }),
+  dataModelWithFieldsSchema,
+]);
+
+export type DataModelWithFields = z.infer<typeof dataModelWithFieldsSchema>;
 
 export type DataModelField = DataModelWithFields["fields"][number];
 export type ObjectRecordFields = {
   primary: DataModelField;
   rest: DataModelWithFields["fields"];
 };
+
+export function extractDataModelWithFields(
+  response: z.infer<typeof getDataModelWithFieldsSchema>,
+): DataModelWithFields {
+  return "data" in response ? response.data.object : response;
+}


### PR DESCRIPTION
## Description

The Twenty extension currently fails to load on up-to-date Twenty workspaces. Opening **Create Object Record** shows:

```
[ { "expected": "object", "code": "invalid_type", "path": [ "data" ],
    "message": "Invalid input: expected object, received array" } ]
```

Twenty changed the shape of its REST metadata API (the new envelope is gated behind the `IS_REST_METADATA_API_NEW_FORMAT_DIRECT` feature flag, which is now on for workspaces), and the extension's Zod schemas only accepted the old shape:

| | Extension expected | Current Twenty |
|---|---|---|
| `GET /metadata/objects` | `{ data: { objects: [...] } }` | `{ data: [...], pageInfo, totalCount }` |
| `GET /metadata/objects/:id` | `{ data: { object: {...} } }` | the object, with no envelope |
| `isCustom` on objects/fields | required | dropped in 2.12 |
| `description`, `icon`, `isActive`, `isSystem`, `isNullable` | required | optional, and omitted from the JSON when unset |
| pagination | none | id cursor, 60 per page by default |

Both envelopes are still in the wild, so this PR makes the extension accept either rather than switching to the new one — self-hosted instances on older versions keep working.

### Changes

- **`dataModelSchema.ts` / `recordFieldSchema.ts`** — the response envelopes are now unions over both shapes, normalised by `extractDataModels()` / `extractDataModelWithFields()`. Fields the API may omit are `nullish`.
- **`TwentySDK.ts`** — pages through `/metadata/objects` with `limit=200` and `starting_after` until `hasNextPage` is false (capped at 25 pages), so workspaces with more than 60 objects are listed in full. Filters now use `isSystem !== true` / `isActive !== false` so records aren't dropped when those flags are absent.
- **`TwentySDK.ts`** — failures now surface Twenty's own error message (e.g. `Missing authentication token`) instead of `statusText`, and a schema mismatch reports the failing path in prose rather than dumping the raw validation array into the UI, which is what produced the error above.
- **`create-object-record.tsx`** — with `isCustom` gone there is no way to tell standard and custom objects apart, so they render as a single "Objects" section; on servers that still send `isCustom` the original Standard/Custom split is unchanged. List keys switched from `randomUUID()` to the object id, which was remounting the whole list on every render.

No changes to `package.json`, commands, preferences, or assets.

## Screencast

No screenshot: this is a bug fix with no intentional UI change — before the fix the command renders only the error above, after it the object list renders as it always did (with the Standard/Custom sections merged when the server no longer reports `isCustom`).

Verified by:

- `npm run build` and `npx ray lint` both clean
- running the extension against a live Twenty workspace on the new API format — the object list loads and record creation works again
- parsing checks over both response envelopes, servers that send no `pageInfo`, payloads with the optional flags absent, and the exact `{ data: [...] }` payload from the report

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
