### PR TITLE
ccusage: rename extension to "Claude Usage"

### DIFF
--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,4 +1,11 @@
-# Claude Code Usage (ccusage) Changelog
+# Claude Usage (ccusage) Changelog
+
+## [Rename to Claude Usage] - {PR_MERGE_DATE}
+
+### Changed
+
+- Renamed the extension from "Claude Code Usage" to "Claude Usage" — the Usage Limits and menu bar tracking reflect your overall Claude plan, not just Claude Code
+- Documented the Pie Chart menu bar icon style in the README
 
 ## [Add pie chart icon, pies progress style, and time remaining display] - 2026-07-28
 

--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Claude Usage (ccusage) Changelog
 
-## [Rename to Claude Usage] - {PR_MERGE_DATE}
+## [Rename to Claude Usage] - 2026-07-29
 
 ### Changed
 

--- a/extensions/ccusage/README.md
+++ b/extensions/ccusage/README.md
@@ -1,7 +1,7 @@
-# Claude Code Usage (ccusage)
+# Claude Usage (ccusage)
 
 <div align="center">
-  <img src="https://github.com/user-attachments/assets/4ae63a5c-3064-4050-8077-45b508dcc4ff" alt="Claude Code Usage Icon" width="128" height="128">
+  <img src="https://github.com/user-attachments/assets/4ae63a5c-3064-4050-8077-45b508dcc4ff" alt="Claude Usage Icon" width="128" height="128">
   
   A Raycast extension that provides real-time monitoring of Claude Code usage statistics using the [ccusage](https://github.com/ryoppippi/ccusage) CLI tool.
   
@@ -19,6 +19,7 @@ Monitor your Claude Code usage with comprehensive real-time statistics:
 - **Model Statistics**: Usage analytics by Claude model (Opus, Sonnet, Haiku) with tier grouping
 - **Usage Limits**: OAuth-backed 5-hour and 7-day Claude usage limits when Claude Code is authenticated with Claude OAuth
 - **Menu Bar Integration**: Quick access to usage stats directly from your system menu bar
+- **Pie Chart Icon**: Menu bar icon that fills clockwise with a pie chart showing 5-hour usage utilization
 - **AI Extension Support**: Comprehensive integration with Raycast AI Extensions for Claude models
 - **Default View Preference**: Choose which section to display first when opening the extension
 - **Custom npx Path**: Support for custom npx installations and non-standard Node.js setups
@@ -27,7 +28,7 @@ Monitor your Claude Code usage with comprehensive real-time statistics:
 
 ### Main Usage View
 
-![Claude Code Usage](metadata/ccusage-2.png)
+![Claude Usage](metadata/ccusage-2.png)
 
 ## Requirements
 
@@ -67,7 +68,7 @@ Access preferences with **Cmd+Shift+,** when the extension is open.
 
 ## Support
 
-If you encounter any issues or have suggestions, please [create an issue](<https://github.com/raycast/extensions/issues/new?title=%5BClaude+Code+Usage+(ccusage)%5D+...&template=extension_bug_report.yml&labels=extension,bug&extension-url=https://www.raycast.com/nyatinte/ccusage&body=%0A%3C!--%0APlease+update+the+title+above+to+consisely+describe+the+issue%0A--%3E%0A%0A%23%23%23+Extension%0A%0Ahttps://raycast.com/%23%7Bextension_path(extension)%7D%0A%0A%23%23%23+Description%0A%0A%3C!--%0APlease+provide+a+clear+and+concise+description+of+what+the+bug+is.+Include+screenshots+if+needed.+Please+test+using+the+latest+version+of+the+extension,+Raycast+and+API.%0A--%3E%0A%0A%23%23%23+Steps+To+Reproduce%0A%0A%3C!--%0AYour+bug+will+get+fixed+much+faster+if+the+extension+author+can+easily+reproduce+it.+Issues+without+reproduction+steps+may+be+immediately+closed+as+not+actionable.%0A--%3E%0A%0A1.+In+this+environment...%0A2.+With+this+config...%0A3.+Run+'...'%0A4.+See+error...%0A%0A%23%23%23+Current+Behavior%0A%0A%23%23%23+Expected+Behavior%0A%0A>) in the repository.
+If you encounter any issues or have suggestions, please [create an issue](<https://github.com/raycast/extensions/issues/new?title=%5BClaude+Usage+(ccusage)%5D+...&template=extension_bug_report.yml&labels=extension,bug&extension-url=https://www.raycast.com/nyatinte/ccusage&body=%0A%3C!--%0APlease+update+the+title+above+to+consisely+describe+the+issue%0A--%3E%0A%0A%23%23%23+Extension%0A%0Ahttps://raycast.com/%23%7Bextension_path(extension)%7D%0A%0A%23%23%23+Description%0A%0A%3C!--%0APlease+provide+a+clear+and+concise+description+of+what+the+bug+is.+Include+screenshots+if+needed.+Please+test+using+the+latest+version+of+the+extension,+Raycast+and+API.%0A--%3E%0A%0A%23%23%23+Steps+To+Reproduce%0A%0A%3C!--%0AYour+bug+will+get+fixed+much+faster+if+the+extension+author+can+easily+reproduce+it.+Issues+without+reproduction+steps+may+be+immediately+closed+as+not+actionable.%0A--%3E%0A%0A1.+In+this+environment...%0A2.+With+this+config...%0A3.+Run+'...'%0A4.+See+error...%0A%0A%23%23%23+Current+Behavior%0A%0A%23%23%23+Expected+Behavior%0A%0A>) in the repository.
 
 ## Credits
 

--- a/extensions/ccusage/package.json
+++ b/extensions/ccusage/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "ccusage",
-  "title": "Claude Code Usage (ccusage)",
+  "title": "Claude Usage (ccusage)",
   "description": "Monitor Claude Code usage with real-time tracking",
   "categories": [
     "Developer Tools"
@@ -22,14 +22,14 @@
   "commands": [
     {
       "name": "ccusage",
-      "title": "Claude Code Usage",
+      "title": "Claude Usage",
       "subtitle": "ccusage",
       "description": "Monitor Claude Code usage with real-time tracking",
       "mode": "view"
     },
     {
       "name": "menubar-ccusage",
-      "title": "Claude Code Usage in Menu Bar",
+      "title": "Claude Usage in Menu Bar",
       "subtitle": "ccusage",
       "description": "Show Claude Code usage in menu bar",
       "mode": "menu-bar",


### PR DESCRIPTION
## Summary
- The extension is useful for regular Claude users (web, app, etc.) – not just Claude Code users – so this renames the extension display name from "Claude Code Usage" to "Claude Usage" (title fields in `package.json`, README, CHANGELOG heading) — the Usage Limits and menu bar tracking reflect the user's overall Claude plan (5-hour/7-day rate limits), not just Claude Code CLI usage, so the name shouldn't imply Claude-Code-only
- Adds the Pie Chart menu bar icon style (shipped in #29782) to the README's Features list, which was missed at the time

## Notes
- The technical extension slug (`name: "ccusage"`) and command names are unchanged — only the user-facing display titles
- No code changes

## Test plan
- [x] `ray lint` passes
- [x] `ray build` passes