### PR TITLE
Add JobYap to MCP registry (official)

### DIFF
--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Model Context Protocol Registry Changelog
 
-## [Add JobYap MCP Server] - {PR_MERGE_DATE}
+## [Add JobYap MCP Server] - 2026-08-03
 
 Add JobYap to the official registry: search job postings aggregated from companies' official careers sites — salaries, locations, and a community discussion thread on every job. Remote Streamable HTTP MCP server via mcp-remote; no auth required.
 

--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Model Context Protocol Registry Changelog
 
+## [Add JobYap MCP Server] - {PR_MERGE_DATE}
+
+Add JobYap to the official registry: search job postings aggregated from companies' official careers sites — salaries, locations, and a community discussion thread on every job. Remote Streamable HTTP MCP server via mcp-remote; no auth required.
+
 ## [Add Webhound MCP Server] - 2026-07-29
 
 Add Webhound to the official registry for private, budgeted reports and datasets. The remote Streamable HTTP MCP server uses OAuth so each connection authenticates to that user's own Webhound account.

--- a/extensions/model-context-protocol-registry/README.md
+++ b/extensions/model-context-protocol-registry/README.md
@@ -83,6 +83,7 @@ To add a new MCP registry to the registry, you need to create a new entry in the
 | [Appwrite](https://github.com/appwrite/mcp) | The official Appwrite MCP server lets AI assistants securely inspect and manage Appwrite projects and resources through Appwrite's API. |
 | [Agentcard](https://agentcard.sh) | Prepaid virtual cards for AI agents. Fund a wallet, set spend caps and human approvals, and your agent mints a one-time virtual card for each purchase that works at any merchant. Connects to the remote Agentcard MCP server over OAuth 2.0. |
 | [UseMyContext](https://usemycontext.ai) | The personal context layer for AI: one user-owned profile plus files, read by any MCP client so you never re-introduce yourself. 8 tools for profile, file search and reads, cited answers from your documents, and exact table queries. Connects to the remote UseMyContext server over OAuth 2.1. |
+| [JobYap](https://jobyap.com/agents) | Search job postings aggregated from companies' official careers sites — salaries, locations, and a community discussion thread on every job. Remote Streamable HTTP MCP server; no auth required. |
 
 ### Community MCP Servers
 

--- a/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
+++ b/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
@@ -799,6 +799,18 @@ export const OFFICIAL_ENTRIES: RegistryEntry[] = [
       args: ["-y", "mcp-remote", "https://mcp.usemycontext.ai/mcp"],
     },
   },
+  {
+    name: "jobyap",
+    title: "JobYap",
+    description:
+      "Search job postings aggregated from companies' official careers sites — salaries, locations, and a community discussion thread on every job. Remote Streamable HTTP MCP server; no auth required.",
+    icon: "https://raw.githubusercontent.com/jobyap/agent-skills/main/assets/logo.png",
+    homepage: "https://jobyap.com/agents",
+    configuration: {
+      command: "npx",
+      args: ["-y", "mcp-remote", "https://mcp.jobyap.com/mcp"],
+    },
+  },
 ];
 
 export const COMMUNITY_ENTRIES: RegistryEntry[] = [


### PR DESCRIPTION
## Description

Adds JobYap to the extension's official MCP server registry (`OFFICIAL_ENTRIES`).

JobYap aggregates job postings from companies' official careers sites and attaches a community discussion thread to every posting. The remote Streamable HTTP MCP server at `https://mcp.jobyap.com/mcp` is read-only, requires no auth, and exposes tools for searching jobs, fetching a job, reading comments, searching locations, listing companies, and job stats.

- Site: https://jobyap.com
- Agent docs: https://jobyap.com/agents
- MCP endpoint: https://mcp.jobyap.com/mcp
- Official MCP Registry: `com.jobyap/jobs`
- Public repo (MIT): https://github.com/jobyap/agent-skills

## Changes

- `src/registries/builtin/entries.ts`: new `OFFICIAL_ENTRIES` remote entry via `npx -y mcp-remote https://mcp.jobyap.com/mcp`
- `README.md`: registry table row under Official MCP Servers
- `CHANGELOG.md`: changelog entry with `{PR_MERGE_DATE}` placeholder

## Screencast

N/A ? data-only registry entry (same class of change as other MCP server additions).

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration) ? not applicable for a registry-data-only change; configuration mirrors existing remote `mcp-remote` entries (e.g. Jellypod)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

## Notes

- Only the `model-context-protocol-registry` extension is modified; no code changes, data-only diff.
- Icon: https://raw.githubusercontent.com/jobyap/agent-skills/main/assets/logo.png
- Disclosure: I maintain JobYap.
