### PR TITLE
Fix VoiceInk render tree JSON failures

### DIFF
--- a/extensions/voiceink/CHANGELOG.md
+++ b/extensions/voiceink/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Render Stability] - 2026-08-03
+
+- Prevent large transcription histories from overflowing Raycast's render payload
+- Use Raycast's native SQLite utility and show database errors instead of silently returning an empty history
+- Support the current database schemas used by both VoiceInk Official and VoiceInk CE
+
 ## [Initial Release] - 2026-02-20
 
 - Browse and search through transcription history with multi-word matching

--- a/extensions/voiceink/CHANGELOG.md
+++ b/extensions/voiceink/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Render Stability] - 2026-08-03
+## [Render Stability] - {PR_MERGE_DATE}
 
 - Prevent large transcription histories from overflowing Raycast's render payload
 - Use Raycast's native SQLite utility and show database errors instead of silently returning an empty history

--- a/extensions/voiceink/CHANGELOG.md
+++ b/extensions/voiceink/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Render Stability] - {PR_MERGE_DATE}
+## [Render Stability] - 2026-08-03
 
 - Prevent large transcription histories from overflowing Raycast's render payload
 - Use Raycast's native SQLite utility and show database errors instead of silently returning an empty history

--- a/extensions/voiceink/src/components/TranscriptionDetail.tsx
+++ b/extensions/voiceink/src/components/TranscriptionDetail.tsx
@@ -1,4 +1,4 @@
-import { Action, ActionPanel, Detail } from "@raycast/api";
+import { Action, ActionPanel, Clipboard, Detail, Icon } from "@raycast/api";
 import type { Transcription } from "../lib/types";
 import { cfTimeToDate, formatDuration, getDisplayText } from "../lib/database";
 
@@ -32,15 +32,21 @@ export function TranscriptionDetail({ transcription }: Props) {
       }
       actions={
         <ActionPanel>
-          <Action.CopyToClipboard title="Copy Text" content={displayText} />
+          <Action title="Copy Text" icon={Icon.Clipboard} onAction={() => Clipboard.copy(displayText)} />
           {transcription.enhancedText && transcription.text !== transcription.enhancedText && (
-            <Action.CopyToClipboard
+            <Action
               title="Copy Original Text"
-              content={transcription.text}
+              icon={Icon.Clipboard}
+              onAction={() => Clipboard.copy(transcription.text)}
               shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
             />
           )}
-          <Action.Paste title="Paste Text" content={displayText} shortcut={{ modifiers: ["cmd", "shift"], key: "v" }} />
+          <Action
+            title="Paste Text"
+            icon={Icon.TextCursor}
+            onAction={() => Clipboard.paste(displayText)}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "v" }}
+          />
         </ActionPanel>
       }
     />

--- a/extensions/voiceink/src/components/TranscriptionItem.tsx
+++ b/extensions/voiceink/src/components/TranscriptionItem.tsx
@@ -1,4 +1,4 @@
-import { Action, ActionPanel, Icon, List, Color } from "@raycast/api";
+import { Action, ActionPanel, Clipboard, Color, Icon, List, useNavigation } from "@raycast/api";
 import type { Transcription } from "../lib/types";
 import { formatRelativeTime, getDisplayText, truncateText } from "../lib/database";
 import { TranscriptionDetail } from "./TranscriptionDetail";
