### PR TITLE
Kesha Voice Kit: detect setup state from structured CLI output

### DIFF
--- a/extensions/kesha-voice-kit/CHANGELOG.md
+++ b/extensions/kesha-voice-kit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Kesha Voice Kit Changelog
 
+## [Sturdier setup detection] - {PR_MERGE_DATE}
+
+- Detect whether the engine is installed from the CLI's machine-readable status output instead of matching its wording, so a reworded CLI message can no longer be mistaken for a broken install. Older CLIs keep working through the previous check.
+- Refuse to start a session when the engine is installed but cannot run, instead of recording audio that could never be transcribed, and say how to repair it.
+- Tell a CLI/extension version mismatch apart from a broken engine, so the suggested fix matches the actual problem.
+
 ## [Setup guidance and faster failure feedback] - 2026-07-27
 
 - Rewrite the "kesha CLI not found" message as numbered setup steps, leading with Homebrew so the guidance works without knowing about bun, and include the required `kesha install` step.

--- a/extensions/kesha-voice-kit/CHANGELOG.md
+++ b/extensions/kesha-voice-kit/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Kesha Voice Kit Changelog
 
-## [Sturdier setup detection] - {PR_MERGE_DATE}
+## [Sturdier setup detection] - 2026-08-03
 
 - Detect whether the engine is installed from the CLI's machine-readable status output instead of matching its wording, so a reworded CLI message can no longer be mistaken for a broken install. Older CLIs keep working through the previous check.
 - Refuse to start a session when the engine is installed but cannot run, instead of recording audio that could never be transcribed, and say how to repair it.

--- a/extensions/kesha-voice-kit/src/lib/dictation-controller.ts
+++ b/extensions/kesha-voice-kit/src/lib/dictation-controller.ts
@@ -248,9 +248,7 @@ export function startDictationSession(
   }
 }
 
