### PR TITLE
fix(mutedeck): accept `call: "inactive"` so commands work outside a meeting

### DIFF
--- a/extensions/mutedeck/CHANGELOG.md
+++ b/extensions/mutedeck/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Fix commands failing when not in a meeting] - {PR_MERGE_DATE}
+
+- Fixed all four commands failing with "Invalid API response format" whenever no meeting was active. MuteDeck 4.x reports `call: "inactive"`, but the status validator only accepted `call` being absent or `"active"`, so `getStatus()` threw before any command could run.
+- Unrecognized `control` platforms are now logged and allowed through instead of failing validation, so a future MuteDeck release adding a conference app cannot break every command the same way. A non-string `control` is still rejected.
+
 ## [Initial Version] - 2025-03-02
 
 - Initial version of the MuteDeck extension

--- a/extensions/mutedeck/CHANGELOG.md
+++ b/extensions/mutedeck/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Fix commands failing when not in a meeting] - {PR_MERGE_DATE}
+## [Fix commands failing when not in a meeting] - 2026-08-03
 
 - Fixed all four commands failing with "Invalid API response format" whenever no meeting was active. MuteDeck 4.x reports `call: "inactive"`, but the status validator only accepted `call` being absent or `"active"`, so `getStatus()` threw before any command could run.
 - Unrecognized `control` platforms are now logged and allowed through instead of failing validation, so a future MuteDeck release adding a conference app cannot break every command the same way. A non-string `control` is still rejected.

--- a/extensions/mutedeck/package.json
+++ b/extensions/mutedeck/package.json
@@ -127,5 +127,8 @@
     "lint": "ray lint",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/mutedeck/src/utils/api.ts
+++ b/extensions/mutedeck/src/utils/api.ts
@@ -19,14 +19,19 @@ export interface MuteDeckPreferences {
 export const getPreferences = getPreferenceValues<MuteDeckPreferences>;
 
 // API Response Types
-export type CallStatus = "active";
+// MuteDeck reports "inactive" when no meeting is detected. Treating "inactive"
+// as invalid caused every command to fail outside a meeting (MuteDeck >= 4.x).
+export type CallStatus = "active" | "inactive";
+/** Platforms MuteDeck is known to report. It may add more at any time. */
 export type ControlSystem = "system" | "zoom" | "webex" | "teams" | "google-meet";
 export type ActiveStatus = "active" | "inactive";
 export type FeatureStatus = "active" | "inactive" | "disabled";
 
 export interface MuteDeckStatus {
   call?: CallStatus;
-  control?: ControlSystem;
+  /** A {@link ControlSystem} when recognized. Typed as string because MuteDeck
+   * can introduce new platforms, and an unknown one must not fail validation. */
+  control?: string;
   mute: ActiveStatus;
   video: FeatureStatus;
   share: FeatureStatus;
@@ -78,7 +83,7 @@ function isValidFeatureStatus(value: unknown): value is FeatureStatus {
   return value === "active" || value === "inactive" || value === "disabled";
 }
 
-function isValidControlSystem(value: unknown): value is ControlSystem {
+function isKnownControlSystem(value: unknown): value is ControlSystem {
   return value === "system" || value === "zoom" || value === "webex" || value === "teams" || value === "google-meet";
 }
 
@@ -107,8 +112,15 @@ function isValidMuteDeckStatus(value: unknown): value is MuteDeckStatus {
   if (!isValidFeatureStatus(status.record)) return false;
 
   // Optional fields
-  if (status.call !== undefined && status.call !== "active") return false;
-  if (status.control !== undefined && !isValidControlSystem(status.control)) return false;
+  if (status.call !== undefined && !isValidActiveStatus(status.call)) return false;
+  // Warn-and-continue: an unrecognized platform is surfaced in the logs but must
+  // not fail the whole response, or every command breaks on a MuteDeck update.
+  if (status.control !== undefined) {
+    if (typeof status.control !== "string") return false;
+    if (!isKnownControlSystem(status.control)) {
+      console.warn(`MuteDeck reported an unrecognized control system: ${status.control}`);
+    }
+  }
 
   return true;
 }


### PR DESCRIPTION
## Description

Every MuteDeck command has been failing with **"Invalid API response format"** whenever no meeting is active.

`isValidMuteDeckStatus` treats `call` as *optional, and if present, only ever `"active"`*:

```ts
export type CallStatus = "active";
...
if (status.call !== undefined && status.call !== "active") return false;
```

MuteDeck 4.x reports `call: "inactive"` when it detects no meeting, so the validator rejects the response, `getStatus()` throws, and — because all four commands call `getStatus()` before doing anything — every command fails. It only breaks *outside* a meeting, which is what made it look intermittent.

Reproduced against a live MuteDeck 4.9.2 instance on `http://localhost:3491/v1/status`:

```json
{"call":"inactive","control":"system","mute":"inactive","record":"disabled",
 "share":"disabled","status":200,"teams_api":"disabled","version":"4.9.2","video":"disabled"}
```

Running the extension's own validator against that payload returns `false` on the `call` check. Delete the `call` key, or set it to `"active"`, and it passes — confirming that single line as the cause.

### Changes

1. **`CallStatus` now admits `"inactive"`**, and the check delegates to the existing `isValidActiveStatus` helper.
2. **`control` is relaxed to warn-and-continue.** It was validated against a closed set (`system | zoom | webex | teams | google-meet`), so the next conference app MuteDeck supports would break every command in exactly the same way. Unknown platforms are now logged and allowed through. A non-string `control` is still rejected.

Nothing else changed — no dependency bumps, no refactoring.

### Verification

A 21-assertion harness covering the live payload and the full status matrix:

- Accepts: live MuteDeck 4.9.2 payload, in-meeting (zoom / teams presenting + recording), legacy payloads with no `call` key, and an unknown future platform.
- Still rejects: garbage `call` values, non-string `control`, missing `mute`, non-numeric `status`, and `null`.

`tsc --noEmit` is clean and `prettier --check` passes against this extension's `.prettierrc`.

## Screencast

Straightforward validation fix with no UI change. Before: every command showed "Failed to Get Status — Invalid API response format" outside a meeting. After: Show Status correctly reports MuteDeck as Running / Not in Meeting, and the toggle commands work.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