@@ -8,6 +8,7 @@ interface Props {
 }
 
 export function TranscriptionItem({ transcription }: Props) {
+  const { push } = useNavigation();
   const displayText = getDisplayText(transcription);
   const hasEnhancement = Boolean(transcription.enhancedText && transcription.text !== transcription.enhancedText);
 
@@ -15,30 +16,32 @@ export function TranscriptionItem({ transcription }: Props) {
     <List.Item
       title={truncateText(displayText.replace(/\n/g, " "), 60)}
       subtitle={formatRelativeTime(transcription.timestamp)}
-      icon={transcription.powerModeEmoji || Icon.Message}
+      icon={Icon.Message}
       accessories={buildAccessories(transcription, hasEnhancement)}
       actions={
         <ActionPanel>
           <ActionPanel.Section>
-            <Action.CopyToClipboard title="Copy Text" content={displayText} />
+            <Action title="Copy Text" icon={Icon.Clipboard} onAction={() => Clipboard.copy(displayText)} />
             {hasEnhancement && (
-              <Action.CopyToClipboard
+              <Action
                 title="Copy Original Text"
-                content={transcription.text}
+                icon={Icon.Clipboard}
+                onAction={() => Clipboard.copy(transcription.text)}
                 shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
               />
             )}
-            <Action.Paste
+            <Action
               title="Paste Text"
-              content={displayText}
+              icon={Icon.TextCursor}
+              onAction={() => Clipboard.paste(displayText)}
               shortcut={{ modifiers: ["cmd", "shift"], key: "v" }}
             />
           </ActionPanel.Section>
           <ActionPanel.Section>
-            <Action.Push
+            <Action
               title="View Details"
               icon={Icon.Eye}
-              target={<TranscriptionDetail transcription={transcription} />}
+              onAction={() => push(<TranscriptionDetail transcription={transcription} />)}
               shortcut={{ modifiers: ["cmd"], key: "d" }}
             />
           </ActionPanel.Section>

--- a/extensions/voiceink/src/lib/database.ts
+++ b/extensions/voiceink/src/lib/database.ts
@@ -99,7 +99,14 @@ export function formatDuration(seconds: number): string {
   return `${mins}m ${secs}s`;
 }
 
-export function buildQuery(limit: number, searchTerm?: string): string {
+export function buildQuery(limit: number, searchTerm?: string, source: DatabaseInfo["source"] = "custom"): string {
+  const modeColumns =
+    source === "official"
+      ? "ZPOWERMODENAME as powerModeName, ZPOWERMODEEMOJI as powerModeEmoji"
+      : source === "ce"
+        ? "ZMODENAME as powerModeName, ZMODEEMOJI as powerModeEmoji"
+        : "NULL as powerModeName, NULL as powerModeEmoji";
+
   const baseQuery = `
     SELECT
       hex(ZID) as id,
@@ -108,8 +115,7 @@ export function buildQuery(limit: number, searchTerm?: string): string {
       ZTIMESTAMP as timestamp,
       ZDURATION as duration,
       ZTRANSCRIPTIONMODELNAME as modelName,
-      ZPOWERMODENAME as powerModeName,
-      ZPOWERMODEEMOJI as powerModeEmoji
+      ${modeColumns}
     FROM ZTRANSCRIPTION
     WHERE ZTRANSCRIPTIONSTATUS = 'completed'
   `;
@@ -130,27 +136,20 @@ export function buildQuery(limit: number, searchTerm?: string): string {
 }
 
 function escapeSqlString(str: string): string {
-  return str.replace(/'/g, "''").replace(/%/g, "\\%").replace(/_/g, "\\_");
+  return str.replace(/\\/g, "\\\\").replace(/'/g, "''").replace(/%/g, "\\%").replace(/_/g, "\\_");
 }
 
-export function parseTranscriptions(stdout: string): Transcription[] {
-  if (!stdout.trim()) return [];
-
-  try {
-    const rows: Transcription[] = JSON.parse(stdout);
-    return rows.map((row) => ({
-      id: row.id,
-      text: row.text || "",
-      enhancedText: row.enhancedText,
-      timestamp: row.timestamp,
-      duration: row.duration || 0,
-      modelName: row.modelName,
-      powerModeName: row.powerModeName,
-      powerModeEmoji: row.powerModeEmoji,
-    }));
-  } catch {
-    return [];
-  }
+export function normalizeTranscriptions(rows: Transcription[]): Transcription[] {
+  return rows.map((row) => ({
+    id: row.id,
+    text: row.text || "",
+    enhancedText: row.enhancedText,
+    timestamp: row.timestamp,
+    duration: row.duration || 0,
+    modelName: row.modelName,
+    powerModeName: row.powerModeName,
+    powerModeEmoji: row.powerModeEmoji,
+  }));
 }
 
 export function truncateText(text: string, maxLength: number): string {

--- a/extensions/voiceink/src/lib/database.ts
+++ b/extensions/voiceink/src/lib/database.ts
@@ -47,10 +47,15 @@ export function getDatabaseInfo(): DatabaseInfo {
     case "custom":
       if (prefs.customDatabasePath) {
         const customPath = expandTilde(prefs.customDatabasePath);
+        const customSource = customPath.includes("com.prakashjoshipax.VoiceInk")
+          ? "official"
+          : customPath.includes("com.metrovoc.VoiceInk")
+            ? "ce"
+            : "custom";
         return {
           path: customPath,
           available: existsSync(customPath),
-          source: "custom",
+          source: customSource,
         };
       }
       return { path: "", available: false, source: "none" };

--- a/extensions/voiceink/src/search-transcriptions.tsx
+++ b/extensions/voiceink/src/search-transcriptions.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
-import { Action, ActionPanel, List, showToast, Toast, Icon, openExtensionPreferences } from "@raycast/api";
-import { useExec } from "@raycast/utils";
-import { getDatabaseInfo, buildQuery, parseTranscriptions } from "./lib/database";
+import { Action, ActionPanel, List, Icon, openExtensionPreferences } from "@raycast/api";
+import { useSQL } from "@raycast/utils";
+import { getDatabaseInfo, buildQuery, normalizeTranscriptions } from "./lib/database";
+import type { Transcription } from "./lib/types";
 import { TranscriptionItem } from "./components/TranscriptionItem";
 
 const DISPLAY_LIMIT = 100;
@@ -10,19 +11,20 @@ export default function SearchTranscriptions() {
   const [searchText, setSearchText] = useState("");
   const dbInfo = getDatabaseInfo();
 
-  const query = buildQuery(DISPLAY_LIMIT, searchText || undefined);
+  const query = buildQuery(DISPLAY_LIMIT, searchText || undefined, dbInfo.source);
+  const queryDatabasePath = dbInfo.available ? dbInfo.path : "/dev/null";
 
-  const { isLoading, data } = useExec("sqlite3", ["-json", "-readonly", dbInfo.path, query], {
+  const { isLoading, data, error, permissionView } = useSQL<Transcription>(queryDatabasePath, query, {
     execute: dbInfo.available,
-    parseOutput: ({ stdout }) => parseTranscriptions(stdout),
-    onError: (error) => {
-      showToast({
-        style: Toast.Style.Failure,
-        title: "Failed to load transcriptions",
-        message: error.message,
-      });
+    permissionPriming: "VoiceInk stores your transcription history in a local database.",
+    failureToastOptions: {
+      title: "Failed to load transcriptions",
     },
   });
+
+  if (permissionView) {
+    return permissionView;
+  }
 
   if (!dbInfo.available) {
     return (
@@ -41,7 +43,7 @@ export default function SearchTranscriptions() {
     );
   }
 
-  const transcriptions = data || [];
+  const transcriptions = normalizeTranscriptions(data || []);
 
   return (
     <List
@@ -51,7 +53,9 @@ export default function SearchTranscriptions() {
       searchBarPlaceholder="Search transcriptions..."
       throttle
     >
-      {transcriptions.length === 0 && !isLoading ? (
+      {error ? (
+        <List.EmptyView icon={Icon.Warning} title="Unable to Read Transcriptions" description={error.message} />
+      ) : transcriptions.length === 0 && !isLoading ? (
         <List.EmptyView
           icon={searchText ? Icon.MagnifyingGlass : Icon.Message}
           title={searchText ? "No Results" : "No Transcriptions"}


### PR DESCRIPTION
## Description

Fixes the recurring `Cannot parse render tree JSON` error reported by Raycast for VoiceInk.

The transcription list previously embedded full transcription text in Copy/Paste action props and eagerly constructed every detail view. With up to 100 history entries, that duplicated large strings throughout Raycast's serialized render tree. The actions now use callbacks and details are pushed lazily.

This update also replaces the external `sqlite3 -json` process with Raycast's native `useSQL` hook, surfaces database errors instead of silently returning an empty history, and supports the current column names used by both VoiceInk Official and VoiceInk CE.

Issue: https://www.raycast.com/extension-issues/metrovoc/voiceink/7357622915

## Verification

- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- Real database queries against VoiceInk Official and VoiceInk CE
- Search escaping for `%`, `_`, backslashes, single quotes, and multi-word input
- Independent subagent review of hooks, SQL schemas, actions, error handling, and render payload behavior
- Distribution build tested with a 100-item transcription history

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
