### PR TITLE
[1Password] Stop re-authenticating while the desktop app session is usable

### DIFF
--- a/extensions/1password/CHANGELOG.md
+++ b/extensions/1password/CHANGELOG.md
@@ -1,5 +1,13 @@
 # 1Password Changelog
 
+## [Fix Repeated Re-Authentication] - {PR_MERGE_DATE}
+
+- Fixed the "Authentication Required" screen appearing on macOS even though the 1Password desktop-app integration works. The `op account get` fallback added in the previous release only ran on Windows, so macOS still trusted `op whoami`, which reports "account is not signed in" without an `op signin` session.
+- Because the same check gates **Auto Renew Authorization**, that command starts renewing on macOS for people who sign in through the desktop app. Its guard always failed for them before, so it never renewed anything.
+- Failures while loading accounts or items now show the error with **Retry** and **Copy Error Details** instead of the "No items found" empty state.
+- Authentication errors from the 1Password CLI keep their full output, including the steps the CLI suggests, instead of only the first line.
+- Documented the desktop app integration, the available commands and preferences, and how to enable Auto Renew Authorization in the README.
+
 ## [Windows Desktop-App Integration Fixes] - 2026-08-13
 
 - Fixed constant "cannot connect to 1Password app" failures on Windows. The 1Password app briefly has no CLI pipe listener right after a previous `op` process disconnects; back-to-back `op` invocations are now serialized and connection failures are retried instead of surfacing immediately.

--- a/extensions/1password/CHANGELOG.md
+++ b/extensions/1password/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1Password Changelog
 
-## [Fix Repeated Re-Authentication] - {PR_MERGE_DATE}
+## [Fix Repeated Re-Authentication] - 2026-08-14
 
 - Fixed the "Authentication Required" screen appearing on macOS even though the 1Password desktop-app integration works. The `op account get` fallback added in the previous release only ran on Windows, so macOS still trusted `op whoami`, which reports "account is not signed in" without an `op signin` session.
 - Because the same check gates **Auto Renew Authorization**, that command starts renewing on macOS for people who sign in through the desktop app. Its guard always failed for them before, so it never renewed anything.

--- a/extensions/1password/README.md
+++ b/extensions/1password/README.md
@@ -1,14 +1,91 @@
 # 1Password
 
-## Features
+Browse your 1Password items from Raycast, copy or paste credentials and one-time
+passwords, open items in the app or the browser, and generate new passwords.
 
-- Browse and copy passwords
-- Browse and manage vault list
-- Generate passwords
-- Support 1Password 7 and 1Password 8
+Works with 1Password 8 and 1Password 7. Pick which one you use under
+**1Password App Version** in the extension preferences.
 
-## FAQ
+## Requirements
 
-### I got the Authorization Requires prompt while using this extension
+### 1Password 8
 
