### PR TITLE
Add Store link to Tutti README

### DIFF
--- a/extensions/tutti/CHANGELOG.md
+++ b/extensions/tutti/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Tutti Changelog
 
+## [Documentation] - 2026-07-31
+
+- Add a Store screenshot and install button to the README.
+
 ## [Initial Version] - 2026-07-30
 
 - Apply Preset — pick a saved preset and switch to it.

--- a/extensions/tutti/CHANGELOG.md
+++ b/extensions/tutti/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Tutti Changelog
 
-## [Documentation] - 2026-07-31
+## [Documentation] - {PR_MERGE_DATE}
 
 - Add a Store screenshot and install button to the README.
 

--- a/extensions/tutti/CHANGELOG.md
+++ b/extensions/tutti/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Tutti Changelog
 
-## [Documentation] - {PR_MERGE_DATE}
+## [Documentation] - 2026-07-31
 
 - Add a Store screenshot and install button to the README.
 

--- a/extensions/tutti/README.md
+++ b/extensions/tutti/README.md
@@ -3,6 +3,16 @@
 Control [Tutti](https://tutti.barrybarrywu.com) — play the same audio through many
 output devices at once on macOS — straight from the Raycast launcher.
 
+<p align="center">
+  <img src="metadata/tutti-1.png" alt="Tutti commands in Raycast" width="800" />
+</p>
+
+<p align="center">
+  <a href="https://www.raycast.com/Barrybarrywu/tutti" title="Install Tutti Raycast Extension">
+    <img src="https://www.raycast.com/Barrybarrywu/tutti/install_button@2x.png?v=1.1" height="64" alt="Install Tutti on Raycast" />
+  </a>
+</p>
+
 ## Commands
 
 - **Apply Preset** — pick one of your saved presets and switch to it.


### PR DESCRIPTION
## Summary
- show the current Raycast Store screenshot in the Tutti README
- add the official install button linking to the Raycast Store

No extension code or metadata assets changed.