### PR TITLE
ccusage: add menu bar section visibility toggles

### DIFF
--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Claude Code Usage (ccusage) Changelog
 
-## [Add menu bar section visibility toggles] - {PR_MERGE_DATE}
+## [Add menu bar section visibility toggles] - 2026-07-29
 
 ### Added
 

--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Claude Code Usage (ccusage) Changelog
 
+## [Add menu bar section visibility toggles] - {PR_MERGE_DATE}
+
+### Added
+
+- **Section visibility toggles:** Individually show or hide each menu bar dropdown section — Rate Limits, Today's Usage, This Week, Monthly Usage, Total Usage, Current Block, and Working Time. All default to visible, so existing menus are unchanged.
+
 ## [Add pie chart icon, pies progress style, and time remaining display] - 2026-07-28
 
 ### Added

--- a/extensions/ccusage/package.json
+++ b/extensions/ccusage/package.json
@@ -152,7 +152,7 @@
               "value": "ascii"
             },
             {
-              "title": "Pies (●)",
+              "title": "Pies (◔)",
               "value": "pies"
             }
           ]
@@ -173,6 +173,62 @@
           "description": "Format string for time remaining. Placeholders: {h} hours, {m} minutes, {M} total minutes, {h.f} fractional hours. Example: {h}h{m}m → 1h23m",
           "default": "{h}h{m}m",
           "placeholder": "e.g., {h}h{m}m or {M}m or {h.f}h"
+        },
+        {
+          "name": "sectionRateLimits",
+          "type": "checkbox",
+          "required": false,
+          "label": "Show Rate Limits",
+          "description": "Show the rate limits section in the menu bar dropdown",
+          "default": true
+        },
+        {
+          "name": "sectionTodayUsage",
+          "type": "checkbox",
+          "required": false,
+          "label": "Show Today's Usage",
+          "description": "Show today's usage section in the menu bar dropdown",
+          "default": true
+        },
+        {
+          "name": "sectionThisWeek",
+          "type": "checkbox",
+          "required": false,
+          "label": "Show This Week",
+          "description": "Show this week's usage section in the menu bar dropdown",
+          "default": true
+        },
+        {
+          "name": "sectionMonthlyUsage",
+          "type": "checkbox",
+          "required": false,
+          "label": "Show Monthly Usage",
+          "description": "Show the monthly usage section in the menu bar dropdown",
+          "default": true
+        },
+        {
+          "name": "sectionTotalUsage",
+          "type": "checkbox",
+          "required": false,
+          "label": "Show Total Usage",
+          "description": "Show the total usage section in the menu bar dropdown",
+          "default": true
+        },
+        {
+          "name": "sectionCurrentBlock",
+          "type": "checkbox",
+          "required": false,
+          "label": "Show Current Block",
+          "description": "Show the current block section in the menu bar dropdown",
+          "default": true
+        },
+        {
+          "name": "sectionWorkingTime",
+          "type": "checkbox",
+          "required": false,
+          "label": "Show Working Time",
+          "description": "Show the working time section in the menu bar dropdown",
+          "default": true
         }
       ]
     },

