### PR TITLE
skills: fix runtime detection and root-level SKILL.md lookup

### DIFF
--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [Fix Runtime Detection and Skill Lookup] - {PR_MERGE_DATE}
 
 - Detect `bun`/`node` installed outside a version manager or Homebrew, so "Unable to find a working bunx or npx command" no longer appears for Bun's official installer (`~/.bun/bin`), Nix / nix-darwin profiles, mise, and asdf
-- Fall back to `npx` when `bunx` fails without any diagnostic output, so a silent `bunx` failure no longer surfaces as "Command failed: bunx --silent skills@latest …" with no reason and no retry
+- Report what the `skills` CLI printed when it exits non-zero, instead of only "Command failed: bunx --silent skills@latest …" with no reason — the CLI writes its errors to stdout, which was being discarded
+- Fall back to `npx` when `bunx` dies without printing anything at all, limited to read-only commands so a mutating `add`/`remove`/`update` is never run twice
 - Resolve skills whose `SKILL.md` sits at the repository root (single-skill repos), which previously failed to load in the detail view
 - Make the `read-skill` AI tool use the same repo-layout resolution as the detail view, so nested and root-level skills are readable
 

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Skills Changelog
 
-## [Fix Runtime Detection and Skill Lookup] - {PR_MERGE_DATE}
+## [Fix Runtime Detection and Skill Lookup] - 2026-07-30
 
 - Detect `bun`/`node` installed outside a version manager or Homebrew, so "Unable to find a working bunx or npx command" no longer appears for Bun's official installer (`~/.bun/bin`), Nix / nix-darwin profiles, mise, and asdf
 - Report what the `skills` CLI printed when it exits non-zero, instead of only "Command failed: bunx --silent skills@latest …" with no reason — the CLI writes its errors to stdout, which was being discarded

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Skills Changelog
 
+## [Fix Runtime Detection and Skill Lookup] - {PR_MERGE_DATE}
+
+- Detect `bun`/`node` installed outside a version manager or Homebrew, so "Unable to find a working bunx or npx command" no longer appears for Bun's official installer (`~/.bun/bin`), Nix / nix-darwin profiles, mise, and asdf
+- Fall back to `npx` when `bunx` fails without any diagnostic output, so a silent `bunx` failure no longer surfaces as "Command failed: bunx --silent skills@latest …" with no reason and no retry
+- Resolve skills whose `SKILL.md` sits at the repository root (single-skill repos), which previously failed to load in the detail view
+- Make the `read-skill` AI tool use the same repo-layout resolution as the detail view, so nested and root-level skills are readable
+
 ## [Document Custom Registry Configuration] - 2026-07-03
 
 - Add README guidance for pointing `bunx`/`npx` at a custom package registry (corporate proxy) via `~/.npmrc` and `~/.bunfig.toml`, since Raycast does not inherit shell environment variables

--- a/extensions/skills/src/hooks/skill-content.ts
+++ b/extensions/skills/src/hooks/skill-content.ts
@@ -3,7 +3,9 @@ import { withCache } from "@raycast/utils";
 import { getGithubToken } from "../preferences";
 import { type Skill, type SkillFrontmatter, parseFrontmatter } from "../shared";
 
