### PR TITLE
[Linear] Add My Issues sub views

### DIFF
--- a/extensions/linear/CHANGELOG.md
+++ b/extensions/linear/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Linear Changelog
 
-## [My Issues Sub Views] - {PR_MERGE_DATE}
+## [My Issues Sub Views] - 2026-07-30
 
 - Add a dropdown to the "My Issues" command to switch between the Assigned, Created, and Subscribed sub views, matching the Linear app. Assigned stays the default.
 

--- a/extensions/linear/CHANGELOG.md
+++ b/extensions/linear/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Linear Changelog
 
+## [My Issues Sub Views] - {PR_MERGE_DATE}
+
+- Add a dropdown to the "My Issues" command to switch between the Assigned, Created, and Subscribed sub views, matching the Linear app. Assigned stays the default.
+
 ## [Add Copy Shortcuts] - 2026-07-18
 
 - Add `Cmd/Ctrl + Shift + U` shortcut to the "Copy Issue URL" action.

--- a/extensions/linear/src/api/getIssues.ts
+++ b/extensions/linear/src/api/getIssues.ts
@@ -294,22 +294,34 @@ export async function getCreatedIssues() {
 
 export async function getSubscribedIssues() {
   const { graphQLClient } = getLinearClient();
-  const { data } = await graphQLClient.rawRequest<{ issues: { nodes: IssueResult[] } }, Record<string, unknown>>(
-    `
-      query {
-        issues(orderBy: updatedAt, filter: { subscribers: { some: { isMe: { eq: true } } }${getCompletedIssuesFilter({
-          inFilterBlock: true,
-          addComma: true,
-        })} }) {
-          nodes {
-            ${IssueFragment}
-          }
-        }
-      }
-    `,
-  );
 
-  return data?.issues.nodes;
+  const { pageSize, pageLimit } = getPageLimits();
+
+  return getPaginated(
+    async (cursor) =>
+      graphQLClient.rawRequest<{ issues: { nodes: IssueResult[]; pageInfo: PageInfo } }, Record<string, unknown>>(
+        `
+          query($cursor: String) {
+            issues(first: ${pageSize}, after: $cursor, orderBy: updatedAt, filter: { subscribers: { some: { isMe: { eq: true } } }${getCompletedIssuesFilter(
+              { inFilterBlock: true, addComma: true },
+            )} }) {
+              nodes {
+                ${IssueFragment}
+              }
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+            }
+          }
+        `,
+        { cursor },
+      ),
+    (r) => r.data?.issues.pageInfo,
+    (accumulator: IssueResult[], currentValue) => accumulator.concat(currentValue.data?.issues.nodes || []),
+    [],
+    pageLimit,
+  );
 }
 
 export type MyIssuesView = "assigned" | "created" | "subscribed";

--- a/extensions/linear/src/api/getIssues.ts
+++ b/extensions/linear/src/api/getIssues.ts
@@ -292,6 +292,39 @@ export async function getCreatedIssues() {
   return data?.viewer.createdIssues.nodes;
 }
 
+export async function getSubscribedIssues() {
+  const { graphQLClient } = getLinearClient();
+  const { data } = await graphQLClient.rawRequest<{ issues: { nodes: IssueResult[] } }, Record<string, unknown>>(
+    `
+      query {
+        issues(orderBy: updatedAt, filter: { subscribers: { some: { isMe: { eq: true } } }${getCompletedIssuesFilter({
+          inFilterBlock: true,
+          addComma: true,
+        })} }) {
+          nodes {
+            ${IssueFragment}
+          }
+        }
+      }
+    `,
+  );
+
+  return data?.issues.nodes;
+}
+
+export type MyIssuesView = "assigned" | "created" | "subscribed";
+
+export function getMyIssuesByView(view: MyIssuesView) {
+  switch (view) {
+    case "assigned":
+      return getMyIssues();
+    case "created":
+      return getCreatedIssues();
+    case "subscribed":
+      return getSubscribedIssues();
+  }
+}
+
 export async function getActiveCycleIssues(cycleId?: string) {
   if (!cycleId) {
     return [];

--- a/extensions/linear/src/assigned-issues.tsx
+++ b/extensions/linear/src/assigned-issues.tsx
@@ -1,6 +1,7 @@
-import { Action, ActionPanel, List } from "@raycast/api";
+import { Action, ActionPanel, Icon, List } from "@raycast/api";
+import { useState } from "react";
 
-import { getMyIssues } from "./api/getIssues";
+import { getMyIssuesByView, MyIssuesView } from "./api/getIssues";
 import CreateIssueForm from "./components/CreateIssueForm";
 import StateIssueList from "./components/StateIssueList";
 import View from "./components/View";
@@ -8,25 +9,63 @@ import useIssues from "./hooks/useIssues";
 import useMe from "./hooks/useMe";
 import usePriorities from "./hooks/usePriorities";
 
+const views: { id: MyIssuesView; title: string; icon: Icon; emptyDescription: string }[] = [
+  {
+    id: "assigned",
+    title: "Assigned",
+    icon: Icon.Person,
+    emptyDescription: "There are no issues assigned to you.",
+  },
+  {
+    id: "created",
+    title: "Created",
+    icon: Icon.PlusCircle,
+    emptyDescription: "There are no issues created by you.",
+  },
+  {
+    id: "subscribed",
+    title: "Subscribed",
+    icon: Icon.Bell,
+    emptyDescription: "There are no issues you are subscribed to.",
+  },
+];
+
 function MyIssues() {
-  const { issues, isLoadingIssues, mutateList } = useIssues(getMyIssues);
+  const [view, setView] = useState<MyIssuesView>("assigned");
+
+  const { issues, isLoadingIssues, mutateList } = useIssues(getMyIssuesByView, [view]);
   const { priorities, isLoadingPriorities } = usePriorities();
   const { me, isLoadingMe } = useMe();
 
+  const selectedView = views.find(({ id }) => id === view) ?? views[0];
+
   return (
     <List
-      isLoading={isLoadingIssues || isLoadingMe || isLoadingPriorities || isLoadingMe}
+      isLoading={isLoadingIssues || isLoadingPriorities || isLoadingMe}
       searchBarPlaceholder="Filter by ID, title, status, assignee or priority"
       filtering={{ keepSectionOrder: true }}
+      searchBarAccessory={
+        <List.Dropdown tooltip="Change View" value={view} onChange={(value) => setView(value as MyIssuesView)}>
+          {views.map(({ id, title, icon }) => (
+            <List.Dropdown.Item key={id} value={id} title={title} icon={icon} />
+          ))}
+        </List.Dropdown>
+      }
     >
       <List.EmptyView
         title="No issues"
-        description="There are no issues assigned to you."
+        description={selectedView.emptyDescription}
         actions={
           <ActionPanel>
             <Action.Push
               title="Create Issue"
-              target={<CreateIssueForm assigneeId={me?.id} priorities={priorities} me={me} />}
+              target={
+                <CreateIssueForm
+                  assigneeId={view === "assigned" ? me?.id : undefined}
+                  priorities={priorities}
+                  me={me}
+                />
+              }
             />
           </ActionPanel>
         }


### PR DESCRIPTION
## Description

The Linear app splits My Issues into four sub views: Assigned, Created, Subscribed, and Activity. The extension's My Issues command only ever showed Assigned.

This adds a dropdown to the command's search bar for switching between Assigned, Created, and Subscribed. It defaults to Assigned on every launch, matching the app. `storeValue` is deliberately not set, so the dropdown does not remember the last selection.

Subscribed is a new query, `issues(orderBy: updatedAt, filter: { subscribers: { some: { isMe: { eq: true } } } })`. It honors the existing Hide Redundant Issues preference like the other issue queries.

Notes:

**Activity is not included.** Linear's Activity tab lists issues by date for actions including state changes, comment reactions, and opened pull requests. `IssueFilter` has no issue history filter and `ReactionFilter` has no author field, so those actions are not reachable from the API. Building the tab out of the filters that do exist would ship something that quietly disagrees with the app, which seemed worse than leaving it out.

**The selected view is passed as an argument to `useIssues` rather than swapping the fetcher function.** `useCachedPromise` derives its cache key from the arguments alone, so three separate fetchers called with no arguments would share one cache entry and show each other's issues.

The standalone Created Issues command is untouched. It now overlaps with the Created sub view, but removing a published command is breaking, so that call is left to the extension owners.

## Screencast

<img width="901" height="587" alt="Screenshot 2026-07-29 at 15 38 27 2" src="https://github.com/user-attachments/assets/14f3deac-1119-4492-854b-a26b90042304" />
<img width="862" height="587" alt="Screenshot 2026-07-29 at 15 42 03 2" src="https://github.com/user-attachments/assets/7eb4e17a-c9a7-4108-8a3b-42e7ce4a4c41" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
