### PR TITLE
fix(renaming): prevent silent data loss from case-only renames, hard links, and dangling symlinks

### DIFF
--- a/extensions/renaming/CHANGELOG.md
+++ b/extensions/renaming/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Rename Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Fix a case-only rename silently overwriting a different file on case-sensitive volumes
+- Decide whether a rename target is the same file by inode identity rather than by lowercasing the path, so the overwrite guard and batch conflict detection are correct on any filesystem
+
 ## [Security Fix] - 2026-04-06
 
 - Replace AppleScript-based renaming with native Node.js `fs.rename()` to fix shell injection vulnerability

--- a/extensions/renaming/CHANGELOG.md
+++ b/extensions/renaming/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fix a case-only rename silently overwriting a different file on case-sensitive volumes
 - Decide whether a rename target is the same file by inode identity rather than by lowercasing the path, so the overwrite guard and batch conflict detection are correct on any filesystem
+- Fix a rename silently destroying a symlink at the target path when the symlink's own target was missing
+- Allow renaming a symlink whose target is missing, instead of reporting the source as gone
 
 ## [Security Fix] - 2026-04-06
 

--- a/extensions/renaming/CHANGELOG.md
+++ b/extensions/renaming/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Rename Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-08-03
 
 - Fix a case-only rename silently overwriting a different file on case-sensitive volumes
 - Decide whether a rename target is the same file by inode identity rather than by lowercasing the path, so the overwrite guard and batch conflict detection are correct on any filesystem

--- a/extensions/renaming/package-lock.json
+++ b/extensions/renaming/package-lock.json
@@ -259,7 +259,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -308,18 +307,43 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
     },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1076,7 +1100,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.19.0.tgz",
       "integrity": "sha512-1DyBLG5SH7PYCd00QlroiW60YJ4rWMuUGa/JBV0iZuqi4l4IK3twKPq5ZkEebmGqRjXWVgsUzfd3+nZveewgow==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.19.0",
         "@typescript-eslint/types": "6.19.0",
@@ -1455,7 +1478,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1909,7 +1931,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
       "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3368,7 +3389,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
       "integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3716,7 +3736,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3862,7 +3881,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3901,7 +3919,6 @@
       "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.2",
         "@vitest/mocker": "4.1.2",
@@ -4024,7 +4041,6 @@
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/extensions/renaming/src/__tests__/case-sensitivity.test.ts
+++ b/extensions/renaming/src/__tests__/case-sensitivity.test.ts
@@ -3,7 +3,7 @@
  *
  * macOS is case-insensitive by default but APFS can be formatted case-sensitive,
  * and neither CI nor a contributor's machine can be assumed to be either. These
- * tests therefore fake the *identity* answer rather than the volume: `isSameFile`
+ * tests therefore fake the *identity* answer rather than the volume: `isSameEntry`
  * is stubbed to compare exact paths, which is how a case-sensitive volume behaves
  * and is the single fact that separates the two filesystems as far as rename
  * safety is concerned.
@@ -26,7 +26,7 @@ vi.mock("../lib/paths", async (importOriginal) => {
 
   return {
     ...actual,
-    isSameFile: async (a: string, b: string) => (volume.caseSensitive ? a === b : actual.isSameFile(a, b)),
+    isSameEntry: async (a: string, b: string) => (volume.caseSensitive ? a === b : actual.isSameEntry(a, b)),
   };
 });
 

--- a/extensions/renaming/src/__tests__/case-sensitivity.test.ts
+++ b/extensions/renaming/src/__tests__/case-sensitivity.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Case-only renames across both filesystem behaviours.
+ *
+ * macOS is case-insensitive by default but APFS can be formatted case-sensitive,
+ * and neither CI nor a contributor's machine can be assumed to be either. These
+ * tests therefore fake the *identity* answer rather than the volume: `isSameFile`
+ * is stubbed to compare exact paths, which is how a case-sensitive volume behaves
+ * and is the single fact that separates the two filesystems as far as rename
+ * safety is concerned.
+ *
+ * `paths.test.ts` covers the unfaked primitive, probing the volume it runs on.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { tmpdir } from "os";
+import { mkdtemp, writeFile, readFile, rm } from "fs/promises";
+import { join } from "path";
+import type { RenameOperation } from "../types";
+import { renameFile } from "../lib/files";
+import { checkConflicts, batchRename } from "../lib/batch";
+
+const volume = vi.hoisted(() => ({ caseSensitive: false }));
+
+vi.mock("../lib/paths", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/paths")>();
+
+  return {
+    ...actual,
+    isSameFile: async (a: string, b: string) => (volume.caseSensitive ? a === b : actual.isSameFile(a, b)),
+  };
+});
+
+describe("case-only renames", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), "renaming-test-"));
+    volume.caseSensitive = false;
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  describe("when the destination resolves to the source itself", () => {
+    it("should allow the rename", async () => {
+      const filePath = join(testDir, "REPORT.txt");
+      await writeFile(filePath, "content");
+
+      const result = await renameFile(filePath, "report.txt");
+
+      expect(result.success).toBe(true);
+      expect(result.error).toBeUndefined();
+      expect(result.newPath).toBe(join(testDir, "report.txt"));
+    });
+
+    it("should not report the rename as a conflict", async () => {
+      const filePath = join(testDir, "REPORT.txt");
+      await writeFile(filePath, "content");
+
+      const operations: RenameOperation[] = [
+        { oldPath: filePath, newName: "report.txt", newPath: join(testDir, "report.txt") },
+      ];
+
+      expect(await checkConflicts(operations)).toHaveLength(0);
+    });
+  });
+
+  describe("when the destination is a distinct file differing only in case", () => {
+    let source: string;
+    let destination: string;
+    let operations: RenameOperation[];
+
+    beforeEach(async () => {
+      source = join(testDir, "REPORT.txt");
+      destination = join(testDir, "report.txt");
+      await writeFile(source, "source");
+      await writeFile(destination, "destination");
+      operations = [{ oldPath: source, newName: "report.txt", newPath: destination }];
+      volume.caseSensitive = true;
+    });
+
+    it("should refuse the rename instead of overwriting", async () => {
+      const result = await renameFile(source, "report.txt");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("already exists");
+    });
+
+    it("should report it as a batch conflict", async () => {
+      const conflicts = await checkConflicts(operations);
+
+      expect(conflicts).toHaveLength(1);
+      expect(conflicts[0]).toContain("already exists");
+    });
+
+    it("should leave the destination intact when the batch runs anyway", async () => {
+      const results = await batchRename(operations);
+
+      expect(results[0]!.success).toBe(false);
+      expect(await readFile(destination, "utf8")).toBe("destination");
+    });
+  });
+});