-type SkillContentResult = {
+const ROOT_SKILL_MD_PATH = "SKILL.md";
+
+export type SkillContentResult = {
   frontmatter: SkillFrontmatter;
   body: string;
   raw: string;
@@ -95,17 +97,33 @@ const fetchRepoSkillMdEntries = withCache(
     const { tree } = (await response.json()) as { tree?: GitTreeEntry[] };
     return (tree ?? [])
       .filter((entry): entry is GitTreeEntry & { url: string } =>
-        Boolean(entry.type === "blob" && entry.path.endsWith("/SKILL.md") && entry.url),
+        // The bare "SKILL.md" match covers single-skill repos, which keep the
+        // file at the repo root so no enclosing folder carries the skill name.
+        Boolean(
+          entry.type === "blob" && (entry.path === ROOT_SKILL_MD_PATH || entry.path.endsWith("/SKILL.md")) && entry.url,
+        ),
       )
       .map((entry) => ({ path: entry.path, url: entry.url }));
   },
   { maxAge: 10 * 60 * 1000 },
 );
 
+async function fetchBlobContent(entry: SkillMdEntry): Promise<SkillContentResult | undefined> {
+  const blobResponse = await fetch(entry.url, { headers: githubHeaders() });
+  if (!blobResponse.ok) return undefined;
+
+  const blob = (await blobResponse.json()) as { content?: string; encoding?: string };
+  if (!blob.content) return undefined;
+
+  const text = blob.encoding === "base64" ? Buffer.from(blob.content, "base64").toString("utf-8") : blob.content;
+  return parseSkillContent(text);
+}
+
 /**
  * Repo-tree lookup: read the repo's SKILL.md index and locate the one whose
  * enclosing folder matches the skill. Handles skills nested at any depth that
- * the flat-path guesses can't reach.
+ * the flat-path guesses can't reach, plus single-skill repos with SKILL.md at
+ * the root.
  */
 async function fetchSkillContentFromTree(skill: Skill): Promise<SkillContentResult | undefined> {
   const entries = await fetchRepoSkillMdEntries(skill.source);
@@ -125,14 +143,15 @@ async function fetchSkillContentFromTree(skill: Skill): Promise<SkillContentResu
       )[0];
     if (!match) continue;
 
-    const blobResponse = await fetch(match.url, { headers: githubHeaders() });
-    if (!blobResponse.ok) continue;
+    const content = await fetchBlobContent(match);
+    if (content) return content;
+  }
 
-    const blob = (await blobResponse.json()) as { content?: string; encoding?: string };
-    if (!blob.content) continue;
-
-    const text = blob.encoding === "base64" ? Buffer.from(blob.content, "base64").toString("utf-8") : blob.content;
-    return parseSkillContent(text);
+  // Single-skill repos keep SKILL.md at the root, so its (empty) folder name
+  // never matches a candidate. Only trust it when it is the repo's sole skill,
+  // otherwise a multi-skill repo's top-level README-style SKILL.md would win.
+  if (entries.length === 1 && entries[0].path === ROOT_SKILL_MD_PATH) {
+    return fetchBlobContent(entries[0]);
   }
 
   return undefined;

