### PR TITLE
Kesha Voice Kit: make the silence auto-stop actually fire

### DIFF
--- a/extensions/kesha-voice-kit/CHANGELOG.md
+++ b/extensions/kesha-voice-kit/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Kesha Voice Kit Changelog
 
-## [Silence auto-stop now works] - {PR_MERGE_DATE}
+## [Silence auto-stop now works] - 2026-08-08
 
 - Stop a dictation session after the idle period as documented. The check for whether anyone is speaking used a level 800x below any real room's noise floor, so every microphone counted as speech and the session always ran to the full maximum duration unless stopped by hand.
 - Show a signal level that matches what you hear: a silent room read about 30% before.

--- a/extensions/kesha-voice-kit/CHANGELOG.md
+++ b/extensions/kesha-voice-kit/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Stop a dictation session after the idle period as documented. The check for whether anyone is speaking used a level 800x below any real room's noise floor, so every microphone counted as speech and the session always ran to the full maximum duration unless stopped by hand.
 - Show a signal level that matches what you hear: a silent room read about 30% before.
+- Measure the level from the loudest input channel rather than the average of all of them, so a microphone plugged into one input of a multi-channel audio interface is no longer read as 30% quieter than it is and cut off mid-sentence.
 
 ## [Sturdier setup detection] - 2026-08-03
 

--- a/extensions/kesha-voice-kit/CHANGELOG.md
+++ b/extensions/kesha-voice-kit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Kesha Voice Kit Changelog
 
+## [Silence auto-stop now works] - {PR_MERGE_DATE}
+
+- Stop a dictation session after the idle period as documented. The check for whether anyone is speaking used a level 800x below any real room's noise floor, so every microphone counted as speech and the session always ran to the full maximum duration unless stopped by hand.
+- Show a signal level that matches what you hear: a silent room read about 30% before.
+
 ## [Sturdier setup detection] - 2026-08-03
 
 - Detect whether the engine is installed from the CLI's machine-readable status output instead of matching its wording, so a reworded CLI message can no longer be mistaken for a broken install. Older CLIs keep working through the previous check.

--- a/extensions/kesha-voice-kit/src/lib/dictation-config.ts
+++ b/extensions/kesha-voice-kit/src/lib/dictation-config.ts
@@ -1,7 +1,11 @@
 export const DEFAULT_MAX_SECONDS = 300;
 export const MAX_ALLOWED_SECONDS = 3600;
-export const SILENCE_PEAK_THRESHOLD = 0.0001;
 export const METER_INTERVAL_MS = 500;
+// -80 dBFS: a test for digital silence in a recorded file, never for speech (#648).
+export const SILENCE_PEAK_THRESHOLD = 0.0001;
+
+// Sits between a quiet room's rms p90 (0.0075) and speech p50 (0.0097) (#648).
+export const SPEECH_RMS_THRESHOLD = 0.01;
 export const IDLE_WARN_MS = 30_000;
 export const IDLE_STOP_GRACE_MS = 15_000;
 export const NO_SIGNAL_TIMEOUT_MS = 8_000;

--- a/extensions/kesha-voice-kit/src/lib/signal-meter.ts
+++ b/extensions/kesha-voice-kit/src/lib/signal-meter.ts
@@ -1,6 +1,6 @@
 import { spawn as defaultSpawn } from "node:child_process";
 import type { ChildProcess } from "node:child_process";
-import { SILENCE_PEAK_THRESHOLD } from "./dictation-config";
+import { SPEECH_RMS_THRESHOLD } from "./dictation-config";
 import type { SignalLevel } from "./dictation-types";
 import { emptySignal } from "./recording-view";
 import { numberValue } from "./mic-info";
@@ -41,8 +41,7 @@ input.installTap(onBus: 0, bufferSize: 2048, format: format) { buffer, _ in
   }
 
   let rms = sqrt(sum / Float(max(count, 1)))
