### PR TITLE
fix(brew): stop Show Installed rendering empty from a warm cache

### DIFF
--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Brew Changelog
 
-## [Bug fix] - {PR_MERGE_DATE}
+## [Bug fix] - 2026-08-03
 
 - Fixed "Show Installed" listing no packages on every open after the first. The installed-package lookups are `Map`s, which serialise to `{}`, so the cached value was emptied on write and then re-served empty forever. The serialisable form is cached now and the lookups are rebuilt on read; cache entries written by earlier versions are discarded rather than trusted.
 - Fixed Search intermittently failing to mark packages as installed, which had the same cause.

--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Brew Changelog
 
+## [Bug fix] - {PR_MERGE_DATE}
+
+- Fixed "Show Installed" listing no packages on every open after the first. The installed-package lookups are `Map`s, which serialise to `{}`, so the cached value was emptied on write and then re-served empty forever. The serialisable form is cached now and the lookups are rebuilt on read; cache entries written by earlier versions are discarded rather than trusted.
+- Fixed Search intermittently failing to mark packages as installed, which had the same cause.
+
 ## [Bug fix] - 2026-07-10
 
 - Search now works instantly against the existing package index while it refreshes in the background, instead of blocking until the refresh completes

--- a/extensions/brew/src/hooks/useBrewInstalled.ts
+++ b/extensions/brew/src/hooks/useBrewInstalled.ts
@@ -5,9 +5,18 @@
  * to show stale data while revalidating.
  */
 
+import { useMemo } from "react";
 import { showToast, Toast } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