--- a/extensions/renaming/src/__tests__/files.test.ts
+++ b/extensions/renaming/src/__tests__/files.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { tmpdir } from "os";
-import { mkdtemp, writeFile, rm, mkdir, symlink, readlink, lstat } from "fs/promises";
+import { mkdtemp, writeFile, rm, mkdir, symlink, readlink, lstat, link } from "fs/promises";
 import { join } from "path";
 import { getFileInfo, fileExists, renameFile } from "../lib/files";
 
@@ -147,6 +147,23 @@ describe("renameFile", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain("already exists");
+  });
+
+  it("should refuse to rename onto a hard link of the same file", async () => {
+    // Both names are one inode but two directory entries, and POSIX rename() between
+    // them does nothing at all — so allowing it would report a rename that never
+    // happened and leave both entries in place
+    const filePath = join(testDir, "file.txt");
+    const hardLink = join(testDir, "link.txt");
+    await writeFile(filePath, "content");
+    await link(filePath, hardLink);
+
+    const result = await renameFile(filePath, "link.txt");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("already exists");
+    expect(await fileExists(filePath)).toBe(true);
+    expect(await fileExists(hardLink)).toBe(true);
   });
 
   it("should refuse to overwrite a dangling symlink at the target", async () => {

--- a/extensions/renaming/src/__tests__/files.test.ts
+++ b/extensions/renaming/src/__tests__/files.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { tmpdir } from "os";
-import { mkdtemp, writeFile, rm, mkdir } from "fs/promises";
+import { mkdtemp, writeFile, rm, mkdir, symlink, readlink, lstat } from "fs/promises";
 import { join } from "path";
 import { getFileInfo, fileExists, renameFile } from "../lib/files";
 
@@ -94,6 +94,14 @@ describe("fileExists", () => {
 
     expect(await fileExists(dirPath)).toBe(true);
   });
+
+  it("should return true for a symlink whose target is missing", async () => {
+    // The symlink still occupies the path, so a rename onto it would destroy it
+    const linkPath = join(testDir, "dangling.txt");
+    await symlink(join(testDir, "no-such-target.txt"), linkPath);
+
+    expect(await fileExists(linkPath)).toBe(true);
+  });
 });
 
 describe("renameFile", () => {
@@ -139,6 +147,30 @@ describe("renameFile", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain("already exists");
+  });
+
+  it("should refuse to overwrite a dangling symlink at the target", async () => {
+    const filePath = join(testDir, "file.txt");
+    const danglingLink = join(testDir, "link.txt");
+    await writeFile(filePath, "content");
+    await symlink(join(testDir, "no-such-target.txt"), danglingLink);
+
+    const result = await renameFile(filePath, "link.txt");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("already exists");
+    expect((await lstat(danglingLink)).isSymbolicLink()).toBe(true);
+  });
+
+  it("should rename a symlink whose target is missing", async () => {
+    const danglingLink = join(testDir, "link.txt");
+    const target = join(testDir, "no-such-target.txt");
+    await symlink(target, danglingLink);
+
+    const result = await renameFile(danglingLink, "renamed-link.txt");
+
+    expect(result.success).toBe(true);
+    expect(await readlink(join(testDir, "renamed-link.txt"))).toBe(target);
   });
 
   it("should fail for invalid filename", async () => {

--- a/extensions/renaming/src/__tests__/paths.test.ts
+++ b/extensions/renaming/src/__tests__/paths.test.ts
@@ -140,6 +140,24 @@ describe("isSameEntry", () => {
     expect(await isSameEntry(file1, file2)).toBe(false);
   });
 
+  it("should return false for hard links whose names differ only in case", async () => {
+    // Only constructible on a case-sensitive volume — elsewhere the two names are
+    // one entry by definition and this scenario cannot exist
+    if (await isCaseInsensitiveVolume(testDir)) {
+      return;
+    }
+
+    const upper = join(testDir, "LINKED.txt");
+    const lower = join(testDir, "linked.txt");
+    await writeFile(upper, "content");
+    await link(upper, lower);
+
+    // Case-folding the names would call these one entry; the directory listing
+    // shows they are two
+    expect(await isSameFile(upper, lower)).toBe(true);
+    expect(await isSameEntry(upper, lower)).toBe(false);
+  });
+
   it("should answer case-only renames according to the volume", async () => {
     const upper = join(testDir, "CASE.txt");
     const lower = join(testDir, "case.txt");

--- a/extensions/renaming/src/__tests__/paths.test.ts
+++ b/extensions/renaming/src/__tests__/paths.test.ts
@@ -140,6 +140,45 @@ describe("isSameEntry", () => {
     expect(await isSameEntry(file1, file2)).toBe(false);
   });
 
+  it("should return false for a hard link spelled in a different Unicode normalization", async () => {
+    // macOS resolves either normalization to the same entry, so matching the name
+    // against the directory listing would miss the link and wrongly clear a rename
+    // that rename() will silently refuse to perform
+    const source = join(testDir, "plain.txt");
+    const composed = "café.txt"; // é as one codepoint
+    const decomposed = "café.txt"; // e + combining acute
+    await writeFile(source, "content");
+    await link(source, join(testDir, composed));
+
+    expect(await isSameEntry(source, join(testDir, decomposed))).toBe(false);
+  });
+
+  it("should return false for a hard link spelled in a different case", async () => {
+    // On a case-insensitive volume "BAR.txt" resolves onto the existing bar.txt
+    // entry, and POSIX rename() between two links to one inode is a silent no-op —
+    // so skipping the guard would report a rename that never happened. On a
+    // case-sensitive volume "BAR.txt" simply doesn't exist and the answer is the
+    // same for the simpler reason.
+    const foo = join(testDir, "foo.txt");
+    const bar = join(testDir, "bar.txt");
+    await writeFile(foo, "content");
+    await link(foo, bar);
+
+    expect(await isSameEntry(foo, join(testDir, "BAR.txt"))).toBe(false);
+  });
+
+  it("should conservatively block a case-only rename of a file that has a hard link in the same directory", async () => {
+    // With two entries for one inode in the directory, telling which entry a
+    // differently-spelled target resolves to would require replicating the volume's
+    // folding rules — so the guard stays on. Blocking is the safe direction: the
+    // rename it prevents is at worst a no-op, never an overwrite.
+    const file = join(testDir, "CASE.txt");
+    await writeFile(file, "content");
+    await link(file, join(testDir, "other-link.txt"));
+
+    expect(await isSameEntry(file, join(testDir, "case.txt"))).toBe(false);
+  });
+
   it("should return false for hard links whose names differ only in case", async () => {
     // Only constructible on a case-sensitive volume — elsewhere the two names are
     // one entry by definition and this scenario cannot exist
@@ -152,8 +191,8 @@ describe("isSameEntry", () => {
     await writeFile(upper, "content");
     await link(upper, lower);
 
-    // Case-folding the names would call these one entry; the directory listing
-    // shows they are two
+    // Case-folding the names would call these one entry; counting the directory's
+    // entries for the inode shows they are two
     expect(await isSameFile(upper, lower)).toBe(true);
     expect(await isSameEntry(upper, lower)).toBe(false);
   });

--- a/extensions/renaming/src/__tests__/paths.test.ts
+++ b/extensions/renaming/src/__tests__/paths.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { tmpdir } from "os";
 import { mkdtemp, writeFile, rm, mkdir, link, symlink } from "fs/promises";
 import { join } from "path";
-import { isSameFile, normalizePath } from "../lib/paths";
+import { isSameEntry, isSameFile, normalizePath } from "../lib/paths";
 
 /**
  * Whether the volume backing `dir` collapses names that differ only in case.
@@ -99,6 +99,60 @@ describe("isSameFile", () => {
     // Case-insensitive: both names reach one inode, so a case-only rename is a no-op.
     // Case-sensitive: they are two files, and a case-only rename would overwrite one.
     expect(await isSameFile(upper, lower)).toBe(caseInsensitive);
+  });
+});
+
+describe("isSameEntry", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), "renaming-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it("should return true for the identical path", async () => {
+    const filePath = join(testDir, "file.txt");
+    await writeFile(filePath, "content");
+
+    expect(await isSameEntry(filePath, filePath)).toBe(true);
+  });
+
+  it("should return false for two hard links to one inode", async () => {
+    // One file, but two directory entries — narrower than isSameFile on purpose
+    const original = join(testDir, "original.txt");
+    const hardLink = join(testDir, "hardlink.txt");
+    await writeFile(original, "content");
+    await link(original, hardLink);
+
+    expect(await isSameFile(original, hardLink)).toBe(true);
+    expect(await isSameEntry(original, hardLink)).toBe(false);
+  });
+
+  it("should return false for two unrelated files", async () => {
+    const file1 = join(testDir, "file1.txt");
+    const file2 = join(testDir, "file2.txt");
+    await writeFile(file1, "content1");
+    await writeFile(file2, "content2");
+
+    expect(await isSameEntry(file1, file2)).toBe(false);
+  });
+
+  it("should answer case-only renames according to the volume", async () => {
+    const upper = join(testDir, "CASE.txt");
+    const lower = join(testDir, "case.txt");
+    await writeFile(upper, "content");
+
+    const caseInsensitive = await isCaseInsensitiveVolume(testDir);
+    if (!caseInsensitive) {
+      await writeFile(lower, "other content");
+    }
+
+    // The one case the overwrite guard is allowed to skip — and only where the
+    // volume really does treat both spellings as a single entry
+    expect(await isSameEntry(upper, lower)).toBe(caseInsensitive);
   });
 });
 

--- a/extensions/renaming/src/__tests__/paths.test.ts
+++ b/extensions/renaming/src/__tests__/paths.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { tmpdir } from "os";
+import { mkdtemp, writeFile, rm, mkdir, link, symlink } from "fs/promises";
+import { join } from "path";
+import { isSameFile, normalizePath } from "../lib/paths";
+
+/**
+ * Whether the volume backing `dir` collapses names that differ only in case.
+ * macOS is case-insensitive by default but APFS can be formatted case-sensitive,
+ * so the expected result of a case-only comparison is a property of wherever the
+ * test happens to be running.
+ */
+async function isCaseInsensitiveVolume(dir: string): Promise<boolean> {
+  const probe = join(dir, ".case-probe-Aa");
+  await writeFile(probe, "");
+  try {
+    const { access } = await import("fs/promises");
+    await access(join(dir, ".case-probe-aA"));
+    return true;
+  } catch {
+    return false;
+  } finally {
+    await rm(probe, { force: true });
+  }
+}
+
+describe("isSameFile", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), "renaming-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it("should return true for the identical path", async () => {
+    const filePath = join(testDir, "file.txt");
+    await writeFile(filePath, "content");
+
+    expect(await isSameFile(filePath, filePath)).toBe(true);
+  });
+
+  it("should return false for two distinct files", async () => {
+    const file1 = join(testDir, "file1.txt");
+    const file2 = join(testDir, "file2.txt");
+    await writeFile(file1, "content1");
+    await writeFile(file2, "content2");
+
+    expect(await isSameFile(file1, file2)).toBe(false);
+  });
+
+  it("should return true for two hard links to one inode", async () => {
+    const original = join(testDir, "original.txt");
+    const hardLink = join(testDir, "hardlink.txt");
+    await writeFile(original, "content");
+    await link(original, hardLink);
+
+    expect(await isSameFile(original, hardLink)).toBe(true);
+  });
+
+  it("should return false for a symlink and its target", async () => {
+    // rename operates on the directory entry, so a symlink is a different file
+    // from what it points at even though stat() would follow through to it
+    const target = join(testDir, "target.txt");
+    const linkPath = join(testDir, "link.txt");
+    await writeFile(target, "content");
+    await symlink(target, linkPath);
+
+    expect(await isSameFile(linkPath, target)).toBe(false);
+  });
+
+  it("should return false when a path does not exist", async () => {
+    const filePath = join(testDir, "file.txt");
+    await writeFile(filePath, "content");
+
+    expect(await isSameFile(filePath, join(testDir, "missing.txt"))).toBe(false);
+    expect(await isSameFile(join(testDir, "missing.txt"), filePath)).toBe(false);
+  });
+
+  it("should return true for directories that are the same directory", async () => {
+    const dirPath = join(testDir, "subdir");
+    await mkdir(dirPath);
+
+    expect(await isSameFile(dirPath, join(testDir, "subdir"))).toBe(true);
+  });
+
+  it("should answer case-only comparisons according to the volume, not the platform", async () => {
+    const upper = join(testDir, "CASE.txt");
+    const lower = join(testDir, "case.txt");
+    await writeFile(upper, "content");
+
+    const caseInsensitive = await isCaseInsensitiveVolume(testDir);
+    if (!caseInsensitive) {
+      await writeFile(lower, "other content");
+    }
+
+    // Case-insensitive: both names reach one inode, so a case-only rename is a no-op.
+    // Case-sensitive: they are two files, and a case-only rename would overwrite one.
+    expect(await isSameFile(upper, lower)).toBe(caseInsensitive);
+  });
+});
+
+describe("normalizePath", () => {
+  it("should collapse case on case-insensitive platforms", () => {
+    const expected = process.platform === "darwin" || process.platform === "win32" ? "/tmp/foo.txt" : "/tmp/FOO.txt";
+
+    expect(normalizePath("/tmp/FOO.txt")).toBe(expected);
+  });
+
+  it("should be stable for already-normalized paths", () => {
+    expect(normalizePath("/tmp/foo.txt")).toBe("/tmp/foo.txt");
+  });
+});

--- a/extensions/renaming/src/lib/batch.ts
+++ b/extensions/renaming/src/lib/batch.ts
@@ -8,7 +8,7 @@ import path, { basename, dirname, join } from "path";
 import type { RenameOperation, RenameResult } from "../types";
 import { getUserFriendlyErrorMessage } from "./errors";
 import { log } from "./logger";
-import { validatePathTraversal, normalizePath, isSamePath } from "./paths";
+import { validatePathTraversal, normalizePath, isSameFile } from "./paths";
 import { fileExists, renameFile } from "./files";
 
 /**
@@ -20,11 +20,20 @@ export async function checkConflicts(operations: RenameOperation[]): Promise<str
   const conflicts: string[] = [];
   const targetPaths = new Set<string>();
 
-  // Build set of source paths that are being moved to a different name
-  const sourcesBeingMoved = new Set<string>();
+  // Build the source paths that are being moved to a different name, bucketed by
+  // normalized path. The bucket is only a cheap lookup key — a candidate still has
+  // to be confirmed as the same file below, or a case-sensitive volume would treat
+  // a differently-cased source as if it were vacating the target slot.
+  const sourcesBeingMoved = new Map<string, string[]>();
   for (const op of operations) {
-    if (!isSamePath(op.oldPath, op.newPath)) {
-      sourcesBeingMoved.add(normalizePath(op.oldPath));
+    if (!(await isSameFile(op.oldPath, op.newPath))) {
+      const key = normalizePath(op.oldPath);
+      const bucket = sourcesBeingMoved.get(key);
+      if (bucket) {
+        bucket.push(op.oldPath);
+      } else {
+        sourcesBeingMoved.set(key, [op.oldPath]);
+      }
     }
   }
 
@@ -45,10 +54,20 @@ export async function checkConflicts(operations: RenameOperation[]): Promise<str
     }
     targetPaths.add(normalizedNewPath);
 
-    // Check if target already exists (and isn't the source file itself)
-    if (!isSamePath(op.oldPath, op.newPath) && (await fileExists(op.newPath))) {
+    // Check if target already exists (and isn't the source file itself — decided by
+    // inode identity, so a case-only rename onto a distinct file on a case-sensitive
+    // volume is reported as the conflict it is)
+    if ((await fileExists(op.newPath)) && !(await isSameFile(op.oldPath, op.newPath))) {
       // Not a conflict if the file at the target is itself being moved away in this batch
-      if (!sourcesBeingMoved.has(normalizedNewPath)) {
+      let vacatedByBatch = false;
+      for (const source of sourcesBeingMoved.get(normalizedNewPath) ?? []) {
+        if (await isSameFile(source, op.newPath)) {
+          vacatedByBatch = true;
+          break;
+        }
+      }
+
+      if (!vacatedByBatch) {
         conflicts.push(`"${basename(op.newPath)}" already exists`);
       }
     }
@@ -83,9 +102,9 @@ export async function batchRename(
 
   const needsTemp = new Set<number>();
   for (const op of operations) {
-    if (isSamePath(op.oldPath, op.newPath)) continue;
+    if (await isSameFile(op.oldPath, op.newPath)) continue;
     const blockingIdx = sourceToIndex.get(normalizePath(op.newPath));
-    if (blockingIdx !== undefined && !isSamePath(operations[blockingIdx]!.oldPath, op.oldPath)) {
+    if (blockingIdx !== undefined && !(await isSameFile(operations[blockingIdx]!.oldPath, op.oldPath))) {
       // The file at our target is also a source being moved — it needs to go to temp first
       needsTemp.add(blockingIdx);
     }
@@ -170,7 +189,9 @@ export async function batchRename(
 
     // After a successful directory rename, fix up the newPath of
     // already-processed child results so undo history stays correct
-    if (result.success && !isSamePath(op.oldPath, result.newPath)) {
+    // Exact string comparison: the question here is whether the recorded child paths
+    // are now stale, which a case-only directory rename also makes true.
+    if (result.success && op.oldPath !== result.newPath) {
       const oldPrefix = op.oldPath + path.sep;
       for (let j = 0; j < results.length; j++) {
         const r = results[j];

--- a/extensions/renaming/src/lib/batch.ts
+++ b/extensions/renaming/src/lib/batch.ts
@@ -8,7 +8,7 @@ import path, { basename, dirname, join } from "path";
 import type { RenameOperation, RenameResult } from "../types";
 import { getUserFriendlyErrorMessage } from "./errors";
 import { log } from "./logger";
-import { validatePathTraversal, normalizePath, isSameFile } from "./paths";
+import { validatePathTraversal, normalizePath, isSameEntry } from "./paths";
 import { fileExists, renameFile } from "./files";
 
 /**
@@ -26,7 +26,7 @@ export async function checkConflicts(operations: RenameOperation[]): Promise<str
   // a differently-cased source as if it were vacating the target slot.
   const sourcesBeingMoved = new Map<string, string[]>();
   for (const op of operations) {
-    if (!(await isSameFile(op.oldPath, op.newPath))) {
+    if (!(await isSameEntry(op.oldPath, op.newPath))) {
       const key = normalizePath(op.oldPath);
       const bucket = sourcesBeingMoved.get(key);
       if (bucket) {
@@ -57,11 +57,11 @@ export async function checkConflicts(operations: RenameOperation[]): Promise<str
     // Check if target already exists (and isn't the source file itself — decided by
     // inode identity, so a case-only rename onto a distinct file on a case-sensitive
     // volume is reported as the conflict it is)
-    if ((await fileExists(op.newPath)) && !(await isSameFile(op.oldPath, op.newPath))) {
+    if ((await fileExists(op.newPath)) && !(await isSameEntry(op.oldPath, op.newPath))) {
       // Not a conflict if the file at the target is itself being moved away in this batch
       let vacatedByBatch = false;
       for (const source of sourcesBeingMoved.get(normalizedNewPath) ?? []) {
-        if (await isSameFile(source, op.newPath)) {
+        if (await isSameEntry(source, op.newPath)) {
           vacatedByBatch = true;
           break;
         }
@@ -95,18 +95,31 @@ export async function batchRename(
 
   // --- Phase 0: Detect within-batch conflicts ---
   // A source is "blocking" if another operation wants to write to its path.
-  const sourceToIndex = new Map<string, number>();
+  // Sources are bucketed by normalized path and every index in a bucket is kept: on a
+  // case-sensitive volume two sources can differ only in case, and keeping just one
+  // would stage the wrong file and leave the target still occupied.
+  const sourcesByPath = new Map<string, number[]>();
   for (let i = 0; i < operations.length; i++) {
-    sourceToIndex.set(normalizePath(operations[i]!.oldPath), i);
+    const key = normalizePath(operations[i]!.oldPath);
+    const bucket = sourcesByPath.get(key);
+    if (bucket) {
+      bucket.push(i);
+    } else {
+      sourcesByPath.set(key, [i]);
+    }
   }
 
   const needsTemp = new Set<number>();
   for (const op of operations) {
-    if (await isSameFile(op.oldPath, op.newPath)) continue;
-    const blockingIdx = sourceToIndex.get(normalizePath(op.newPath));
-    if (blockingIdx !== undefined && !(await isSameFile(operations[blockingIdx]!.oldPath, op.oldPath))) {
-      // The file at our target is also a source being moved — it needs to go to temp first
-      needsTemp.add(blockingIdx);
+    if (await isSameEntry(op.oldPath, op.newPath)) continue;
+    for (const blockingIdx of sourcesByPath.get(normalizePath(op.newPath)) ?? []) {
+      const blocking = operations[blockingIdx]!.oldPath;
+      // The file at our target is also a source being moved — it needs to go to temp
+      // first. Confirm it really occupies the target rather than merely sharing a
+      // normalized key with it, and that it isn't this operation's own source.
+      if ((await isSameEntry(blocking, op.newPath)) && !(await isSameEntry(blocking, op.oldPath))) {
+        needsTemp.add(blockingIdx);
+      }
     }
   }
 

--- a/extensions/renaming/src/lib/files.ts
+++ b/extensions/renaming/src/lib/files.ts
@@ -2,8 +2,7 @@
  * Single-file operations: info, existence checks, renaming, unique name generation.
  */
 
-import { rename, stat, access } from "fs/promises";
-import { constants } from "fs";
+import { rename, stat, lstat } from "fs/promises";
 import { basename, dirname, extname, join } from "path";
 import type { FileInfo, RenameResult } from "../types";
 import { validateFilename } from "./validation";
@@ -34,11 +33,16 @@ export async function getFileInfo(filePath: string): Promise<FileInfo> {
 }
 
 /**
- * Check if a file exists at the given path
+ * Check whether a directory entry exists at the given path.
+ *
+ * Uses `lstat` rather than `access`, for the same reason {@link isSameFile} does:
+ * rename operates on the directory entry, so a symlink occupies its path even when
+ * the target it points at is missing. `access` follows symlinks and would report a
+ * dangling symlink as absent, letting fs.rename silently destroy it.
  */
 export async function fileExists(filePath: string): Promise<boolean> {
   try {
-    await access(filePath, constants.F_OK);
+    await lstat(filePath);
     return true;
   } catch {
     return false;

--- a/extensions/renaming/src/lib/files.ts
+++ b/extensions/renaming/src/lib/files.ts
@@ -8,7 +8,7 @@ import type { FileInfo, RenameResult } from "../types";
 import { validateFilename } from "./validation";
 import { getUserFriendlyErrorMessage } from "./errors";
 import { log } from "./logger";
-import { validatePathTraversal, isSameFile } from "./paths";
+import { validatePathTraversal, isSameEntry } from "./paths";
 
 /**
  * Get detailed file info
@@ -91,11 +91,11 @@ export async function renameFile(oldPath: string, newName: string): Promise<Rena
   }
 
   // Check if target already exists (safety check).
-  // Whether the destination is "the same file" is decided by inode identity, not by
-  // name: a case-only rename resolves to the source itself on a case-insensitive
-  // volume and is allowed through, but on a case-sensitive volume it is a distinct
-  // existing file that fs.rename would silently overwrite.
-  if ((await fileExists(newPath)) && !(await isSameFile(oldPath, newPath))) {
+  // The guard is skipped only when the destination is the very entry being renamed:
+  // a case-only rename resolves to the source itself on a case-insensitive volume,
+  // but on a case-sensitive volume it is a distinct existing file that fs.rename
+  // would silently overwrite.
+  if ((await fileExists(newPath)) && !(await isSameEntry(oldPath, newPath))) {
     log.files.warn("Target already exists", { oldPath, newPath, newName });
     return {
       oldPath,

--- a/extensions/renaming/src/lib/files.ts
+++ b/extensions/renaming/src/lib/files.ts
@@ -9,7 +9,7 @@ import type { FileInfo, RenameResult } from "../types";
 import { validateFilename } from "./validation";
 import { getUserFriendlyErrorMessage } from "./errors";
 import { log } from "./logger";
-import { validatePathTraversal, isSamePath } from "./paths";
+import { validatePathTraversal, isSameFile } from "./paths";
 
 /**
  * Get detailed file info
@@ -86,9 +86,12 @@ export async function renameFile(oldPath: string, newName: string): Promise<Rena
     };
   }
 
-  // Check if target already exists (safety check)
-  // Use case-insensitive comparison on macOS (case-insensitive FS)
-  if (!isSamePath(oldPath, newPath) && (await fileExists(newPath))) {
+  // Check if target already exists (safety check).
+  // Whether the destination is "the same file" is decided by inode identity, not by
+  // name: a case-only rename resolves to the source itself on a case-insensitive
+  // volume and is allowed through, but on a case-sensitive volume it is a distinct
+  // existing file that fs.rename would silently overwrite.
+  if ((await fileExists(newPath)) && !(await isSameFile(oldPath, newPath))) {
     log.files.warn("Target already exists", { oldPath, newPath, newName });
     return {
       oldPath,

--- a/extensions/renaming/src/lib/paths.ts
+++ b/extensions/renaming/src/lib/paths.ts
@@ -3,7 +3,7 @@
  */
 
 import { lstat, readdir, realpath } from "fs/promises";
-import { basename, dirname, resolve } from "path";
+import { dirname, join, resolve } from "path";
 
 /**
  * Validate that a new path stays within the expected directory (prevents path traversal).
@@ -82,11 +82,21 @@ export async function isSameFile(a: string, b: string): Promise<boolean> {
  * between them does nothing at all, so letting one through would report a rename
  * that never happened while both entries remain on disk.
  *
- * When both spellings reach one inode, the two are told apart by asking the
- * directory which names it actually holds — not by case-folding, which would have
- * to guess at the volume. If `to` is listed, it is a real entry of its own and must
- * be protected; if it is not, the filesystem resolved it case-insensitively onto
- * `from`, and the rename is the case-only no-op it appears to be.
+ * When both spellings reach one inode, the two are told apart by counting entries,
+ * never by comparing names — a case-insensitive volume resolves case *and* Unicode
+ * normalization, and string comparison would have to replicate its exact folding
+ * rules to be right. Instead:
+ *
+ * - A directory is always its own sole entry (hard links to directories don't
+ *   exist), so same inode means same entry.
+ * - A file whose inode has a single link anywhere (`nlink === 1`) has exactly one
+ *   entry for both spellings to resolve to — same entry.
+ * - Otherwise, count this directory's entries sharing the inode. One means the
+ *   remaining links live elsewhere and both spellings still resolve to it — same
+ *   entry. Two or more means `to` may be a distinct entry, and the guard applies.
+ *   This conservatively blocks a case-only rename of a file that also has a hard
+ *   link in the same directory, which is the safe direction: rename() between two
+ *   links is a silent no-op, not an overwrite.
  */
 export async function isSameEntry(from: string, to: string): Promise<boolean> {
   if (from === to) {
@@ -98,8 +108,24 @@ export async function isSameEntry(from: string, to: string): Promise<boolean> {
   }
 
   try {
-    const entries = await readdir(dirname(to));
-    return !entries.includes(basename(to));
+    const fromStat = await lstat(from);
+    if (fromStat.isDirectory() || fromStat.nlink === 1) {
+      return true;
+    }
+
+    const dir = dirname(to);
+    const entries = await readdir(dir);
+    let linksInDir = 0;
+    for (const entry of entries) {
+      const entryStat = await lstat(join(dir, entry)).catch(() => null);
+      if (entryStat && entryStat.dev === fromStat.dev && entryStat.ino === fromStat.ino) {
+        linksInDir++;
+        if (linksInDir > 1) {
+          return false;
+        }
+      }
+    }
+    return linksInDir === 1;
   } catch {
     return false;
   }

--- a/extensions/renaming/src/lib/paths.ts
+++ b/extensions/renaming/src/lib/paths.ts
@@ -55,9 +55,10 @@ export function normalizePath(filePath: string): string {
  * Uses `lstat`, not `stat`: rename operates on the directory entry, so two distinct
  * symlinks pointing at one target are different files for this purpose.
  *
- * Returns false when either path cannot be stat'd (it does not exist, or vanished
- * mid-operation). That is the conservative answer — callers then treat the
- * destination as a distinct file and refuse to overwrite it.
+ * Two identical paths are trivially one entry and answer true without touching the
+ * filesystem. Otherwise, returns false when either path cannot be stat'd (it does
+ * not exist, or vanished mid-operation) — the conservative answer, which makes
+ * callers treat the destination as a distinct file and refuse to overwrite it.
  */
 export async function isSameFile(a: string, b: string): Promise<boolean> {
   if (a === b) {
@@ -70,4 +71,22 @@ export async function isSameFile(a: string, b: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+/**
+ * Check whether renaming `from` to `to` would land on the very entry being renamed.
+ *
+ * This is the only case in which the "target already exists" guard may be skipped,
+ * and it is narrower than {@link isSameFile}: the paths must also be the same name
+ * up to case. Sharing an inode is not enough, because two hard links are one file
+ * under two distinct directory entries — POSIX rename() between them does nothing
+ * at all, so letting one through would report a rename that never happened while
+ * both entries remain on disk.
+ *
+ * True for a rename to an identical path, and for a case-only rename on a volume
+ * that treats the two spellings as one entry. False on a case-sensitive volume,
+ * where those spellings are two files and the destination must be protected.
+ */
+export async function isSameEntry(from: string, to: string): Promise<boolean> {
+  return normalizePath(from) === normalizePath(to) && (await isSameFile(from, to));
 }

--- a/extensions/renaming/src/lib/paths.ts
+++ b/extensions/renaming/src/lib/paths.ts
@@ -2,8 +2,8 @@
  * Shared path helpers for rename operations.
  */
 
-import { lstat, realpath } from "fs/promises";
-import { dirname, resolve } from "path";
+import { lstat, readdir, realpath } from "fs/promises";
+import { basename, dirname, resolve } from "path";
 
 /**
  * Validate that a new path stays within the expected directory (prevents path traversal).
@@ -77,16 +77,30 @@ export async function isSameFile(a: string, b: string): Promise<boolean> {
  * Check whether renaming `from` to `to` would land on the very entry being renamed.
  *
  * This is the only case in which the "target already exists" guard may be skipped,
- * and it is narrower than {@link isSameFile}: the paths must also be the same name
- * up to case. Sharing an inode is not enough, because two hard links are one file
- * under two distinct directory entries — POSIX rename() between them does nothing
- * at all, so letting one through would report a rename that never happened while
- * both entries remain on disk.
+ * and it is narrower than {@link isSameFile}. Sharing an inode is not enough: two
+ * hard links are one file under two distinct directory entries, and POSIX rename()
+ * between them does nothing at all, so letting one through would report a rename
+ * that never happened while both entries remain on disk.
  *
- * True for a rename to an identical path, and for a case-only rename on a volume
- * that treats the two spellings as one entry. False on a case-sensitive volume,
- * where those spellings are two files and the destination must be protected.
+ * When both spellings reach one inode, the two are told apart by asking the
+ * directory which names it actually holds — not by case-folding, which would have
+ * to guess at the volume. If `to` is listed, it is a real entry of its own and must
+ * be protected; if it is not, the filesystem resolved it case-insensitively onto
+ * `from`, and the rename is the case-only no-op it appears to be.
  */
 export async function isSameEntry(from: string, to: string): Promise<boolean> {
-  return normalizePath(from) === normalizePath(to) && (await isSameFile(from, to));
+  if (from === to) {
+    return true;
+  }
+
+  if (!(await isSameFile(from, to))) {
+    return false;
+  }
+
+  try {
+    const entries = await readdir(dirname(to));
+    return !entries.includes(basename(to));
+  } catch {
+    return false;
+  }
 }

--- a/extensions/renaming/src/lib/paths.ts
+++ b/extensions/renaming/src/lib/paths.ts
@@ -2,7 +2,7 @@
  * Shared path helpers for rename operations.
  */
 
-import { realpath } from "fs/promises";
+import { lstat, realpath } from "fs/promises";
 import { dirname, resolve } from "path";
 
 /**
@@ -31,15 +31,43 @@ export async function validatePathTraversal(oldPath: string, newPath: string): P
 }
 
 /**
- * Normalize a path for case-insensitive comparison (macOS uses case-insensitive FS by default)
+ * Group paths that a case-insensitive filesystem would collapse onto each other.
+ *
+ * This is a deliberately conservative bucketing key, not a claim that two paths are
+ * the same file — on a case-sensitive volume it groups paths that are in fact
+ * distinct. Use it to decide which comparisons are worth making; use
+ * {@link isSameFile} to decide whether two paths actually are one file.
  */
 export function normalizePath(filePath: string): string {
   return process.platform === "darwin" || process.platform === "win32" ? filePath.toLowerCase() : filePath;
 }
 
 /**
- * Check if two paths refer to the same file on the current filesystem
+ * Check whether two paths refer to the same underlying filesystem entry.
+ *
+ * Compares device + inode rather than the path strings, so the answer is a property
+ * of the volume rather than of the platform. macOS is case-insensitive by default
+ * but not by requirement — APFS can be formatted case-sensitive. On a
+ * case-insensitive volume `FOO.txt` and `foo.txt` resolve to one inode and a
+ * case-only rename is a no-op; on a case-sensitive volume they are two files and
+ * that same rename would overwrite one with the other.
+ *
+ * Uses `lstat`, not `stat`: rename operates on the directory entry, so two distinct
+ * symlinks pointing at one target are different files for this purpose.
+ *
+ * Returns false when either path cannot be stat'd (it does not exist, or vanished
+ * mid-operation). That is the conservative answer — callers then treat the
+ * destination as a distinct file and refuse to overwrite it.
  */
-export function isSamePath(a: string, b: string): boolean {
-  return normalizePath(a) === normalizePath(b);
+export async function isSameFile(a: string, b: string): Promise<boolean> {
+  if (a === b) {
+    return true;
+  }
+
+  try {
+    const [statA, statB] = await Promise.all([lstat(a), lstat(b)]);
+    return statA.dev === statB.dev && statA.ino === statB.ino;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
### 🤖 Disclosure

This extension was developed with AI assistance (Claude Code, Cursor, CodeRabbitAI and Greptile), with my guidance on architecture, requirements, and testing. All code was reviewed and validated by me, including manual testing in Raycast.

## Description

This PR fixes one guard: the "target already exists" check that protects every rename. It
answered "are these two names the same file?" from the platform (`darwin` ⇒ lowercase both
strings) instead of from the filesystem, which fails in both directions — it lets a rename
destroy a real file on a case-sensitive volume, and it clears renames the filesystem will
silently refuse to perform. The guard now asks the filesystem directly (inode identity +
directory-entry counting), so it is correct on any volume without probing or special-casing.
No new commands, no UI changes, no new dependencies.

### Bug fixes

- **A case-only rename can silently destroy a file on a case-sensitive volume.** macOS is
  case-insensitive by default, not by requirement — APFS can be formatted case-sensitive, and
  commonly is on developer machines and external drives. There, `FOO.txt` and `foo.txt` are two
  files, but the guard lowercased both names, concluded "same file", and skipped the overwrite
  check — so renaming one onto the other replaced the target with no warning and no record.
  Batch pre-flight missed the same conflict for the same reason. The guard now compares
  `dev`+`ino`, so the answer is a property of the volume, not the platform.
- **Renaming a file onto a hard link of itself reported success while doing nothing.** POSIX
  `rename()` between two directory entries of one inode is a silent no-op, so inode identity
  alone is not enough to skip the guard — the extension reported a successful rename while both
  entries remained on disk. This held even for differently-cased or differently-normalized
  spellings of the link's name (`BAR.txt` for `bar.txt`, NFD for NFC), which a case-insensitive
  volume resolves onto the existing entry; verified against real `fs.rename` behaviour on APFS.
  Such renames are now blocked as "already exists".
- **A rename could silently destroy a symlink whose target is missing.** The existence check
  used `access()`, which follows symlinks — a dangling symlink at the target path was reported
  as "nothing there" and overwritten. `rename` operates on directory entries, so the check now
  uses `lstat`. The same change lets a dangling symlink itself be renamed (previously the
  source was reported missing).

### Technical Highlights

- `isSamePath` (string comparison) is replaced by two explicit predicates: `isSameFile`
  (`dev`+`ino` via `lstat`) and the stricter `isSameEntry`, the only check allowed to skip the
  overwrite guard. `isSameEntry` never compares names — a case-insensitive volume folds case
  *and* Unicode normalization, and replicating its exact rules is a losing game. Instead it
  counts directory entries for the inode (`nlink === 1` fast path; directories are always their
  own sole entry), and blocks conservatively when the inode has two entries in the directory.
- Every failure path answers conservatively: an unreadable path or directory means "treat the
  target as a distinct existing file and refuse to overwrite".
- Batch conflict detection keeps its case-collapsed keys, but only as a cheap prefilter — every
  candidate is confirmed with `isSameEntry` before a conflict is raised or suppressed, so a
  case-sensitive volume no longer treats a differently-cased source as vacating the target.
- 26 new tests (109 total) run against the real filesystem — hard links, dangling symlinks,
  Unicode normalization — plus mocked-identity tests so both volume behaviours are exercised
  regardless of where the suite runs, and a conditional test that only runs on a genuinely
  case-sensitive volume.

## Screencast

No new captures — this PR changes guard logic only; commands, UI and preferences are unchanged.

## How to Test

No special hardware or credentials needed; the headline bug needs a case-sensitive volume,
which a throwaway disk image provides.

1. `npm ci && npm run dev` inside `extensions/renaming`
2. **Everyday path (unchanged behaviour):** rename any file to a name differing only in case —
   it succeeds, as it always has.
3. **Hard-link false success:** `touch /tmp/foo.txt && ln /tmp/foo.txt /tmp/bar.txt`, then use
   Rename File(s) to rename `foo.txt` to `bar.txt` (or `BAR.txt`). The store version reports
   success while nothing happens; this version reports "already exists".
4. **The headline data-loss bug:** create a case-sensitive volume with
   `hdiutil create -size 10m -fs "Case-sensitive APFS" -volname CS /tmp/cs.dmg && hdiutil attach /tmp/cs.dmg`,
   create `/Volumes/CS/FOO.txt` and `/Volumes/CS/foo.txt` with different contents, then rename
   `FOO.txt` to `foo.txt`. The store version silently replaces `foo.txt`; this version blocks
   with "already exists".
5. `npm test` — 109 tests.

## Checklist

- [x] I read the [Prepare an Extension for Store](https://developers.raycast.com/basics/prepare-an-extension-for-store) guidelines
- [x] I read the [Publish an Extension](https://developers.raycast.com/basics/publish-an-extension) guidelines
- [x] Ran `npm run build` and tested the build in Raycast
- [x] All assets used are in the `assets` folder; README media outside `metadata/`
- [x] `npm run lint` passes