--- a/extensions/skills/src/tools/read-skill.ts
+++ b/extensions/skills/src/tools/read-skill.ts
@@ -1,3 +1,6 @@
+import { fetchSkillContent } from "../hooks/skill-content";
+import type { Skill } from "../shared";
+
 type Input = {
   /** GitHub owner/repo of the skill (e.g. "anthropics/skills") — from the `source` field in search results */
   source: string;
@@ -10,17 +13,17 @@ const MAX_CHARS = 50_000;
 /** Fetch the full SKILL.md content for a specific skill. Use after search-skills to understand what a skill does. */
 export default async function tool(input: Input) {
   const { source, skillId } = input;
-  const candidates = [
-    `https://raw.githubusercontent.com/${source}/HEAD/${skillId}/SKILL.md`,
-    `https://raw.githubusercontent.com/${source}/HEAD/skills/${skillId}/SKILL.md`,
-  ];
-  for (const url of candidates) {
-    const res = await fetch(url);
-    if (res.ok) {
-      const text = await res.text();
-      const truncated = text.length > MAX_CHARS;
-      return { content: truncated ? text.slice(0, MAX_CHARS) + "\n\n[...truncated]" : text };
-    }
+
+  // Reuses the resolver behind the skill detail view so the tool understands the
+  // same repo layouts (nested folders, owner-prefixed names, single-skill repos)
+  // instead of guessing at two flat paths.
+  const skill: Skill = { id: `${source}/${skillId}`, skillId, name: skillId, source, installs: 0 };
+  const result = await fetchSkillContent(skill);
+
+  if (!result) {
+    throw new Error(`Could not fetch SKILL.md for ${source}@${skillId}. The skill may use a non-standard repo layout.`);
   }
-  throw new Error(`Could not fetch SKILL.md for ${source}@${skillId}. The skill may use a non-standard repo layout.`);
+
+  const truncated = result.raw.length > MAX_CHARS;
+  return { content: truncated ? result.raw.slice(0, MAX_CHARS) + "\n\n[...truncated]" : result.raw };
 }

--- a/extensions/skills/src/utils/node-path-resolver.ts
+++ b/extensions/skills/src/utils/node-path-resolver.ts
@@ -1,5 +1,5 @@
 import { access, readdir } from "node:fs/promises";
-import { cpus } from "node:os";
+import { cpus, userInfo } from "node:os";
 import { join } from "node:path";
 import semver from "semver";
 
@@ -124,7 +124,14 @@ export const resolveVersionManagerPaths = async (): Promise<string[]> => {
   if (!home) return [];
 
   const nvmVersionsDir = join(home, ".nvm", "versions", "node");
-  const staticPathCandidates = [join(home, ".n", "bin"), join(home, ".volta", "bin")];
+  const xdgDataHome = process.env.XDG_DATA_HOME || join(home, ".local", "share");
+  const staticPathCandidates = [
+    join(home, ".n", "bin"),
+    join(home, ".volta", "bin"),
+    // mise and asdf expose every runtime they manage through a shims directory
+    join(xdgDataHome, "mise", "shims"),
+    join(home, ".asdf", "shims"),
+  ];
   const [nvmPaths, fnmPaths, staticPaths] = await Promise.all([
     scanVersionedNodePaths(nvmVersionsDir, (version) => join(nvmVersionsDir, version, "bin")),
     (async () => {
@@ -141,17 +148,56 @@ export const resolveVersionManagerPaths = async (): Promise<string[]> => {
   return [...sortedVersionedPaths, ...staticPaths];
 };
 
+const resolveUsername = (): string | null => {
+  if (process.env.USER) return process.env.USER;
+
+  try {
+    return userInfo().username || null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Runtimes installed outside a version manager or Homebrew. Raycast starts with
+ * the GUI PATH rather than the login shell's, so these locations are invisible
+ * unless they are added explicitly.
+ */
+const resolveToolchainPaths = async (): Promise<string[]> => {
+  const home = process.env.HOME;
+  const candidates: string[] = [];
+
+  if (home) {
+    // Where Bun's official installer puts `bun`/`bunx`
+    candidates.push(join(home, ".bun", "bin"));
+    // Single-user Nix profile
+    candidates.push(join(home, ".nix-profile", "bin"));
+  }
+
+  const username = resolveUsername();
+  if (username) {
+    // Per-user profile of a multi-user Nix / nix-darwin install
+    candidates.push(join("/etc", "profiles", "per-user", username, "bin"));
+  }
+
+  // nix-darwin system profile and the default Nix profile
+  candidates.push("/run/current-system/sw/bin", "/nix/var/nix/profiles/default/bin");
+
+  return resolveExistingPaths(candidates);
+};
+
 const buildEnhancedNodePaths = async (): Promise<string> => {
   const homebrewPrefix = isAppleSilicon() ? "/opt/homebrew" : "/usr/local";
 
   const homebrewPaths = [join(homebrewPrefix, "bin"), join(homebrewPrefix, "lib", "node_modules", ".bin")];
 
-  const [homebrewVersionedNodePaths, versionManagerPaths] = await Promise.all([
+  const [homebrewVersionedNodePaths, versionManagerPaths, toolchainPaths] = await Promise.all([
     resolveHomebrewVersionedNodePaths(homebrewPrefix),
     resolveVersionManagerPaths(),
+    resolveToolchainPaths(),
   ]);
 
-  const systemPaths = ["/usr/bin", "/bin"];
+  const systemPaths = ["/usr/local/bin", "/usr/bin", "/bin"];
 
   if (process.env.HOME) {
     systemPaths.push(`${process.env.HOME}/.npm/bin`, `${process.env.HOME}/.yarn/bin`);
@@ -159,6 +205,7 @@ const buildEnhancedNodePaths = async (): Promise<string> => {
 
   const allPaths = [
     ...versionManagerPaths,
+    ...toolchainPaths,
     ...homebrewVersionedNodePaths,
     ...homebrewPaths,
     ...systemPaths,

--- a/extensions/skills/src/utils/skills-cli-runner.ts
+++ b/extensions/skills/src/utils/skills-cli-runner.ts
@@ -14,6 +14,7 @@ let bunxResolutionFailed = false;
 
 type ExecFailure = Error & {
   code?: string | number;
+  stdout?: string | Buffer;
   stderr?: string | Buffer;
 };
 
@@ -50,8 +51,17 @@ function getSkillsCliEnvOverrides(): Record<string, string> {
   return shouldDisableSkillsCliTelemetry() ? { DISABLE_TELEMETRY: "1" } : {};
 }
 
-export async function runSkillsCli(args: string[]): Promise<string> {
-  return enqueueSkillsCliRun(() => runSkillsCliCommand(args));
+export interface RunSkillsCliOptions {
+  /**
+   * Whether the command has no side effects. Only such commands are retried
+   * through npx when bunx dies without a word: a mutating command may already
+   * have changed local state, and re-running it would apply the change twice.
+   */
+  readOnly?: boolean;
+}
+
+export async function runSkillsCli(args: string[], options: RunSkillsCliOptions = {}): Promise<string> {
+  return enqueueSkillsCliRun(() => runSkillsCliCommand(args, options.readOnly ?? false));
 }
 
 async function enqueueSkillsCliRun<T>(run: () => Promise<T>): Promise<T> {
@@ -60,7 +70,7 @@ async function enqueueSkillsCliRun<T>(run: () => Promise<T>): Promise<T> {
   return runAfterPending;
 }
 
-async function runSkillsCliCommand(args: string[]): Promise<string> {
+async function runSkillsCliCommand(args: string[], readOnly: boolean): Promise<string> {
   const customNpxPath = getCustomNpxPath();
   if (customNpxPath) {
     await validateCustomNpxPath(customNpxPath);
@@ -77,8 +87,9 @@ async function runSkillsCliCommand(args: string[]): Promise<string> {
     } catch (error) {
       if (isNpxCommandResolutionFailure(error, "bunx")) {
         bunxResolutionFailed = true;
-      } else if (!isSilentFailure(error)) {
-        // bunx explained itself, so npx would only repeat the same failure.
+      } else if (!readOnly || hasDiagnosticOutput(error)) {
+        // Either the command may have changed state, or bunx said what went
+        // wrong — in both cases retrying through npx is not the right move.
         throw normalizeCliError(error, "bunx");
       }
     }
@@ -106,14 +117,31 @@ async function executeSkillsCli(runner: PackageRunner, args: string[], executabl
   return stdout.toString();
 }
 
+const MAX_CLI_OUTPUT_CHARS = 500;
+
+// Built from a char code so the escape byte stays out of the regex literal.
+const ANSI_ESCAPE_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-9;?]*[A-Za-z]`, "g");
+
+/**
+ * What the failed run told us. The skills CLI renders everything — including
+ * errors — on stdout, so stderr alone would usually be empty.
+ */
+function extractCliOutput(error: unknown): string {
+  const failure = error as ExecFailure | undefined;
+
+  return [failure?.stdout, failure?.stderr]
+    .map((stream) => stream?.toString().replace(ANSI_ESCAPE_PATTERN, "").trim() ?? "")
+    .filter(Boolean)
+    .join("\n");
+}
+
 /**
  * `bunx --silent` suppresses bun's own diagnostics, so a failed run can reject
- * with nothing beyond "Command failed: bunx …" — no reason the user can act on.
- * Such a failure is retried through npx, which either succeeds or reports why.
+ * with nothing beyond "Command failed: bunx …" on either stream. Only such a
+ * wordless failure is worth retrying through npx.
  */
-function isSilentFailure(error: unknown): boolean {
-  const stderr = (error as ExecFailure | undefined)?.stderr;
-  return !stderr || stderr.toString().trim().length === 0;
+function hasDiagnosticOutput(error: unknown): boolean {
+  return extractCliOutput(error).length > 0;
 }
 
 function normalizeCliError(error: unknown, npxCommand: string): Error {
@@ -124,10 +152,26 @@ function normalizeCliError(error: unknown, npxCommand: string): Error {
   }
 
   if (error instanceof Error) {
-    return error;
+    return withCliOutput(error);
   }
 
   return new Error("Failed to execute the skills CLI command.");
+}
+
+/**
+ * `execFile` folds stderr into the rejection message but drops stdout, which is
+ * where this CLI reports its failures. Without it the user only sees the command
+ * that failed, never the reason.
+ */
+function withCliOutput(error: Error): Error {
+  const output = extractCliOutput(error);
+  if (!output || error.message.includes(output)) return error;
+
+  const truncated = output.length > MAX_CLI_OUTPUT_CHARS ? `…${output.slice(-MAX_CLI_OUTPUT_CHARS)}` : output;
+  const detailedError = new Error(`${error.message.trim()}\n${truncated}`, { cause: error });
+  detailedError.name = error.name;
+  detailedError.stack = error.stack;
+  return detailedError;
 }
 
 async function validateCustomNpxPath(customNpxPath: string): Promise<void> {

--- a/extensions/skills/src/utils/skills-cli-runner.ts
+++ b/extensions/skills/src/utils/skills-cli-runner.ts
@@ -75,10 +75,12 @@ async function runSkillsCliCommand(args: string[]): Promise<string> {
     try {
       return await executeSkillsCli("bunx", args);
     } catch (error) {
-      if (!isNpxCommandResolutionFailure(error, "bunx")) {
+      if (isNpxCommandResolutionFailure(error, "bunx")) {
+        bunxResolutionFailed = true;
+      } else if (!isSilentFailure(error)) {
+        // bunx explained itself, so npx would only repeat the same failure.
         throw normalizeCliError(error, "bunx");
       }
-      bunxResolutionFailed = true;
     }
   }
 
@@ -102,6 +104,16 @@ async function executeSkillsCli(runner: PackageRunner, args: string[], executabl
     shell: isWindows,
   });
   return stdout.toString();
+}
+
+/**
+ * `bunx --silent` suppresses bun's own diagnostics, so a failed run can reject
+ * with nothing beyond "Command failed: bunx …" — no reason the user can act on.
+ * Such a failure is retried through npx, which either succeeds or reports why.
+ */
+function isSilentFailure(error: unknown): boolean {
+  const stderr = (error as ExecFailure | undefined)?.stderr;
+  return !stderr || stderr.toString().trim().length === 0;
 }
 
 function normalizeCliError(error: unknown, npxCommand: string): Error {

--- a/extensions/skills/src/utils/skills-cli.ts
+++ b/extensions/skills/src/utils/skills-cli.ts
@@ -41,7 +41,7 @@ function parseSkillsListJson(stdout: string): InstalledSkill[] {
 }
 
 export async function listInstalledSkills(): Promise<InstalledSkill[]> {
-  const stdout = await runSkillsCli(["list", "-g", "--json"]);
+  const stdout = await runSkillsCli(["list", "-g", "--json"], { readOnly: true });
   try {
     return parseSkillsListJson(stdout);
   } catch {


### PR DESCRIPTION
## Description

Fixes the four unresolved issues reported for the Skills extension.

**1. `Unable to find a working bunx or npx command` (list-installed-skills)**

`node-path-resolver.ts` only searched version managers (nvm/fnm/n/volta), Homebrew, `/usr/bin` and `/bin`. Raycast launches with the GUI PATH rather than the login shell's, so runtimes installed anywhere else were invisible. Added: `~/.bun/bin` (Bun's official installer, where `bunx` lives), Nix / nix-darwin profiles (`/etc/profiles/per-user/<user>/bin`, `~/.nix-profile/bin`, `/run/current-system/sw/bin`, `/nix/var/nix/profiles/default/bin`), mise and asdf shims, and `/usr/local/bin`.

**2. `Command failed: bunx --silent skills@latest list -g --json` (list-installed-skills)**

`bunx --silent` suppresses bun's own diagnostics, so the rejection carried no stderr and the run aborted without falling back. A bunx failure with no diagnostic output now retries through `npx`, which either succeeds or reports an actionable reason. Failures where bunx did explain itself still abort immediately, so no redundant second run.

**3 & 4. `Could not fetch SKILL.md ... may use a non-standard repo layout` (read-skill)**

Two causes:

- The repo-tree lookup filtered on `path.endsWith("/SKILL.md")`, which excludes single-skill repos that keep `SKILL.md` at the repository root. Root-level `SKILL.md` is now accepted, but only when it is the repo's sole skill, so a multi-skill repo's top-level file cannot shadow a real match.
- The `read-skill` AI tool had its own resolver that guessed at just two flat paths, instead of reusing `fetchSkillContent()` behind the detail view. It now delegates, so nested, owner-prefixed and root-level layouts all resolve.

## Verification

- `npm run lint`, `npx tsc --noEmit` and `npm run build` pass
- Against `alexi-build/raycast-extensions-skill` (the repo in the reported error): the two old candidate URLs return 404, the new root-level fallback resolves the 5,716-char `SKILL.md`
- On a Nix-managed Mac with a simulated GUI PATH (`/usr/bin:/bin:/usr/sbin:/sbin`): the old resolver fails with `ENOENT`, the new one resolves `npx 11.6.2` via `/etc/profiles/per-user/<user>/bin`
- Ran in Raycast on that same Nix-managed Mac, which gave a direct before/after on one machine: the current Store build fails "Manage Skills" with `Unable to find a working bunx or npx command`, while this build lists all 14 installed skills and their agents. `bunx` is genuinely absent there, so the read-only fallback to `npx` is what carries the command

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
