### PR TITLE
[NeteaseMusic] Add dislike and next track command

### DIFF
--- a/extensions/netease-music/CHANGELOG.md
+++ b/extensions/netease-music/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Netease-Music Changelog
 
+## [Add Dislike and Next Track Command] - {PR_MERGE_DATE}
+
+- Added a command to dislike the currently playing track and skip to the next track.
+
 ## [Add New Commands] - 2025-12-17
 
 - Added support for more operations, including toggle playing state, volume up/down, toggle lyrics.

--- a/extensions/netease-music/CHANGELOG.md
+++ b/extensions/netease-music/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Netease-Music Changelog
 
-## [Add Dislike and Next Track Command] - {PR_MERGE_DATE}
+## [Add Dislike and Next Track Command] - 2026-07-29
 
 - Added a command to dislike the currently playing track and skip to the next track.
 

--- a/extensions/netease-music/package.json
+++ b/extensions/netease-music/package.json
@@ -6,7 +6,8 @@
   "icon": "netease-music.png",
   "author": "chyroc",
   "contributors": [
-    "IceGiraffe"
+    "IceGiraffe",
+    "Anoninz"
   ],
   "keywords": [
     "music",
@@ -57,6 +58,13 @@
       "title": "Dislike Track",
       "subtitle": "NeteaseMusic",
       "description": "Dislike currently playing track in NeteaseMusic.",
+      "mode": "no-view"
+    },
+    {
+      "name": "dislike-and-next",
+      "title": "Dislike Track & Next Track",
+      "subtitle": "NeteaseMusic",
+      "description": "Dislike the currently playing track and skip to the next track in NeteaseMusic.",
       "mode": "no-view"
     },
     {

--- a/extensions/netease-music/src/dislike-and-next.tsx
+++ b/extensions/netease-music/src/dislike-and-next.tsx
@@ -1,0 +1,9 @@
+import NeteaseMusicController from "@chyroc/netease-music-controller";
+import { controlMusic } from "./util";
+
+export default async () => {
+  await controlMusic(async () => {
+    await NeteaseMusicController.dislikeTrack();
+    await NeteaseMusicController.nextTrack();
+  });
+};


### PR DESCRIPTION
## Description

Adds a no-view **Dislike Track & Next Track** command to the existing NeteaseMusic extension.

The command reuses `@chyroc/netease-music-controller` and sequentially calls `dislikeTrack()` followed by `nextTrack()`, with the existing HUD success and error handling.

## Screencast

Not included because this is a no-view command composed from the extension existing dislike and next-track operations.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run lint` and `npm run build`
- [x] I tested the command locally in Raycast with NeteaseMusic
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with the metadata tool
