### PR TITLE
Update github extension

### DIFF
--- a/extensions/github/CHANGELOG.md
+++ b/extensions/github/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GitHub Changelog
 
+## [Show README in repository actions] - {PR_MERGE_DATE}
+
+- Added a "Show Readme" action to the Search Repositories, My Latest Repositories, and My Starred Repositories commands that renders the repository's README inside Raycast, with relative links and images resolved to absolute URLs.
+
 ## [Mark draft pull requests as ready for review] - 2026-07-09
 
 - Added a "Ready for Review" action to pull request lists, shown for your own draft pull requests.

--- a/extensions/github/CHANGELOG.md
+++ b/extensions/github/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GitHub Changelog
 
-## [Show README in repository actions] - {PR_MERGE_DATE}
+## [Show README in repository actions] - 2026-08-03
 
 - Added a "Show Readme" action to the Search Repositories, My Latest Repositories, and My Starred Repositories commands that renders the repository's README inside Raycast, with relative links and images resolved to absolute URLs.
 

--- a/extensions/github/src/components/RepositoryActions.tsx
+++ b/extensions/github/src/components/RepositoryActions.tsx
@@ -12,6 +12,7 @@ import DownloadRepositoryForm from "./DownloadRepositoryForm";
 import { RepositoryDiscussionList } from "./RepositoryDiscussions";
 import { RepositoryIssueList } from "./RepositoryIssues";
 import { RepositoryPullRequestList } from "./RepositoryPullRequest";
+import RepositoryReadme from "./RepositoryReadme";
 import RepositoryReleases from "./RepositoryReleases";
 import { SortAction, SortActionProps, SortTypesDataProps } from "./SortAction";
 
@@ -158,6 +159,13 @@ export default function RepositoryActions<T = ExtendedRepositoryFieldsFragment[]
       </ActionPanel.Section>
 
       <ActionPanel.Section title="Open in Raycast">
+        <Action.Push
+          title="Show Readme"
+          icon={Icon.Book}
+          shortcut={{ modifiers: ["cmd", "opt"], key: "r" }}
+          target={<RepositoryReadme repository={repository} />}
+          onPush={() => onVisit(repository)}
+        />
         <Action.Push
           title="Show Issues"
           icon={{ source: "issue-open.svg", tintColor: Color.PrimaryText }}

--- a/extensions/github/src/components/RepositoryReadme.tsx
+++ b/extensions/github/src/components/RepositoryReadme.tsx
@@ -1,0 +1,27 @@
+import { Action, ActionPanel, Detail } from "@raycast/api";
+
+import { ExtendedRepositoryFieldsFragment } from "../generated/graphql";
+import { useReadme } from "../hooks/useRepositories";
+
+export default function RepositoryReadme({ repository }: { repository: ExtendedRepositoryFieldsFragment }) {
+  const { data, isLoading } = useReadme(repository);
+
+  const markdown =
+    !isLoading && data && !data.found
+      ? `# ${repository.nameWithOwner}\n\n> This repository doesn't have a README.`
+      : (data?.markdown ?? "");
+
+  return (
+    <Detail
+      isLoading={isLoading}
+      navigationTitle={`${repository.nameWithOwner} · README`}
+      markdown={markdown}
+      actions={
+        <ActionPanel title={repository.nameWithOwner}>
+          <Action.OpenInBrowser url={repository.url} />
+          <Action.CopyToClipboard content={repository.url} title="Copy Repository URL" />
+        </ActionPanel>
+      }
+    />
+  );
+}

--- a/extensions/github/src/components/RepositoryReadme.tsx
+++ b/extensions/github/src/components/RepositoryReadme.tsx
@@ -7,7 +7,7 @@ export default function RepositoryReadme({ repository }: { repository: ExtendedR
   const { data, isLoading } = useReadme(repository);
 
   const markdown =
-    !isLoading && data && !data.found
+    data && !data.found
       ? `# ${repository.nameWithOwner}\n\n> This repository doesn't have a README.`
       : (data?.markdown ?? "");
 

--- a/extensions/github/src/helpers/repository.ts
+++ b/extensions/github/src/helpers/repository.ts
@@ -215,10 +215,13 @@ export function rewriteReadmeUrls(markdown: string, rawDownloadUrl: string): str
     return markdown;
   }
 
+  // Insert `/blob/` after `owner/repo` instead of guessing the ref segment, so
+  // subdirectory READMEs (`.github/`, `docs/`) and slash-containing refs stay intact.
   const rawBase = rawDownloadUrl.slice(0, rawDownloadUrl.lastIndexOf("/") + 1);
-  const blobBase = rawBase
-    .replace("https://raw.githubusercontent.com/", "https://github.com/")
-    .replace(/\/([^/]+)\/$/, "/blob/$1/");
+  const blobBase = rawBase.replace(
+    /^https:\/\/raw\.githubusercontent\.com\/([^/]+)\/([^/]+)\//,
+    "https://github.com/$1/$2/blob/",
+  );
 
   const isAbsolute = (url: string) => /^[a-z][a-z0-9+.-]*:/i.test(url) || url.startsWith("//") || url.startsWith("#");
 
@@ -234,12 +237,15 @@ export function rewriteReadmeUrls(markdown: string, rawDownloadUrl: string): str
     }
   };
 