-// Each reason has its own remedy, so the headline tracks it: re-downloading a
-// broken engine, finishing a first install, and upgrading a version-skewed CLI
-// are three different instructions (#647).
+// Each reason has a different remedy, so the headline tracks it, not just the hint (#647).
 function preflightMessage(reason: EnginePreflightResult["reason"]): string {
   switch (reason) {
     case "unusable":

--- a/extensions/kesha-voice-kit/src/lib/dictation-controller.ts
+++ b/extensions/kesha-voice-kit/src/lib/dictation-controller.ts
@@ -87,7 +87,7 @@ export function startDictationSession(
       if (!preflight.ok) {
         setState({
           status: "error",
-          message: "Kesha setup isn't finished yet.",
+          message: preflightMessage(preflight.reason),
           hint: preflight.hint ?? notFoundMessage(),
         });
         return;
@@ -245,6 +245,20 @@ export function startDictationSession(
     stopMonitoring = null;
     stopTranscribeTimer?.();
     stopTranscribeTimer = null;
+  }
+}
+
+// Each reason has its own remedy, so the headline tracks it: re-downloading a
+// broken engine, finishing a first install, and upgrading a version-skewed CLI
+// are three different instructions (#647).
+function preflightMessage(reason: EnginePreflightResult["reason"]): string {
+  switch (reason) {
+    case "unusable":
+      return "Kesha's engine is installed but not working.";
+    case "contract":
+      return "Kesha CLI and this extension are out of sync.";
+    default:
+      return "Kesha setup isn't finished yet.";
   }
 }
 

--- a/extensions/kesha-voice-kit/src/lib/kesha-bin.ts
+++ b/extensions/kesha-voice-kit/src/lib/kesha-bin.ts
@@ -149,34 +149,128 @@ export interface ProbeDeps {
 export interface EnginePreflightResult {
   ok: boolean;
   hint?: string;
+  /**
+   * Why the engine is unavailable — lets the setup view name the right remedy.
+   * `contract` is a CLI/extension version skew, not a broken engine: sending
+   * those users to re-download would fix nothing (#647).
+   */
+  reason?: "missing" | "unusable" | "contract";
 }
 
-function runKesha(spawn: KeshaSpawn, verb: string, deps: ProbeDeps) {
+const MISSING_ENGINE_MARKER = "not installed";
+// A corrupt binary is not repaired by a plain `kesha install`: that hits the
+// cached-engine path and only re-trusts it. `--no-cache` forces the re-download,
+// except on a read-only engine dir (Nix store), where it is deliberately a no-op
+// (`cacheValid = versionMatches && (!noCache || !canWriteEngineDir)`). The probe
+// cannot tell the two installs apart, so the hint names both rather than
+// promising a fix that would silently skip.
+const REPAIR_HINT =
+  "Run `kesha install --no-cache` to re-download the engine. On a read-only (Nix) install, repair it through your package manager instead.";
+const CONTRACT_HINT =
+  "Update the kesha CLI and this extension to matching versions — `bun add -g @drakulavich/kesha-voice-kit@latest`.";
+
+function runKesha(spawn: KeshaSpawn, args: string[], deps: ProbeDeps) {
   const run = deps.execFile ?? execFileAsync;
-  return run(spawn.command, [...spawn.prefixArgs, verb], {
+  return run(spawn.command, [...spawn.prefixArgs, ...args], {
     timeout: PROBE_TIMEOUT_MS,
   });
 }
 
-// `kesha status` marks a missing engine as "not installed" on stdout and warns
-// on stderr with the exact remaining setup command (`installHint()`). Keying
-// off the stdout marker keeps unrelated stderr (KESHA_DEBUG traces, warnings)
-// from failing a healthy install; a probe that cannot run at all fails open —
-// the CLI's own guards report the real problem with a better message.
+function parseStatusObject(stdout: string): Record<string, unknown> | null {
+  const trimmed = stdout.trim();
+  if (!trimmed.startsWith("{")) return null;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+// Anchored to the Binary line rather than the whole output: "not installed" is
+// `formatStatusLine`'s default missing label, so a future missing line would
+// otherwise read as the engine being absent. No Binary line means this is not
+// status output at all — garbage fails open rather than matching loose text.
+function proseSaysEngineMissing(stdout: string): boolean {
+  const binaryLine = stdout
+    .split("\n")
+    .find((line) => line.includes("Binary:"));
+  return binaryLine !== undefined && binaryLine.includes(MISSING_ENGINE_MARKER);
+}
+
+// The CLI validates this shape too, but the extension ships through the Raycast
+// Store against whatever CLI version is on the machine — including ones that
+// predate that validation and forward `{}` or `[]` as capabilities.
+function capabilitiesAreReadable(capabilities: unknown): boolean {
+  return (
+    typeof capabilities === "object" &&
+    capabilities !== null &&
+    !Array.isArray(capabilities) &&
+    Object.keys(capabilities).length > 0
+  );
+}
+
+function readStructuredStatus(
+  payload: Record<string, unknown>,
+): EnginePreflightResult {
+  const contractError: EnginePreflightResult = {
+    ok: false,
+    reason: "contract",
+    hint: CONTRACT_HINT,
+  };
+  const engine = payload.engine;
+  if (!engine || typeof engine !== "object") return contractError;
+  const { installed, capabilities } = engine as Record<string, unknown>;
+  if (typeof installed !== "boolean") return contractError;
+
+  if (!installed) {
+    const hint = typeof payload.hint === "string" ? payload.hint.trim() : "";
+    return { ok: false, reason: "missing", hint: hint || undefined };
+  }
+  // Present is not usable: a binary that cannot report its capabilities would
+  // fail during transcription, after the recording is already gone (#647).
+  if (!capabilitiesAreReadable(capabilities)) {
+    return { ok: false, reason: "unusable", hint: REPAIR_HINT };
+  }
+  return { ok: true };
+}
+
+/**
+ * Decides whether the engine can run before a session starts.
+ *
+ * Reads `kesha status --json` when the resolved CLI emits it. A CLI too old for
+ * that flag prints human text instead (citty ignores unknown flags), which is
+ * the signal to fall back to the prose marker — so the fallback is chosen by
+ * stdout *kind*, never by parse outcome. Output that is a JSON object but
+ * breaks the contract fails closed: it would also miss the prose marker and be
+ * reported as healthy. A probe that cannot run at all still fails open, letting
+ * the CLI's own guards report the real problem with a better message.
+ */
 export async function probeEngineAvailability(
   spawn: KeshaSpawn,
   deps: ProbeDeps = {},
 ): Promise<EnginePreflightResult> {
   try {
-    const { stdout, stderr } = await runKesha(spawn, "status", deps);
-    if (!stdout.includes("not installed")) return { ok: true };
-    return { ok: false, hint: stderr.trim() || undefined };
+    const { stdout, stderr } = await runKesha(
+      spawn,
+      ["status", "--json"],
+      deps,
+    );
+    const payload = parseStatusObject(stdout);
+    if (payload) return readStructuredStatus(payload);
+    if (proseSaysEngineMissing(stdout)) {
+      return { ok: false, reason: "missing", hint: stderr.trim() || undefined };
+    }
+    return { ok: true };
   } catch (err) {
     const stderr =
       err && typeof err === "object" && "stderr" in err
         ? String((err as { stderr?: unknown }).stderr ?? "").trim()
         : "";
-    if (stderr.includes("kesha install")) return { ok: false, hint: stderr };
+    if (stderr.includes("kesha install"))
+      return { ok: false, reason: "missing", hint: stderr };
     return { ok: true };
   }
 }

--- a/extensions/kesha-voice-kit/src/lib/kesha-bin.ts
+++ b/extensions/kesha-voice-kit/src/lib/kesha-bin.ts
@@ -158,12 +158,7 @@ export interface EnginePreflightResult {
 }
 
 const MISSING_ENGINE_MARKER = "not installed";
-// A corrupt binary is not repaired by a plain `kesha install`: that hits the
-// cached-engine path and only re-trusts it. `--no-cache` forces the re-download,
-// except on a read-only engine dir (Nix store), where it is deliberately a no-op
-// (`cacheValid = versionMatches && (!noCache || !canWriteEngineDir)`). The probe
-// cannot tell the two installs apart, so the hint names both rather than
-// promising a fix that would silently skip.
+// Plain `kesha install` only re-trusts a cached binary; `--no-cache` re-downloads, except on a read-only (Nix) dir.
 const REPAIR_HINT =
   "Run `kesha install --no-cache` to re-download the engine. On a read-only (Nix) install, repair it through your package manager instead.";
 const CONTRACT_HINT =
@@ -176,23 +171,28 @@ function runKesha(spawn: KeshaSpawn, args: string[], deps: ProbeDeps) {
   });
 }
 
-function parseStatusObject(stdout: string): Record<string, unknown> | null {
+type StatusStdout =
+  | { kind: "payload"; value: Record<string, unknown> }
+  | { kind: "contract" }
+  | { kind: "prose" };
+
+// An older CLI prints human text, never JSON — so a non-object is a broken contract, not a fallback.
+function classifyStatusStdout(stdout: string): StatusStdout {
   const trimmed = stdout.trim();
-  if (!trimmed.startsWith("{")) return null;
+  if (!trimmed) return { kind: "prose" };
+  let parsed: unknown;
   try {
-    const parsed: unknown = JSON.parse(trimmed);
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : null;
+    parsed = JSON.parse(trimmed);
   } catch {
-    return null;
+    return { kind: "prose" };
   }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { kind: "contract" };
+  }
+  return { kind: "payload", value: parsed as Record<string, unknown> };
 }
 
-// Anchored to the Binary line rather than the whole output: "not installed" is
-// `formatStatusLine`'s default missing label, so a future missing line would
-// otherwise read as the engine being absent. No Binary line means this is not
-// status output at all — garbage fails open rather than matching loose text.
+// Anchored to the Binary line: "not installed" is the default missing label, so other lines would false-positive.
 function proseSaysEngineMissing(stdout: string): boolean {
   const binaryLine = stdout
     .split("\n")
@@ -200,9 +200,7 @@ function proseSaysEngineMissing(stdout: string): boolean {
   return binaryLine !== undefined && binaryLine.includes(MISSING_ENGINE_MARKER);
 }
 
-// The CLI validates this shape too, but the extension ships through the Raycast
-// Store against whatever CLI version is on the machine — including ones that
-// predate that validation and forward `{}` or `[]` as capabilities.
+// Re-checked here because the Store extension meets CLI versions predating the CLI-side validation.
 function capabilitiesAreReadable(capabilities: unknown): boolean {
   return (
     typeof capabilities === "object" &&
@@ -229,8 +227,7 @@ function readStructuredStatus(
     const hint = typeof payload.hint === "string" ? payload.hint.trim() : "";
     return { ok: false, reason: "missing", hint: hint || undefined };
   }
-  // Present is not usable: a binary that cannot report its capabilities would
-  // fail during transcription, after the recording is already gone (#647).
+  // Present is not usable: it would fail during transcription, after the recording is gone (#647).
   if (!capabilitiesAreReadable(capabilities)) {
     return { ok: false, reason: "unusable", hint: REPAIR_HINT };
   }
@@ -258,8 +255,12 @@ export async function probeEngineAvailability(
       ["status", "--json"],
       deps,
     );
-    const payload = parseStatusObject(stdout);
-    if (payload) return readStructuredStatus(payload);
+    const classified = classifyStatusStdout(stdout);
+    if (classified.kind === "payload")
+      return readStructuredStatus(classified.value);
+    if (classified.kind === "contract") {
+      return { ok: false, reason: "contract", hint: CONTRACT_HINT };
+    }
     if (proseSaysEngineMissing(stdout)) {
       return { ok: false, reason: "missing", hint: stderr.trim() || undefined };
     }

--- a/extensions/kesha-voice-kit/tests/dictation-controller.test.ts
+++ b/extensions/kesha-voice-kit/tests/dictation-controller.test.ts
@@ -13,9 +13,24 @@ import type {
   SignalLevel,
 } from "../src/lib/dictation-types";
 import { emptySignal } from "../src/lib/recording-view";
-import { deferred, flushPromises } from "./helpers/async";
+import { deferred, flushPromises, waitFor } from "./helpers/async";
 
 describe("dictation controller", () => {
+  it("waits for queued setup before asserting controller state", async () => {
+    let ready = false;
+    let attempts = 0;
+    queueMicrotask(() => {
+      ready = true;
+    });
+
+    await waitFor(() => {
+      attempts++;
+      expect(ready).toBe(true);
+    });
+
+    expect(attempts).toBeGreaterThan(1);
+  });
+
   it("runs the happy path and copies the trimmed transcript", async () => {
     const deps = createDeps();
     const { states, toasts } = deps;
@@ -123,6 +138,46 @@ describe("dictation controller", () => {
     });
   });
 
+  it("names a broken install differently from a missing one (#647)", async () => {
+    const deps = createDeps({
+      preflight: vi.fn(async () => ({
+        ok: false,
+        reason: "unusable" as const,
+        hint: "Run `kesha install --no-cache` to re-download the engine.",
+      })),
+    });
+    const { states } = deps;
+
+    const session = startDictationSession({}, deps.setState, deps);
+    await session.done;
+
+    expect(deps.startRecorder).not.toHaveBeenCalled();
+    expect(states.at(-1)).toEqual({
+      status: "error",
+      message: "Kesha's engine is installed but not working.",
+      hint: "Run `kesha install --no-cache` to re-download the engine.",
+    });
+  });
+
+  it("does not blame the engine for a CLI/extension version skew (#647)", async () => {
+    const deps = createDeps({
+      preflight: vi.fn(async () => ({
+        ok: false,
+        reason: "contract" as const,
+        hint: "Update the kesha CLI and this extension to matching versions.",
+      })),
+    });
+    const { states } = deps;
+
+    const session = startDictationSession({}, deps.setState, deps);
+    await session.done;
+
+    expect(deps.startRecorder).not.toHaveBeenCalled();
+    const last = states.at(-1);
+    expect(last?.message).toBe("Kesha CLI and this extension are out of sync.");
+    expect(last?.message).not.toContain("engine");
+  });
+
   it("falls back to the not-found hint when preflight fails without one", async () => {
     const deps = createDeps({
       preflight: vi.fn(async () => ({ ok: false })),
@@ -185,7 +240,7 @@ describe("dictation controller", () => {
     const { states } = deps;
 
     const session = startDictationSession({}, deps.setState, deps);
-    await vi.waitFor(() => expect(deps.startRecorder).toHaveBeenCalled());
+    await waitFor(() => expect(deps.startRecorder).toHaveBeenCalled());
     session.stopRecording();
     session.cancel();
     recorder.resolve();
@@ -208,7 +263,7 @@ describe("dictation controller", () => {
     });
 
     const session = startDictationSession({}, deps.setState, deps);
-    await vi.waitFor(() => expect(deps.current().status).toBe("recording"));
+    await waitFor(() => expect(deps.current().status).toBe("recording"));
 
     session.stopRecording();
     expect(deps.startRecorder).not.toHaveBeenCalled();
@@ -238,7 +293,7 @@ describe("dictation controller", () => {
     });
 
     const session = startDictationSession({}, deps.setState, deps);
-    await vi.waitFor(() => expect(deps.current().status).toBe("recording"));
+    await waitFor(() => expect(deps.current().status).toBe("recording"));
 
     session.cancel();
     recordingToast.resolve();
@@ -284,7 +339,7 @@ describe("dictation controller", () => {
     const { states } = deps;
 
     const session = startDictationSession({}, deps.setState, deps);
-    await vi.waitFor(() => expect(states.at(-1)?.status).toBe("transcribing"));
+    await waitFor(() => expect(states.at(-1)?.status).toBe("transcribing"));
 
     expect(states.at(-1)).toMatchObject({
       status: "transcribing",
@@ -316,7 +371,7 @@ describe("dictation controller", () => {
     const { states } = deps;
 
     const session = startDictationSession({}, deps.setState, deps);
-    await vi.waitFor(() => expect(states.at(-1)?.status).toBe("transcribing"));
+    await waitFor(() => expect(states.at(-1)?.status).toBe("transcribing"));
 
     session.cancelTranscription();
     transcribingToast.resolve();
@@ -344,7 +399,7 @@ describe("dictation controller", () => {
     });
 
     const session = startDictationSession({}, deps.setState, deps);
-    await vi.waitFor(() => expect(deps.startRecorder).toHaveBeenCalled());
+    await waitFor(() => expect(deps.startRecorder).toHaveBeenCalled());
 
     emit({ signal: emptySignal("listening") });
     clock = 30_000;
@@ -382,7 +437,7 @@ describe("dictation controller", () => {
     });
 
     const session = startDictationSession({}, deps.setState, deps);
-    await vi.waitFor(() => expect(deps.startRecorder).toHaveBeenCalled());
+    await waitFor(() => expect(deps.startRecorder).toHaveBeenCalled());
 
     emit({ signal: emptySignal("listening") });
     clock = 30_000;
@@ -420,7 +475,7 @@ describe("dictation controller", () => {
     });
 
     const session = startDictationSession({}, deps.setState, deps);
-    await vi.waitFor(() => expect(deps.startRecorder).toHaveBeenCalled());
+    await waitFor(() => expect(deps.startRecorder).toHaveBeenCalled());
 
     const warning = expect.objectContaining({
       style: "failure",
@@ -470,7 +525,7 @@ describe("dictation controller", () => {
     });
 
     const session = startDictationSession({}, deps.setState, deps);
-    await vi.waitFor(() => expect(deps.startRecorder).toHaveBeenCalled());
+    await waitFor(() => expect(deps.startRecorder).toHaveBeenCalled());
 
     emit({ signal: signalTick() });
     clock = 9_000;

--- a/extensions/kesha-voice-kit/tests/helpers/async.ts
+++ b/extensions/kesha-voice-kit/tests/helpers/async.ts
@@ -12,3 +12,16 @@ export async function flushPromises() {
   await Promise.resolve();
   await Promise.resolve();
 }
+
+export async function waitFor(assertion: () => void, timeoutMs = 1_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      assertion();
+      return;
+    } catch (err) {
+      if (Date.now() >= deadline) throw err;
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    }
+  }
+}

--- a/extensions/kesha-voice-kit/tests/kesha-bin-status-json.test.ts
+++ b/extensions/kesha-voice-kit/tests/kesha-bin-status-json.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from "vitest";
+import { probeEngineAvailability } from "../src/lib/kesha-bin";
+import type { ProbeDeps } from "../src/lib/kesha-bin";
+
+// One case per row of the probe matrix in
+// openspec/changes/status-json-output/design.md.
+describe("probeEngineAvailability — structured status (#647)", () => {
+  const kesha = { command: "/opt/homebrew/bin/kesha", prefixArgs: [] };
+
+  function jsonStdout(payload: unknown): ProbeDeps["execFile"] {
+    return vi.fn(async () => ({
+      stdout: JSON.stringify(payload, null, 2),
+      stderr: "",
+    }));
+  }
+
+  function textStdout(stdout: string, stderr = ""): ProbeDeps["execFile"] {
+    return vi.fn(async () => ({ stdout, stderr }));
+  }
+
+  it("asks the CLI for machine-readable status", async () => {
+    const execFile = jsonStdout({
+      engine: { installed: true, path: "/x", capabilities: { backend: "coreml" } },
+    });
+    await probeEngineAvailability(kesha, { execFile });
+    expect(execFile).toHaveBeenCalledWith(
+      "/opt/homebrew/bin/kesha",
+      ["status", "--json"],
+      expect.anything(),
+    );
+  });
+
+  it("reports ok for an installed engine with readable capabilities", async () => {
+    const execFile = jsonStdout({
+      engine: {
+        installed: true,
+        path: "/x",
+        capabilities: { protocolVersion: 3, backend: "coreml", features: ["tts"] },
+      },
+      hint: null,
+    });
+    expect(await probeEngineAvailability(kesha, { execFile })).toEqual({ ok: true });
+  });
+
+  it("takes the hint from the payload when the engine is missing", async () => {
+    const execFile = jsonStdout({
+      engine: { installed: false, path: "/x", capabilities: null },
+      hint: "Run `kesha install` to download the engine and models.",
+    });
+    expect(await probeEngineAvailability(kesha, { execFile })).toEqual({
+      ok: false,
+      reason: "missing",
+      hint: "Run `kesha install` to download the engine and models.",
+    });
+  });
+
+  it("rejects an engine that is present but cannot report capabilities", async () => {
+    const execFile = jsonStdout({
+      engine: { installed: true, path: "/x", capabilities: null },
+      hint: null,
+    });
+    const result = await probeEngineAvailability(kesha, { execFile });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("unusable");
+    expect(result.hint).toContain("--no-cache");
+    // A read-only (Nix) install ignores --no-cache for the engine, so the hint
+    // must not promise a fix those users cannot get.
+    expect(result.hint).toContain("read-only");
+  });
+
+  it("fails closed on JSON that breaks the contract instead of matching prose", async () => {
+    // Parses fine and misses the prose marker: the old rule called this healthy.
+    const execFile = jsonStdout({ ok: true, engine: { path: "/x" }, hint: "setup" });
+    const result = await probeEngineAvailability(kesha, { execFile });
+    expect(result.ok).toBe(false);
+    // Version skew is not a broken engine — re-downloading would fix nothing.
+    expect(result.reason).toBe("contract");
+    expect(result.hint).not.toContain("--no-cache");
+  });
+
+  it("fails closed when installed is present but not a boolean", async () => {
+    const execFile = jsonStdout({ engine: { installed: "yes", capabilities: null } });
+    const result = await probeEngineAvailability(kesha, { execFile });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("contract");
+  });
+
+  it("does not accept junk in place of capabilities", async () => {
+    for (const capabilities of [{}, [], false, "", "coreml", 0]) {
+      const execFile = jsonStdout({
+        engine: { installed: true, path: "/x", capabilities },
+        hint: null,
+      });
+      const result = await probeEngineAvailability(kesha, { execFile });
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("unusable");
+    }
+  });
+
+  it("falls back to prose for an older CLI reporting a missing engine", async () => {
+    const execFile = textStdout(
+      "Engine:\n  ✗ Binary: not installed\n\n  ✓ Runtime: Bun 1.3.13\n",
+      "Run `kesha install` to download the engine and models.",
+    );
+    expect(await probeEngineAvailability(kesha, { execFile })).toEqual({
+      ok: false,
+      reason: "missing",
+      hint: "Run `kesha install` to download the engine and models.",
+    });
+  });
+
+  it("falls back to prose for an older CLI reporting a healthy engine", async () => {
+    const execFile = textStdout(
+      "Engine:\n  ✓ Binary: /opt/homebrew/bin/kesha-engine\n  ✓ Backend: coreml\n",
+    );
+    expect(await probeEngineAvailability(kesha, { execFile })).toEqual({ ok: true });
+  });
+
+  it("does not read the marker off a line other than Binary", async () => {
+    const execFile = textStdout(
+      "Engine:\n  ✓ Binary: /opt/homebrew/bin/kesha-engine\n  ✗ Diarization: not installed\n",
+    );
+    expect(await probeEngineAvailability(kesha, { execFile })).toEqual({ ok: true });
+  });
+
+  it("fails open on empty or garbage stdout", async () => {
+    // `{not installed` is the trap: it opens like JSON, fails to parse, and
+    // carries the marker — matching loose text would flip it closed.
+    for (const stdout of ["", "   ", " garbage", "{not json at all", "{not installed"]) {
+      expect(await probeEngineAvailability(kesha, { execFile: textStdout(stdout) })).toEqual({
+        ok: true,
+      });
+    }
+  });
+
+  it("fails open on a JSON array", async () => {
+    expect(await probeEngineAvailability(kesha, { execFile: textStdout("[1,2,3]") })).toEqual({
+      ok: true,
+    });
+  });
+});

--- a/extensions/kesha-voice-kit/tests/kesha-bin-status-json.test.ts
+++ b/extensions/kesha-voice-kit/tests/kesha-bin-status-json.test.ts
@@ -2,8 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { probeEngineAvailability } from "../src/lib/kesha-bin";
 import type { ProbeDeps } from "../src/lib/kesha-bin";
 
-// One case per row of the probe matrix in
-// openspec/changes/status-json-output/design.md.
+// One case per row of the probe matrix in the status-json-output design.
 describe("probeEngineAvailability — structured status (#647)", () => {
   const kesha = { command: "/opt/homebrew/bin/kesha", prefixArgs: [] };
 
@@ -63,8 +62,7 @@ describe("probeEngineAvailability — structured status (#647)", () => {
     expect(result.ok).toBe(false);
     expect(result.reason).toBe("unusable");
     expect(result.hint).toContain("--no-cache");
-    // A read-only (Nix) install ignores --no-cache for the engine, so the hint
-    // must not promise a fix those users cannot get.
+    // A read-only (Nix) install ignores --no-cache, so the hint must not promise that fix alone.
     expect(result.hint).toContain("read-only");
   });
 
@@ -133,9 +131,12 @@ describe("probeEngineAvailability — structured status (#647)", () => {
     }
   });
 
-  it("fails open on a JSON array", async () => {
-    expect(await probeEngineAvailability(kesha, { execFile: textStdout("[1,2,3]") })).toEqual({
-      ok: true,
-    });
+  it("fails closed on valid JSON that is not an object", async () => {
+    // As prose this would miss the marker and report a missing engine as healthy.
+    for (const stdout of ["[1,2,3]", "42", '"ok"', "null", "true"]) {
+      const result = await probeEngineAvailability(kesha, { execFile: textStdout(stdout) });
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("contract");
+    }
   });
 });

--- a/extensions/kesha-voice-kit/tests/kesha-bin.test.ts
+++ b/extensions/kesha-voice-kit/tests/kesha-bin.test.ts
@@ -203,6 +203,7 @@ describe("probeEngineAvailability", () => {
     }));
     expect(await probeEngineAvailability(kesha, { execFile })).toEqual({
       ok: false,
+      reason: "missing",
       hint: "Run `kesha install` to download the engine and models.",
     });
   });
@@ -224,6 +225,7 @@ describe("probeEngineAvailability", () => {
     });
     expect(await probeEngineAvailability(kesha, { execFile })).toEqual({
       ok: false,
+      reason: "missing",
       hint: "Run `kesha install` to download the engine and models.",
     });
   });


### PR DESCRIPTION
## Description

Update to the existing **Kesha Voice Kit** extension.

Before starting a dictation session the extension checks that the `kesha` CLI and its speech engine are actually usable. That check decided whether the engine was installed by matching the string `"not installed"` in `kesha status` output — coupling the extension to human-readable wording the CLI could reword at any time, which would have shipped a broken setup check to Store users.

It now reads `kesha status --json`, a machine-readable payload added in kesha CLI 1.25.0.

Compatibility matters here because the CLI is installed by the user from npm/Homebrew and is versioned independently of this extension, so a given machine can have an older one. A CLI too old for the flag prints its usual human output instead (the CLI's arg parser ignores unknown flags), which is the signal to fall back to the previous text check. The fallback is selected by the *kind* of output rather than by whether parsing succeeded — output that is JSON but does not satisfy the contract is reported as a CLI/extension version mismatch instead of being passed to the text match, which would have missed its marker and reported a missing engine as healthy.

Two behaviour improvements come with it:

- An engine that is installed but cannot report its capabilities (corrupt or incompatible binary) is now refused before recording starts, instead of capturing audio that could never be transcribed.
- The finish-setup view names the remedy that matches the actual problem — completing a first install, repairing a broken one, or updating a version-skewed CLI — rather than one message for all three.

`tests/helpers/async.ts` picks up a `waitFor` helper that the updated controller test depends on.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` — it completes cleanly
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder

## Verification

Run in `extensions/kesha-voice-kit`:

- `npm test` — 91 passed
- `npm run lint` — clean
- `npm run build` — built successfully

The probe's behaviour is covered case by case in `tests/kesha-bin-status-json.test.ts`: structured payload for an installed / missing / unusable engine, contract-breaking JSON, an older CLI's text output with and without the marker, and empty or malformed output, which stays permissive so the CLI's own error reporting takes over.

One caveat I would rather state than imply: this change was verified through the automated suite and the build, **not** by driving a dictation session in the Raycast app against all four setup states — reproducing a corrupt-but-present engine and a version-skewed CLI by hand is awkward. The affected code paths are the preflight decision and the copy shown in the setup view; the recording, transcription, and clipboard paths are untouched. Happy to do a manual pass on anything specific a reviewer wants covered.