--- a/extensions/ccusage/src/menubar-ccusage.tsx
+++ b/extensions/ccusage/src/menubar-ccusage.tsx
@@ -60,9 +60,33 @@ export default function MenuBarccusage() {
 
   const effectiveLimitsData = MOCK_LIMITS_ENABLED ? MOCK_LIMITS_DATA : limitsData;
 
-  const hasData = todayUsage || weeklyUsage || monthlyUsage || totalUsage;
-  const hasError = !hasData && (dailyError || weeklyError || monthlyError || totalError);
-  const isLoading = dailyLoading || monthlyLoading || totalLoading;
+  const sections = {
+    rateLimits: isSectionVisible("sectionRateLimits"),
+    todayUsage: isSectionVisible("sectionTodayUsage"),
+    thisWeek: isSectionVisible("sectionThisWeek"),
+    monthlyUsage: isSectionVisible("sectionMonthlyUsage"),
+    totalUsage: isSectionVisible("sectionTotalUsage"),
+    currentBlock: isSectionVisible("sectionCurrentBlock"),
+    workingTime: isSectionVisible("sectionWorkingTime"),
+  };
+
+  // A hidden section's hook still runs (rules of hooks), but its loading/error
+  // state shouldn't block sections the user actually chose to see.
+  const hasData =
+    (sections.todayUsage ? todayUsage : undefined) ||
+    (sections.thisWeek ? weeklyUsage : undefined) ||
+    (sections.monthlyUsage ? monthlyUsage : undefined) ||
+    (sections.totalUsage ? totalUsage : undefined);
+  const hasError =
+    !hasData &&
+    ((sections.todayUsage ? dailyError : undefined) ||
+      (sections.thisWeek ? weeklyError : undefined) ||
+      (sections.monthlyUsage ? monthlyError : undefined) ||
+      (sections.totalUsage ? totalError : undefined));
+  const isLoading =
+    (sections.todayUsage && dailyLoading) ||
+    (sections.monthlyUsage && monthlyLoading) ||
+    (sections.totalUsage && totalLoading);
 
   if (isLoading) {
     return <MenuBarExtra icon={{ source: Icon.Clock }} tooltip="Loading Claude usage..." isLoading={true} />;
@@ -99,16 +123,6 @@ export default function MenuBarccusage() {
   const showTimeRemaining = getMenuBarTimeRemaining();
   const timeRemainingFormat = getMenuBarTimeRemainingFormat();
   const usePies = progressBarStyle === "pies";
-
-  const sections = {
-    rateLimits: isSectionVisible("sectionRateLimits"),
-    todayUsage: isSectionVisible("sectionTodayUsage"),
-    thisWeek: isSectionVisible("sectionThisWeek"),
-    monthlyUsage: isSectionVisible("sectionMonthlyUsage"),
-    totalUsage: isSectionVisible("sectionTotalUsage"),
-    currentBlock: isSectionVisible("sectionCurrentBlock"),
-    workingTime: isSectionVisible("sectionWorkingTime"),
-  };
 
   const displayUtil = (utilization: number): number => (preferRemaining ? 100 - utilization : utilization);
 

--- a/extensions/ccusage/src/menubar-ccusage.tsx
+++ b/extensions/ccusage/src/menubar-ccusage.tsx
@@ -19,6 +19,7 @@ import {
   getMenuBarIconStyle,
   getMenuBarTimeRemaining,
   getMenuBarTimeRemainingFormat,
+  isSectionVisible,
 } from "./preferences";
 import { TotalUsageData } from "./types/usage-types";
 
@@ -98,6 +99,16 @@ export default function MenuBarccusage() {
   const showTimeRemaining = getMenuBarTimeRemaining();
   const timeRemainingFormat = getMenuBarTimeRemainingFormat();
   const usePies = progressBarStyle === "pies";
+
+  const sections = {
+    rateLimits: isSectionVisible("sectionRateLimits"),
+    todayUsage: isSectionVisible("sectionTodayUsage"),
+    thisWeek: isSectionVisible("sectionThisWeek"),
+    monthlyUsage: isSectionVisible("sectionMonthlyUsage"),
+    totalUsage: isSectionVisible("sectionTotalUsage"),
+    currentBlock: isSectionVisible("sectionCurrentBlock"),
+    workingTime: isSectionVisible("sectionWorkingTime"),
+  };
 
   const displayUtil = (utilization: number): number => (preferRemaining ? 100 - utilization : utilization);
 
@@ -195,7 +206,7 @@ export default function MenuBarccusage() {
 
       {!hasError && (
         <>
-          {isUsageLimitsAvailable && (
+          {sections.rateLimits && isUsageLimitsAvailable && (
             <MenuBarExtra.Section title={rateLimitsSectionTitle}>
               {limitsRateLimited && !limitsData && (
                 <MenuBarExtra.Item
@@ -274,49 +285,65 @@ export default function MenuBarccusage() {
             </MenuBarExtra.Section>
           )}
 
-          <MenuBarExtra.Section title="Today's Usage">
-            <MenuBarExtra.Item
-              title={formatUsageTitle(dailyLoading, todayUsage, "No usage data available")}
-              subtitle={
-                todayUsage && previousDayData
-                  ? `vs yesterday: ${formatCostDelta(todayUsage.totalCost, previousDayData.totalCost)}`
-                  : undefined
-              }
-              icon={Icon.Calendar}
-              onAction={() => open(`${process.env.RAYCAST_SCHEME ?? "raycast"}://extensions/nyatinte/ccusage/ccusage`)}
-            />
-          </MenuBarExtra.Section>
+          {sections.todayUsage && (
+            <MenuBarExtra.Section title="Today's Usage">
+              <MenuBarExtra.Item
+                title={formatUsageTitle(dailyLoading, todayUsage, "No usage data available")}
+                subtitle={
+                  todayUsage && previousDayData
+                    ? `vs yesterday: ${formatCostDelta(todayUsage.totalCost, previousDayData.totalCost)}`
+                    : undefined
+                }
+                icon={Icon.Calendar}
+                onAction={() =>
+                  open(`${process.env.RAYCAST_SCHEME ?? "raycast"}://extensions/nyatinte/ccusage/ccusage`)
+                }
+              />
+            </MenuBarExtra.Section>
+          )}
 
-          <MenuBarExtra.Section title="This Week">
-            <MenuBarExtra.Item
-              title={formatUsageTitle(weeklyLoading, weeklyUsage, "No usage data available")}
-              subtitle={
-                weeklyUsage && previousWeekData
-                  ? `vs last week: ${formatCostDelta(weeklyUsage.totalCost, previousWeekData.totalCost)}`
-                  : undefined
-              }
-              icon={Icon.Calendar}
-              onAction={() => open(`${process.env.RAYCAST_SCHEME ?? "raycast"}://extensions/nyatinte/ccusage/ccusage`)}
-            />
-          </MenuBarExtra.Section>
+          {sections.thisWeek && (
+            <MenuBarExtra.Section title="This Week">
+              <MenuBarExtra.Item
+                title={formatUsageTitle(weeklyLoading, weeklyUsage, "No usage data available")}
+                subtitle={
+                  weeklyUsage && previousWeekData
+                    ? `vs last week: ${formatCostDelta(weeklyUsage.totalCost, previousWeekData.totalCost)}`
+                    : undefined
+                }
+                icon={Icon.Calendar}
+                onAction={() =>
+                  open(`${process.env.RAYCAST_SCHEME ?? "raycast"}://extensions/nyatinte/ccusage/ccusage`)
+                }
+              />
+            </MenuBarExtra.Section>
+          )}
 
-          <MenuBarExtra.Section title="Monthly Usage">
-            <MenuBarExtra.Item
-              title={formatUsageTitle(monthlyLoading, monthlyUsage, "No usage data available")}
-              icon={Icon.BarChart}
-              onAction={() => open(`${process.env.RAYCAST_SCHEME ?? "raycast"}://extensions/nyatinte/ccusage/ccusage`)}
-            />
-          </MenuBarExtra.Section>
+          {sections.monthlyUsage && (
+            <MenuBarExtra.Section title="Monthly Usage">
+              <MenuBarExtra.Item
+                title={formatUsageTitle(monthlyLoading, monthlyUsage, "No usage data available")}
+                icon={Icon.BarChart}
+                onAction={() =>
+                  open(`${process.env.RAYCAST_SCHEME ?? "raycast"}://extensions/nyatinte/ccusage/ccusage`)
+                }
+              />
+            </MenuBarExtra.Section>
+          )}
 
-          <MenuBarExtra.Section title="Total Usage">
-            <MenuBarExtra.Item
-              title={formatUsageTitle(totalLoading, totalUsage, "No usage data available")}
-              icon={Icon.Coins}
-              onAction={() => open(`${process.env.RAYCAST_SCHEME ?? "raycast"}://extensions/nyatinte/ccusage/ccusage`)}
-            />
-          </MenuBarExtra.Section>
+          {sections.totalUsage && (
+            <MenuBarExtra.Section title="Total Usage">
+              <MenuBarExtra.Item
+                title={formatUsageTitle(totalLoading, totalUsage, "No usage data available")}
+                icon={Icon.Coins}
+                onAction={() =>
+                  open(`${process.env.RAYCAST_SCHEME ?? "raycast"}://extensions/nyatinte/ccusage/ccusage`)
+                }
+              />
+            </MenuBarExtra.Section>
+          )}
 
-          {workingTime.activeBlock && (
+          {sections.currentBlock && workingTime.activeBlock && (
             <MenuBarExtra.Section title="Current Block">
               <MenuBarExtra.Item
                 title={
@@ -343,22 +370,26 @@ export default function MenuBarccusage() {
             </MenuBarExtra.Section>
           )}
 
-          <MenuBarExtra.Section title="Working Time">
-            <MenuBarExtra.Item
-              title={
-                workingTime.isLoading
-                  ? "Loading..."
-                  : workingTime.todayMs > 0
-                    ? formatDuration(workingTime.todayMs)
-                    : "No activity today"
-              }
-              subtitle={
-                workingTime.yesterdayMs > 0 ? `vs yesterday: ${formatDuration(workingTime.yesterdayMs)}` : undefined
-              }
-              icon={Icon.Clock}
-              onAction={() => open(`${process.env.RAYCAST_SCHEME ?? "raycast"}://extensions/nyatinte/ccusage/ccusage`)}
-            />
-          </MenuBarExtra.Section>
+          {sections.workingTime && (
+            <MenuBarExtra.Section title="Working Time">
+              <MenuBarExtra.Item
+                title={
+                  workingTime.isLoading
+                    ? "Loading..."
+                    : workingTime.todayMs > 0
+                      ? formatDuration(workingTime.todayMs)
+                      : "No activity today"
+                }
+                subtitle={
+                  workingTime.yesterdayMs > 0 ? `vs yesterday: ${formatDuration(workingTime.yesterdayMs)}` : undefined
+                }
+                icon={Icon.Clock}
+                onAction={() =>
+                  open(`${process.env.RAYCAST_SCHEME ?? "raycast"}://extensions/nyatinte/ccusage/ccusage`)
+                }
+              />
+            </MenuBarExtra.Section>
+          )}
 
           <MenuBarExtra.Section>
             <MenuBarExtra.Item title="Configure Command" icon={Icon.Gear} onAction={openCommandPreferences} />

--- a/extensions/ccusage/src/preferences.ts
+++ b/extensions/ccusage/src/preferences.ts
@@ -41,10 +41,36 @@ export const getMenuBarIcon = (): Image.Source => {
   return "extension-icon.png";
 };
 
-export const getMenuBarTimeRemaining = (): boolean => menuBarPreferences.menuBarTimeRemaining === true;
+/**
+ * Read a checkbox preference.
+ *
+ * A key is `undefined` when the running command predates the preference being
+ * added to the manifest, so fall back to the declared default rather than
+ * treating it as unchecked.
+ */
+const checkboxPref = (value: unknown, defaultValue: boolean): boolean => {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") return value === "true";
+  return defaultValue;
+};
+
+export const getMenuBarTimeRemaining = (): boolean => checkboxPref(menuBarPreferences.menuBarTimeRemaining, false);
 
 export const getMenuBarTimeRemainingFormat = (): string =>
   (menuBarPreferences.menuBarTimeRemainingFormat as string) || "{h}h{m}m";
+
+/** Which dropdown sections the menu bar renders. All default to visible. */
+export type MenuBarSection =
+  | "sectionRateLimits"
+  | "sectionTodayUsage"
+  | "sectionThisWeek"
+  | "sectionMonthlyUsage"
+  | "sectionTotalUsage"
+  | "sectionCurrentBlock"
+  | "sectionWorkingTime";
+
+export const isSectionVisible = (section: MenuBarSection): boolean =>
+  checkboxPref((menuBarPreferences as Record<string, unknown>)[section], true);
 
 export const getCustomNpxPath = (): string | undefined => {
   const customPath = preferences.customNpxPath?.trim();

--- a/extensions/ccusage/src/utils/time-remaining-formatter.ts
+++ b/extensions/ccusage/src/utils/time-remaining-formatter.ts
@@ -15,7 +15,7 @@ export function formatTimeRemainingCustom(resetAt: string | null | undefined, fo
   const diffMs = new Date(resetAt).getTime() - Date.now();
   if (Number.isNaN(diffMs) || diffMs <= 0) return null;
 
-  const totalMinutes = Math.max(0, Math.round(diffMs / 60000));
+  const totalMinutes = Math.round(diffMs / 60000);
   const h = Math.floor(totalMinutes / 60);
   const m = totalMinutes % 60;
 


### PR DESCRIPTION
## Summary
- Adds seven checkbox preferences to the `menubar-ccusage` command letting users individually show or hide each dropdown section: Rate Limits, Today's Usage, This Week, Monthly Usage, Total Usage, Current Block, and Working Time
- All default to visible, so existing menus are unchanged
- Follow-up to #29782 (pie chart icon, pies progress style, time remaining display)

## Test plan
- [x] `ray lint` passes
- [x] `ray build` passes
- [x] Verified in `ray develop` that toggling each preference off hides the corresponding section and toggling it back on restores it