+  // Allow one level of balanced parentheses so filenames like `image(1).png`
+  // aren't truncated; the trailing group captures an optional title.
+  const destination = "((?:\\([^)]*\\)|[^()\\s])+)([^)]*)";
+  const imagePattern = new RegExp(`!\\[([^\\]]*)\\]\\(${destination}\\)`, "g");
+  const linkPattern = new RegExp(`(?<!!)\\[([^\\]]+)\\]\\(${destination}\\)`, "g");
+
   return markdown
-    .replace(/!\[([^\]]*)\]\(([^)\s]+)([^)]*)\)/g, (_m, alt, url, tail) => `![${alt}](${resolve(url, rawBase)}${tail})`)
-    .replace(
-      /(?<!!)\[([^\]]+)\]\(([^)\s]+)([^)]*)\)/g,
-      (_m, text, url, tail) => `[${text}](${resolve(url, blobBase)}${tail})`,
-    )
+    .replace(imagePattern, (_m, alt, url, tail) => `![${alt}](${resolve(url, rawBase)}${tail})`)
+    .replace(linkPattern, (_m, text, url, tail) => `[${text}](${resolve(url, blobBase)}${tail})`)
     .replace(/(<img[^>]+src=["'])([^"']+)(["'])/gi, (_m, pre, url, post) => `${pre}${resolve(url, rawBase)}${post}`)
     .replace(/(<a[^>]+href=["'])([^"']+)(["'])/gi, (_m, pre, url, post) => `${pre}${resolve(url, blobBase)}${post}`);
 }