-import { brewFetchInstalled, InstalledMap, isBrewLockError, getErrorMessage, brewLogger } from "../utils";
+import {
+  brewFetchInstallableResults,
+  brewMapInstalled,
+  asInstallableResults,
+  InstallableResults,
+  isBrewLockError,
+  getErrorMessage,
+  brewLogger,
+} from "../utils";
 
 /**
  * Hook to fetch and cache installed brew packages.
@@ -17,12 +26,17 @@ import { brewFetchInstalled, InstalledMap, isBrewLockError, getErrorMessage, bre
  * - Fetches fresh data in background
  * - Loading state is true until data is available
  *
+ * The cached value is the serialisable `InstallableResults` rather than the
+ * `InstalledMap` consumers want: useCachedPromise persists through a JSON
+ * cache, and `JSON.stringify(new Map())` is `{}`, so caching the mapped form
+ * loses every package. The lookup maps are rebuilt on read instead.
+ *
  * @returns Object containing loading state, data, and revalidate function
  */
 export function useBrewInstalled() {
   const result = useCachedPromise(
-    async (): Promise<InstalledMap | undefined> => {
-      return await brewFetchInstalled(true);
+    async (): Promise<InstallableResults | undefined> => {
+      return await brewFetchInstallableResults(true);
     },
     [],
     {
@@ -53,5 +67,11 @@ export function useBrewInstalled() {
     },
   );
 
-  return result;
+  // Rebuild the name-keyed lookups on every change of the cached value. An
+  // entry written by an earlier version of the extension holds `{}` in place
+  // of each Map, which asInstallableResults rejects so the stale value is
+  // re-fetched rather than rendered as an empty list.
+  const data = useMemo(() => brewMapInstalled(asInstallableResults(result.data)), [result.data]);
+
+  return { ...result, data };
 }

--- a/extensions/brew/src/utils/brew/fetch.ts
+++ b/extensions/brew/src/utils/brew/fetch.ts
@@ -267,7 +267,15 @@ export async function brewFetchInstalled(useCache: boolean, cancel?: AbortSignal
   return mapped;
 }
 
-async function brewFetchInstallableResults(
+/**
+ * Fetch all installed packages with full metadata, in their serialisable form.
+ *
+ * Prefer this over {@link brewFetchInstalled} when the result is persisted:
+ * `InstalledMap` holds `Map`s, and `JSON.stringify(new Map())` is `{}`, so a
+ * mapped value does not survive a cache round-trip. Rebuild the lookup
+ * structures on read with {@link brewMapInstalled}.
+ */
+export async function brewFetchInstallableResults(
   useCache: boolean,
   cancel?: AbortSignal,
 ): Promise<InstallableResults | undefined> {
@@ -362,7 +370,28 @@ async function brewFetchInstallableResults(
   }
 }
 
-function brewMapInstalled(installed?: InstallableResults): InstalledMap | undefined {
+/**
+ * Narrow an untrusted value to {@link InstallableResults}.
+ *
+ * Values read back out of a cache are not guaranteed to be what was written:
+ * an entry persisted by an earlier version of the extension holds the mapped
+ * form, whose `Map`s serialised to `{}`. Such an entry must be rejected rather
+ * than rendered as an empty package list.
+ */
+export function asInstallableResults(value: unknown): InstallableResults | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+
+  const { formulae, casks } = value as Partial<InstallableResults>;
+  if (!Array.isArray(formulae) || !Array.isArray(casks)) {
+    return undefined;
+  }
+
+  return { formulae, casks };
+}
+
+export function brewMapInstalled(installed?: InstallableResults): InstalledMap | undefined {
   if (!installed) {
     return undefined;
   }

--- a/extensions/brew/src/utils/brew/index.ts
+++ b/extensions/brew/src/utils/brew/index.ts
@@ -34,7 +34,10 @@ export type { BrewPhase, BrewProgress, ProgressCallback } from "./progress";
 // Fetching
 export {
   brewFetchInstalled,
+  brewFetchInstallableResults,
   brewFetchInstalledFast,
+  brewMapInstalled,
+  asInstallableResults,
   brewFetchOutdated,
   brewUpdate,
   brewFetchFormulaInfo,


### PR DESCRIPTION
### 🤖 Disclosure

This extension was developed with AI assistance (Claude Code, Cursor, CodeRabbitAI and Greptile), with my guidance on architecture, requirements, and testing. All code was reviewed and validated by me, including manual testing in Raycast.

## Description

This PR fixes **Show Installed rendering an empty list on every open after the first** — a permanent
failure, not a transient one, because the broken value is what gets cached and re-served. Search is
affected by the same cause. No new commands, no new dependencies, no user-visible surface changes.

### Bug fixes

- **Show Installed lists nothing once the cache is warm.** The installed-packages hook resolves to a
  value holding two `Map`s (formulae and casks, keyed by name/token). `useCachedPromise` persists that
  value through a JSON cache, and `JSON.stringify(new Map())` is `{}` — so every entry is dropped on
  the way in. On the next open the value rehydrates as `{ formulae: {}, casks: {} }`, fails the
  consumer's `instanceof Map` guard, and both lists render empty while the user has hundreds of
  packages installed. It never recovers, because the poisoned entry keeps being re-served. Switching
  the filter dropdown doesn't help — it re-renders from the same broken value.

  Confirmed from disk rather than inferred. The serialised cache entry read, in full:

  ```json
  {"formulae":{},"casks":{}}
  ```

  Every other cached entry for the extension holds real data, because those values are plain arrays
  and survive serialisation.

- **Search stops marking installed packages** once that entry is poisoned — it consumes the same hook
  for installed-state detection on every row.

### Technical Highlights

- The hook now caches the serialisable `InstallableResults` (plain arrays) instead of the mapped
  `InstalledMap`, and rebuilds the name-keyed `Map`s in a `useMemo` on read. Lookup stays keyed
  access, not a linear scan.
- `asInstallableResults` rejects any cached value whose `formulae`/`casks` are not arrays, so entries
  written by earlier versions of the extension are discarded rather than rendered as an empty list.
- The hook's **returned shape is unchanged**, so no consumer needed editing.
- The `instanceof Map` guards in `showInstalledPackages` and `isInstalled` are deliberately left in
  place. They are redundant once the cause is fixed, but removing them belongs with the tests that
  would prove the new path — and they are what converts this failure into silent emptiness rather
  than a crash.
- Measured against real `brew info --json=v2 --installed` output (207 formulae, 48 casks): before,
  the cache entry serialised to `{"formulae":{},"casks":{}}` and a warm open rendered 0 formulae /
  0 casks; after, it renders 207 / 48.
- **Cache footprint grows from 26 bytes to ~670 KB** for that install set, since the entry now holds
  the real payload instead of nothing. This is the size the code always intended to store and it sits
  well inside Raycast's cache capacity, but it is a genuine change worth stating.
- No new dependencies, runtime or dev. No unrelated version bumps.

## Screencast

No new screenshots. This changes no visible surface — it makes an existing one work — so the current
`metadata/` captures remain accurate.

## How to Test

No special hardware or credentials needed. The bug is invisible on a first open, which is presumably
how it shipped, so **the second open is the case that matters**.

1. `npm ci && npm run dev` inside `extensions/brew`
2. Run **Brew: Clear Cache** to start cold.
3. Open **Show Installed**. The list populates. *(This works on `main` too.)*
4. Close the command and open **Show Installed** again. **On `main` this renders "No Results"
   permanently; with this change it populates.**
5. With the list populated, switch the filter to Formulae, then Casks, then back to All — each renders
   the correct subset.
6. Open **Search**, type a package you have installed, and confirm it is still marked as installed.
7. To see the old failure mode directly, inspect the extension's cached value between steps 3 and 4 —
   on `main` it reads `{"formulae":{},"casks":{}}`.
8. `npm run lint`, `npm run build`, `npx tsc --noEmit` all pass.

## Checklist

- [x] I read the [Prepare an Extension for Store](https://developers.raycast.com/basics/prepare-an-extension-for-store) guidelines
- [x] I read the [Publish an Extension](https://developers.raycast.com/basics/publish-an-extension) guidelines
- [x] Ran `npm run build` and tested the build in Raycast
- [x] All assets used are in the `assets` folder; README media outside `metadata/`
- [x] `npm run lint` passes