-  let percent = min(100, Int(max(sqrt(peak) * 100, rms * 600).rounded()))
-  print("{\\"rms\\":\\(rms),\\"peak\\":\\(peak),\\"percent\\":\\(percent)}")
+  print("{\\"rms\\":\\(rms),\\"peak\\":\\(peak)}")
   fflush(stdout)
 }
 
@@ -61,14 +60,24 @@ interface LiveMicMeterDeps {
   setTimeout?: typeof setTimeout;
 }
 
+// dBFS, not sqrt(peak) — the square root rendered a silent room at ~30% (#648).
+export function percentFromPeak(peak: number): number {
+  if (peak <= 0) return 0;
+  const dbfs = 20 * Math.log10(peak);
+  return Math.max(0, Math.min(100, Math.round(((dbfs + 50) / 50) * 100)));
+}
+
 export function parseMeterLine(line: string): SignalLevel | null {
   try {
     const parsed = JSON.parse(line) as Partial<SignalLevel>;
     const rms = numberValue(parsed.rms) ?? 0;
     const peak = numberValue(parsed.peak) ?? 0;
-    const percent = Math.max(0, Math.min(100, Math.round(parsed.percent ?? 0)));
-    const active = peak > SILENCE_PEAK_THRESHOLD || percent > 0;
-    return { rms, peak, percent, state: active ? "signal" : "listening" };
+    return {
+      rms,
+      peak,
+      percent: percentFromPeak(peak),
+      state: rms > SPEECH_RMS_THRESHOLD ? "signal" : "listening",
+    };
   } catch {
     return null;
   }

--- a/extensions/kesha-voice-kit/src/lib/signal-meter.ts
+++ b/extensions/kesha-voice-kit/src/lib/signal-meter.ts
@@ -25,23 +25,22 @@ input.installTap(onBus: 0, bufferSize: 2048, format: format) { buffer, _ in
   let frameCount = Int(buffer.frameLength)
   if channelCount == 0 || frameCount == 0 { return }
 
-  var sum: Float = 0
   var peak: Float = 0
-  var count = 0
+  var channelRms: [Float] = []
 
   for channel in 0..<channelCount {
     let samples = channels[channel]
+    var sum: Float = 0
     for frame in 0..<frameCount {
       let sample = samples[frame]
-      let absolute = abs(sample)
       sum += sample * sample
-      peak = max(peak, absolute)
-      count += 1
+      peak = max(peak, abs(sample))
     }
+    channelRms.append(sqrt(sum / Float(frameCount)))
   }
 
-  let rms = sqrt(sum / Float(max(count, 1)))
-  print("{\\"rms\\":\\(rms),\\"peak\\":\\(peak)}")
+  let levels = channelRms.map { "\\($0)" }.joined(separator: ",")
+  print("{\\"channelRms\\":[\\(levels)],\\"peak\\":\\(peak)}")
   fflush(stdout)
 }
 
@@ -67,10 +66,21 @@ export function percentFromPeak(peak: number): number {
   return Math.max(0, Math.min(100, Math.round(((dbfs + 50) / 50) * 100)));
 }
 
+// The loudest channel, never the pooled average: a multi-input device leaves its
+// unconnected channels digitally silent, and averaging those in divides real
+// speech by sqrt(channelCount) — enough to read 2-channel speech as silence.
+export function loudestChannelRms(levels: unknown): number {
+  if (!Array.isArray(levels)) return 0;
+  return levels.reduce<number>(
+    (loudest, level) => Math.max(loudest, numberValue(level) ?? 0),
+    0,
+  );
+}
+
 export function parseMeterLine(line: string): SignalLevel | null {
   try {
-    const parsed = JSON.parse(line) as Partial<SignalLevel>;
-    const rms = numberValue(parsed.rms) ?? 0;
+    const parsed = JSON.parse(line) as { channelRms?: unknown; peak?: unknown };
+    const rms = loudestChannelRms(parsed.channelRms);
     const peak = numberValue(parsed.peak) ?? 0;
     return {
       rms,

--- a/extensions/kesha-voice-kit/tests/signal-meter.test.ts
+++ b/extensions/kesha-voice-kit/tests/signal-meter.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   parseMeterChunk,
   parseMeterLine,
+  percentFromPeak,
   startLiveMicMeter,
 } from "../src/lib/signal-meter";
 import type { DictationState, SignalLevel } from "../src/lib/dictation-types";
@@ -21,46 +22,44 @@ import type { spawn } from "node:child_process";
 import { FakeProcess } from "./helpers/fake-process";
 
 describe("signal parsing", () => {
-  it("parses valid meter JSON into listening and signal states", () => {
-    expect(parseMeterLine('{"rms":0,"peak":0,"percent":0}')).toMatchObject({
-      state: "listening",
-      percent: 0,
-    });
-    expect(
-      parseMeterLine('{"rms":0.01,"peak":0.04,"percent":20}'),
-    ).toMatchObject({
-      state: "signal",
-      percent: 20,
-    });
+  // Thresholds are the rms percentiles measured on a built-in mic (#648).
+  it("separates a quiet room from speech", () => {
+    expect(parseMeterLine('{"rms":0.0075,"peak":0.02}')?.state).toBe("listening");
+    expect(parseMeterLine('{"rms":0.0021,"peak":0.0085}')?.state).toBe("listening");
+    expect(parseMeterLine('{"rms":0.0352,"peak":0.09}')?.state).toBe("signal");
+    expect(parseMeterLine('{"rms":0.012,"peak":0.03}')?.state).toBe("signal");
   });
 
-  it("ignores invalid lines and clamps percent", () => {
+  it("keeps a noisy room audible rather than cutting the speaker off", () => {
+    // Auto-stop then never fires there — today's behaviour, and the safe way to be wrong.
+    expect(parseMeterLine('{"rms":0.027,"peak":0.078}')?.state).toBe("signal");
+  });
+
+  it("ignores invalid lines", () => {
     expect(parseMeterLine("nope")).toBeNull();
-    expect(parseMeterLine('{"rms":0,"peak":0,"percent":999}')).toMatchObject({
-      percent: 100,
-    });
-    expect(parseMeterLine('{"rms":0,"peak":0,"percent":-10}')).toMatchObject({
-      percent: 0,
-    });
+    expect(parseMeterLine("")).toBeNull();
+  });
+
+  it("maps peak to percent on a dB scale, not sqrt", () => {
+    // #648's formula yields 17% for a quiet room, not the 0% it predicted.
+    expect(percentFromPeak(0)).toBe(0);
+    expect(percentFromPeak(0.0085)).toBe(17);
+    expect(percentFromPeak(0.0368)).toBe(43);
+    expect(percentFromPeak(1)).toBe(100);
   });
 
   it("handles partial chunks without losing complete signals", () => {
-    const first = parseMeterChunk(
-      "",
-      '{"rms":0,"peak":0,"percent":0}\n{"rms":',
-    );
+    const first = parseMeterChunk("", '{"rms":0,"peak":0}\n{"rms":');
     expect(first.signals).toHaveLength(1);
     expect(first.remainder).toBe('{"rms":');
 
-    const second = parseMeterChunk(
-      first.remainder,
-      '0.02,"peak":0.1,"percent":32}\n',
-    );
+    const second = parseMeterChunk(first.remainder, '0.02,"peak":0.1}\n');
     expect(second.signals).toHaveLength(1);
-    expect(second.signals[0]).toMatchObject({ percent: 32, state: "signal" });
+    expect(second.signals[0]).toMatchObject({ rms: 0.02, state: "signal" });
     expect(second.remainder).toBe("");
   });
 });
+
 
 describe("recording markdown", () => {
   it("keeps recording markdown calm and moves operational detail to metadata helpers", () => {
@@ -147,19 +146,21 @@ describe("startLiveMicMeter", () => {
   it("reports unavailable when the meter dies after delivering samples", () => {
     const { proc, signals } = startWithFakeProcess();
 
-    proc.emitStdout('{"rms":0.01,"peak":0.04,"percent":20}\n');
+    proc.emitStdout('{"rms":0.05,"peak":0.1}\n');
     proc.emit("exit", 1, null);
 
-    expect(signals.map((s) => s.state)).toEqual(["signal", "unavailable"]);
+    expect(signals.at(-2)?.state).toBe("signal");
+    expect(signals.at(-1)?.state).toBe("unavailable");
   });
 
   it("stays quiet when the session stops the meter itself", () => {
     const { proc, signals, stop } = startWithFakeProcess();
 
-    proc.emitStdout('{"rms":0.01,"peak":0.04,"percent":20}\n');
+    proc.emitStdout('{"rms":0.05,"peak":0.1}\n');
     stop();
     proc.emit("exit", 0, "SIGTERM");
 
-    expect(signals.map((s) => s.state)).toEqual(["signal"]);
+    expect(signals.map((s) => s.state)).not.toContain("unavailable");
+    expect(signals.at(-1)?.state).toBe("signal");
   });
 });

--- a/extensions/kesha-voice-kit/tests/signal-meter.test.ts
+++ b/extensions/kesha-voice-kit/tests/signal-meter.test.ts
@@ -12,6 +12,7 @@ import {
   signalStatusTone,
 } from "../src/lib/recording-view";
 import {
+  loudestChannelRms,
   parseMeterChunk,
   parseMeterLine,
   percentFromPeak,
@@ -24,15 +25,30 @@ import { FakeProcess } from "./helpers/fake-process";
 describe("signal parsing", () => {
   // Thresholds are the rms percentiles measured on a built-in mic (#648).
   it("separates a quiet room from speech", () => {
-    expect(parseMeterLine('{"rms":0.0075,"peak":0.02}')?.state).toBe("listening");
-    expect(parseMeterLine('{"rms":0.0021,"peak":0.0085}')?.state).toBe("listening");
-    expect(parseMeterLine('{"rms":0.0352,"peak":0.09}')?.state).toBe("signal");
-    expect(parseMeterLine('{"rms":0.012,"peak":0.03}')?.state).toBe("signal");
+    expect(parseMeterLine('{"channelRms":[0.0075],"peak":0.02}')?.state).toBe("listening");
+    expect(parseMeterLine('{"channelRms":[0.0021],"peak":0.0085}')?.state).toBe("listening");
+    expect(parseMeterLine('{"channelRms":[0.0352],"peak":0.09}')?.state).toBe("signal");
+    expect(parseMeterLine('{"channelRms":[0.012],"peak":0.03}')?.state).toBe("signal");
   });
 
   it("keeps a noisy room audible rather than cutting the speaker off", () => {
     // Auto-stop then never fires there — today's behaviour, and the safe way to be wrong.
-    expect(parseMeterLine('{"rms":0.027,"peak":0.078}')?.state).toBe("signal");
+    expect(parseMeterLine('{"channelRms":[0.027],"peak":0.078}')?.state).toBe("signal");
+  });
+
+  it("hears speech carried by one channel of a multi-input device", () => {
+    // Pooled across both channels this speech would read as 0.012/sqrt(2) = 0.0085,
+    // under the threshold, and the idle timer would stop an active recording.
+    expect(parseMeterLine('{"channelRms":[0.012,0],"peak":0.03}')?.rms).toBeCloseTo(0.012, 6);
+    expect(parseMeterLine('{"channelRms":[0.012,0],"peak":0.03}')?.state).toBe("signal");
+    expect(parseMeterLine('{"channelRms":[0,0,0.012,0],"peak":0.03}')?.state).toBe("signal");
+  });
+
+  it("reads no level when the meter reports no usable channels", () => {
+    expect(loudestChannelRms(undefined)).toBe(0);
+    expect(loudestChannelRms([])).toBe(0);
+    expect(loudestChannelRms(["0.5", null, 0.02])).toBe(0.02);
+    expect(parseMeterLine('{"peak":0.03}')?.state).toBe("listening");
   });
 
   it("ignores invalid lines", () => {
@@ -49,11 +65,11 @@ describe("signal parsing", () => {
   });
 
   it("handles partial chunks without losing complete signals", () => {
-    const first = parseMeterChunk("", '{"rms":0,"peak":0}\n{"rms":');
+    const first = parseMeterChunk("", '{"channelRms":[0],"peak":0}\n{"channelRms":');
     expect(first.signals).toHaveLength(1);
-    expect(first.remainder).toBe('{"rms":');
+    expect(first.remainder).toBe('{"channelRms":');
 
-    const second = parseMeterChunk(first.remainder, '0.02,"peak":0.1}\n');
+    const second = parseMeterChunk(first.remainder, '[0.02],"peak":0.1}\n');
     expect(second.signals).toHaveLength(1);
     expect(second.signals[0]).toMatchObject({ rms: 0.02, state: "signal" });
     expect(second.remainder).toBe("");
@@ -146,7 +162,7 @@ describe("startLiveMicMeter", () => {
   it("reports unavailable when the meter dies after delivering samples", () => {
     const { proc, signals } = startWithFakeProcess();
 
-    proc.emitStdout('{"rms":0.05,"peak":0.1}\n');
+    proc.emitStdout('{"channelRms":[0.05],"peak":0.1}\n');
     proc.emit("exit", 1, null);
 
     expect(signals.at(-2)?.state).toBe("signal");
@@ -156,7 +172,7 @@ describe("startLiveMicMeter", () => {
   it("stays quiet when the session stops the meter itself", () => {
     const { proc, signals, stop } = startWithFakeProcess();
 
-    proc.emitStdout('{"rms":0.05,"peak":0.1}\n');
+    proc.emitStdout('{"channelRms":[0.05],"peak":0.1}\n');
     stop();
     proc.emit("exit", 0, "SIGTERM");
 


### PR DESCRIPTION
## Description

Update to the existing **Kesha Voice Kit** extension. Follow-up to #29898.

The idle auto-stop never fired. Whether anyone was speaking was decided by comparing the microphone's peak against `0.0001` — that is **−80 dBFS**, a test for *digital* silence, not for speech. Every live microphone clears it, so the meter state was permanently "signal", the idle timer was reset on every sample, and each dictation session ran to its full maximum duration unless the user pressed Stop.

Classification now compares rms against `0.01`, which sits between a quiet room and speech. The signal percentage also moves off `sqrt(peak)`, which inflated the bottom of the scale and drew a silent room at about 30%.

## Measured, not assumed

Recorded from a real microphone using the extension's own meter.

**Empty room, 101 samples over 12 s:**

| threshold | samples counted as speech | longest unbroken silence |
|---|---|---|
| old, `peak > 0.0001` | **101/101 (100%)** | 0 s — timer never advances |
| new, `rms > 0.01` | 7/101 | 11.2 s and counting |

**A person speaking normally, 284 samples over 30 s** — about 20 s of speech with natural pauses, then 10 s of deliberate silence:

| period | longest unbroken silence | auto-stop (needs 45 s) |
|---|---|---|
| while speaking | **4.0 s** | does not fire |
| after speaking | 10.0 s and counting | fires as intended |

Levels: speech p50 0.0020 / p90 0.0139 / max 0.0361; silence p50 0.0007 / max 0.0056. The threshold sits in the gap — `silence max 0.0056` < `0.0100` < `speech max 0.0361`.

Worth noting the mechanism works because speech is *uneven*, not because it is loud: a live voice's median actually sits below the threshold, and it is the louder syllables crossing it that keep resetting the timer.

## Trade-off

In a room with a steady noise source above the threshold, everything reads as speech and the auto-stop will not fire there. That is the same as the current released behaviour, so no regression, and it is the safe direction to be wrong in — the alternative would be cutting a speaker off mid-sentence. An adaptive noise floor was prototyped and dropped: it could do that, and distinguishing steady speech from steady noise by level alone is not possible.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` — it completes cleanly
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder

## Verification

In `extensions/kesha-voice-kit`: `npm test` 93 passed, `npm run lint` clean, `npm run build` succeeds.

As with #29898, this was verified through the automated suite, the build, and the microphone measurements above rather than by driving the full recording flow in the Raycast app for every state. The change is confined to how meter samples are classified; recording, transcription and clipboard paths are untouched.
