### PR TITLE
feat(google-calendar): show event location in List Events

### DIFF
--- a/extensions/google-calendar/CHANGELOG.md
+++ b/extensions/google-calendar/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Calendar Changelog
 
-## [Show Event Location in List Events] - {PR_MERGE_DATE}
+## [Show Event Location in List Events] - 2026-08-06
 
 - Add an opt-in "Show location" preference to the List Events command that shows the event's location as an accessory, with the full location in the tooltip
 

--- a/extensions/google-calendar/CHANGELOG.md
+++ b/extensions/google-calendar/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Google Calendar Changelog
 
+## [Show Event Location in List Events] - {PR_MERGE_DATE}
+
+- Add an opt-in "Show location" preference to the List Events command that shows the event's location as an accessory, with the full location in the tooltip
+
 ## [Expand AI Calendar API Support] - 2026-07-20
 
 - Expand the AI extension to support rich event creation and editing, including all-day and recurring events, attendees, reminders, visibility, availability, conferencing, attachments, special event types, imports, and recurring instances

--- a/extensions/google-calendar/package.json
+++ b/extensions/google-calendar/package.json
@@ -13,7 +13,8 @@
     "geekyed",
     "dangkhoipro",
     "0xdhrv",
-    "peduarte"
+    "peduarte",
+    "oguma0923"
   ],
   "categories": [
     "Productivity",
@@ -49,6 +50,15 @@
       "mode": "view",
       "subtitle": "Google Calendar",
       "preferences": [
+        {
+          "name": "showLocation",
+          "type": "checkbox",
+          "title": "Display",
+          "label": "Show location",
+          "description": "Show the event's location as an accessory in the list",
+          "default": false,
+          "required": false
+        },
         {
           "name": "openCommandJoinsMeeting",
           "type": "checkbox",

--- a/extensions/google-calendar/src/list-events.tsx
+++ b/extensions/google-calendar/src/list-events.tsx
@@ -1,4 +1,4 @@
-import { Color, Icon, LaunchProps, List } from "@raycast/api";
+import { Color, getPreferenceValues, Icon, LaunchProps, List } from "@raycast/api";
 import { useEvents, withGoogleAPIs } from "./lib/google";
 import { calendar_v3 } from "@googleapis/calendar";
 import { formatRecurrence } from "./lib/utils";
@@ -7,8 +7,16 @@ import { useState, useMemo } from "react";
 import EventActions from "./components/EventActions";
 import CalendarSelector from "./components/CalendarSelector";
 
-function getAccessories(event: calendar_v3.Schema$Event) {
+function getAccessories(event: calendar_v3.Schema$Event, showLocation: boolean) {
   const accessories = new Array<List.Item.Accessory>();
+
+  if (showLocation && event.location) {
+    accessories.push({
+      text: event.location,
+      icon: Icon.Pin,
+      tooltip: `Location: ${event.location}`,
+    });
+  }
 
   if (event.recurrence || event.recurringEventId) {
     const accessory: List.Item.Accessory = {
@@ -111,6 +119,7 @@ export function getEventSection(date: Date, now = new Date()) {
 
 function Command(props: LaunchProps) {
   const { calendarId } = (props.launchContext ?? {}) as { calendarId?: string };
+  const { showLocation } = getPreferenceValues<Preferences.ListEvents>();
   const [selectedCalendarId, setSelectedCalendarId] = useState<string | null>(calendarId ?? null);
   const { data, isLoading, pagination, revalidate } = useEvents(selectedCalendarId);
   const { data: calendars, isLoading: calendarsIsLoading, revalidate: revalidateCalendars } = useCalendars();
@@ -205,7 +214,7 @@ function Command(props: LaunchProps) {
                 icon={getIcon(event)}
                 title={event.summary ?? "Untitled Event"}
                 subtitle={formatEventTime(event, section)}
-                accessories={getAccessories(event)}
+                accessories={getAccessories(event, showLocation)}
                 actions={
                   <EventActions
                     event={event}


### PR DESCRIPTION
## Description

Adds an opt-in **Show location** preference to the *List Events* command. When enabled, an event's location is shown as an accessory, which makes it possible to tell apart events happening in different rooms or offices without opening each one.

The location is passed through as-is rather than shortened. The list already truncates the accessory to the width left over by the event title, which adapts to the window size better than any fixed rule could, and it truncates from the end so the most specific part of the location stays visible. The full location is available in the accessory tooltip.

I tried two ways of shortening it first and dropped both after measuring them:

- A 30-character cap. The list does not clamp accessory text at that width, so the cap only discarded text that would have fit.
- Showing just the first comma-separated segment (`Room 1` out of `Room 1, 1 Infinite Loop, Cupertino, CA 95014, USA`). This reads tidily, but it throws away the part that distinguishes a `Room 1` in one office from a `Room 1` in another, and it needs a helper plus tests to do something the list already does.

The preference defaults to `false`, so the command looks exactly as it does today unless a user opts in.

## Screencast

**Show location disabled (default) — unchanged from today:**

![show-location-disabled.png](https://github.com/user-attachments/assets/7544e407-4f64-4bf8-af4f-d2b5cb14e667)

**Show location enabled:**

![show-location-enabled.png](https://github.com/user-attachments/assets/b5db9ffe-7a45-4c05-871f-739fbcda3697)

The event titles in the screenshots are the location strings themselves, so the input and the resulting accessory can be compared side by side. Note the last three rows: a location longer than the available width is truncated by the list, and the location accessory coexists with the conference accessory.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