-The usage of 1Password 8 requires [1Password CLI](https://developer.1password.com/docs/cli/get-started/).
+1. Install the [1Password CLI](https://developer.1password.com/docs/cli/get-started/).
+2. Turn on the desktop app integration: **1Password → Settings → Developer →
+   Integrate with 1Password CLI**. It lets the app hand the CLI a session, so unlocking
+   1Password is enough. Without it you have to sign in through `op signin` instead, which
+   the extension prompts for when it cannot find a session.
+
+The extension looks for the CLI in the usual install locations
+(`/usr/local/bin/op` and `/opt/homebrew/bin/op` on macOS, the Program Files and WinGet
+paths on Windows). If yours lives somewhere else, set **1Password CLI path** in the
+preferences.
+
+### 1Password 7
+
+No CLI needed. The extension reads the metadata cache that 1Password 7 keeps in its
+own macOS container, so this path only works on macOS and only shows items 1Password 7
+has already cached.
+
+## Commands
+
+| Command                      | Version | What it does                                                                                                                        |
+| ---------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **My Passwords**             | both    | Lists every item. Open it in 1Password or the browser, copy or paste the username, password, or one-time password, and share items. |
+| **My Vaults**                | v8      | Lists your vaults and the items in each one. Shows nothing on 1Password 7.                                                          |
+| **Generate Password**        | v8      | Generates a password with the 1Password CLI. Shows nothing on 1Password 7.                                                          |
+| **Auto Renew Authorization** | v8      | Runs in the background every 9 minutes to keep the CLI session alive. Off until you turn it on — see below.                         |
+
+### Auto Renew Authorization
+
+The 1Password CLI session expires after about ten minutes. Once it does, the next
+command has to re-authorize, and if the desktop app asks you to confirm, that request
+blocks until you answer it.
+
+This command keeps the session from getting that far. It is a background command, so
+Raycast keeps it disabled until you ask for it: open **Raycast Settings → Extensions →
+1Password → Auto Renew Authorization** and enable background refresh in that command's
+preferences.
+
+## Preferences
+
+| Preference                        | Applies to | Description                                                                                                                                                                                                                                          |
+| --------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **1Password App Version**         | both       | Whether to talk to 1Password 8 or 1Password 7.                                                                                                                                                                                                       |
+| **Primary Action**                | v8         | What Enter does on a login item.                                                                                                                                                                                                                     |
+| **Secondary Action**              | v8         | What the second action does on a login item.                                                                                                                                                                                                         |
+| **Close window after copying**    | —          | Currently has no effect. The copy and paste actions show a HUD, which dismisses Raycast either way.                                                                                                                                                  |
+| **Reduce item list memory usage** | v8         | Lists a lightweight summary instead of full item details. Username and email subtitles and search over those fields are unavailable until an action fetches the full item, and the list renders the first 200 matches. Useful for very large vaults. |
+| **1Password CLI path**            | v8         | Where the `op` binary lives, if it is not in one of the default locations.                                                                                                                                                                           |
+| **1Password SHELL path**          | v8, macOS  | Shell used to run `op signin`. Defaults to `/bin/zsh`.                                                                                                                                                                                               |
+
+## Troubleshooting
+
+### "Authentication Required"
+
+The CLI could not reach a signed-in account. The message underneath shows the cause,
+though the view cuts off long output after a line or two — use **Copy Error Details**
+in the action panel to get the whole thing, including the steps the CLI suggests. Most
+often one of these applies:
+
+- The desktop app integration is off. Turn it on under **1Password → Settings →
+  Developer**.
+- 1Password is locked. Unlock it and run the command again.
+- The CLI is installed somewhere the extension does not look. Set **1Password CLI
+  path** in the preferences.
+
+### The list shows an error instead of my items
+
+Loading the account or the item list failed. **Retry** runs it again, and **Copy Error
+Details** gives you the CLI's full output. An empty list with "No items found" means
+the opposite — the commands succeeded and returned nothing.
+
+### Raycast keeps asking me to authenticate
+
+Enable **Auto Renew Authorization** as described above. It refreshes the session
+before it expires.
+
+### "1Password CLI is not found"
+
+The extension could not find the `op` binary. Install it, or point **1Password CLI
+path** at it.

--- a/extensions/1password/src/v8/components/AuthContext.tsx
+++ b/extensions/1password/src/v8/components/AuthContext.tsx
@@ -16,7 +16,7 @@ import React, { createContext, ReactNode, useContext, useEffect, useState } from
 import {
   checkZsh,
   CommandLineMissingError,
-  errorRegex,
+  extractOpErrorMessage,
   getCliPath,
   getSignInStatus,
   isWindows,
@@ -45,7 +45,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     return <Guide />;
   }
 
-  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(getSignInStatus());
+  // Lazy: called directly, this would shell out to the CLI on every render.
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(() => getSignInStatus());
   const [zshMissing] = useState<boolean>(!checkZsh());
   const [accountSelected, setAccountSelected] = useState<boolean>(true);
   const [errorMessage, setErrorMessage] = useState("");
@@ -111,13 +112,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         return;
       }
 
-      const errorMessageMatches = err.message.match(errorRegex);
-
-      if (errorMessageMatches && errorMessageMatches[1]) {
-        setErrorMessage(errorMessageMatches[1]);
-      } else {
-        setErrorMessage(err.message);
-      }
+      setErrorMessage(extractOpErrorMessage(err.message));
 
       if (err.message.includes("multiple accounts found")) return setAccountSelected(false);
       toast.style = Toast.Style.Failure;
@@ -165,6 +160,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           actions={
             <ActionPanel>
               <Action icon={Icon.Repeat} key="reload-view" onAction={() => authenticate()} title="Reload" />
+              {errorMessage ? (
+                <Action.CopyToClipboard
+                  content={errorMessage}
+                  icon={Icon.Clipboard}
+                  key="copy-error"
+                  title="Copy Error Details"
+                />
+              ) : null}
             </ActionPanel>
           }
           description={errorMessage || "Please authenticate using the requested method to proceed."}

--- a/extensions/1password/src/v8/components/Items.tsx
+++ b/extensions/1password/src/v8/components/Items.tsx
@@ -3,18 +3,11 @@ import { useCachedState } from "@raycast/utils";
 import { useMemo, useState } from "react";
 
 import { Item } from "../types";
-import {
-  actionsForItem,
-  CommandLineMissingError,
-  ConnectionError,
-  ExtensionError,
-  getCategoryIcon,
-  useAccount,
-  usePasswords2,
-} from "../utils";
+import { actionsForItem, CommandLineMissingError, getCategoryIcon, useAccount, usePasswords2 } from "../utils";
 import { Categories, DEFAULT_CATEGORY } from "./Categories";
 import { Error as ErrorGuide } from "./Error";
 import { ItemActionPanel } from "./ItemActionPanel";
+import { LoadError } from "./LoadError";
 
 const MAX_LIGHTWEIGHT_RENDERED_ITEMS = 200;
 const URL_HOSTNAME_REGEX = /^(?:https?:\/\/)?(?:[^@\n]+@)?(?:www\.)?([^:/\n?]+)/i;
@@ -56,11 +49,17 @@ export function Items({ flags }: { flags?: string[] }) {
   const [category, setCategory] = useCachedState<string>("selected_category", DEFAULT_CATEGORY);
   const [searchText, setSearchText] = useState("");
   const reduceItemListMemoryUsage = preferences.reduceItemListMemoryUsage;
-  const { data: account, error: accountError, isLoading: accountIsLoading } = useAccount();
+  const {
+    data: account,
+    error: accountError,
+    isLoading: accountIsLoading,
+    revalidate: revalidateAccount,
+  } = useAccount();
   const {
     data: items,
     error: itemsError,
     isLoading: itemsIsLoading,
+    revalidate: revalidateItems,
   } = usePasswords2({ account: account?.account_uuid ?? "", execute: !accountError && !accountIsLoading, flags });
 
   const passwords = useMemo(() => {
@@ -88,15 +87,15 @@ export function Items({ flags }: { flags?: string[] }) {
   if (itemsError instanceof CommandLineMissingError || accountError instanceof CommandLineMissingError)
     return <ErrorGuide />;
 
-  if (itemsError instanceof ConnectionError || accountError instanceof ConnectionError) {
+  const loadError = accountError ?? itemsError;
+
+  if (loadError) {
     return (
-      <List>
-        <List.EmptyView
-          description={itemsError?.message || accountError?.message}
-          icon={Icon.WifiDisabled}
-          title={(itemsError as ExtensionError)?.title || (accountError as ExtensionError)?.title}
-        />
-      </List>
+      <LoadError
+        error={loadError}
+        isLoading={accountIsLoading || itemsIsLoading}
+        onRetry={accountError ? revalidateAccount : revalidateItems}
+      />
     );
   }
 

--- a/extensions/1password/src/v8/components/LoadError.tsx
+++ b/extensions/1password/src/v8/components/LoadError.tsx
@@ -1,0 +1,32 @@
+import { Action, ActionPanel, Icon, List } from "@raycast/api";
+
+import { ConnectionError, ExtensionError, extractOpErrorMessage } from "../utils";
+
+interface LoadErrorProps {
+  error: Error;
+  isLoading?: boolean;
+  onRetry: () => void;
+}
+
+export function LoadError({ error, isLoading, onRetry }: LoadErrorProps) {
+  const details = extractOpErrorMessage(error.message);
+  // `handleErrors` falls back to `new ExtensionError(stderr)`, which leaves the title equal to the
+  // raw stderr. Only the curated errors have a title worth showing.
+  const hasCuratedTitle = error instanceof ExtensionError && error.title !== error.message;
+
+  return (
+    <List isLoading={isLoading}>
+      <List.EmptyView
+        actions={
+          <ActionPanel>
+            <Action icon={Icon.Repeat} onAction={onRetry} title="Retry" />
+            <Action.CopyToClipboard content={details} icon={Icon.Clipboard} title="Copy Error Details" />
+          </ActionPanel>
+        }
+        description={details}
+        icon={error instanceof ConnectionError ? Icon.WifiDisabled : Icon.ExclamationMark}
+        title={hasCuratedTitle ? error.title : "Could not load from 1Password"}
+      />
+    </List>
+  );
+}

--- a/extensions/1password/src/v8/components/VaultActionPanel.tsx
+++ b/extensions/1password/src/v8/components/VaultActionPanel.tsx
@@ -1,10 +1,10 @@
 import { Action, ActionPanel, Icon, useNavigation } from "@raycast/api";
 
-import { User, Vault } from "../types";
+import { Vault } from "../types";
 import { SwitchAccount } from "./ActionSwitchAccount";
 import { Items } from "./Items";
 
-export function VaultActionPanel({ vault }: { account: undefined | User; vault: Vault }) {
+export function VaultActionPanel({ vault }: { vault: Vault }) {
   const { push } = useNavigation();
 
   return (

--- a/extensions/1password/src/v8/components/Vaults.tsx
+++ b/extensions/1password/src/v8/components/Vaults.tsx
@@ -2,37 +2,28 @@ import { Color, Icon, List } from "@raycast/api";
 import { useMemo, useState } from "react";
 
 import { Vault } from "../types";
-import { CommandLineMissingError, ConnectionError, ExtensionError, useAccount, useVaults } from "../utils";
+import { CommandLineMissingError, useVaults } from "../utils";
 import { Error as ErrorGuide } from "./Error";
+import { LoadError } from "./LoadError";
 import { VaultActionPanel } from "./VaultActionPanel";
 
 export function Items() {
   const [vaults, setVaults] = useState<Vault[]>([]);
-  const { data: account, error: accountError, isLoading: accountIsLoading } = useAccount();
-  const { data: items, error: itemsError, isLoading: itemsIsLoading } = useVaults();
+  const { data: items, error: itemsError, isLoading: itemsIsLoading, revalidate: revalidateItems } = useVaults();
 
   useMemo(() => {
     if (!items) return;
     setVaults(items);
   }, [items]);
 
-  if (itemsError instanceof CommandLineMissingError || accountError instanceof CommandLineMissingError)
-    return <ErrorGuide />;
+  if (itemsError instanceof CommandLineMissingError) return <ErrorGuide />;
 
-  if (itemsError instanceof ConnectionError || accountError instanceof ConnectionError) {
-    return (
-      <List>
-        <List.EmptyView
-          description={itemsError?.message || accountError?.message}
-          icon={Icon.WifiDisabled}
-          title={(itemsError as ExtensionError)?.title || (accountError as ExtensionError)?.title}
-        />
-      </List>
-    );
+  if (itemsError) {
+    return <LoadError error={itemsError} isLoading={itemsIsLoading} onRetry={revalidateItems} />;
   }
 
   return (
-    <List isLoading={itemsIsLoading || accountIsLoading}>
+    <List isLoading={itemsIsLoading}>
       <List.EmptyView
         description="Any vaults you have added in 1Password app will be listed here."
         icon="1password-noview.png"
@@ -42,7 +33,7 @@ export function Items() {
         {vaults?.length &&
           vaults.map((item) => (
             <List.Item
-              actions={<VaultActionPanel account={account} vault={item} />}
+              actions={<VaultActionPanel vault={item} />}
               icon={{
                 tooltip: "Vault",
                 value: { source: Icon.Folder, tintColor: Color.Blue },

--- a/extensions/1password/src/v8/utils.ts
+++ b/extensions/1password/src/v8/utils.ts
@@ -55,7 +55,17 @@ export const getCliPath = () => {
   return cliPath;
 };
 export const ZSH_PATH = isWindows ? undefined : [preferences.zshPath, "/bin/zsh"].find((path) => existsSync(path));
-export const errorRegex = new RegExp(/\[\w+\]\s+\d{4}\/\d{2}\/\d{2}\s+\d{2}:\d{2}:\d{2}\s+(.*)$/m);
+const OP_LOG_PREFIX = /\[\w+\]\s+\d{4}\/\d{2}\/\d{2}\s+\d{2}:\d{2}:\d{2}\s+/;
+const OP_LOG_PREFIX_GLOBAL = new RegExp(OP_LOG_PREFIX, "g");
+
+// `op` puts the cause on its first log line and the steps to fix it on the ones after, so keep
+// everything from that line onwards instead of just the first match.
+export const extractOpErrorMessage = (message: string): string => {
+  const start = message.search(OP_LOG_PREFIX);
+  const body = start === -1 ? message : message.slice(start);
+
+  return body.replace(OP_LOG_PREFIX_GLOBAL, "").trim();
+};
 export function actionsForItem(item: Item): ActionID[] {
   // all actions in the default order
   const defaultActions: ActionID[] = [

--- a/extensions/1password/src/v8/utils.ts
+++ b/extensions/1password/src/v8/utils.ts
@@ -202,6 +202,8 @@ export const signIn = (account?: string) => {
     execSync(`${getCliPath()} signin ${account ? account : ""}`, { shell: ZSH_PATH });
   }
 };
+const SIGN_IN_STATUS_TIMEOUT_MS = 30000;
+
 export const getSignInStatus = () => {
   try {
     if (isWindows) {
@@ -211,14 +213,14 @@ export const getSignInStatus = () => {
     }
     return true;
   } catch {
-    if (!isWindows) {
-      return false;
-    }
     // With the 1Password app integration and no `op signin` session, `whoami` reports
     // "account is not signed in" even though delegated sessions work. Probe the app
-    // directly before asking the user to sign in.
+    // directly before asking the user to sign in. This is not a read-only probe: it
+    // establishes the delegated session, which is what later lets `useAccount` resolve
+    // through `whoami`. It took 6.1s on macOS when it had to set one up, so the timeout
+    // here is only a guard against the app waiting forever on a prompt nobody answers.
     try {
-      execOpSync(["account", "get"]);
+      execOpSync(["account", "get"], { timeout: SIGN_IN_STATUS_TIMEOUT_MS });
       return true;
     } catch {
       return false;


### PR DESCRIPTION
## Description

Rebased onto `main` after #30195 landed, which rewrote most of `src/v8/utils.ts` and already covers the first review point. What is left is the macOS half of the same bug, plus the two error-surfacing gaps.

### The sign-in check still trusts `op whoami` on macOS

#30195 added an `op account get` fallback for `getSignInStatus()`, but returned early on every other platform:

```ts
} catch {
  if (!isWindows) {
    return false;
  }
```

So macOS still reports a signed-out state whenever the desktop app's delegated session is the only one available, and the extension shows **Authentication Required** even though the CLI can read items. This PR deletes those three lines; the reasoning in the comment right below them already applies to both platforms.

Measured on macOS 26.4.1 with `op` 2.34.0, app integration enabled, immediately after `op signout --all`:

| command | exit | time |
| --- | --- | --- |
| `op whoami` | 1 — `account is not signed in` | 104 ms |
| `op account get` | 0 — establishes the delegated session | 6147 ms |

Following the extension's own call order from that state, the whole chain now succeeds:

```
getSignInStatus()   op whoami                        exit 1    104ms
                    op account get                   exit 0   6147ms   -> true
useAccount()        op whoami --format=json          exit 0    132ms
usePasswords2()     op --account <id> items list     exit 0   1347ms   -> 639 items
```

### Errors during loading fall through to "No items found"

Only `ConnectionError` had a view of its own. Every other failure — including anything `handleErrors` maps to a generic `ExtensionError` — fell through to the empty-success state, which reads as an empty vault rather than a command that failed. Both list commands now render a shared `LoadError` view with **Retry** and **Copy Error Details**, so "No items found" means what it says.

The title falls back to a generic one unless the error carries a curated title, because `handleErrors` ends in `new ExtensionError(stderr)` and `ExtensionError` copies the title from the message when none is given — so a generic error would otherwise put raw `stderr` in the heading.

**My Vaults** also stopped resolving the account. It only passed it to `VaultActionPanel`, which never destructured it, and `vault list` does not need it — so an account lookup failing would otherwise have hidden a vault list that loaded fine. The unused `account` prop is gone too.

### Authentication errors lose everything after the first line

`errorRegex` captured a single log line, so the steps `op` prints for fixing the error were dropped. `extractOpErrorMessage` keeps everything from the first log line onwards. Because `List.EmptyView`'s description clamps to about two lines, the rest is reachable through **Copy Error Details**.

Checked against real `op` output — a multi-line error goes from 1 line to 3 including the remediation steps, and input with no `op` prefix (`spawn op ENOENT`) and empty input both pass through unchanged.

### README

The README listed four features and one FAQ entry, and did not mention the desktop app integration that 1Password 8 needs, the **Auto Renew Authorization** command, or any preference. Rewritten to cover requirements, commands, preferences, and troubleshooting.

`closeWindowAfterCopying` is documented as having no effect: it appears only in `package.json`, is never read in `src/`, and the copy/paste actions call `showHUD`, which dismisses Raycast either way.

## Review feedback

> **`useAccount()` still uses `op whoami`** … align account resolution with the delegated session

Resolved by #30195, which added the `whoami` → `account get` fallback with field mapping. Re-verified end-to-end above: from a signed-out state the list loads 639 items rather than falling through to "No items found".

> **Error EmptyViews** — when `accountError` / `itemsError` is set, show a failure `EmptyView`

Done in `LoadError.tsx`, used by both `Items.tsx` and `Vaults.tsx`.

One caveat on how the above was checked: the sign-in and account-resolution chain was verified by driving `op` directly in the states described, and the extension was run through `ray develop`, but I did not force a load failure to look at the new `LoadError` view in the UI. Worth a look when you test it.

## Trade-off worth flagging

`getSignInStatus()` runs synchronously while the view renders, and the `account get` fallback took 6.1 s when it had to establish the session. That cost only applies when no session exists — the state that previously showed **Authentication Required** and required a manual **Reload** — and `whoami` returns in ~130 ms once a session is live. It is the same behaviour #30195 already ships on Windows, so this PR does not change the shape of it, but it is worth a second opinion.

I tried guarding the probe with `OP_NO_AUTO_SIGNIN=1` to avoid the blocking. Measurements showed that makes the probe equivalent to `whoami` in every state I could produce — the variable disables exactly the session establishment that makes `account get` useful here — so I dropped it. What is left is a 30 s timeout, matching the one `signIn` already uses: not a budget for the probe, just a stop against the call hanging on a prompt nobody answers.

That hang matters most in **Auto Renew Authorization**, which runs unattended every 9 minutes. Before this PR the command was a no-op on macOS for delegated-session users, because its `getSignInStatus()` guard always failed for them — so this is new behaviour there, and if the app is locked the renewal can surface an authorization prompt. I have not been able to observe the locked-app path directly; if that is a concern, I am happy to gate the fallback out of the background command.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