--- a/extensions/github/src/helpers/repository.ts
+++ b/extensions/github/src/helpers/repository.ts
@@ -208,30 +208,38 @@ const formatRepositoryUrl = (repoNameWithOwner: string, protocol: "https" | "ssh
  *
  * @param markdown {string} Raw README markdown.
  * @param rawDownloadUrl {string} The README's raw download URL from the GitHub API.
+ * @param readmePath {string} The README's path within the repository (e.g. `.github/README.md`),
+ *   used to resolve root-relative paths (starting with `/`) against the repository root.
  * @returns {string} Markdown with relative URLs rewritten to absolute ones.
  */
-export function rewriteReadmeUrls(markdown: string, rawDownloadUrl: string): string {
+export function rewriteReadmeUrls(markdown: string, rawDownloadUrl: string, readmePath = ""): string {
   if (!rawDownloadUrl) {
     return markdown;
   }
 
   // Insert `/blob/` after `owner/repo` instead of guessing the ref segment, so
   // subdirectory READMEs (`.github/`, `docs/`) and slash-containing refs stay intact.
-  const rawBase = rawDownloadUrl.slice(0, rawDownloadUrl.lastIndexOf("/") + 1);
-  const blobBase = rawBase.replace(
-    /^https:\/\/raw\.githubusercontent\.com\/([^/]+)\/([^/]+)\//,
-    "https://github.com/$1/$2/blob/",
-  );
+  const toBlob = (raw: string) =>
+    raw.replace(/^https:\/\/raw\.githubusercontent\.com\/([^/]+)\/([^/]+)\//, "https://github.com/$1/$2/blob/");
+
+  // `*Dir` is the README's own directory (for normal relative paths); `*Root` is the
+  // repository root at the same ref (for root-relative paths that start with `/`).
+  const rawDir = rawDownloadUrl.slice(0, rawDownloadUrl.lastIndexOf("/") + 1);
+  const rawRoot = readmePath ? rawDownloadUrl.slice(0, rawDownloadUrl.length - readmePath.length) : rawDir;
+  const blobDir = toBlob(rawDir);
+  const blobRoot = toBlob(rawRoot);
 
   const isAbsolute = (url: string) => /^[a-z][a-z0-9+.-]*:/i.test(url) || url.startsWith("//") || url.startsWith("#");
 
-  const resolve = (url: string, base: string) => {
+  const resolve = (url: string, dirBase: string, rootBase: string) => {
     const trimmed = url.trim();
     if (!trimmed || isAbsolute(trimmed)) {
       return url;
     }
     try {
-      return new URL(trimmed.replace(/^\/+/, ""), base).toString();
+      return trimmed.startsWith("/")
+        ? new URL(trimmed.replace(/^\/+/, ""), rootBase).toString()
+        : new URL(trimmed, dirBase).toString();
     } catch {
       return url;
     }
@@ -244,10 +252,16 @@ export function rewriteReadmeUrls(markdown: string, rawDownloadUrl: string): str
   const linkPattern = new RegExp(`(?<!!)\\[([^\\]]+)\\]\\(${destination}\\)`, "g");
 
   return markdown
-    .replace(imagePattern, (_m, alt, url, tail) => `![${alt}](${resolve(url, rawBase)}${tail})`)
-    .replace(linkPattern, (_m, text, url, tail) => `[${text}](${resolve(url, blobBase)}${tail})`)
-    .replace(/(<img[^>]+src=["'])([^"']+)(["'])/gi, (_m, pre, url, post) => `${pre}${resolve(url, rawBase)}${post}`)
-    .replace(/(<a[^>]+href=["'])([^"']+)(["'])/gi, (_m, pre, url, post) => `${pre}${resolve(url, blobBase)}${post}`);
+    .replace(imagePattern, (_m, alt, url, tail) => `![${alt}](${resolve(url, rawDir, rawRoot)}${tail})`)
+    .replace(linkPattern, (_m, text, url, tail) => `[${text}](${resolve(url, blobDir, blobRoot)}${tail})`)
+    .replace(
+      /(<img[^>]+src=["'])([^"']+)(["'])/gi,
+      (_m, pre, url, post) => `${pre}${resolve(url, rawDir, rawRoot)}${post}`,
+    )
+    .replace(
+      /(<a[^>]+href=["'])([^"']+)(["'])/gi,
+      (_m, pre, url, post) => `${pre}${resolve(url, blobDir, blobRoot)}${post}`,
+    );
 }
 
 /**

--- a/extensions/github/src/helpers/repository.ts
+++ b/extensions/github/src/helpers/repository.ts
@@ -195,6 +195,56 @@ const formatRepositoryUrl = (repoNameWithOwner: string, protocol: "https" | "ssh
   protocol === "https" ? `https://github.com/${repoNameWithOwner}.git` : `git@github.com:${repoNameWithOwner}.git`;
 
 /**
+ * Rewrite relative links and images in a README so they render correctly in a
+ * Raycast `Detail` view.
+ *
+ * GitHub returns README content with paths relative to the repository, which
+ * Raycast cannot resolve on its own. Using the raw `download_url` of the README
+ * (e.g. `https://raw.githubusercontent.com/owner/repo/main/README.md`) as the
+ * base, relative image sources are rewritten to absolute `raw.githubusercontent.com`
+ * URLs (so they display) and relative links are rewritten to `github.com/.../blob/...`
+ * URLs (so they open the right page). Absolute URLs, anchors and other schemes are
+ * left untouched.
+ *
+ * @param markdown {string} Raw README markdown.
+ * @param rawDownloadUrl {string} The README's raw download URL from the GitHub API.
+ * @returns {string} Markdown with relative URLs rewritten to absolute ones.
+ */
+export function rewriteReadmeUrls(markdown: string, rawDownloadUrl: string): string {
+  if (!rawDownloadUrl) {
+    return markdown;
+  }
+
+  const rawBase = rawDownloadUrl.slice(0, rawDownloadUrl.lastIndexOf("/") + 1);
+  const blobBase = rawBase
+    .replace("https://raw.githubusercontent.com/", "https://github.com/")
+    .replace(/\/([^/]+)\/$/, "/blob/$1/");
+
+  const isAbsolute = (url: string) => /^[a-z][a-z0-9+.-]*:/i.test(url) || url.startsWith("//") || url.startsWith("#");
+
+  const resolve = (url: string, base: string) => {
+    const trimmed = url.trim();
+    if (!trimmed || isAbsolute(trimmed)) {
+      return url;
+    }
+    try {
+      return new URL(trimmed.replace(/^\/+/, ""), base).toString();
+    } catch {
+      return url;
+    }
+  };
+
+  return markdown
+    .replace(/!\[([^\]]*)\]\(([^)\s]+)([^)]*)\)/g, (_m, alt, url, tail) => `![${alt}](${resolve(url, rawBase)}${tail})`)
+    .replace(
+      /(?<!!)\[([^\]]+)\]\(([^)\s]+)([^)]*)\)/g,
+      (_m, text, url, tail) => `[${text}](${resolve(url, blobBase)}${tail})`,
+    )
+    .replace(/(<img[^>]+src=["'])([^"']+)(["'])/gi, (_m, pre, url, post) => `${pre}${resolve(url, rawBase)}${post}`)
+    .replace(/(<a[^>]+href=["'])([^"']+)(["'])/gi, (_m, pre, url, post) => `${pre}${resolve(url, blobBase)}${post}`);
+}
+
+/**
  * Get the repository filter string based on the filter mode, repository list, and selected repository.
  *
  * @param {Preferences.MyIssues["repositoryFilterMode"]} filterMode - The mode to filter repositories ("all", "include", or "exclude").

--- a/extensions/github/src/hooks/useRepositories.ts
+++ b/extensions/github/src/hooks/useRepositories.ts
@@ -46,6 +46,8 @@ export function useReleases(repository: ExtendedRepositoryFieldsFragment) {
   return useCachedPromise((owner, name) => github.repositoryReleases({ owner, name }), [owner, name]);
 }
 
+const MARKDOWN_EXTENSION = /\.(md|markdown|mdown|mkdn?)$/i;
+
 export function useReadme(repository: ExtendedRepositoryFieldsFragment) {
   const { octokit } = getGitHubClient();
 
@@ -53,9 +55,26 @@ export function useReadme(repository: ExtendedRepositoryFieldsFragment) {
   return useCachedPromise(
     async (owner: string, name: string) => {
       try {
-        const { data } = await octokit.rest.repos.getReadme({ owner, repo: name });
+        const { data } = await octokit.repos.getReadme({ owner, repo: name });
+
+        // The Contents API omits the body (encoding "none") for files larger than 1 MB.
+        if (data.encoding !== "base64" || !data.content) {
+          return {
+            markdown: "> This README is too large to preview here. Open the repository in your browser to read it.",
+            found: true,
+          };
+        }
+
         const content = Buffer.from(data.content, "base64").toString("utf-8");
-        return { markdown: rewriteReadmeUrls(content, data.download_url ?? ""), found: true };
+
+        // `getReadme` returns whatever file GitHub picked, which isn't always Markdown
+        // (e.g. README.rst, README.asciidoc). Show non-Markdown content verbatim in a
+        // code block instead of letting Raycast mangle it as Markdown.
+        const markdown = MARKDOWN_EXTENSION.test(data.name)
+          ? rewriteReadmeUrls(content, data.download_url ?? "", data.path)
+          : `\`\`\`\n${content}\n\`\`\``;
+
+        return { markdown, found: true };
       } catch (error) {
         if ((error as { status?: number }).status === 404) {
           return { markdown: "", found: false };

--- a/extensions/github/src/hooks/useRepositories.ts
+++ b/extensions/github/src/hooks/useRepositories.ts
@@ -2,6 +2,7 @@ import { useCachedPromise } from "@raycast/utils";
 
 import { getGitHubClient } from "../api/githubClient";
 import { ExtendedRepositoryFieldsFragment } from "../generated/graphql";
+import { rewriteReadmeUrls } from "../helpers/repository";
 
 import { useViewer } from "./useViewer";
 
@@ -43,4 +44,25 @@ export function useReleases(repository: ExtendedRepositoryFieldsFragment) {
 
   const [owner, name] = repository.nameWithOwner.split("/");
   return useCachedPromise((owner, name) => github.repositoryReleases({ owner, name }), [owner, name]);
+}
+
+export function useReadme(repository: ExtendedRepositoryFieldsFragment) {
+  const { octokit } = getGitHubClient();
+
+  const [owner, name] = repository.nameWithOwner.split("/");
+  return useCachedPromise(
+    async (owner: string, name: string) => {
+      try {
+        const { data } = await octokit.rest.repos.getReadme({ owner, repo: name });
+        const content = Buffer.from(data.content, "base64").toString("utf-8");
+        return { markdown: rewriteReadmeUrls(content, data.download_url ?? ""), found: true };
+      } catch (error) {
+        if ((error as { status?: number }).status === 404) {
+          return { markdown: "", found: false };
+        }
+        throw error;
+      }
+    },
+    [owner, name],
+  );
 }


### PR DESCRIPTION
## Description
- Added a "Show Readme" action to the Search Repositories, My Latest Repositories, and My Starred Repositories commands that renders the repository's README inside Raycast, with relative links and images resolved to absolute URLs. Close #29778.
<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast
<img width="1809" height="1260" alt="CleanShot 2026-07-30 at 14 17 29@2x" src="https://github.com/user-attachments/assets/ac06e426-d258-480b-9eee-f09674059d3f" />
<img width="1809" height="1260" alt="CleanShot 2026-07-30 at 14 25 15@2x" src="https://github.com/user-attachments/assets/e6f4f25f-3e6f-4154-bd35-8cd334ab1d50" />

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
