### PR TITLE
Update git extension

### DIFF
--- a/extensions/git/CHANGELOG.md
+++ b/extensions/git/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Update] - 2026-07-30
 
+### Fixed
+- **Diff**: Fix crash when opening the file diff view caused by a missing `strtok3` runtime import from `file-type`
+
+## [Update] - 2026-07-30
+
 ### Added
 - **Worktrees**: Add "Worktrees" view listing all worktrees of the repository with actions to open, copy the path and delete a worktree
 - **Branches**: Show an indicator on branches that are checked out in another worktree and open that worktree on checkout

--- a/extensions/git/src/hooks/useGitDiff.ts
+++ b/extensions/git/src/hooks/useGitDiff.ts
@@ -2,8 +2,8 @@ import { usePromise } from "@raycast/utils";
 import { GitManager } from "../utils/git-manager";
 import { FileStatus } from "../types";
 import { join } from "path";
-import { fileTypeFromFile } from "file-type";
-import { existsSync } from "fs";
+import { fileTypeFromBuffer } from "file-type";
+import { existsSync, openSync, readSync, closeSync } from "fs";
 
 interface UseGitDiffProps {
   gitManager: GitManager;
@@ -12,6 +12,25 @@ interface UseGitDiffProps {
 }
 
 const MAX_DIFF_LINES = 200;
+
+/** Bytes needed for `file-type` magic-number detection (`reasonableDetectionSizeInBytes`). */
+const FILE_TYPE_SAMPLE_SIZE = 4100;
+
+/**
+ * Reads the start of a file for binary/MIME detection without loading the whole file.
+ * Prefer this over `fileTypeFromFile`: that API dynamically imports `strtok3` at runtime,
+ * which fails in Raycast's bundled extension (no `node_modules` next to the command).
+ */
+function readFileHead(filePath: string, size: number): Uint8Array {
+  const fd = openSync(filePath, "r");
+  try {
+    const buffer = Buffer.alloc(size);
+    const bytesRead = readSync(fd, buffer, 0, size, 0);
+    return buffer.subarray(0, bytesRead);
+  } finally {
+    closeSync(fd);
+  }
+}
 
 /**
  * Hook for fetching the diff for a file or commit with smart caching.
@@ -26,7 +45,7 @@ export function useGitDiff({ gitManager, options, execute = true }: UseGitDiffPr
       const absolutePath = join(repoPath, file);
 
       if (existsSync(absolutePath)) {
-        const binaryFormatInfo = await fileTypeFromFile(absolutePath);
+        const binaryFormatInfo = await fileTypeFromBuffer(readFileHead(absolutePath, FILE_TYPE_SAMPLE_SIZE));
 
         if (binaryFormatInfo) {
           if (binaryFormatInfo.mime.startsWith("image/")) {

--- a/extensions/git/src/types/file-type.d.ts
+++ b/extensions/git/src/types/file-type.d.ts
@@ -2,6 +2,9 @@
  * Ambient types for `file-type`.
  * The package is ESM-only (`exports` map) and does not resolve under the extension's
  * default TypeScript `moduleResolution`, while Raycast's bundler still loads it at runtime.
+ *
+ * Prefer `fileTypeFromBuffer` over `fileTypeFromFile`: the latter dynamically imports
+ * `strtok3` at runtime, which is unavailable in Raycast's installed extension bundle.
  */
 declare module "file-type" {
   export type FileTypeResult = {
@@ -9,5 +12,5 @@ declare module "file-type" {
     mime: string;
   };
 
-  export function fileTypeFromFile(filePath: string): Promise<FileTypeResult | undefined>;
+  export function fileTypeFromBuffer(buffer: Uint8Array | ArrayBuffer): Promise<FileTypeResult | undefined>;
 }


### PR DESCRIPTION
## Description

### Fixed
- **Diff**: Fix crash when opening the file diff view caused by a missing `strtok3` runtime import from `file-type`

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder