### PR TITLE
fix(espanso): resolve the binary by probing absolute paths

### DIFF
--- a/extensions/espanso/CHANGELOG.md
+++ b/extensions/espanso/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Espanso Changelog
 
+## [Fix Espanso binary not being found] - {PR_MERGE_DATE}
+
+### Bug Fixes
+
+- Fixed all commands failing with `Failed to run 'espanso path'` when the Espanso Binary Path preference was left empty. Raycast is launched by launchd and so inherits `PATH=/usr/bin:/bin:/usr/sbin:/sbin`, which contains neither Homebrew prefix — a bare `espanso` could never resolve there. The binary is now located by probing `/opt/homebrew/bin/espanso`, `/usr/local/bin/espanso`, and the `Espanso.app` bundle, so the extension works out of the box on both Apple Silicon and Intel, and with a Homebrew-less install. Setting the preference still overrides the probe, and surrounding whitespace in it is now ignored.
+
 ## [Fix Search Matches memory usage] - 2026-05-28
 
 - Reduced Search Matches memory usage by loading replacement previews only for the selected match.

--- a/extensions/espanso/CHANGELOG.md
+++ b/extensions/espanso/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Espanso Changelog
 
-## [Fix Espanso binary not being found] - {PR_MERGE_DATE}
+## [Fix Espanso binary not being found] - 2026-08-03
 
 ### Bug Fixes
 

--- a/extensions/espanso/src/lib/utils.test.ts
+++ b/extensions/espanso/src/lib/utils.test.ts
@@ -33,7 +33,9 @@ vi.mock("fs-extra", () => ({
 }));
 
 // Import after mocks are in place
-import { updateMatchInFile } from "./utils";
+import fse from "fs-extra";
+import { getPreferenceValues } from "@raycast/api";
+import { getEspansoCmd, updateMatchInFile } from "./utils";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -328,5 +330,67 @@ describe("updateMatchInFile", () => {
         replace: "bar",
       }),
     ).toThrow(/No 'matches' sequence/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEspansoCmd — binary resolution
+// ---------------------------------------------------------------------------
+
+describe("getEspansoCmd", () => {
+  const onlyExisting = (...paths: string[]) =>
+    vi.mocked(fse.existsSync).mockImplementation((p) => paths.includes(String(p)));
+
+  beforeEach(() => {
+    vi.mocked(getPreferenceValues).mockReturnValue({});
+    onlyExisting();
+  });
+
+  it("prefers the configured preference over any installed binary", () => {
+    vi.mocked(getPreferenceValues).mockReturnValue({ espansoPath: "/custom/espanso" });
+    onlyExisting("/opt/homebrew/bin/espanso");
+
+    expect(getEspansoCmd()).toBe("/custom/espanso");
+  });
+
+  it("trims whitespace around the configured preference", () => {
+    vi.mocked(getPreferenceValues).mockReturnValue({ espansoPath: "  /custom/espanso  " });
+
+    expect(getEspansoCmd()).toBe("/custom/espanso");
+  });
+
+  it("ignores a blank preference and probes instead", () => {
+    vi.mocked(getPreferenceValues).mockReturnValue({ espansoPath: "   " });
+    onlyExisting("/opt/homebrew/bin/espanso");
+
+    expect(getEspansoCmd()).toBe("/opt/homebrew/bin/espanso");
+  });
+
+  it("finds the Intel Homebrew location when Apple Silicon's is absent", () => {
+    onlyExisting("/usr/local/bin/espanso");
+
+    expect(getEspansoCmd()).toBe("/usr/local/bin/espanso");
+  });
+
+  it("falls back to the app bundle when Homebrew is not installed at all", () => {
+    onlyExisting("/Applications/Espanso.app/Contents/MacOS/espanso");
+
+    expect(getEspansoCmd()).toBe("/Applications/Espanso.app/Contents/MacOS/espanso");
+  });
+
+  it("prefers Apple Silicon Homebrew when several candidates exist", () => {
+    onlyExisting(
+      "/opt/homebrew/bin/espanso",
+      "/usr/local/bin/espanso",
+      "/Applications/Espanso.app/Contents/MacOS/espanso",
+    );
+
+    expect(getEspansoCmd()).toBe("/opt/homebrew/bin/espanso");
+  });
+
+  // Raycast's PATH cannot resolve a bare name, so this is a last resort that
+  // surfaces a clear error rather than a silent wrong path.
+  it("returns the bare command when nothing is found on disk", () => {
+    expect(getEspansoCmd()).toBe("espanso");
   });
 });

--- a/extensions/espanso/src/lib/utils.ts
+++ b/extensions/espanso/src/lib/utils.ts
@@ -85,9 +85,23 @@ export function formatCategoryName(category: string, separator: string = " · ")
   return formatted;
 }
 
+// Raycast is launched by launchd, so extensions inherit launchd's PATH —
+// /usr/bin:/bin:/usr/sbin:/sbin — and never the interactive shell's. Homebrew's
+// bin is not on it, so a bare `espanso` is unresolvable no matter how the user's
+// zsh is set up. Probing absolute locations is the only lookup that works here.
+//
+// The app bundle comes last but matters most: it is what the Homebrew symlink
+// points at, and it is the only path that survives a Homebrew-less install.
+const ESPANSO_CANDIDATES = [
+  "/opt/homebrew/bin/espanso",
+  "/usr/local/bin/espanso",
+  "/Applications/Espanso.app/Contents/MacOS/espanso",
+];
+
 export function getEspansoCmd(): string {
   const { espansoPath } = getPreferenceValues<{ espansoPath?: string }>();
-  return espansoPath && espansoPath.trim() !== "" ? espansoPath : "espanso";
+  if (espansoPath && espansoPath.trim() !== "") return espansoPath.trim();
+  return ESPANSO_CANDIDATES.find((candidate) => fse.existsSync(candidate)) ?? "espanso";
 }
 
 export const execPromise = promisify(exec);


### PR DESCRIPTION
## Description

Fixes all Espanso commands failing with `Failed to run 'espanso path'` when the **Espanso Binary Path** preference is left empty — which is the default.

`getEspansoCmd()` fell back to a bare `"espanso"` and relied on `PATH` to resolve it. That cannot work inside Raycast: Raycast is launched by launchd, so its Node subprocesses inherit launchd's `PATH`, not the user's shell `PATH`. Verified on an affected machine by reading the live process environment:

```
$ ps eww -p $(pgrep -x Raycast) | tr ' ' '\n' | grep '^PATH='
PATH=/usr/bin:/bin:/usr/sbin:/sbin
```

Neither `/opt/homebrew/bin` nor `/usr/local/bin` is present, so a bare `espanso` is unresolvable regardless of how the user's shell is configured. `execSync` goes through `/bin/sh -c`, which reads no shell rc files, so nothing restores the missing entries.

The binary is now located by probing absolute candidates:

```
/opt/homebrew/bin/espanso                          (Homebrew, Apple Silicon)
/usr/local/bin/espanso                             (Homebrew, Intel)
/Applications/Espanso.app/Contents/MacOS/espanso   (app bundle)
```

The app bundle is last but is the one that always exists — the Homebrew entries are symlinks into it — so this also covers installs without Homebrew. Homebrew paths are probed first so that a deliberately brew-installed espanso wins over a stale `.app`.

Setting the preference still overrides the probe entirely, and surrounding whitespace in it is now trimmed. The bare-name fallback is kept as a last resort so that a genuinely missing install produces a clear error rather than a silently wrong path.

### Verification

- `npm test` — 18 passed (11 existing, 7 new covering preference precedence, whitespace trimming, both Homebrew prefixes, the app-bundle fallback, candidate ordering, and the no-install case)
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run build` — succeeds
- Runtime check under a stripped `PATH=/usr/bin:/bin:/usr/sbin:/sbin`: the old bare-name call fails with `Command failed: espanso path`, while the probed path returns the real `Config:` / `Packages:` / `Runtime:` output that `getEspansoConfig()` parses.

## Screencast

Not included — this is a behavioural fix with no UI change. The observable difference is that the extension's commands work on a default install instead of erroring, without the user first having to discover and fill in the binary-path preference.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

