### PR TITLE
refactor(zshrc-manager): unify parsing on one registry and bring the write path under test

### DIFF
--- a/extensions/zshrc-manager/CHANGELOG.md
+++ b/extensions/zshrc-manager/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [One parser for every surface] - {PR_MERGE_DATE}
+## [One parser for every surface] - 2026-08-04
 
 ### Fixed
 

--- a/extensions/zshrc-manager/CHANGELOG.md
+++ b/extensions/zshrc-manager/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [One parser for every surface] - {PR_MERGE_DATE}
+
+### Fixed
+
+- Statistics, section counts, and the type views now agree — all of them derive from a single parser (the pattern registry), so the count you see on a section can no longer differ from the list you drill into. Previously two independently written parser systems could disagree about what is in the file
+- Multi-line `plugins=(…)`, `path+=(…)` and `fpath=(…)` array declarations — the standard Oh My Zsh layout — are now parsed everywhere; sections and search previously missed them
+- PATH and FPATH declarations in all supported forms (`export`/`typeset -x`/`declare -x`, `+=` string append, array append/set, `$PATH:`-relative, and plain assignment) are recognized consistently across every surface
+- Keybinding counts no longer include bare mode lines like `bindkey -e` that the Keybindings view has nothing to show for
+- Sources with quoted operands or trailing inline comments resolve correctly in the detail pane's `Source Exists` fact; plugin install checks honor `ZSH_CUSTOM`/`ZSH` set as plain (unexported) assignments; `$HOMEBREW_PREFIX`-style variables are no longer mis-expanded as `$HOME`
+
+### Changed
+
+- Every parsed entry now carries the line it was defined on internally, laying the groundwork for addressing duplicate definitions directly
+
 ## [Resolved facts: shadowed commands, missing sources, missing plugins] - 2026-08-03
 
 ### Added

--- a/extensions/zshrc-manager/CHANGELOG.md
+++ b/extensions/zshrc-manager/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Multi-line `plugins=(…)`, `path+=(…)` and `fpath=(…)` array declarations — the standard Oh My Zsh layout — are now parsed everywhere; sections and search previously missed them
 - PATH and FPATH declarations in all supported forms (`export`/`typeset -x`/`declare -x`, `+=` string append, array append/set, `$PATH:`-relative, and plain assignment) are recognized consistently across every surface
 - Keybinding counts no longer include bare mode lines like `bindkey -e` that the Keybindings view has nothing to show for
+- Array parsing follows zsh quoting: quoted elements may contain whitespace, parentheses and escaped quotes; `$(…)` command substitutions stay one element with their text kept verbatim; inline comments inside array bodies are ignored
+- A comment inside a multi-line array that happens to match a section-header format (`## group`, `# Section: X`) no longer splits the array — per-section counts stay consistent with the views, and adding an item can no longer insert a line into the middle of an array
 - Sources with quoted operands or trailing inline comments resolve correctly in the detail pane's `Source Exists` fact; plugin install checks honor `ZSH_CUSTOM`/`ZSH` set as plain (unexported) assignments; `$HOMEBREW_PREFIX`-style variables are no longer mis-expanded as `$HOME`
 - **Undo now actually reverts adds and edits.** History entries for add/edit operations recorded the post-change file as their restore point, so undoing them silently restored the very state you were trying to revert. Every write now records the pre-change snapshot, and only after the write is verified — so a failed write can no longer leave a restore point for a change that never happened
 

--- a/extensions/zshrc-manager/CHANGELOG.md
+++ b/extensions/zshrc-manager/CHANGELOG.md
@@ -9,6 +9,7 @@
 - PATH and FPATH declarations in all supported forms (`export`/`typeset -x`/`declare -x`, `+=` string append, array append/set, `$PATH:`-relative, and plain assignment) are recognized consistently across every surface
 - Keybinding counts no longer include bare mode lines like `bindkey -e` that the Keybindings view has nothing to show for
 - Sources with quoted operands or trailing inline comments resolve correctly in the detail pane's `Source Exists` fact; plugin install checks honor `ZSH_CUSTOM`/`ZSH` set as plain (unexported) assignments; `$HOMEBREW_PREFIX`-style variables are no longer mis-expanded as `$HOME`
+- **Undo now actually reverts adds and edits.** History entries for add/edit operations recorded the post-change file as their restore point, so undoing them silently restored the very state you were trying to revert. Every write now records the pre-change snapshot, and only after the write is verified — so a failed write can no longer leave a restore point for a change that never happened
 
 ### Changed
 

--- a/extensions/zshrc-manager/src/__tests__/__mocks__/@raycast/api.ts
+++ b/extensions/zshrc-manager/src/__tests__/__mocks__/@raycast/api.ts
@@ -145,9 +145,13 @@ Form.TextField = ({ children, value, onChange, ...props }: any) => {
   );
 };
 
-Form.Dropdown = ({ children, ...props }: any) => {
+const FormDropdown = ({ children, ...props }: any) => {
   return React.createElement("select", { "data-testid": "form-dropdown", ...props }, children);
 };
+FormDropdown.Item = ({ title, value, ...props }: any) => {
+  return React.createElement("option", { "data-testid": "form-dropdown-item", value, ...props }, title);
+};
+Form.Dropdown = FormDropdown;
 
 Form.TextArea = ({ children, ...props }: any) => {
   return React.createElement("textarea", { "data-testid": "form-textarea", ...props }, children);
@@ -231,6 +235,10 @@ const ListItemDetail = ({ children, markdown, metadata, ...props }: any) => {
   }
   if (children) content.push(children);
   return React.createElement("div", { "data-testid": "list-item-detail-metadata-label", ...props }, content);
+};
+
+(ListItemDetail as any).Metadata.Separator = (props: any) => {
+  return React.createElement("hr", { "data-testid": "metadata-separator", ...props });
 };
 
 (ListItemDetail as any).Metadata.TagList = ({ children, ...props }: any) => {

--- a/extensions/zshrc-manager/src/__tests__/backup-history-views.test.tsx
+++ b/extensions/zshrc-manager/src/__tests__/backup-history-views.test.tsx
@@ -103,6 +103,19 @@ describe("BackupManager", () => {
     await waitFor(() => {
       expect(zshMocks.deleteBackup).toHaveBeenCalled();
     });
+    expect(vi.mocked(confirmAlert)).toHaveBeenCalled();
+  });
+
+  it("cancelled delete never removes the backup", async () => {
+    vi.mocked(confirmAlert).mockResolvedValue(false);
+    render(<BackupManager />);
+    await waitFor(() => expect(screen.getByText("Current Backup")).toBeTruthy());
+
+    const del = screen.getAllByText(/Delete Backup/i)[0];
+    fireEvent.click(del!);
+
+    await waitFor(() => expect(vi.mocked(confirmAlert)).toHaveBeenCalled());
+    expect(zshMocks.deleteBackup).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/zshrc-manager/src/__tests__/backup-history-views.test.tsx
+++ b/extensions/zshrc-manager/src/__tests__/backup-history-views.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * Component tests for backup-manager.tsx and history-view.tsx — the two
+ * restore surfaces. Covers: rendering with and without data, the
+ * confirm-guarded restore/delete/undo/clear flows (both confirmed and
+ * cancelled), and the diff view path.
+ */
+
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { confirmAlert, showToast } from "@raycast/api";
+
+vi.mock("../lib/zsh", () => ({
+  getBackupInfo: vi.fn(),
+  getBackupPath: vi.fn(() => "/t/.zshrc.backup"),
+  getZshrcPath: vi.fn(() => "/t/.zshrc"),
+  readBackupFile: vi.fn(),
+  readZshrcFile: vi.fn(),
+  restoreFromBackup: vi.fn().mockResolvedValue(undefined),
+  deleteBackup: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../lib/cache", () => ({ clearCache: vi.fn() }));
+vi.mock("../lib/history", () => ({
+  getHistory: vi.fn(),
+  undoToPoint: vi.fn(),
+  clearHistory: vi.fn().mockResolvedValue(undefined),
+}));
+
+import BackupManager from "../backup-manager";
+import HistoryView from "../history-view";
+import * as zshLib from "../lib/zsh";
+import * as historyLib from "../lib/history";
+
+const zshMocks = vi.mocked(zshLib);
+const historyMocks = vi.mocked(historyLib);
+
+const BACKUP_INFO = {
+  exists: true,
+  path: "/t/.zshrc.backup",
+  size: 1234,
+  sizeFormatted: "1.2 KB",
+  modifiedAt: new Date("2026-08-01T10:00:00Z"),
+};
+
+describe("BackupManager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    zshMocks.getBackupInfo.mockResolvedValue(BACKUP_INFO);
+    vi.mocked(confirmAlert).mockResolvedValue(true);
+  });
+
+  it("shows the empty view when no backup exists", async () => {
+    zshMocks.getBackupInfo.mockResolvedValue({ ...BACKUP_INFO, exists: false });
+    render(<BackupManager />);
+    await waitFor(() => {
+      expect(screen.getByText("No Backup Found")).toBeTruthy();
+    });
+  });
+
+  it("renders backup details when a backup exists", async () => {
+    render(<BackupManager />);
+    await waitFor(() => {
+      expect(screen.getByText("Current Backup")).toBeTruthy();
+    });
+  });
+
+  it("restore is guarded by confirmation and runs when confirmed", async () => {
+    render(<BackupManager />);
+    await waitFor(() => expect(screen.getByText("Current Backup")).toBeTruthy());
+
+    const restore = screen.getAllByText(/Restore from Backup/i)[0];
+    fireEvent.click(restore!);
+
+    await waitFor(() => {
+      expect(zshMocks.restoreFromBackup).toHaveBeenCalled();
+    });
+    expect(vi.mocked(showToast)).toHaveBeenCalledWith(expect.objectContaining({ title: "Backup Restored" }));
+  });
+
+  it("cancelled restore never touches the file", async () => {
+    vi.mocked(confirmAlert).mockResolvedValue(false);
+    render(<BackupManager />);
+    await waitFor(() => expect(screen.getByText("Current Backup")).toBeTruthy());
+
+    const restore = screen.getAllByText(/Restore from Backup/i)[0];
+    fireEvent.click(restore!);
+
+    await waitFor(() => expect(vi.mocked(confirmAlert)).toHaveBeenCalled());
+    expect(zshMocks.restoreFromBackup).not.toHaveBeenCalled();
+  });
+
+  it("delete is guarded by confirmation", async () => {
+    render(<BackupManager />);
+    await waitFor(() => expect(screen.getByText("Current Backup")).toBeTruthy());
+
+    const del = screen.getAllByText(/Delete Backup/i)[0];
+    fireEvent.click(del!);
+
+    await waitFor(() => {
+      expect(zshMocks.deleteBackup).toHaveBeenCalled();
+    });
+  });
+});
+
+describe("HistoryView", () => {
+  const ENTRIES = [
+    {
+      timestamp: Date.parse("2026-08-02T10:00:00Z"),
+      description: 'Add alias "gl"',
+      previousContent: "before-2",
+      filePath: "/t/.zshrc",
+    },
+    {
+      timestamp: Date.parse("2026-08-01T10:00:00Z"),
+      description: 'Delete alias "gg"',
+      previousContent: "before-1",
+      filePath: "/t/.zshrc",
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    historyMocks.getHistory.mockResolvedValue(ENTRIES);
+    historyMocks.undoToPoint.mockResolvedValue(true);
+    vi.mocked(confirmAlert).mockResolvedValue(true);
+  });
+
+  it("renders history entries", async () => {
+    render(<HistoryView />);
+    await waitFor(() => {
+      expect(screen.getAllByText('Add alias "gl"').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Delete alias "gg"').length).toBeGreaterThan(0);
+    });
+  });
+
+  it("undo restores to the selected point after confirmation", async () => {
+    const onRefresh = vi.fn();
+    render(<HistoryView onRefresh={onRefresh} />);
+    await waitFor(() => expect(screen.getAllByText('Add alias "gl"').length).toBeGreaterThan(0));
+
+    const undo = screen.getAllByText("Undo This Change")[0];
+    fireEvent.click(undo!);
+
+    await waitFor(() => {
+      expect(historyMocks.undoToPoint).toHaveBeenCalledWith(0);
+      expect(onRefresh).toHaveBeenCalled();
+    });
+  });
+
+  it("cancelled undo leaves history untouched", async () => {
+    vi.mocked(confirmAlert).mockResolvedValue(false);
+    render(<HistoryView />);
+    await waitFor(() => expect(screen.getAllByText('Add alias "gl"').length).toBeGreaterThan(0));
+
+    const undo = screen.getAllByText("Undo This Change")[0];
+    fireEvent.click(undo!);
+
+    await waitFor(() => expect(vi.mocked(confirmAlert)).toHaveBeenCalled());
+    expect(historyMocks.undoToPoint).not.toHaveBeenCalled();
+  });
+
+  it("failed undo surfaces an error toast", async () => {
+    historyMocks.undoToPoint.mockResolvedValue(false);
+    render(<HistoryView />);
+    await waitFor(() => expect(screen.getAllByText('Add alias "gl"').length).toBeGreaterThan(0));
+
+    const undo = screen.getAllByText("Undo This Change")[0];
+    fireEvent.click(undo!);
+
+    await waitFor(() => {
+      expect(vi.mocked(showToast)).toHaveBeenCalledWith(expect.objectContaining({ title: "Undo Failed" }));
+    });
+  });
+
+  it("clear history is guarded by confirmation", async () => {
+    render(<HistoryView />);
+    await waitFor(() => expect(screen.getAllByText('Add alias "gl"').length).toBeGreaterThan(0));
+
+    const clear = screen.getAllByText("Clear All History")[0];
+    fireEvent.click(clear!);
+
+    await waitFor(() => {
+      expect(historyMocks.clearHistory).toHaveBeenCalled();
+    });
+  });
+});

--- a/extensions/zshrc-manager/src/__tests__/backup-history-views.test.tsx
+++ b/extensions/zshrc-manager/src/__tests__/backup-history-views.test.tsx
@@ -62,6 +62,10 @@ describe("BackupManager", () => {
     await waitFor(() => {
       expect(screen.getByText("Current Backup")).toBeTruthy();
     });
+    // The metadata itself must render, not just the section header
+    const rendered = document.body.textContent ?? "";
+    expect(rendered).toContain("1.2 KB");
+    expect(rendered).toContain("/t/.zshrc.backup");
   });
 
   it("restore is guarded by confirmation and runs when confirmed", async () => {

--- a/extensions/zshrc-manager/src/__tests__/backup-history-views.test.tsx
+++ b/extensions/zshrc-manager/src/__tests__/backup-history-views.test.tsx
@@ -199,5 +199,18 @@ describe("HistoryView", () => {
     await waitFor(() => {
       expect(historyMocks.clearHistory).toHaveBeenCalled();
     });
+    expect(vi.mocked(confirmAlert)).toHaveBeenCalled();
+  });
+
+  it("declined clear confirmation leaves history untouched", async () => {
+    vi.mocked(confirmAlert).mockResolvedValue(false);
+    render(<HistoryView />);
+    await waitFor(() => expect(screen.getAllByText('Add alias "gl"').length).toBeGreaterThan(0));
+
+    const clear = screen.getAllByText("Clear All History")[0];
+    fireEvent.click(clear!);
+
+    await waitFor(() => expect(vi.mocked(confirmAlert)).toHaveBeenCalled());
+    expect(historyMocks.clearHistory).not.toHaveBeenCalled();
   });
 });

--- a/extensions/zshrc-manager/src/__tests__/edit-item-form.test.tsx
+++ b/extensions/zshrc-manager/src/__tests__/edit-item-form.test.tsx
@@ -8,7 +8,7 @@
 import React from "react";
 import { render, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { confirmAlert, showToast, useNavigation } from "@raycast/api";
+import { confirmAlert, showToast, Toast, useNavigation } from "@raycast/api";
 import type { EditItemConfig } from "../lib/edit-item-write";
 
 const mockReadRaw = vi.fn();
@@ -89,7 +89,9 @@ describe("EditItemForm", () => {
     const written = mockWrite.mock.calls[0]![0] as string;
     expect(written).toContain("alias gl='git log'");
     expect(written).toContain("alias gg='git grep'");
-    expect(vi.mocked(showToast)).toHaveBeenCalledWith(expect.objectContaining({ title: "Alias Added" }));
+    expect(vi.mocked(showToast)).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Alias Added", style: Toast.Style.Success }),
+    );
   });
 
   it("edit flow rewrites the existing definition in place", async () => {
@@ -107,7 +109,9 @@ describe("EditItemForm", () => {
     const written = mockWrite.mock.calls[0]![0] as string;
     expect(written).toContain("alias gg='rg'");
     expect(written).not.toContain("git grep");
-    expect(vi.mocked(showToast)).toHaveBeenCalledWith(expect.objectContaining({ title: "Alias Updated" }));
+    expect(vi.mocked(showToast)).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Alias Updated", style: Toast.Style.Success }),
+    );
   });
 
   it("missing key or value fails validation without writing", async () => {
@@ -115,7 +119,9 @@ describe("EditItemForm", () => {
     await submit({ key: "", value: "x", section: "Uncategorized", newSectionName: "" });
 
     expect(mockWrite).not.toHaveBeenCalled();
-    expect(vi.mocked(showToast)).toHaveBeenCalledWith(expect.objectContaining({ title: "Validation Error" }));
+    expect(vi.mocked(showToast)).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Validation Error", style: Toast.Style.Failure }),
+    );
   });
 
   it("structural warnings ask for confirmation and cancel aborts the save", async () => {
@@ -171,7 +177,7 @@ describe("EditItemForm", () => {
 
     expect(mockWrite).not.toHaveBeenCalled();
     expect(vi.mocked(showToast)).toHaveBeenCalledWith(
-      expect.objectContaining({ message: expect.stringContaining("Multiple definitions") }),
+      expect.objectContaining({ message: expect.stringContaining("Multiple definitions"), style: Toast.Style.Failure }),
     );
   });
 

--- a/extensions/zshrc-manager/src/__tests__/edit-item-form.test.tsx
+++ b/extensions/zshrc-manager/src/__tests__/edit-item-form.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * Component tests for lib/edit-item-form.tsx — the create, edit,
+ * validation-warning confirm, cancel, and delete flows, exercised through
+ * the submit handler with the write layer mocked. The diff preview is
+ * covered in edit-item-preview.test.tsx.
+ */
+
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { confirmAlert, showToast, useNavigation } from "@raycast/api";
+import type { EditItemConfig } from "../lib/edit-item-write";
+
+const mockReadRaw = vi.fn();
+const mockWrite = vi.fn();
+const mockReadPretty = vi.fn();
+vi.mock("../lib/zsh", () => ({
+  readZshrcFileRaw: (...args: unknown[]) => mockReadRaw(...args),
+  writeZshrcFile: (...args: unknown[]) => mockWrite(...args),
+  readZshrcFile: (...args: unknown[]) => mockReadPretty(...args),
+  checkZshrcAccess: vi.fn().mockResolvedValue({ path: "/t/.zshrc", exists: true, readable: true, writable: true }),
+  getZshrcPath: vi.fn(() => "/t/.zshrc"),
+}));
+vi.mock("../lib/cache", () => ({ clearCache: vi.fn() }));
+vi.mock("../lib/history", () => ({ saveToHistory: vi.fn().mockResolvedValue(undefined) }));
+
+// Capture useForm wiring so submits can be driven directly
+let capturedOnSubmit: ((values: Record<string, string>) => Promise<void>) | undefined;
+vi.mock("@raycast/utils", () => ({
+  useForm: vi.fn((options: { onSubmit: (values: Record<string, string>) => Promise<void> }) => {
+    capturedOnSubmit = options.onSubmit;
+    return {
+      itemProps: {
+        key: { id: "key", value: "" },
+        value: { id: "value", value: "" },
+        section: { id: "section", value: "Uncategorized" },
+        newSectionName: { id: "newSectionName", value: "" },
+      },
+      handleSubmit: vi.fn(),
+    };
+  }),
+}));
+
+import EditItemForm from "../lib/edit-item-form";
+
+const aliasConfig: EditItemConfig = {
+  keyLabel: "Alias Name",
+  valueLabel: "Command",
+  keyPlaceholder: "e.g., ll",
+  valuePlaceholder: "e.g., ls -la",
+  keyPattern: /^[A-Za-z0-9_.:-]+$/,
+  keyValidationError: "Invalid alias name",
+  generateLine: (key, value) => `alias ${key}='${value}'`,
+  generatePattern: (key) => new RegExp(`^(\\s*)alias\\s+${key}=(?:'|")(.*?)(?:'|")(\\s*#.*)?$`),
+  generateReplacement: (key, value) => `alias ${key}='${value}'`,
+  matchesDisplayLine: (line, key) => new RegExp(`^\\s*alias\\s+${key}=(?:'|")(.*?)(?:'|")\\s*(#.*)?$`).test(line),
+  itemType: "alias",
+  itemTypeCapitalized: "Alias",
+};
+
+const FILE = ["# Section: Tools", "alias gg='git grep'"].join("\n");
+
+const submit = (values: Record<string, string>) => capturedOnSubmit!(values);
+
+describe("EditItemForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedOnSubmit = undefined;
+    mockReadPretty.mockResolvedValue(FILE);
+    mockReadRaw.mockResolvedValue(FILE);
+    // Write verification re-reads: return whatever was last written
+    mockWrite.mockImplementation(async (content: string) => {
+      mockReadRaw.mockResolvedValue(content);
+    });
+    vi.mocked(confirmAlert).mockResolvedValue(true);
+  });
+
+  it("create flow writes the new definition into the target section", async () => {
+    render(<EditItemForm config={aliasConfig} />);
+    await submit({ key: "gl", value: "git log", section: "Tools", newSectionName: "" });
+
+    expect(mockWrite).toHaveBeenCalledTimes(1);
+    const written = mockWrite.mock.calls[0]![0] as string;
+    expect(written).toContain("alias gl='git log'");
+    expect(written).toContain("alias gg='git grep'");
+    expect(vi.mocked(showToast)).toHaveBeenCalledWith(expect.objectContaining({ title: "Alias Added" }));
+  });
+
+  it("edit flow rewrites the existing definition in place", async () => {
+    render(
+      <EditItemForm
+        config={aliasConfig}
+        existingKey="gg"
+        existingValue="git grep"
+        sectionLabel="Tools"
+        sectionOccurrence={0}
+      />,
+    );
+    await submit({ key: "gg", value: "rg", section: "Tools", newSectionName: "" });
+
+    const written = mockWrite.mock.calls[0]![0] as string;
+    expect(written).toContain("alias gg='rg'");
+    expect(written).not.toContain("git grep");
+    expect(vi.mocked(showToast)).toHaveBeenCalledWith(expect.objectContaining({ title: "Alias Updated" }));
+  });
+
+  it("missing key or value fails validation without writing", async () => {
+    render(<EditItemForm config={aliasConfig} />);
+    await submit({ key: "", value: "x", section: "Uncategorized", newSectionName: "" });
+
+    expect(mockWrite).not.toHaveBeenCalled();
+    expect(vi.mocked(showToast)).toHaveBeenCalledWith(expect.objectContaining({ title: "Validation Error" }));
+  });
+
+  it("structural warnings ask for confirmation and cancel aborts the save", async () => {
+    vi.mocked(confirmAlert).mockResolvedValue(false);
+    render(<EditItemForm config={aliasConfig} />);
+    // Unbalanced quote triggers a structural warning
+    await submit({ key: "bad", value: "echo 'unclosed", section: "Uncategorized", newSectionName: "" });
+
+    expect(vi.mocked(confirmAlert)).toHaveBeenCalled();
+    expect(mockWrite).not.toHaveBeenCalled();
+  });
+
+  it("structural warnings save when the user confirms", async () => {
+    vi.mocked(confirmAlert).mockResolvedValue(true);
+    render(<EditItemForm config={aliasConfig} />);
+    await submit({ key: "bad", value: "echo 'unclosed", section: "Uncategorized", newSectionName: "" });
+
+    expect(vi.mocked(confirmAlert)).toHaveBeenCalled();
+    expect(mockWrite).toHaveBeenCalledTimes(1);
+  });
+
+  it("New Section without a name is rejected before writing", async () => {
+    render(<EditItemForm config={aliasConfig} />);
+    await submit({ key: "gl", value: "git log", section: "New Section", newSectionName: "" });
+
+    expect(mockWrite).not.toHaveBeenCalled();
+    expect(vi.mocked(showToast)).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Please provide a name for the new section" }),
+    );
+  });
+
+  it("New Section with a name creates the section", async () => {
+    render(<EditItemForm config={aliasConfig} />);
+    await submit({ key: "gl", value: "git log", section: "New Section", newSectionName: "Fresh" });
+
+    const written = mockWrite.mock.calls[0]![0] as string;
+    expect(written).toContain("# --- Fresh --- #\nalias gl='git log'");
+  });
+
+  it("ambiguous duplicates surface the fail-closed error instead of writing", async () => {
+    const dup = ["# Section: Tools", "alias gg='one'", "alias gg='two'"].join("\n");
+    mockReadRaw.mockResolvedValue(dup);
+    render(
+      <EditItemForm
+        config={aliasConfig}
+        existingKey="gg"
+        existingValue="one"
+        sectionLabel="Tools"
+        sectionOccurrence={0}
+      />,
+    );
+    await submit({ key: "gg", value: "three", section: "Tools", newSectionName: "" });
+
+    expect(mockWrite).not.toHaveBeenCalled();
+    expect(vi.mocked(showToast)).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining("Multiple definitions") }),
+    );
+  });
+
+  it("write-verification mismatch surfaces an error", async () => {
+    // Simulate the file changing between write and verification re-read
+    mockWrite.mockImplementation(async () => {
+      mockReadRaw.mockResolvedValue("something else entirely");
+    });
+    render(<EditItemForm config={aliasConfig} />);
+    await submit({ key: "gl", value: "git log", section: "Tools", newSectionName: "" });
+
+    expect(vi.mocked(showToast)).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining("Write verification failed") }),
+    );
+  });
+
+  it("successful save invokes onSave and pops navigation", async () => {
+    const onSave = vi.fn();
+    const pop = vi.fn();
+    vi.mocked(useNavigation).mockReturnValue({ pop, push: vi.fn() } as never);
+
+    render(<EditItemForm config={aliasConfig} onSave={onSave} />);
+    await submit({ key: "gl", value: "git log", section: "Tools", newSectionName: "" });
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalled();
+      expect(pop).toHaveBeenCalled();
+    });
+  });
+});

--- a/extensions/zshrc-manager/src/__tests__/edit-item-form.test.tsx
+++ b/extensions/zshrc-manager/src/__tests__/edit-item-form.test.tsx
@@ -24,7 +24,11 @@ vi.mock("../lib/zsh", () => ({
 vi.mock("../lib/cache", () => ({ clearCache: vi.fn() }));
 vi.mock("../lib/history", () => ({ saveToHistory: vi.fn().mockResolvedValue(undefined) }));
 
-// Capture useForm wiring so submits can be driven directly
+// Capture useForm wiring so submits can be driven directly.
+// Known tradeoff: driving capturedOnSubmit couples these tests to useForm
+// as the form-management approach — accepted because Raycast's real Form
+// cannot run outside the app; the delete flow below goes through the
+// rendered Action button instead.
 let capturedOnSubmit: ((values: Record<string, string>) => Promise<void>) | undefined;
 vi.mock("@raycast/utils", () => ({
   useForm: vi.fn((options: { onSubmit: (values: Record<string, string>) => Promise<void> }) => {
@@ -42,6 +46,8 @@ vi.mock("@raycast/utils", () => ({
 }));
 
 import EditItemForm from "../lib/edit-item-form";
+import { saveToHistory } from "../lib/history";
+import { fireEvent, screen } from "@testing-library/react";
 
 const aliasConfig: EditItemConfig = {
   keyLabel: "Alias Name",
@@ -180,6 +186,64 @@ describe("EditItemForm", () => {
     expect(vi.mocked(showToast)).toHaveBeenCalledWith(
       expect.objectContaining({ message: expect.stringContaining("Write verification failed") }),
     );
+  });
+
+  it("history records the PRE-change snapshot after a verified write", async () => {
+    render(<EditItemForm config={aliasConfig} />);
+    await submit({ key: "gl", value: "git log", section: "Tools", newSectionName: "" });
+
+    // The undo target must be the content before this save
+    expect(vi.mocked(saveToHistory)).toHaveBeenCalledWith('Add alias "gl"', FILE);
+    // And history is only recorded after the write happened
+    const writeOrder = mockWrite.mock.invocationCallOrder[0]!;
+    const historyOrder = vi.mocked(saveToHistory).mock.invocationCallOrder[0]!;
+    expect(historyOrder).toBeGreaterThan(writeOrder);
+  });
+
+  it("delete flow (via the rendered action) writes, then records the pre-delete snapshot", async () => {
+    render(
+      <EditItemForm
+        config={aliasConfig}
+        existingKey="gg"
+        existingValue="git grep"
+        sectionLabel="Tools"
+        sectionOccurrence={0}
+      />,
+    );
+    fireEvent.click(screen.getAllByText("Delete Alias")[0]!);
+
+    await waitFor(() => {
+      expect(mockWrite).toHaveBeenCalledTimes(1);
+    });
+    const written = mockWrite.mock.calls[0]![0] as string;
+    expect(written).not.toContain("alias gg=");
+    expect(vi.mocked(saveToHistory)).toHaveBeenCalledWith('Delete alias "gg"', FILE);
+    const writeOrder = mockWrite.mock.invocationCallOrder[0]!;
+    const historyOrder = vi.mocked(saveToHistory).mock.invocationCallOrder[0]!;
+    expect(historyOrder).toBeGreaterThan(writeOrder);
+  });
+
+  it("delete write failure surfaces an error and records no history", async () => {
+    mockWrite.mockImplementation(async () => {
+      mockReadRaw.mockResolvedValue("corrupted");
+    });
+    render(
+      <EditItemForm
+        config={aliasConfig}
+        existingKey="gg"
+        existingValue="git grep"
+        sectionLabel="Tools"
+        sectionOccurrence={0}
+      />,
+    );
+    fireEvent.click(screen.getAllByText("Delete Alias")[0]!);
+
+    await waitFor(() => {
+      expect(vi.mocked(showToast)).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining("Write verification failed") }),
+      );
+    });
+    expect(vi.mocked(saveToHistory)).not.toHaveBeenCalled();
   });
 
   it("successful save invokes onSave and pops navigation", async () => {

--- a/extensions/zshrc-manager/src/__tests__/edit-item-preview.test.tsx
+++ b/extensions/zshrc-manager/src/__tests__/edit-item-preview.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * Component tests for lib/edit-item-preview.tsx — the diff preview must
+ * show exactly what a save would write, the guidance states when fields
+ * are missing, and the error state on fail-closed refusals.
+ */
+
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { DiffPreviewView } from "../lib/edit-item-preview";
+import type { EditItemConfig } from "../lib/edit-item-write";
+
+const mockReadRaw = vi.fn();
+vi.mock("../lib/zsh", () => ({
+  readZshrcFileRaw: (...args: unknown[]) => mockReadRaw(...args),
+}));
+
+const aliasConfig: EditItemConfig = {
+  keyLabel: "Alias Name",
+  valueLabel: "Command",
+  keyPlaceholder: "",
+  valuePlaceholder: "",
+  keyPattern: /^[A-Za-z0-9_.:-]+$/,
+  keyValidationError: "Invalid",
+  generateLine: (key, value) => `alias ${key}='${value}'`,
+  generatePattern: (key) => new RegExp(`^(\\s*)alias\\s+${key}=(?:'|")(.*?)(?:'|")(\\s*#.*)?$`),
+  generateReplacement: (key, value) => `alias ${key}='${value}'`,
+  matchesDisplayLine: (line, key) => new RegExp(`^\\s*alias\\s+${key}=`).test(line),
+  itemType: "alias",
+  itemTypeCapitalized: "Alias",
+};
+
+const FILE = ["# Section: Tools", "alias gg='git grep'"].join("\n");
+
+const baseProps = {
+  currentKey: "gl",
+  currentValue: "git log",
+  currentSection: "Tools",
+  newSectionName: "",
+  config: aliasConfig,
+  isEditing: false,
+};
+
+describe("DiffPreviewView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockReadRaw.mockResolvedValue(FILE);
+  });
+
+  it("renders the additive diff for a new item", async () => {
+    render(<DiffPreviewView {...baseProps} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("detail").textContent).toContain("Preview: Add Alias");
+    });
+    expect(screen.getByTestId("detail").textContent).toContain("alias gl='git log'");
+  });
+
+  it("asks for both fields before previewing", async () => {
+    render(<DiffPreviewView {...baseProps} currentValue="" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("detail").textContent).toContain("Preview Not Available");
+    });
+    expect(mockReadRaw).not.toHaveBeenCalled();
+  });
+
+  it("asks for a section name when New Section is selected without one", async () => {
+    render(<DiffPreviewView {...baseProps} currentSection="New Section" newSectionName="" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("detail").textContent).toContain("name for the new section");
+    });
+  });
+
+  it("reports No Changes when the values match the file", async () => {
+    render(
+      <DiffPreviewView
+        {...baseProps}
+        isEditing={true}
+        existingKey="gg"
+        currentKey="gg"
+        currentValue="git grep"
+        originalSection="Tools"
+        sectionOccurrence={0}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("detail").textContent).toContain("No Changes");
+    });
+  });
+
+  it("surfaces the fail-closed message when the target is ambiguous", async () => {
+    mockReadRaw.mockResolvedValue(["# Section: Tools", "alias gg='one'", "alias gg='two'"].join("\n"));
+    render(
+      <DiffPreviewView
+        {...baseProps}
+        isEditing={true}
+        existingKey="gg"
+        currentKey="gg"
+        currentValue="three"
+        originalSection="Tools"
+        sectionOccurrence={0}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("detail").textContent).toContain("Error Generating Preview");
+    });
+    expect(screen.getByTestId("detail").textContent).toContain("Multiple definitions");
+  });
+});

--- a/extensions/zshrc-manager/src/__tests__/edit-item-write.test.ts
+++ b/extensions/zshrc-manager/src/__tests__/edit-item-write.test.ts
@@ -61,6 +61,15 @@ describe("edit-item-write.ts", () => {
       const result = insertIntoSection(CONTENT, "Misc", "alias new='x'");
       expect(result.endsWith("alias m='make'\nalias new='x'")).toBe(true);
     });
+
+    it("a section-like comment inside an array is not an insertion target", () => {
+      const content = ["# Section: Plugins", "plugins=(", "  git", "  ## extras", "  docker", ")"].join("\n");
+      const result = insertIntoSection(content, "extras", "alias new='x'");
+      // "extras" does not exist as a section — the array must stay intact
+      // and the new section is created at the end of the file.
+      expect(result).toContain("plugins=(\n  git\n  ## extras\n  docker\n)");
+      expect(result.endsWith("# --- extras --- #\nalias new='x'")).toBe(true);
+    });
   });
 
   describe("preservingReplacer", () => {

--- a/extensions/zshrc-manager/src/__tests__/edit-item-write.test.ts
+++ b/extensions/zshrc-manager/src/__tests__/edit-item-write.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for lib/edit-item-write.ts — the pure content computation behind
+ * every save, move, and delete. These functions decide exactly what gets
+ * written to the user's shell config, so every branch is covered:
+ * insertion into existing/missing sections, in-place updates preserving
+ * whitespace and comments, section moves, deletes, and the fail-closed
+ * refusals.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  computeDeletedContent,
+  computeUpdatedContent,
+  insertIntoSection,
+  preservingReplacer,
+  scopedFailureMessage,
+  type EditItemConfig,
+} from "../lib/edit-item-write";
+
+/** Alias config mirroring src/edit-alias.tsx */
+const aliasConfig: EditItemConfig = {
+  keyLabel: "Alias Name",
+  valueLabel: "Command",
+  keyPlaceholder: "e.g., ll",
+  valuePlaceholder: "e.g., ls -la",
+  keyPattern: /^[A-Za-z0-9_.:-]+$/,
+  keyValidationError: "Invalid alias name",
+  generateLine: (key, value) => `alias ${key}='${value}'`,
+  generatePattern: (key) => new RegExp(`^(\\s*)alias\\s+${key}=(?:'|")(.*?)(?:'|")(\\s*#.*)?$`),
+  generateReplacement: (key, value) => `alias ${key}='${value}'`,
+  matchesDisplayLine: (line, key) => new RegExp(`^\\s*alias\\s+${key}=(?:'|")(.*?)(?:'|")\\s*(#.*)?$`).test(line),
+  itemType: "alias",
+  itemTypeCapitalized: "Alias",
+};
+
+const CONTENT = [
+  "# Section: Tools",
+  "alias gg='git grep'",
+  "alias gs='git status'",
+  "",
+  "# Section: Misc",
+  "alias m='make'",
+].join("\n");
+
+describe("edit-item-write.ts", () => {
+  describe("insertIntoSection", () => {
+    it("inserts after the last non-empty line of an existing section", () => {
+      const result = insertIntoSection(CONTENT, "Tools", "alias new='x'");
+      const lines = result.split("\n");
+      expect(lines[lines.indexOf("alias gs='git status'") + 1]).toBe("alias new='x'");
+      // The other section is untouched
+      expect(result).toContain("# Section: Misc\nalias m='make'");
+    });
+
+    it("creates a missing section at the end of the file", () => {
+      const result = insertIntoSection(CONTENT, "Brand New", "alias new='x'");
+      expect(result.endsWith("# --- Brand New --- #\nalias new='x'")).toBe(true);
+    });
+
+    it("appends without a trailing newline when the section ends the file", () => {
+      const result = insertIntoSection(CONTENT, "Misc", "alias new='x'");
+      expect(result.endsWith("alias m='make'\nalias new='x'")).toBe(true);
+    });
+  });
+
+  describe("preservingReplacer", () => {
+    it("preserves leading whitespace and inline comment", () => {
+      const pattern = aliasConfig.generatePattern("gg");
+      const replace = preservingReplacer(pattern, "alias gg='new value'");
+      expect(replace("  alias gg='old' # keep me")).toBe("  alias gg='new value' # keep me");
+    });
+  });
+
+  describe("computeUpdatedContent — add", () => {
+    it("adds a new item into the target section", () => {
+      const result = computeUpdatedContent(CONTENT, {
+        config: aliasConfig,
+        key: "gl",
+        value: "git log",
+        targetSection: "Tools",
+        isEditing: false,
+      });
+      expect(result).toContain("alias gl='git log'");
+      expect(result.indexOf("alias gl=")).toBeGreaterThan(result.indexOf("alias gs="));
+      expect(result.indexOf("alias gl=")).toBeLessThan(result.indexOf("# Section: Misc"));
+    });
+  });
+
+  describe("computeUpdatedContent — edit in place", () => {
+    it("updates the definition without touching anything else", () => {
+      const result = computeUpdatedContent(CONTENT, {
+        config: aliasConfig,
+        key: "gg",
+        value: "rg",
+        targetSection: "Tools",
+        isEditing: true,
+        existingKey: "gg",
+        originalSection: "Tools",
+        sectionOccurrence: 0,
+      });
+      expect(result).toContain("alias gg='rg'");
+      expect(result).not.toContain("git grep");
+      expect(result).toContain("alias gs='git status'");
+      expect(result).toContain("alias m='make'");
+    });
+
+    it("throws the fail-closed message when the definition is ambiguous", () => {
+      const dup = ["# Section: Tools", "alias gg='one'", "alias gg='two'"].join("\n");
+      expect(() =>
+        computeUpdatedContent(dup, {
+          config: aliasConfig,
+          key: "gg",
+          value: "three",
+          targetSection: "Tools",
+          isEditing: true,
+          existingKey: "gg",
+          originalSection: "Tools",
+          sectionOccurrence: 0,
+        }),
+      ).toThrow(/Multiple definitions of "gg"/);
+    });
+
+    it("throws not-found when the definition vanished", () => {
+      expect(() =>
+        computeUpdatedContent(CONTENT, {
+          config: aliasConfig,
+          key: "ghost",
+          value: "x",
+          targetSection: "Tools",
+          isEditing: true,
+          existingKey: "ghost",
+          originalSection: "Tools",
+          sectionOccurrence: 0,
+        }),
+      ).toThrow(/"ghost" not found/);
+    });
+  });
+
+  describe("computeUpdatedContent — move between sections", () => {
+    it("removes from the original section and inserts into the target", () => {
+      const result = computeUpdatedContent(CONTENT, {
+        config: aliasConfig,
+        key: "gg",
+        value: "git grep",
+        targetSection: "Misc",
+        isEditing: true,
+        existingKey: "gg",
+        originalSection: "Tools",
+        sectionOccurrence: 0,
+      });
+      // Gone from Tools, present in Misc after the existing entry
+      const miscIndex = result.indexOf("# Section: Misc");
+      expect(result.indexOf("alias gg=")).toBeGreaterThan(miscIndex);
+      expect(result.indexOf("alias gs=")).toBeLessThan(miscIndex);
+    });
+
+    it("creates the target section when it does not exist", () => {
+      const result = computeUpdatedContent(CONTENT, {
+        config: aliasConfig,
+        key: "gg",
+        value: "git grep",
+        targetSection: "Fresh",
+        isEditing: true,
+        existingKey: "gg",
+        originalSection: "Tools",
+        sectionOccurrence: 0,
+      });
+      expect(result).toContain("# --- Fresh --- #\nalias gg='git grep'");
+    });
+  });
+
+  describe("computeDeletedContent", () => {
+    it("removes exactly the targeted definition", () => {
+      const result = computeDeletedContent(CONTENT, {
+        config: aliasConfig,
+        existingKey: "gg",
+        sectionLabel: "Tools",
+        sectionOccurrence: 0,
+      });
+      expect(result).not.toContain("alias gg=");
+      expect(result).toContain("alias gs='git status'");
+      expect(result).toContain("alias m='make'");
+    });
+
+    it("refuses ambiguous same-section duplicates without modifying content", () => {
+      const dup = ["# Section: Tools", "alias gg='one'", "alias gg='two'"].join("\n");
+      expect(() =>
+        computeDeletedContent(dup, {
+          config: aliasConfig,
+          existingKey: "gg",
+          sectionLabel: "Tools",
+          sectionOccurrence: 0,
+        }),
+      ).toThrow(/Multiple definitions/);
+    });
+  });
+
+  describe("scopedFailureMessage", () => {
+    it("maps each refusal reason to its user-facing message", () => {
+      expect(scopedFailureMessage("ambiguous", "Alias", "gg")).toMatch(/Multiple definitions/);
+      expect(scopedFailureMessage("unsupported", "Alias", "gg")).toMatch(/cannot rewrite safely/);
+      expect(scopedFailureMessage("not-found", "Alias", "gg")).toMatch(/not found/);
+      expect(scopedFailureMessage(undefined, "Alias", "gg")).toMatch(/not found/);
+    });
+  });
+});

--- a/extensions/zshrc-manager/src/__tests__/import-export.test.ts
+++ b/extensions/zshrc-manager/src/__tests__/import-export.test.ts
@@ -283,6 +283,11 @@ describe("import-export.ts", () => {
 
       expect(count).toBe(2);
       expect(mockWriteZshrcFile).toHaveBeenCalled();
+      // History records the pre-change snapshot, and only after the write
+      expect(mockSaveToHistory).toHaveBeenCalledWith("Import 2 exports", expect.any(String));
+      expect(mockWriteZshrcFile.mock.invocationCallOrder[0]!).toBeLessThan(
+        mockSaveToHistory.mock.invocationCallOrder[0]!,
+      );
     });
 
     it("should add section header when specified", async () => {

--- a/extensions/zshrc-manager/src/__tests__/import-export.test.ts
+++ b/extensions/zshrc-manager/src/__tests__/import-export.test.ts
@@ -164,7 +164,8 @@ describe("import-export.ts", () => {
 
       expect(count).toBe(2);
       expect(mockWriteZshrcFile).toHaveBeenCalled();
-      expect(mockSaveToHistory).toHaveBeenCalledWith("Import 2 aliases");
+      // History now records the pre-change snapshot explicitly
+      expect(mockSaveToHistory).toHaveBeenCalledWith("Import 2 aliases", expect.any(String));
     });
 
     it("should add section header when specified", async () => {

--- a/extensions/zshrc-manager/src/__tests__/list-view-controller.test.tsx
+++ b/extensions/zshrc-manager/src/__tests__/list-view-controller.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * Component tests for lib/list-view-controller.tsx — the shared list that
+ * every type view renders through: parsing sections into items, warning
+ * accessories and the warning filter dropdown, frecency-off ordering,
+ * overview row, and the empty state.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Icon, Color } from "@raycast/api";
+import { ListViewController, type FilterableItem, type ItemWarning } from "../lib/list-view-controller";
+import type { LogicalSection } from "../lib/parse-zshrc";
+
+const mockRefresh = vi.fn();
+const mockUseZshrcLoader = vi.fn();
+vi.mock("../hooks/useZshrcLoader", () => ({
+  useZshrcLoader: (...args: unknown[]) => mockUseZshrcLoader(...args),
+}));
+
+vi.mock("@raycast/utils", () => ({
+  useFrecencySorting: vi.fn((items: unknown[]) => ({ data: items, visitItem: vi.fn() })),
+}));
+
+interface TestItem extends FilterableItem {
+  name: string;
+}
+
+const section = (label: string, content: string, startLine = 1): LogicalSection => ({
+  label,
+  startLine,
+  endLine: startLine + content.split("\n").length,
+  content,
+  aliasCount: 0,
+  exportCount: 0,
+  evalCount: 0,
+  setoptCount: 0,
+  pluginCount: 0,
+  functionCount: 0,
+  sourceCount: 0,
+  autoloadCount: 0,
+  fpathCount: 0,
+  pathCount: 0,
+  themeCount: 0,
+  completionCount: 0,
+  historyCount: 0,
+  keybindingCount: 0,
+  otherCount: 0,
+});
+
+const parser = (content: string): Array<Partial<TestItem>> =>
+  content
+    .split("\n")
+    .filter((line) => line.startsWith("item "))
+    .map((line) => ({ name: line.slice(5) }));
+
+const baseConfig = {
+  commandName: "Test",
+  navigationTitle: "Test Items",
+  searchPlaceholder: "Search...",
+  icon: Icon.Terminal,
+  tintColor: "#000000",
+  itemType: "test item",
+  itemTypePlural: "test items",
+  parser,
+  searchFields: ["name", "section"],
+  generateTitle: (item: TestItem) => item.name,
+  generateOverviewMarkdown: () => "# Overview",
+  generateItemMarkdown: (item: TestItem) => `# ${item.name}`,
+};
+
+describe("ListViewController", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseZshrcLoader.mockReturnValue({
+      sections: [section("Alpha", "item one\nitem two"), section("Beta", "item three", 10)],
+      isLoading: false,
+      refresh: mockRefresh,
+    });
+  });
+
+  it("renders parsed items grouped by section", () => {
+    render(<ListViewController<TestItem> {...baseConfig} />);
+    expect(screen.getByText("one")).toBeTruthy();
+    expect(screen.getByText("two")).toBeTruthy();
+    expect(screen.getByText("three")).toBeTruthy();
+    // Section names render as accessories
+    expect(screen.getAllByText("Alpha").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Beta").length).toBeGreaterThan(0);
+  });
+
+  it("renders the overview row with the total count", () => {
+    render(<ListViewController<TestItem> {...baseConfig} />);
+    expect(screen.getByText("Test item Summary")).toBeTruthy();
+    expect(screen.getByText("3")).toBeTruthy();
+  });
+
+  it("shows warning accessories for items the generator flags", () => {
+    const warningGenerator = (item: TestItem): ItemWarning | null =>
+      item.name === "two" ? { type: "broken", message: "flagged", icon: Icon.ExclamationMark, color: Color.Red } : null;
+
+    render(<ListViewController<TestItem> {...baseConfig} warningGenerator={warningGenerator} />);
+    // One warning icon accessory rendered (mock renders accessories' icons as "icon")
+    expect(screen.getAllByText("icon").length).toBeGreaterThan(0);
+  });
+
+  it("renders the warning filter dropdown when enabled", () => {
+    const warningGenerator = (item: TestItem): ItemWarning | null =>
+      item.name === "two" ? { type: "broken", message: "flagged", icon: Icon.ExclamationMark, color: Color.Red } : null;
+
+    render(
+      <ListViewController<TestItem> {...baseConfig} warningGenerator={warningGenerator} showWarningFilter={true} />,
+    );
+    const accessory = screen.getByTestId("search-bar-accessory");
+    expect(accessory.textContent).toContain("With Warnings (1)");
+    expect(accessory.textContent).toContain("Without Warnings");
+  });
+
+  it("omits the warning filter when disabled", () => {
+    render(<ListViewController<TestItem> {...baseConfig} />);
+    expect(screen.queryByTestId("search-bar-accessory")).toBeNull();
+  });
+
+  it("shows the empty state when nothing parses", () => {
+    mockUseZshrcLoader.mockReturnValue({
+      sections: [section("Alpha", "nothing here")],
+      isLoading: false,
+      refresh: mockRefresh,
+    });
+    render(<ListViewController<TestItem> {...baseConfig} />);
+    expect(screen.getByText("No test items match your search")).toBeTruthy();
+  });
+
+  it("applies postProcessItems before rendering", () => {
+    render(
+      <ListViewController<TestItem>
+        {...baseConfig}
+        postProcessItems={(items) => items.filter((item) => item.name !== "two")}
+      />,
+    );
+    expect(screen.getByText("one")).toBeTruthy();
+    expect(screen.queryByText("two")).toBeNull();
+  });
+});

--- a/extensions/zshrc-manager/src/__tests__/parse-zshrc.test.ts
+++ b/extensions/zshrc-manager/src/__tests__/parse-zshrc.test.ts
@@ -152,8 +152,11 @@ alias another="incomplete
       const content = `export PATH="/usr/local/bin:$PATH"`;
       const entries = parseZshrc(content);
 
-      expect(entries).toHaveLength(1);
+      // An `export PATH=…` line is both an export and a PATH declaration —
+      // matching what the Exports and PATH views have always shown.
+      expect(entries).toHaveLength(2);
       expect(entries[0]?.type).toBe("export");
+      expect(entries[1]?.type).toBe("path");
 
       const exportEntry = entries[0] as ExportEntry;
       expect(exportEntry.variable).toBe("PATH");

--- a/extensions/zshrc-manager/src/__tests__/parser-unification.test.ts
+++ b/extensions/zshrc-manager/src/__tests__/parser-unification.test.ts
@@ -272,6 +272,22 @@ describe("parser unification", () => {
       expect(extractEntries(content).plugins.map((p) => p.name)).toEqual(['my" plugin', "docker"]);
     });
 
+    it("command substitution stays one element and does not terminate the array", () => {
+      const content = "path+=($(brew --prefix)/bin /usr/local/bin)";
+      expect(extractEntries(content).pathEntries.map((p) => p.entry)).toEqual([
+        "$(brew --prefix)/bin",
+        "/usr/local/bin",
+      ]);
+    });
+
+    it("nested and double-quoted command substitutions stay whole", () => {
+      expect(tokenizeArrayBody(['$(dirname $(which node))/lib "$(brew --prefix)/sbin" plain'])).toEqual([
+        "$(dirname $(which node))/lib",
+        "$(brew --prefix)/sbin",
+        "plain",
+      ]);
+    });
+
     it("backslashes escape outside quotes but not inside single quotes", () => {
       expect(tokenizeArrayBody(["my\\ plugin docker"])).toEqual(["my plugin", "docker"]);
       expect(tokenizeArrayBody(["'a\\b' next"])).toEqual(["a\\b", "next"]);

--- a/extensions/zshrc-manager/src/__tests__/parser-unification.test.ts
+++ b/extensions/zshrc-manager/src/__tests__/parser-unification.test.ts
@@ -326,6 +326,37 @@ describe("parser unification", () => {
     });
   });
 
+  describe("section-like comments inside multi-line arrays", () => {
+    // A comment matching a section-header format (`## tools`,
+    // `# Section: X`) inside an array body must not split the array:
+    // section detection would slice it into two unparseable halves and
+    // per-section counts would disagree with what every view shows.
+    const CONTENT = [
+      "# Section: Plugins",
+      "plugins=(",
+      "  git",
+      "  ## docker things",
+      "  docker",
+      ")",
+      "alias after='still in Plugins'",
+    ].join("\n");
+
+    it("does not split the array or shift section context", () => {
+      const sections = toLogicalSections(CONTENT);
+      expect(sections.map((s) => s.label)).toEqual(["Plugins"]);
+      expect(sections[0]!.pluginCount).toBe(extractEntries(CONTENT).plugins.length);
+      expect(sections[0]!.pluginCount).toBe(2);
+      expect(sections[0]!.aliasCount).toBe(1);
+      expect(sections[0]!.otherCount).toBe(0);
+    });
+
+    it("keeps entries attributed to the enclosing section", () => {
+      const entries = parseZshrc(CONTENT);
+      const after = entries.find((e) => e.originalLine.includes("after"));
+      expect(after?.sectionLabel).toBe("Plugins");
+    });
+  });
+
   describe("Other counts lines the registry did not recognize", () => {
     it("a recognized multi-line array contributes nothing to Other", () => {
       const content = ["plugins=(", "  git", "  docker", "  z", ")", "some-unrecognized-command --flag"].join("\n");

--- a/extensions/zshrc-manager/src/__tests__/parser-unification.test.ts
+++ b/extensions/zshrc-manager/src/__tests__/parser-unification.test.ts
@@ -295,6 +295,19 @@ describe("parser unification", () => {
       ]);
     });
 
+    it("quotes inside a command substitution are kept verbatim", () => {
+      const content = `path+=("$(printf '%s' "hello")" /usr/local/bin)`;
+      expect(extractEntries(content).pathEntries.map((p) => p.entry)).toEqual([
+        `$(printf '%s' "hello")`,
+        "/usr/local/bin",
+      ]);
+    });
+
+    it("a quoted close paren inside a substitution is content, not the close", () => {
+      const content = `plugins=($(echo "a)b") git)`;
+      expect(extractEntries(content).plugins.map((p) => p.name)).toEqual([`$(echo "a)b")`, "git"]);
+    });
+
     it("backslashes escape outside quotes but not inside single quotes", () => {
       expect(tokenizeArrayBody(["my\\ plugin docker"])).toEqual(["my plugin", "docker"]);
       expect(tokenizeArrayBody(["'a\\b' next"])).toEqual(["a\\b", "next"]);

--- a/extensions/zshrc-manager/src/__tests__/parser-unification.test.ts
+++ b/extensions/zshrc-manager/src/__tests__/parser-unification.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Parser-unification guarantees.
+ *
+ * Every surface — type views, statistics, sections, search — derives from
+ * the single pattern registry. These tests hold the three invariants the
+ * unification promises:
+ *
+ * 1. Property: every entry any view surfaces appears in the registry
+ *    output exactly once (per type), on a corpus of real-world constructs.
+ * 2. Golden count: statistics counts equal the per-type view counts on
+ *    the same fixture.
+ * 3. Occurrence targeting: identical definitions in same-labeled section
+ *    instances are addressed individually by the write path, and two
+ *    identical definitions inside ONE section are refused rather than
+ *    guessed at.
+ */
+
+import { describe, it, expect } from "vitest";
+import { extractEntries, countAllPatterns } from "../lib/pattern-registry";
+import { parseZshrc, toLogicalSections } from "../lib/parse-zshrc";
+import { calculateStatistics } from "../utils/statistics";
+import { replaceFirstScoped } from "../lib/scoped-replace";
+import {
+  parseAliases,
+  parseExports,
+  parseEvals,
+  parseSetopts,
+  parsePlugins,
+  parseFunctions,
+  parseSources,
+  parsePathEntries,
+  parseFpathEntries,
+  parseKeybindings,
+} from "../utils/parsers";
+
+/**
+ * Corpus of real-world constructs, exercising every deliberate
+ * unification decision: dual export/PATH surfacing, multi-line plugin
+ * arrays, typeset/declare and += PATH forms, quoted source operands with
+ * trailing comments, structured keybindings, and constructs that must
+ * NOT be parsed (unquoted alias values, bare bindkey mode flags).
+ */
+const CORPUS = `# Section: Core
+alias ll='ls -la'
+alias gs="git status"
+alias broken=unquoted-value-is-not-parsed
+export EDITOR=vim
+export PATH="/usr/local/bin:$PATH"
+typeset -x PATH="/custom/bin:$PATH"
+PATH+=:/appended/bin
+path+=(/array/one /array/two)
+
+# Section: Shell
+setopt HIST_IGNORE_DUPS
+eval "$(rbenv init -)"
+my_func() {
+  echo hi
+}
+source "/opt/with space/file.zsh" # trailing comment
+source ~/.zshrc.local
+fpath=(~/.zsh/functions)
+
+# Section: OMZ
+plugins=(
+  git
+  docker
+)
+ZSH_THEME="robbyrussell"
+autoload -Uz compinit
+compinit
+HISTSIZE=10000
+bindkey '^R' history-incremental-search-backward
+bindkey -M viins 'jj' vi-cmd-mode
+bindkey -e
+`;
+
+describe("parser unification", () => {
+  describe("property: view entries appear in registry output exactly once", () => {
+    const sections = toLogicalSections(CORPUS);
+    // Views parse section content, so the registry is compared over the
+    // same domain. (Top-level `name() {` lines are section BOUNDARIES,
+    // excluded from every section's content — tested separately below.)
+    const sectionContent = sections.map((s) => s.content).join("\n");
+    const registry = extractEntries(sectionContent);
+
+    /** Aggregate a view parser over sections, the way views consume it. */
+    const viaSections = <T>(parse: (content: string) => ReadonlyArray<T>): T[] =>
+      sections.flatMap((section) => [...parse(section.content)]);
+
+    it.each([
+      ["aliases", () => viaSections(parseAliases), () => registry.aliases, (e: { name: string }) => e.name],
+      ["exports", () => viaSections(parseExports), () => registry.exports, (e: { variable: string }) => e.variable],
+      ["evals", () => viaSections(parseEvals), () => registry.evals, (e: { command: string }) => e.command],
+      ["setopts", () => viaSections(parseSetopts), () => registry.setopts, (e: { option: string }) => e.option],
+      ["plugins", () => viaSections(parsePlugins), () => registry.plugins, (e: { name: string }) => e.name],
+      [
+        "functions",
+        // Indented function definitions are view-visible; top-level ones
+        // become sections (see the dedicated test below)
+        () => viaSections(parseFunctions),
+        () => registry.functions,
+        (e: { name: string }) => e.name,
+      ],
+      ["sources", () => viaSections(parseSources), () => registry.sources, (e: { path: string }) => e.path],
+      [
+        "pathEntries",
+        () => viaSections(parsePathEntries),
+        () => registry.pathEntries,
+        (e: { entry: string }) => e.entry,
+      ],
+      [
+        "fpathEntries",
+        () => viaSections(parseFpathEntries),
+        () => registry.fpathEntries,
+        (e: { entry: string }) => e.entry,
+      ],
+      ["keybindings", () => viaSections(parseKeybindings), () => registry.keybindings, (e: { key: string }) => e.key],
+    ] as const)("%s", (type, view, fromRegistry, keyOf) => {
+      const viewKeys = view().map((e) => keyOf(e as never));
+      const registryKeys = fromRegistry().map((e) => keyOf(e as never));
+      // Same multiset: every view entry present in registry output exactly once
+      expect(viewKeys.slice().sort()).toEqual(registryKeys.slice().sort());
+      if (type !== "functions") {
+        expect(viewKeys.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("top-level function definitions become sections, not view entries", () => {
+      // Deliberate, pre-existing behavior kept by the unification:
+      // `my_func() {` at section level is a function-style section marker.
+      // No view lists it as an entry; it navigates as a section instead.
+      const labels = sections.map((s) => s.label);
+      expect(labels).toContain("my_func");
+      expect(viaSections(parseFunctions).some((f) => f.name === "my_func")).toBe(false);
+      // The registry still extracts it from raw (whole-file) content for
+      // whole-file surfaces:
+      expect(
+        extractEntries(CORPUS)
+          .functions.map((f) => f.name)
+          .sort(),
+      ).toEqual(["my_func"]);
+    });
+
+    it("registry entries carry their line position", () => {
+      for (const collection of Object.values(registry)) {
+        for (const entry of collection) {
+          expect(entry.line).toBeGreaterThan(0);
+        }
+      }
+      // Spot check against whole-file extraction: the multi-line plugins
+      // array is attributed to its opening line
+      const wholeFile = extractEntries(CORPUS);
+      const gitPlugin = wholeFile.plugins.find((p) => p.name === "git");
+      const corpusLines = CORPUS.split("\n");
+      expect(corpusLines[gitPlugin!.line - 1]).toContain("plugins=(");
+    });
+
+    it("deliberately unparsed constructs appear on no surface", () => {
+      // Unquoted alias values are excluded everywhere (write-path safety)
+      expect(registry.aliases.some((a) => a.name === "broken")).toBe(false);
+      expect(viaSections(parseAliases).some((a) => a.name === "broken")).toBe(false);
+      // Bare bindkey mode flags have nothing to show and count nowhere
+      expect(registry.keybindings.some((k) => k.key === "-e")).toBe(false);
+      // parseZshrc types them as OTHER rather than inventing an entry
+      const entries = parseZshrc(CORPUS);
+      const bindkeyE = entries.find((e) => e.originalLine.trim() === "bindkey -e");
+      expect(bindkeyE?.type).toBe("other");
+    });
+  });
+
+  describe("golden count: statistics equal view counts", () => {
+    it("calculateStatistics agrees with each view on the same fixture", () => {
+      const sections = toLogicalSections(CORPUS);
+      const stats = calculateStatistics(sections);
+
+      expect(stats.aliases.length).toBe(sections.flatMap((s) => [...parseAliases(s.content)]).length);
+      expect(stats.exports.length).toBe(sections.flatMap((s) => [...parseExports(s.content)]).length);
+      expect(stats.evals.length).toBe(sections.flatMap((s) => [...parseEvals(s.content)]).length);
+      expect(stats.setopts.length).toBe(sections.flatMap((s) => [...parseSetopts(s.content)]).length);
+      expect(stats.plugins.length).toBe(sections.flatMap((s) => [...parsePlugins(s.content)]).length);
+      expect(stats.functions.length).toBe(sections.flatMap((s) => [...parseFunctions(s.content)]).length);
+      expect(stats.sources.length).toBe(sections.flatMap((s) => [...parseSources(s.content)]).length);
+    });
+
+    it("section counts equal view counts per type", () => {
+      for (const section of toLogicalSections(CORPUS)) {
+        expect(section.aliasCount).toBe(parseAliases(section.content).length);
+        expect(section.exportCount).toBe(parseExports(section.content).length);
+        expect(section.pluginCount).toBe(parsePlugins(section.content).length);
+        expect(section.sourceCount).toBe(parseSources(section.content).length);
+        expect(section.pathCount).toBe(parsePathEntries(section.content).length);
+        expect(section.fpathCount).toBe(parseFpathEntries(section.content).length);
+        expect(section.keybindingCount).toBe(parseKeybindings(section.content).length);
+      }
+    });
+
+    it("countAllPatterns is a projection of extractEntries", () => {
+      const counts = countAllPatterns(CORPUS);
+      const entries = extractEntries(CORPUS);
+      expect(counts.aliases).toBe(entries.aliases.length);
+      expect(counts.paths).toBe(entries.pathEntries.length);
+      expect(counts.plugins).toBe(entries.plugins.length);
+      expect(counts.keybindings).toBe(entries.keybindings.length);
+    });
+  });
+
+  describe("occurrence targeting", () => {
+    const ALIAS_PATTERN = /alias\s+gg=(?:'|")(.*?)(?:'|")/;
+    const matchesGG = (line: string) => /^\s*alias\s+gg=(?:'|")(.*?)(?:'|")\s*$/.test(line);
+
+    it("edits the second same-labeled section instance without touching the first", () => {
+      const content = [
+        "# Section: Tools",
+        "alias gg='first definition'",
+        "# Section: Tools",
+        "alias gg='second definition'",
+      ].join("\n");
+
+      const result = replaceFirstScoped(content, "Tools", ALIAS_PATTERN, () => "", matchesGG, 1);
+      expect(result.found).toBe(true);
+      expect(result.content).toContain("first definition");
+      expect(result.content).not.toContain("second definition");
+    });
+
+    it("refuses two identical definitions inside one section instead of guessing", () => {
+      const content = ["# Section: Tools", "alias gg='first'", "alias gg='second'"].join("\n");
+
+      const result = replaceFirstScoped(content, "Tools", ALIAS_PATTERN, () => "", matchesGG, 0);
+      expect(result.found).toBe(false);
+      expect(result.reason).toBe("ambiguous");
+      // A refusal never modifies content
+      expect(result.content).toBe(content);
+    });
+  });
+});

--- a/extensions/zshrc-manager/src/__tests__/parser-unification.test.ts
+++ b/extensions/zshrc-manager/src/__tests__/parser-unification.test.ts
@@ -238,6 +238,11 @@ describe("parser unification", () => {
       expect(tokenizeArrayBody(["foo#bar baz"])).toEqual(["foo#bar", "baz"]);
     });
 
+    it("preserves # inside quoted elements, including after whitespace", () => {
+      expect(tokenizeArrayBody(['"/opt/my #tools/bin" /usr/bin'])).toEqual(["/opt/my #tools/bin", "/usr/bin"]);
+      expect(tokenizeArrayBody(["'plugin #5'  next   # real comment"])).toEqual(["plugin #5", "next"]);
+    });
+
     it("multi-line arrays with comments produce no phantom plugin entries", () => {
       const content = ["plugins=(", "  git    # version control", "  docker  # containers", ")"].join("\n");
       expect(extractEntries(content).plugins.map((p) => p.name)).toEqual(["git", "docker"]);

--- a/extensions/zshrc-manager/src/__tests__/parser-unification.test.ts
+++ b/extensions/zshrc-manager/src/__tests__/parser-unification.test.ts
@@ -294,6 +294,31 @@ describe("parser unification", () => {
     });
   });
 
+  describe("keybinding forms", () => {
+    // The two most common forms (keymap+quoted-key, basic-quoted) are
+    // exercised by the CORPUS; the remaining four each get a ground-truth
+    // assertion here so a regression in any branch is visible.
+    it("keymap string-replacement: bindkey -M <map> -s '<key>' '<cmd>'", () => {
+      const [k] = extractEntries("bindkey -M viins -s 'jk' 'jj'").keybindings;
+      expect(k).toMatchObject({ key: "jk", command: "jj", widget: "string-replacement", keymap: "viins" });
+    });
+
+    it("keymap unquoted key: bindkey -M <map> <key> <widget>", () => {
+      const [k] = extractEntries("bindkey -M emacs ^R history-search-backward").keybindings;
+      expect(k).toMatchObject({ key: "^R", command: "history-search-backward", keymap: "emacs" });
+    });
+
+    it("string-replacement: bindkey -s '<key>' '<cmd>'", () => {
+      const [k] = extractEntries("bindkey -s 'll' 'ls -la'").keybindings;
+      expect(k).toMatchObject({ key: "ll", command: "ls -la", widget: "string-replacement" });
+    });
+
+    it("basic unquoted key: bindkey <key> <widget>", () => {
+      const [k] = extractEntries("bindkey ^P up-history").keybindings;
+      expect(k).toMatchObject({ key: "^P", command: "up-history" });
+    });
+  });
+
   describe("Other counts lines the registry did not recognize", () => {
     it("a recognized multi-line array contributes nothing to Other", () => {
       const content = ["plugins=(", "  git", "  docker", "  z", ")", "some-unrecognized-command --flag"].join("\n");

--- a/extensions/zshrc-manager/src/__tests__/parser-unification.test.ts
+++ b/extensions/zshrc-manager/src/__tests__/parser-unification.test.ts
@@ -252,6 +252,30 @@ describe("parser unification", () => {
       const content = 'path+=("/opt/my tools/bin" /usr/local/bin)';
       expect(extractEntries(content).pathEntries.map((p) => p.entry)).toEqual(["/opt/my tools/bin", "/usr/local/bin"]);
     });
+
+    it("a quoted close paren does not terminate a single-line array", () => {
+      const content = 'path+=("/opt/my (tools)/bin" /usr/local/bin)';
+      expect(extractEntries(content).pathEntries.map((p) => p.entry)).toEqual([
+        "/opt/my (tools)/bin",
+        "/usr/local/bin",
+      ]);
+    });
+
+    it("a quoted close paren does not terminate a multi-line array", () => {
+      const content = ["plugins=(", '  "my (cool) plugin"', "  docker", ")"].join("\n");
+      expect(extractEntries(content).plugins.map((p) => p.name)).toEqual(["my (cool) plugin", "docker"]);
+    });
+
+    it("escaped quotes inside double-quoted elements stay part of the element", () => {
+      expect(tokenizeArrayBody(['"my\\" plugin" docker'])).toEqual(['my" plugin', "docker"]);
+      const content = 'plugins=("my\\" plugin" docker)';
+      expect(extractEntries(content).plugins.map((p) => p.name)).toEqual(['my" plugin', "docker"]);
+    });
+
+    it("backslashes escape outside quotes but not inside single quotes", () => {
+      expect(tokenizeArrayBody(["my\\ plugin docker"])).toEqual(["my plugin", "docker"]);
+      expect(tokenizeArrayBody(["'a\\b' next"])).toEqual(["a\\b", "next"]);
+    });
   });
 
   describe("Other counts lines the registry did not recognize", () => {

--- a/extensions/zshrc-manager/src/__tests__/parser-unification.test.ts
+++ b/extensions/zshrc-manager/src/__tests__/parser-unification.test.ts
@@ -191,6 +191,13 @@ describe("parser unification", () => {
     });
   });
 
+  // These are CONSISTENCY tests, not correctness tests: both sides of
+  // every assertion project from extractEntries, so they prove the
+  // surfaces are wired to one parser (the point of the unification), not
+  // that the parser extracts the right things. Extraction correctness is
+  // covered by the hardcoded ground-truth assertions elsewhere in this
+  // file ("extracts the corpus's ground-truth entries", the keybinding
+  // form tests, and the tokenizer tests).
   describe("golden count: statistics equal view counts", () => {
     it("calculateStatistics agrees with each view on the same fixture", () => {
       const sections = toLogicalSections(CORPUS);

--- a/extensions/zshrc-manager/src/__tests__/parser-unification.test.ts
+++ b/extensions/zshrc-manager/src/__tests__/parser-unification.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { extractEntries, countAllPatterns } from "../lib/pattern-registry";
+import { extractEntries, countAllPatterns, countUnrecognizedLines, tokenizeArrayBody } from "../lib/pattern-registry";
 import { parseZshrc, toLogicalSections } from "../lib/parse-zshrc";
 import { calculateStatistics } from "../utils/statistics";
 import { replaceFirstScoped } from "../lib/scoped-replace";
@@ -125,6 +125,29 @@ describe("parser unification", () => {
       }
     });
 
+    it("extracts the corpus's ground-truth entries (independent of any projection)", () => {
+      // Hardcoded expectations: unlike the multiset comparisons above
+      // (which are projections of the same extraction), these fail if the
+      // registry itself drops or invents entries.
+      const wholeFile = extractEntries(CORPUS);
+      expect(wholeFile.aliases.map((a) => a.name).sort()).toEqual(["gs", "ll"]);
+      expect(wholeFile.plugins.map((p) => p.name).sort()).toEqual(["docker", "git"]);
+      expect(wholeFile.sources.map((s) => s.path).sort()).toEqual(['"/opt/with space/file.zsh"', "~/.zshrc.local"]);
+      expect(wholeFile.pathEntries.map((p) => `${p.type}:${p.entry}`).sort()).toEqual([
+        "append:/appended/bin",
+        "append:/array/one",
+        "append:/array/two",
+        "export:/custom/bin:$PATH",
+        "export:/usr/local/bin:$PATH",
+      ]);
+      expect(wholeFile.fpathEntries.map((f) => f.entry)).toEqual(["~/.zsh/functions"]);
+      expect(wholeFile.keybindings.map((k) => k.key).sort()).toEqual(["^R", "jj"]);
+      expect(wholeFile.exports.map((e) => e.variable).sort()).toEqual(["EDITOR", "PATH", "PATH"]);
+      expect(wholeFile.setopts.map((s) => s.option)).toEqual(["HIST_IGNORE_DUPS"]);
+      expect(wholeFile.themes.map((t) => t.name)).toEqual(["robbyrussell"]);
+      expect(wholeFile.autoloads.map((a) => a.function)).toEqual(["compinit"]);
+    });
+
     it("top-level function definitions become sections, not view entries", () => {
       // Deliberate, pre-existing behavior kept by the unification:
       // `my_func() {` at section level is a function-style section marker.
@@ -201,6 +224,50 @@ describe("parser unification", () => {
       expect(counts.paths).toBe(entries.pathEntries.length);
       expect(counts.plugins).toBe(entries.plugins.length);
       expect(counts.keybindings).toBe(entries.keybindings.length);
+    });
+  });
+
+  describe("array body tokenization", () => {
+    it("drops inline comments and honors quoted elements", () => {
+      expect(tokenizeArrayBody(["  git    # version control", "  docker", '  "some plugin"', "  'other one'"])).toEqual(
+        ["git", "docker", "some plugin", "other one"],
+      );
+    });
+
+    it("keeps # inside a word (not a comment start)", () => {
+      expect(tokenizeArrayBody(["foo#bar baz"])).toEqual(["foo#bar", "baz"]);
+    });
+
+    it("multi-line arrays with comments produce no phantom plugin entries", () => {
+      const content = ["plugins=(", "  git    # version control", "  docker  # containers", ")"].join("\n");
+      expect(extractEntries(content).plugins.map((p) => p.name)).toEqual(["git", "docker"]);
+    });
+
+    it("quoted path elements with whitespace stay whole", () => {
+      const content = 'path+=("/opt/my tools/bin" /usr/local/bin)';
+      expect(extractEntries(content).pathEntries.map((p) => p.entry)).toEqual(["/opt/my tools/bin", "/usr/local/bin"]);
+    });
+  });
+
+  describe("Other counts lines the registry did not recognize", () => {
+    it("a recognized multi-line array contributes nothing to Other", () => {
+      const content = ["plugins=(", "  git", "  docker", "  z", ")", "some-unrecognized-command --flag"].join("\n");
+      // 6 non-empty lines: 5 belong to the recognized array, 1 is genuinely other
+      expect(countUnrecognizedLines(content)).toBe(1);
+    });
+
+    it("section Other counts agree with the line-based definition", () => {
+      const sections = toLogicalSections(CORPUS);
+      for (const section of sections) {
+        expect(section.otherCount).toBe(countUnrecognizedLines(section.content));
+      }
+    });
+
+    it("single-line multi-element declarations no longer distort Other", () => {
+      // Old formula: 1 line minus 3 plugin entries clamped to 0 — and
+      // stole 2 from any real Other lines nearby
+      const content = ["plugins=(git docker z)", "mystery-line-one", "mystery-line-two"].join("\n");
+      expect(countUnrecognizedLines(content)).toBe(2);
     });
   });
 

--- a/extensions/zshrc-manager/src/__tests__/parsers.test.ts
+++ b/extensions/zshrc-manager/src/__tests__/parsers.test.ts
@@ -1,4 +1,11 @@
-import { parseAliases, parseExports, parsePathEntries, parseFpathEntries, parseKeybindings } from "../utils/parsers";
+import {
+  parseAliases,
+  parseExports,
+  parsePathEntries,
+  parseFpathEntries,
+  parseKeybindings,
+  parseSources,
+} from "../utils/parsers";
 
 describe("parsers.ts", () => {
   describe("parseAliases", () => {
@@ -211,6 +218,27 @@ export NODE_ENV=development`;
         { variable: "PYTHON_PATH", value: "/usr/local/bin/python" },
         { variable: "NODE_ENV", value: "development" },
       ]);
+    });
+  });
+
+  describe("parseSources", () => {
+    it("should capture only the operand, not a trailing inline comment", () => {
+      const content = `source "/opt/zsh/highlight.zsh" # syntax highlighting
+source /opt/zsh/plain.zsh # plain form
+source ~/.config/zsh/simple.zsh`;
+
+      const result = parseSources(content);
+
+      expect(result).toEqual([
+        { path: '"/opt/zsh/highlight.zsh"' },
+        { path: "/opt/zsh/plain.zsh" },
+        { path: "~/.config/zsh/simple.zsh" },
+      ]);
+    });
+
+    it("should keep quoted operands intact including spaces", () => {
+      const content = `source "/opt/with space/file.zsh"`;
+      expect(parseSources(content)).toEqual([{ path: '"/opt/with space/file.zsh"' }]);
     });
   });
 

--- a/extensions/zshrc-manager/src/__tests__/pattern-registry.test.ts
+++ b/extensions/zshrc-manager/src/__tests__/pattern-registry.test.ts
@@ -389,10 +389,13 @@ bindkey '^R' history-incremental-search-backward
       expect(result.sources).toBe(1);
       expect(result.evals).toBe(1);
       expect(result.setopts).toBe(1);
-      expect(result.plugins).toBe(1);
+      // Counts now equal what the views list: plugins=(git docker) is two
+      // plugin entries, and both PATH declarations (the export and the
+      // plain prepend) appear in the PATH view.
+      expect(result.plugins).toBe(2);
       expect(result.autoloads).toBe(1);
       expect(result.fpaths).toBe(1);
-      expect(result.paths).toBe(1);
+      expect(result.paths).toBe(2);
       expect(result.themes).toBe(1);
       expect(result.completions).toBe(1);
       expect(result.history).toBe(1);

--- a/extensions/zshrc-manager/src/__tests__/resolve.test.ts
+++ b/extensions/zshrc-manager/src/__tests__/resolve.test.ts
@@ -50,6 +50,9 @@ describe("resolve.ts", () => {
 
     it("returns null for values it cannot expand without a shell", () => {
       expect(expandUserPath("${XDG_CACHE_HOME:-$HOME/.cache}/file", "/Users/me")).toBeNull();
+      // $HOMEBREW_PREFIX must not be mangled into $HOME + "BREW_PREFIX…"
+      expect(expandUserPath("$HOMEBREW_PREFIX/etc/profile.d/z.sh", "/Users/me")).toBeNull();
+      expect(expandUserPath("$HOMEDIR/file", "/Users/me")).toBeNull();
       expect(expandUserPath("$ZSH/oh-my-zsh.sh", "/Users/me")).toBeNull();
       expect(expandUserPath("$(brew --prefix)/etc/profile", "/Users/me")).toBeNull();
       expect(expandUserPath("`which zsh`", "/Users/me")).toBeNull();
@@ -65,6 +68,12 @@ describe("resolve.ts", () => {
       expect(expandUserPath('"$HOME/file.zsh"', "/Users/me")).toBe("/Users/me/file.zsh");
       expect(expandUserPath("'/opt/plain.zsh'", "/Users/me")).toBe("/opt/plain.zsh");
       expect(expandUserPath('"$cache_file"', "/Users/me")).toBeNull();
+    });
+
+    it("ignores trailing inline comments after the operand", () => {
+      expect(expandUserPath('"/opt/file.zsh" # loads things', "/Users/me")).toBe("/opt/file.zsh");
+      expect(expandUserPath("/opt/file.zsh # loads things", "/Users/me")).toBe("/opt/file.zsh");
+      expect(expandUserPath('"unterminated', "/Users/me")).toBeNull();
     });
   });
 
@@ -165,6 +174,12 @@ describe("resolve.ts", () => {
       expect(sourceFileExists(`"${file}"`, tmpRoot)).toBe("yes");
     });
 
+    it("reports yes when a quoted operand carries a trailing comment", () => {
+      const file = join(tmpRoot, "commented.zsh");
+      writeFileSync(file, "# zsh");
+      expect(sourceFileExists(`"${file}" # syntax highlighting`, tmpRoot)).toBe("yes");
+    });
+
     // Root bypasses permission checks, so the EACCES case cannot be
     // provoked when running as root (e.g. some CI containers) — skip
     // rather than silently pass.
@@ -224,6 +239,16 @@ describe("resolve.ts", () => {
       writeFileSync(mockZshrcPath, `export ZSH_CUSTOM="${custom}"\n`);
 
       expect(pluginInstalled("configplugin", tmpRoot, {})).toBe("yes");
+    });
+
+    it("honors a plain (unexported) ZSH_CUSTOM assignment in the config", () => {
+      const custom = join(tmpRoot, "plain-custom");
+      mkdirSync(join(custom, "plugins", "plainplugin"), { recursive: true });
+      mkdirSync(join(tmpRoot, ".oh-my-zsh", "plugins"), { recursive: true });
+      mockZshrcPath = join(tmpRoot, ".zshrc");
+      writeFileSync(mockZshrcPath, `ZSH_CUSTOM=${custom}\n`);
+
+      expect(pluginInstalled("plainplugin", tmpRoot, {})).toBe("yes");
     });
 
     it("reports unknown, not no, when a declared root cannot be expanded", () => {

--- a/extensions/zshrc-manager/src/__tests__/section-writer-add.test.ts
+++ b/extensions/zshrc-manager/src/__tests__/section-writer-add.test.ts
@@ -15,6 +15,19 @@ vi.mock("../lib/zsh", () => ({
 }));
 vi.mock("../lib/history", () => ({ saveToHistory: vi.fn().mockResolvedValue(undefined) }));
 import { addAliasesToZshrc, addSingleAliasToZshrc, formatAliasLines } from "../lib/section-writer";
+import { saveToHistory } from "../lib/history";
+
+/**
+ * The history contract every write shares: the snapshot recorded is the
+ * PRE-change content, and it is recorded only after the write happened
+ * (so a failed write leaves no bogus undo point).
+ */
+function expectHistoryRecordedAfterWrite(previousContent: string): void {
+  const history = vi.mocked(saveToHistory);
+  expect(history).toHaveBeenCalledTimes(1);
+  expect(history.mock.calls[0]![1]).toBe(previousContent);
+  expect(mockWrite.mock.invocationCallOrder[0]!).toBeLessThan(history.mock.invocationCallOrder[0]!);
+}
 
 const ALIASES = [
   { name: "g", value: "git", description: "shortcut" },
@@ -41,7 +54,8 @@ describe("section-writer write path", () => {
 
   describe("addAliasesToZshrc", () => {
     it("appends into an existing matching section", async () => {
-      mockReadRaw.mockResolvedValue(["# --- Git --- #", "alias gs='git status'", "", "# --- End --- #"].join("\n"));
+      const previous = ["# --- Git --- #", "alias gs='git status'", "", "# --- End --- #"].join("\n");
+      mockReadRaw.mockResolvedValue(previous);
 
       const result = await addAliasesToZshrc("Git Aliases", ALIASES, "collection");
       expect(result.success).toBe(true);
@@ -50,10 +64,12 @@ describe("section-writer write path", () => {
       const written = mockWrite.mock.calls[0]![0] as string;
       expect(written).toContain("alias g='git'");
       expect(written).toContain("# Added from Git Aliases (collection)");
+      expectHistoryRecordedAfterWrite(previous);
     });
 
     it("creates a new section when nothing matches", async () => {
-      mockReadRaw.mockResolvedValue("alias unrelated='x'\n");
+      const previous = "alias unrelated='x'\n";
+      mockReadRaw.mockResolvedValue(previous);
 
       const result = await addAliasesToZshrc("Kubernetes", ALIASES);
       expect(result.success).toBe(true);
@@ -63,6 +79,7 @@ describe("section-writer write path", () => {
       const written = mockWrite.mock.calls[0]![0] as string;
       expect(written).toContain("Kubernetes");
       expect(written).toContain("alias ga='git add'");
+      expectHistoryRecordedAfterWrite(previous);
     });
 
     it("starts from empty content when the file is unreadable", async () => {
@@ -77,12 +94,14 @@ describe("section-writer write path", () => {
 
   describe("addSingleAliasToZshrc", () => {
     it("writes a single alias", async () => {
-      mockReadRaw.mockResolvedValue("# --- Tools --- #\nalias t='true'\n");
+      const previous = "# --- Tools --- #\nalias t='true'\n";
+      mockReadRaw.mockResolvedValue(previous);
 
       const result = await addSingleAliasToZshrc({ name: "gl", value: "git log" }, "Tools");
       expect(result.success).toBe(true);
       const written = mockWrite.mock.calls[0]![0] as string;
       expect(written).toContain("alias gl='git log'");
+      expectHistoryRecordedAfterWrite(previous);
     });
   });
 });

--- a/extensions/zshrc-manager/src/__tests__/section-writer-add.test.ts
+++ b/extensions/zshrc-manager/src/__tests__/section-writer-add.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for the write half of lib/section-writer.ts — adding collection
+ * aliases into an existing or new section. (The matching half is covered
+ * in section-writer.test.ts.)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockReadRaw = vi.fn();
+const mockWrite = vi.fn();
+vi.mock("../lib/zsh", () => ({
+  readZshrcFileRaw: (...args: unknown[]) => mockReadRaw(...args),
+  writeZshrcFile: (...args: unknown[]) => mockWrite(...args),
+  getZshrcPath: vi.fn(() => "/t/.zshrc"),
+}));
+vi.mock("../lib/history", () => ({ saveToHistory: vi.fn().mockResolvedValue(undefined) }));
+import { addAliasesToZshrc, addSingleAliasToZshrc, formatAliasLines } from "../lib/section-writer";
+
+const ALIASES = [
+  { name: "g", value: "git", description: "shortcut" },
+  { name: "ga", value: "git add" },
+];
+
+describe("section-writer write path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("formatAliasLines", () => {
+    it("emits alias lines with comments when requested", () => {
+      const lines = formatAliasLines(ALIASES, true);
+      expect(lines.some((line) => line.includes("alias g='git'"))).toBe(true);
+      expect(lines.some((line) => line.includes("shortcut"))).toBe(true);
+    });
+
+    it("omits comments when disabled", () => {
+      const lines = formatAliasLines(ALIASES, false);
+      expect(lines.join("\n")).not.toContain("shortcut");
+    });
+  });
+
+  describe("addAliasesToZshrc", () => {
+    it("appends into an existing matching section", async () => {
+      mockReadRaw.mockResolvedValue(["# --- Git --- #", "alias gs='git status'", "", "# --- End --- #"].join("\n"));
+
+      const result = await addAliasesToZshrc("Git Aliases", ALIASES, "collection");
+      expect(result.success).toBe(true);
+      expect(result.addedTo).toBe("existing");
+
+      const written = mockWrite.mock.calls[0]![0] as string;
+      expect(written).toContain("alias g='git'");
+      expect(written).toContain("# Added from Git Aliases (collection)");
+    });
+
+    it("creates a new section when nothing matches", async () => {
+      mockReadRaw.mockResolvedValue("alias unrelated='x'\n");
+
+      const result = await addAliasesToZshrc("Kubernetes", ALIASES);
+      expect(result.success).toBe(true);
+      expect(result.addedTo).toBe("new");
+      expect(result.sectionName).toBe("Kubernetes");
+
+      const written = mockWrite.mock.calls[0]![0] as string;
+      expect(written).toContain("Kubernetes");
+      expect(written).toContain("alias ga='git add'");
+    });
+
+    it("starts from empty content when the file is unreadable", async () => {
+      mockReadRaw.mockRejectedValue(new Error("missing"));
+
+      const result = await addAliasesToZshrc("Fresh", ALIASES);
+      expect(result.success).toBe(true);
+      expect(result.addedTo).toBe("new");
+      expect(mockWrite).toHaveBeenCalled();
+    });
+  });
+
+  describe("addSingleAliasToZshrc", () => {
+    it("writes a single alias", async () => {
+      mockReadRaw.mockResolvedValue("# --- Tools --- #\nalias t='true'\n");
+
+      const result = await addSingleAliasToZshrc({ name: "gl", value: "git log" }, "Tools");
+      expect(result.success).toBe(true);
+      const written = mockWrite.mock.calls[0]![0] as string;
+      expect(written).toContain("alias gl='git log'");
+    });
+  });
+});

--- a/extensions/zshrc-manager/src/__tests__/toggle-item.test.ts
+++ b/extensions/zshrc-manager/src/__tests__/toggle-item.test.ts
@@ -122,7 +122,7 @@ describe("toggle-item.ts", () => {
       // - Was NOT commented (active) -> returns true after commenting (counter-intuitive)
       expect(result).toBe(true);
       expect(mockWriteZshrcFile).toHaveBeenCalledWith(expectedContent);
-      expect(mockSaveToHistory).toHaveBeenCalledWith('Disable alias "ll"');
+      expect(mockSaveToHistory).toHaveBeenCalledWith('Disable alias "ll"', expect.any(String));
       expect(mockClearCache).toHaveBeenCalledWith(TEST_PATH);
       // Note: Toast shows "Enabled"/"active" when result is true, even though we commented it out
       expect(mockShowToast).toHaveBeenCalledWith({
@@ -145,7 +145,7 @@ describe("toggle-item.ts", () => {
       // - WAS commented (disabled) -> returns false after uncommenting (counter-intuitive)
       expect(result).toBe(false);
       expect(mockWriteZshrcFile).toHaveBeenCalledWith(expectedContent);
-      expect(mockSaveToHistory).toHaveBeenCalledWith('Enable alias "ll"');
+      expect(mockSaveToHistory).toHaveBeenCalledWith('Enable alias "ll"', expect.any(String));
     });
 
     it("should preserve leading whitespace when commenting", async () => {

--- a/extensions/zshrc-manager/src/constants.ts
+++ b/extensions/zshrc-manager/src/constants.ts
@@ -75,7 +75,9 @@ export const PARSING_CONSTANTS = {
     SETOPT: /^(?:\s*)setopt\s+(.+?)(?:\s*)$/,
     PLUGIN: /^(?:\s*)plugins\s*=\s*\(([^)]+)\)(?:\s*)$/,
     FUNCTION: /^(?:\s*)([A-Za-z_][A-Za-z0-9_]*)\s*\(\s*\)\s*\{(?:\s*)$/,
-    SOURCE: /^(?:\s*)source\s+(.+?)(?:\s*)$/,
+    // Capture only the operand (quoted string or unquoted token) — an
+    // inline `# comment` after it is not part of the path
+    SOURCE: /^(?:\s*)source\s+("(?:[^"\\]|\\.)*"|'[^']*'|[^\s#]+)/,
     AUTOLOAD: /^(?:\s*)autoload\s+(?:-Uz\s+)?([A-Za-z_][A-Za-z0-9_]*)(?:\s*)$/,
     FPATH: /^(?:\s*)fpath\s*=\s*\(([^)]+)\)(?:\s*)$/,
     PATH: /^(?:\s*)PATH\s*=\s*(.+?)(?:\s*)$/,

--- a/extensions/zshrc-manager/src/constants.ts
+++ b/extensions/zshrc-manager/src/constants.ts
@@ -73,18 +73,14 @@ export const PARSING_CONSTANTS = {
     EXPORT: /^(?:\s*)(?:export|typeset\s+-x)\s+([A-Za-z_][A-Za-z0-9_]*)=(.*?)(?:\s*)$/,
     EVAL: /^(?:\s*)eval\s+(.+?)(?:\s*)$/,
     SETOPT: /^(?:\s*)setopt\s+(.+?)(?:\s*)$/,
-    PLUGIN: /^(?:\s*)plugins\s*=\s*\(([^)]+)\)(?:\s*)$/,
     FUNCTION: /^(?:\s*)([A-Za-z_][A-Za-z0-9_]*)\s*\(\s*\)\s*\{(?:\s*)$/,
     // Capture only the operand (quoted string or unquoted token) — an
     // inline `# comment` after it is not part of the path
     SOURCE: /^(?:\s*)source\s+("(?:[^"\\]|\\.)*"|'[^']*'|[^\s#]+)/,
     AUTOLOAD: /^(?:\s*)autoload\s+(?:-Uz\s+)?([A-Za-z_][A-Za-z0-9_]*)(?:\s*)$/,
-    FPATH: /^(?:\s*)fpath\s*=\s*\(([^)]+)\)(?:\s*)$/,
-    PATH: /^(?:\s*)PATH\s*=\s*(.+?)(?:\s*)$/,
     THEME: /^(?:\s*)ZSH_THEME\s*=\s*(?:'|")(.*?)(?:'|")(?:\s*)$/,
     COMPLETION: /^(?:\s*)compinit(?:\s*)$/,
     HISTORY: /^(?:\s*)HIST[A-Z_]*\s*=\s*(.+?)(?:\s*)$/,
-    KEYBINDING: /^(?:\s*)bindkey\s+(.+?)(?:\s*)$/,
   },
 
   /** Section detection priorities (higher number = higher priority) */

--- a/extensions/zshrc-manager/src/lib/delete-item.ts
+++ b/extensions/zshrc-manager/src/lib/delete-item.ts
@@ -81,10 +81,6 @@ export async function deleteItem(
 
     log.delete.debug(`Found ${config.itemType} "${key}", proceeding with deletion`);
 
-    // Save to history before writing
-    log.delete.debug("Saving to history before delete");
-    await saveToHistory(`Delete ${config.itemType} "${key}"`);
-
     log.delete.debug("Writing updated content");
     await writeZshrcFile(updatedContent);
     clearCache(getZshrcPath());
@@ -95,6 +91,12 @@ export async function deleteItem(
       log.delete.error("Write verification failed: content mismatch");
       throw new Error("Write verification failed: content mismatch after delete");
     }
+
+    // Record history only after the write is verified, with the pre-delete
+    // snapshot as the undo target — recording earlier risks a restore point
+    // for a delete that never happened
+    log.delete.debug("Saving pre-delete snapshot to history");
+    await saveToHistory(`Delete ${config.itemType} "${key}"`, zshrcContent);
 
     log.delete.info(`Successfully deleted ${config.itemType} "${key}"`);
 

--- a/extensions/zshrc-manager/src/lib/edit-item-form.tsx
+++ b/extensions/zshrc-manager/src/lib/edit-item-form.tsx
@@ -1,92 +1,18 @@
-import {
-  Form,
-  ActionPanel,
-  Action,
-  Icon,
-  showToast,
-  Toast,
-  useNavigation,
-  Detail,
-  confirmAlert,
-  Alert,
-} from "@raycast/api";
+import { Form, ActionPanel, Action, Icon, showToast, Toast, useNavigation, confirmAlert, Alert } from "@raycast/api";
 import { useForm } from "@raycast/utils";
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 import { readZshrcFileRaw, writeZshrcFile, checkZshrcAccess, getZshrcPath, readZshrcFile } from "./zsh";
-import { findSectionBounds } from "./section-detector";
-import { replaceFirstScoped } from "./scoped-replace";
 import { clearCache } from "./cache";
 import { toLogicalSections } from "./parse-zshrc";
 import { saveToHistory } from "./history";
 import { log } from "../utils/logger";
-import { computeDiff } from "../utils/diff";
 import { validateStructure } from "../utils/validation";
 import { SaveCancelledError } from "../utils/errors";
-import type { ScopedReplaceFailure } from "./scoped-replace";
+import { computeDeletedContent, computeUpdatedContent, type EditItemConfig } from "./edit-item-write";
+import { DiffPreviewView } from "./edit-item-preview";
 
-/** Error message for a scoped replacement that refused to guess */
-function scopedFailureMessage(
-  reason: ScopedReplaceFailure | undefined,
-  itemTypeCapitalized: string,
-  key: string,
-): string {
-  switch (reason) {
-    case "ambiguous":
-      return `Multiple definitions of "${key}" exist and the selected one could not be identified — edit ~/.zshrc directly`;
-    case "unsupported":
-      return `The definition of "${key}" uses a format this extension cannot rewrite safely — edit ~/.zshrc directly`;
-    default:
-      return `${itemTypeCapitalized} "${key}" not found in zshrc`;
-  }
-}
-
-/**
- * Replaces a matched definition line while preserving its leading whitespace
- * and inline comment (pattern groups 1 and 3)
- */
-function preservingReplacer(pattern: RegExp, replacement: string): (matchedLine: string) => string {
-  return (matchedLine) => {
-    const single = new RegExp(pattern.source, pattern.flags.replace("g", ""));
-    const match = single.exec(matchedLine);
-    const leadingWhitespace = match?.[1] ?? "";
-    const comment = match?.[3] ?? "";
-    return `${leadingWhitespace}${replacement.trimStart()}${comment}`;
-  };
-}
-
-/**
- * Configuration for EditItemForm component
- */
-export interface EditItemConfig {
-  /** Label for the key field (e.g., "Alias Name" or "Variable Name") */
-  keyLabel: string;
-  /** Label for the value field (e.g., "Command" or "Value") */
-  valueLabel: string;
-  /** Placeholder for key field */
-  keyPlaceholder: string;
-  /** Placeholder for value field */
-  valuePlaceholder: string;
-  /** Validation regex for key field */
-  keyPattern: RegExp;
-  /** Validation error message for key field */
-  keyValidationError: string;
-  /** Function to generate the line to insert */
-  generateLine: (key: string, value: string) => string;
-  /** Function to generate regex pattern for finding existing item */
-  generatePattern: (key: string) => RegExp;
-  /** Function to generate replacement line for update */
-  generateReplacement: (key: string, value: string) => string;
-  /**
-   * Whether a line holds a definition of `key` as the display parser sees it.
-   * The write path only ever targets lines this predicate accepts, so it can
-   * never rewrite a line the UI did not show.
-   */
-  matchesDisplayLine: (line: string, key: string) => boolean;
-  /** Item type name for messages (e.g., "alias" or "export") */
-  itemType: string;
-  /** Item type capitalized for titles (e.g., "Alias" or "Export") */
-  itemTypeCapitalized: string;
-}
+// Re-exported so existing callers keep importing the config type from here
+export type { EditItemConfig } from "./edit-item-write";
 
 interface EditItemFormProps {
   /** Existing key value (for editing) */
@@ -104,6 +30,21 @@ interface EditItemFormProps {
 }
 
 /**
+ * Writes the updated content, invalidates the cache, verifies the write by
+ * re-reading, and records history only after verification succeeds.
+ */
+async function persistAndVerify(updatedContent: string, historyLabel: string, logContext: string): Promise<void> {
+  await writeZshrcFile(updatedContent);
+  clearCache(getZshrcPath());
+  const verify = await readZshrcFileRaw();
+  if (verify !== updatedContent) {
+    log.edit.error(`Write verification failed for ${logContext}`);
+    throw new Error("Write verification failed: content mismatch after save");
+  }
+  await saveToHistory(historyLabel);
+}
+
+/**
  * Generic form component for creating or editing zshrc items (aliases, exports, etc.)
  *
  * This component provides a reusable form interface for managing zshrc configuration items.
@@ -112,6 +53,9 @@ interface EditItemFormProps {
  * - Validation of key/value pairs
  * - Atomic file writes with verification
  * - Section creation and item movement
+ *
+ * The content each save produces is computed by the pure functions in
+ * `edit-item-write.ts`, shared with the diff preview.
  *
  * @param existingKey - Existing key value (for editing mode)
  * @param existingValue - Existing value (for editing mode)
@@ -222,182 +166,43 @@ export default function EditItemForm({
 
       try {
         const zshrcContent = await readZshrcFileRaw();
+        const updatedContent = computeUpdatedContent(zshrcContent, {
+          config,
+          key,
+          value,
+          targetSection,
+          isEditing,
+          existingKey,
+          originalSection: sectionLabel,
+          sectionOccurrence,
+        });
 
         if (isEditing) {
-          // Check if section changed
-          const sectionChanged = sectionLabel !== targetSection;
+          const moved = sectionLabel !== targetSection;
+          log.edit.info(
+            moved
+              ? `Updating ${config.itemType} "${key}" and moving to section "${targetSection}"`
+              : `Updating ${config.itemType} "${key}" in place`,
+          );
+          await persistAndVerify(
+            updatedContent,
+            moved
+              ? `Update ${config.itemType} "${key}" (move to ${targetSection})`
+              : `Update ${config.itemType} "${key}"`,
+            `${config.itemType} "${key}"`,
+          );
+          log.edit.info(`Successfully updated ${config.itemType} "${key}"`);
 
-          if (sectionChanged) {
-            // Moving to a different section - remove from old location and add to new.
-            // Scoped to the original section so a duplicate definition elsewhere
-            // is not the one removed.
-            const pattern = config.generatePattern(existingKey!);
-            const removal = replaceFirstScoped(
-              zshrcContent,
-              sectionLabel,
-              pattern,
-              () => "",
-              (line) => config.matchesDisplayLine(line, existingKey!),
-              sectionOccurrence ?? 0,
-            );
-
-            if (!removal.found) {
-              throw new Error(scopedFailureMessage(removal.reason, config.itemTypeCapitalized, existingKey!));
-            }
-
-            let updatedContent = removal.content;
-
-            // Clean up empty lines left behind
-            updatedContent = updatedContent.replace(/\n\n\n+/g, "\n\n");
-
-            // Generate the new line
-            const itemLine = config.generateLine(key, value);
-
-            // Find the target section to add to. The section dropdown offers
-            // labels, not instances, so when the target label is duplicated
-            // the item is inserted into its first instance by design.
-            const targetSectionBounds = findSectionBounds(updatedContent, targetSection);
-
-            if (targetSectionBounds) {
-              // Found target section - add to it
-              const lines = updatedContent.split(/\r?\n/);
-              let insertLineIndex = targetSectionBounds.endLine - 1;
-
-              // Find the last non-empty line in the section
-              for (let i = targetSectionBounds.endLine - 1; i >= targetSectionBounds.startLine - 1; i--) {
-                const line = lines[i];
-                if (line && line.trim().length > 0) {
-                  insertLineIndex = i;
-                  break;
-                }
-              }
-
-              const beforeLines = lines.slice(0, insertLineIndex + 1);
-              const afterLines = lines.slice(insertLineIndex + 1);
-
-              const beforeSection = beforeLines.join("\n");
-              const afterSection = afterLines.join("\n");
-
-              if (afterSection) {
-                updatedContent = `${beforeSection}\n${itemLine}\n${afterSection}`;
-              } else {
-                updatedContent = `${beforeSection}\n${itemLine}`;
-              }
-            } else {
-              // Target section not found - create it at the end
-              updatedContent = `${updatedContent}\n\n# --- ${targetSection} --- #\n${itemLine}`;
-            }
-
-            log.edit.info(`Updating ${config.itemType} "${key}" and moving to section "${targetSection}"`);
-            await writeZshrcFile(updatedContent);
-            clearCache(getZshrcPath());
-            const verify = await readZshrcFileRaw();
-            if (verify !== updatedContent) {
-              log.edit.error(`Write verification failed for ${config.itemType} "${key}"`);
-              throw new Error("Write verification failed: content mismatch after save");
-            }
-            // Save to history only after successful write verification
-            await saveToHistory(`Update ${config.itemType} "${key}" (move to ${targetSection})`);
-            log.edit.info(`Successfully updated ${config.itemType} "${key}"`);
-
-            await showToast({
-              style: Toast.Style.Success,
-              title: `${config.itemTypeCapitalized} Updated`,
-              message: `Updated ${config.itemType} "${key}" and moved to "${targetSection}"`,
-            });
-          } else {
-            // Same section - just update the line in place, scoped to the item's
-            // section so a duplicate definition elsewhere is not the one edited
-            const pattern = config.generatePattern(existingKey!);
-            const update = replaceFirstScoped(
-              zshrcContent,
-              sectionLabel,
-              pattern,
-              preservingReplacer(pattern, config.generateReplacement(key, value)),
-              (line) => config.matchesDisplayLine(line, existingKey!),
-              sectionOccurrence ?? 0,
-            );
-
-            if (!update.found) {
-              throw new Error(scopedFailureMessage(update.reason, config.itemTypeCapitalized, existingKey!));
-            }
-
-            const updatedContent = update.content;
-            log.edit.info(`Updating ${config.itemType} "${key}" in place`);
-            await writeZshrcFile(updatedContent);
-            clearCache(getZshrcPath());
-            // Verify write by re-reading and comparing
-            const verify = await readZshrcFileRaw();
-            if (verify !== updatedContent) {
-              log.edit.error(`Write verification failed for ${config.itemType} "${key}"`);
-              throw new Error("Write verification failed: content mismatch after save");
-            }
-            // Save to history only after successful write verification
-            await saveToHistory(`Update ${config.itemType} "${key}"`);
-            log.edit.info(`Successfully updated ${config.itemType} "${key}"`);
-
-            await showToast({
-              style: Toast.Style.Success,
-              title: `${config.itemTypeCapitalized} Updated`,
-              message: `Updated ${config.itemType} "${key}"`,
-            });
-          }
+          await showToast({
+            style: Toast.Style.Success,
+            title: `${config.itemTypeCapitalized} Updated`,
+            message: moved
+              ? `Updated ${config.itemType} "${key}" and moved to "${targetSection}"`
+              : `Updated ${config.itemType} "${key}"`,
+          });
         } else {
-          // Add new item
-          const itemLine = config.generateLine(key, value);
-
-          // Find the section to add the item to
-          let updatedContent = zshrcContent;
-
-          // Find the section using all supported formats
-          const sectionBounds = findSectionBounds(zshrcContent, targetSection);
-
-          if (sectionBounds) {
-            // Found existing section - add to it
-            // Find the last non-empty line before the section end
-            const lines = zshrcContent.split(/\r?\n/);
-            let insertLineIndex = sectionBounds.endLine - 1;
-
-            // Find the last non-empty line in the section
-            for (let i = sectionBounds.endLine - 1; i >= sectionBounds.startLine - 1; i--) {
-              const line = lines[i];
-              if (line && line.trim().length > 0) {
-                insertLineIndex = i;
-                break;
-              }
-            }
-
-            // Rebuild content with the new item inserted after the last non-empty line
-            const beforeLines = lines.slice(0, insertLineIndex + 1);
-            const afterLines = lines.slice(insertLineIndex + 1);
-
-            // Join with original line endings preserved
-            const beforeSection = beforeLines.join("\n");
-            const afterSection = afterLines.join("\n");
-
-            // Insert the new item with proper spacing
-            if (afterSection) {
-              updatedContent = `${beforeSection}\n${itemLine}\n${afterSection}`;
-            } else {
-              // End of file - add without trailing newline
-              updatedContent = `${beforeSection}\n${itemLine}`;
-            }
-          } else {
-            // Section not found - create a new section at the end of the file
-            // Use a simple format that's commonly supported
-            updatedContent = `${zshrcContent}\n\n# --- ${targetSection} --- #\n${itemLine}`;
-          }
-
           log.edit.info(`Adding new ${config.itemType} "${key}" to section "${targetSection}"`);
-          await writeZshrcFile(updatedContent);
-          clearCache(getZshrcPath());
-          const verify = await readZshrcFileRaw();
-          if (verify !== updatedContent) {
-            log.edit.error(`Write verification failed for new ${config.itemType} "${key}"`);
-            throw new Error("Write verification failed: content mismatch after save");
-          }
-          // Save to history only after successful write verification
-          await saveToHistory(`Add ${config.itemType} "${key}"`);
+          await persistAndVerify(updatedContent, `Add ${config.itemType} "${key}"`, `new ${config.itemType} "${key}"`);
           log.edit.info(`Successfully added ${config.itemType} "${key}"`);
 
           await showToast({
@@ -440,23 +245,13 @@ export default function EditItemForm({
 
     try {
       const zshrcContent = await readZshrcFileRaw();
-      const pattern = config.generatePattern(existingKey);
-      // Scoped to the item's section so a duplicate definition elsewhere is
-      // not the one removed
-      const removal = replaceFirstScoped(
-        zshrcContent,
+      const updatedContent = computeDeletedContent(zshrcContent, {
+        config,
+        existingKey,
         sectionLabel,
-        pattern,
-        () => "",
-        (line) => config.matchesDisplayLine(line, existingKey),
-        sectionOccurrence ?? 0,
-      );
+        sectionOccurrence,
+      });
 
-      if (!removal.found) {
-        throw new Error(scopedFailureMessage(removal.reason, config.itemTypeCapitalized, existingKey));
-      }
-
-      const updatedContent = removal.content;
       log.edit.info(`Deleting ${config.itemType} "${existingKey}"`);
       await saveToHistory(`Delete ${config.itemType} "${existingKey}"`);
       await writeZshrcFile(updatedContent);
@@ -559,230 +354,5 @@ export default function EditItemForm({
         <Form.TextField {...itemProps.newSectionName} title="New Section Name" placeholder="e.g., My Custom Section" />
       )}
     </Form>
-  );
-}
-
-/**
- * Props for DiffPreviewView
- */
-interface DiffPreviewViewProps {
-  existingKey?: string | undefined;
-  sectionOccurrence?: number | undefined;
-  currentKey: string;
-  currentValue: string;
-  currentSection: string;
-  newSectionName: string;
-  originalSection?: string | undefined;
-  config: EditItemConfig;
-  isEditing: boolean;
-}
-
-/**
- * Diff preview view component
- * Shows the diff between current file and proposed changes
- */
-function DiffPreviewView({
-  existingKey,
-  sectionOccurrence,
-  currentKey,
-  currentValue,
-  currentSection,
-  newSectionName,
-  originalSection,
-  config,
-  isEditing,
-}: DiffPreviewViewProps) {
-  const [diffMarkdown, setDiffMarkdown] = useState<string>("Loading preview...");
-  const [isLoading, setIsLoading] = useState(true);
-
-  const generatePreview = useCallback(async () => {
-    setIsLoading(true);
-    try {
-      const key = currentKey.trim();
-      const value = currentValue.trim();
-
-      if (!key || !value) {
-        setDiffMarkdown(`
-# Preview Not Available
-
-Please fill in both the ${config.keyLabel.toLowerCase()} and ${config.valueLabel.toLowerCase()} fields to preview changes.
-        `);
-        return;
-      }
-
-      // Determine target section
-      let targetSection = currentSection;
-      if (currentSection === "New Section") {
-        if (!newSectionName.trim()) {
-          setDiffMarkdown(`
-# Preview Not Available
-
-Please provide a name for the new section to preview changes.
-          `);
-          return;
-        }
-        targetSection = newSectionName.trim();
-      }
-
-      const zshrcContent = await readZshrcFileRaw();
-      let modifiedContent = zshrcContent;
-
-      if (isEditing && existingKey) {
-        // Editing existing item
-        const sectionChanged = originalSection !== targetSection;
-
-        if (sectionChanged) {
-          // Moving to a different section (scoped to the original section)
-          const pattern = config.generatePattern(existingKey);
-          const removal = replaceFirstScoped(
-            zshrcContent,
-            originalSection,
-            pattern,
-            () => "",
-            (line) => config.matchesDisplayLine(line, existingKey),
-            sectionOccurrence ?? 0,
-          );
-          if (!removal.found) {
-            throw new Error(scopedFailureMessage(removal.reason, config.itemTypeCapitalized, existingKey));
-          }
-          modifiedContent = removal.content;
-          modifiedContent = modifiedContent.replace(/\n\n\n+/g, "\n\n");
-
-          // Generate the new line
-          const itemLine = config.generateLine(key, value);
-
-          // Find the target section
-          const targetSectionBounds = findSectionBounds(modifiedContent, targetSection);
-
-          if (targetSectionBounds) {
-            const lines = modifiedContent.split(/\r?\n/);
-            let insertLineIndex = targetSectionBounds.endLine - 1;
-
-            for (let i = targetSectionBounds.endLine - 1; i >= targetSectionBounds.startLine - 1; i--) {
-              const line = lines[i];
-              if (line && line.trim().length > 0) {
-                insertLineIndex = i;
-                break;
-              }
-            }
-
-            const beforeLines = lines.slice(0, insertLineIndex + 1);
-            const afterLines = lines.slice(insertLineIndex + 1);
-            const beforeSection = beforeLines.join("\n");
-            const afterSection = afterLines.join("\n");
-
-            modifiedContent = afterSection
-              ? `${beforeSection}\n${itemLine}\n${afterSection}`
-              : `${beforeSection}\n${itemLine}`;
-          } else {
-            modifiedContent = `${modifiedContent}\n\n# --- ${targetSection} --- #\n${itemLine}`;
-          }
-        } else {
-          // Same section - update in place (scoped to the item's section)
-          const pattern = config.generatePattern(existingKey);
-          const update = replaceFirstScoped(
-            zshrcContent,
-            originalSection,
-            pattern,
-            preservingReplacer(pattern, config.generateReplacement(key, value)),
-            (line) => config.matchesDisplayLine(line, existingKey),
-            sectionOccurrence ?? 0,
-          );
-          if (!update.found) {
-            throw new Error(scopedFailureMessage(update.reason, config.itemTypeCapitalized, existingKey));
-          }
-          modifiedContent = update.content;
-        }
-      } else {
-        // Adding new item
-        const itemLine = config.generateLine(key, value);
-        const sectionBounds = findSectionBounds(zshrcContent, targetSection);
-
-        if (sectionBounds) {
-          const lines = zshrcContent.split(/\r?\n/);
-          let insertLineIndex = sectionBounds.endLine - 1;
-
-          for (let i = sectionBounds.endLine - 1; i >= sectionBounds.startLine - 1; i--) {
-            const line = lines[i];
-            if (line && line.trim().length > 0) {
-              insertLineIndex = i;
-              break;
-            }
-          }
-
-          const beforeLines = lines.slice(0, insertLineIndex + 1);
-          const afterLines = lines.slice(insertLineIndex + 1);
-          const beforeSection = beforeLines.join("\n");
-          const afterSection = afterLines.join("\n");
-
-          modifiedContent = afterSection
-            ? `${beforeSection}\n${itemLine}\n${afterSection}`
-            : `${beforeSection}\n${itemLine}`;
-        } else {
-          modifiedContent = `${zshrcContent}\n\n# --- ${targetSection} --- #\n${itemLine}`;
-        }
-      }
-
-      // Compute the diff
-      const diff = computeDiff(zshrcContent, modifiedContent);
-
-      if (!diff.hasChanges) {
-        setDiffMarkdown(`
-# No Changes
-
-The current values would not change your zshrc file.
-        `);
-      } else {
-        setDiffMarkdown(`
-# Preview: ${isEditing ? `Update ${config.itemTypeCapitalized}` : `Add ${config.itemTypeCapitalized}`}
-
-${diff.markdown}
-
----
-
-*This preview shows what will change when you save. Lines prefixed with \`-\` will be removed, lines with \`+\` will be added.*
-        `);
-      }
-    } catch (error) {
-      setDiffMarkdown(`
-# Error Generating Preview
-
-${error instanceof Error ? error.message : "Unknown error occurred"}
-      `);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [
-    currentKey,
-    currentValue,
-    currentSection,
-    newSectionName,
-    originalSection,
-    existingKey,
-    sectionOccurrence,
-    config,
-    isEditing,
-  ]);
-
-  useEffect(() => {
-    generatePreview();
-  }, [generatePreview]);
-
-  return (
-    <Detail
-      navigationTitle="Preview Changes"
-      isLoading={isLoading}
-      markdown={diffMarkdown}
-      actions={
-        <ActionPanel>
-          <Action title="Refresh Preview" icon={Icon.ArrowClockwise} onAction={generatePreview} />
-          <Action.CopyToClipboard
-            title="Copy Diff"
-            content={diffMarkdown}
-            shortcut={{ modifiers: ["cmd"], key: "c" }}
-          />
-        </ActionPanel>
-      }
-    />
   );
 }

--- a/extensions/zshrc-manager/src/lib/edit-item-form.tsx
+++ b/extensions/zshrc-manager/src/lib/edit-item-form.tsx
@@ -31,9 +31,16 @@ interface EditItemFormProps {
 
 /**
  * Writes the updated content, invalidates the cache, verifies the write by
- * re-reading, and records history only after verification succeeds.
+ * re-reading, and records history only after verification succeeds. The
+ * history entry stores `previousContent` — the pre-change snapshot — so
+ * undo restores the state before this write.
  */
-async function persistAndVerify(updatedContent: string, historyLabel: string, logContext: string): Promise<void> {
+async function persistAndVerify(
+  updatedContent: string,
+  previousContent: string,
+  historyLabel: string,
+  logContext: string,
+): Promise<void> {
   await writeZshrcFile(updatedContent);
   clearCache(getZshrcPath());
   const verify = await readZshrcFileRaw();
@@ -41,7 +48,7 @@ async function persistAndVerify(updatedContent: string, historyLabel: string, lo
     log.edit.error(`Write verification failed for ${logContext}`);
     throw new Error("Write verification failed: content mismatch after save");
   }
-  await saveToHistory(historyLabel);
+  await saveToHistory(historyLabel, previousContent);
 }
 
 /**
@@ -186,6 +193,7 @@ export default function EditItemForm({
           );
           await persistAndVerify(
             updatedContent,
+            zshrcContent,
             moved
               ? `Update ${config.itemType} "${key}" (move to ${targetSection})`
               : `Update ${config.itemType} "${key}"`,
@@ -202,7 +210,12 @@ export default function EditItemForm({
           });
         } else {
           log.edit.info(`Adding new ${config.itemType} "${key}" to section "${targetSection}"`);
-          await persistAndVerify(updatedContent, `Add ${config.itemType} "${key}"`, `new ${config.itemType} "${key}"`);
+          await persistAndVerify(
+            updatedContent,
+            zshrcContent,
+            `Add ${config.itemType} "${key}"`,
+            `new ${config.itemType} "${key}"`,
+          );
           log.edit.info(`Successfully added ${config.itemType} "${key}"`);
 
           await showToast({
@@ -253,14 +266,12 @@ export default function EditItemForm({
       });
 
       log.edit.info(`Deleting ${config.itemType} "${existingKey}"`);
-      await saveToHistory(`Delete ${config.itemType} "${existingKey}"`);
-      await writeZshrcFile(updatedContent);
-      clearCache(getZshrcPath());
-      const verify = await readZshrcFileRaw();
-      if (verify !== updatedContent) {
-        log.edit.error(`Write verification failed for delete of ${config.itemType} "${existingKey}"`);
-        throw new Error("Write verification failed: content mismatch after delete");
-      }
+      await persistAndVerify(
+        updatedContent,
+        zshrcContent,
+        `Delete ${config.itemType} "${existingKey}"`,
+        `delete of ${config.itemType} "${existingKey}"`,
+      );
       log.edit.info(`Successfully deleted ${config.itemType} "${existingKey}"`);
 
       await showToast({

--- a/extensions/zshrc-manager/src/lib/edit-item-preview.tsx
+++ b/extensions/zshrc-manager/src/lib/edit-item-preview.tsx
@@ -1,0 +1,151 @@
+/**
+ * Diff preview for the edit form.
+ *
+ * Derives the proposed content from the same pure computation the save
+ * path uses (`computeUpdatedContent`), so the preview always shows
+ * exactly what a save would write.
+ */
+
+import { Action, ActionPanel, Detail, Icon } from "@raycast/api";
+import { useCallback, useEffect, useState } from "react";
+import { computeDiff } from "../utils/diff";
+import { computeUpdatedContent, type EditItemConfig } from "./edit-item-write";
+import { readZshrcFileRaw } from "./zsh";
+
+/**
+ * Props for DiffPreviewView
+ */
+export interface DiffPreviewViewProps {
+  existingKey?: string | undefined;
+  sectionOccurrence?: number | undefined;
+  currentKey: string;
+  currentValue: string;
+  currentSection: string;
+  newSectionName: string;
+  originalSection?: string | undefined;
+  config: EditItemConfig;
+  isEditing: boolean;
+}
+
+/**
+ * Diff preview view component
+ * Shows the diff between current file and proposed changes
+ */
+export function DiffPreviewView({
+  existingKey,
+  sectionOccurrence,
+  currentKey,
+  currentValue,
+  currentSection,
+  newSectionName,
+  originalSection,
+  config,
+  isEditing,
+}: DiffPreviewViewProps) {
+  const [diffMarkdown, setDiffMarkdown] = useState<string>("Loading preview...");
+  const [isLoading, setIsLoading] = useState(true);
+
+  const generatePreview = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const key = currentKey.trim();
+      const value = currentValue.trim();
+
+      if (!key || !value) {
+        setDiffMarkdown(`
+# Preview Not Available
+
+Please fill in both the ${config.keyLabel.toLowerCase()} and ${config.valueLabel.toLowerCase()} fields to preview changes.
+        `);
+        return;
+      }
+
+      // Determine target section
+      let targetSection = currentSection;
+      if (currentSection === "New Section") {
+        if (!newSectionName.trim()) {
+          setDiffMarkdown(`
+# Preview Not Available
+
+Please provide a name for the new section to preview changes.
+          `);
+          return;
+        }
+        targetSection = newSectionName.trim();
+      }
+
+      const zshrcContent = await readZshrcFileRaw();
+      const modifiedContent = computeUpdatedContent(zshrcContent, {
+        config,
+        key,
+        value,
+        targetSection,
+        isEditing,
+        existingKey,
+        originalSection,
+        sectionOccurrence,
+      });
+
+      // Compute the diff
+      const diff = computeDiff(zshrcContent, modifiedContent);
+
+      if (!diff.hasChanges) {
+        setDiffMarkdown(`
+# No Changes
+
+The current values would not change your zshrc file.
+        `);
+      } else {
+        setDiffMarkdown(`
+# Preview: ${isEditing ? `Update ${config.itemTypeCapitalized}` : `Add ${config.itemTypeCapitalized}`}
+
+${diff.markdown}
+
+---
+
+*This preview shows what will change when you save. Lines prefixed with \`-\` will be removed, lines with \`+\` will be added.*
+        `);
+      }
+    } catch (error) {
+      setDiffMarkdown(`
+# Error Generating Preview
+
+${error instanceof Error ? error.message : "Unknown error occurred"}
+      `);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [
+    currentKey,
+    currentValue,
+    currentSection,
+    newSectionName,
+    originalSection,
+    existingKey,
+    sectionOccurrence,
+    config,
+    isEditing,
+  ]);
+
+  useEffect(() => {
+    generatePreview();
+  }, [generatePreview]);
+
+  return (
+    <Detail
+      navigationTitle="Preview Changes"
+      isLoading={isLoading}
+      markdown={diffMarkdown}
+      actions={
+        <ActionPanel>
+          <Action title="Refresh Preview" icon={Icon.ArrowClockwise} onAction={generatePreview} />
+          <Action.CopyToClipboard
+            title="Copy Diff"
+            content={diffMarkdown}
+            shortcut={{ modifiers: ["cmd"], key: "c" }}
+          />
+        </ActionPanel>
+      }
+    />
+  );
+}

--- a/extensions/zshrc-manager/src/lib/edit-item-write.ts
+++ b/extensions/zshrc-manager/src/lib/edit-item-write.ts
@@ -1,0 +1,202 @@
+/**
+ * Pure content computation for the edit/delete write path.
+ *
+ * Everything here is side-effect free: given the current file content and
+ * the intended operation, produce the new content (or throw with a
+ * user-facing message when the target cannot be resolved unambiguously).
+ * The form, the delete flow, and the diff preview all derive from these
+ * functions, so the preview always shows exactly what a save would write.
+ */
+
+import { findSectionBounds } from "./section-detector";
+import { replaceFirstScoped, type ScopedReplaceFailure } from "./scoped-replace";
+
+/**
+ * Configuration for EditItemForm component
+ */
+export interface EditItemConfig {
+  /** Label for the key field (e.g., "Alias Name" or "Variable Name") */
+  keyLabel: string;
+  /** Label for the value field (e.g., "Command" or "Value") */
+  valueLabel: string;
+  /** Placeholder for key field */
+  keyPlaceholder: string;
+  /** Placeholder for value field */
+  valuePlaceholder: string;
+  /** Validation regex for key field */
+  keyPattern: RegExp;
+  /** Validation error message for key field */
+  keyValidationError: string;
+  /** Function to generate the line to insert */
+  generateLine: (key: string, value: string) => string;
+  /** Function to generate regex pattern for finding existing item */
+  generatePattern: (key: string) => RegExp;
+  /** Function to generate replacement line for update */
+  generateReplacement: (key: string, value: string) => string;
+  /**
+   * Whether a line holds a definition of `key` as the display parser sees it.
+   * The write path only ever targets lines this predicate accepts, so it can
+   * never rewrite a line the UI did not show.
+   */
+  matchesDisplayLine: (line: string, key: string) => boolean;
+  /** Item type name for messages (e.g., "alias" or "export") */
+  itemType: string;
+  /** Item type capitalized for titles (e.g., "Alias" or "Export") */
+  itemTypeCapitalized: string;
+}
+
+/** Error message for a scoped replacement that refused to guess */
+export function scopedFailureMessage(
+  reason: ScopedReplaceFailure | undefined,
+  itemTypeCapitalized: string,
+  key: string,
+): string {
+  switch (reason) {
+    case "ambiguous":
+      return `Multiple definitions of "${key}" exist and the selected one could not be identified — edit ~/.zshrc directly`;
+    case "unsupported":
+      return `The definition of "${key}" uses a format this extension cannot rewrite safely — edit ~/.zshrc directly`;
+    default:
+      return `${itemTypeCapitalized} "${key}" not found in zshrc`;
+  }
+}
+
+/**
+ * Replaces a matched definition line while preserving its leading whitespace
+ * and inline comment (pattern groups 1 and 3)
+ */
+export function preservingReplacer(pattern: RegExp, replacement: string): (matchedLine: string) => string {
+  return (matchedLine) => {
+    const single = new RegExp(pattern.source, pattern.flags.replace("g", ""));
+    const match = single.exec(matchedLine);
+    const leadingWhitespace = match?.[1] ?? "";
+    const comment = match?.[3] ?? "";
+    return `${leadingWhitespace}${replacement.trimStart()}${comment}`;
+  };
+}
+
+/**
+ * Inserts a line at the end of a named section (after its last non-empty
+ * line). When the section does not exist, it is created at the end of the
+ * file. The section dropdown offers labels, not instances, so when the
+ * target label is duplicated the first instance receives the line by design.
+ */
+export function insertIntoSection(content: string, targetSection: string, itemLine: string): string {
+  const bounds = findSectionBounds(content, targetSection);
+  if (!bounds) {
+    return `${content}\n\n# --- ${targetSection} --- #\n${itemLine}`;
+  }
+
+  const lines = content.split(/\r?\n/);
+  let insertLineIndex = bounds.endLine - 1;
+  for (let i = bounds.endLine - 1; i >= bounds.startLine - 1; i--) {
+    const line = lines[i];
+    if (line && line.trim().length > 0) {
+      insertLineIndex = i;
+      break;
+    }
+  }
+
+  const before = lines.slice(0, insertLineIndex + 1).join("\n");
+  const after = lines.slice(insertLineIndex + 1).join("\n");
+  return after ? `${before}\n${itemLine}\n${after}` : `${before}\n${itemLine}`;
+}
+
+/** Parameters for computing the content a save would produce. */
+export interface ComputeUpdateParams {
+  config: EditItemConfig;
+  /** Trimmed key the user entered */
+  key: string;
+  /** Trimmed value the user entered */
+  value: string;
+  /** Resolved target section label */
+  targetSection: string;
+  /** Editing an existing item (vs adding a new one) */
+  isEditing: boolean;
+  /** The item's original key (editing only) */
+  existingKey?: string | undefined;
+  /** The item's original section label (editing only) */
+  originalSection?: string | undefined;
+  /** 0-based instance of the original section label */
+  sectionOccurrence?: number | undefined;
+}
+
+/**
+ * Computes the file content a save would write.
+ *
+ * Pure: reads nothing, writes nothing. Throws an Error carrying the
+ * user-facing message when the existing definition cannot be resolved
+ * unambiguously (see `replaceFirstScoped`).
+ */
+export function computeUpdatedContent(zshrcContent: string, params: ComputeUpdateParams): string {
+  const { config, key, value, targetSection, isEditing, existingKey, originalSection, sectionOccurrence } = params;
+
+  if (isEditing && existingKey) {
+    const pattern = config.generatePattern(existingKey);
+    const sectionChanged = originalSection !== targetSection;
+
+    if (sectionChanged) {
+      // Moving to a different section — remove from the old location
+      // (scoped so a duplicate elsewhere is not the one removed), then
+      // insert into the target.
+      const removal = replaceFirstScoped(
+        zshrcContent,
+        originalSection,
+        pattern,
+        () => "",
+        (line) => config.matchesDisplayLine(line, existingKey),
+        sectionOccurrence ?? 0,
+      );
+      if (!removal.found) {
+        throw new Error(scopedFailureMessage(removal.reason, config.itemTypeCapitalized, existingKey));
+      }
+      const cleaned = removal.content.replace(/\n\n\n+/g, "\n\n");
+      return insertIntoSection(cleaned, targetSection, config.generateLine(key, value));
+    }
+
+    // Same section — update the line in place
+    const update = replaceFirstScoped(
+      zshrcContent,
+      originalSection,
+      pattern,
+      preservingReplacer(pattern, config.generateReplacement(key, value)),
+      (line) => config.matchesDisplayLine(line, existingKey),
+      sectionOccurrence ?? 0,
+    );
+    if (!update.found) {
+      throw new Error(scopedFailureMessage(update.reason, config.itemTypeCapitalized, existingKey));
+    }
+    return update.content;
+  }
+
+  // Adding a new item
+  return insertIntoSection(zshrcContent, targetSection, config.generateLine(key, value));
+}
+
+/** Parameters for computing the content a delete would produce. */
+export interface ComputeDeleteParams {
+  config: EditItemConfig;
+  existingKey: string;
+  sectionLabel?: string | undefined;
+  sectionOccurrence?: number | undefined;
+}
+
+/**
+ * Computes the file content a delete would write. Pure; throws with the
+ * user-facing message when the definition cannot be resolved.
+ */
+export function computeDeletedContent(zshrcContent: string, params: ComputeDeleteParams): string {
+  const { config, existingKey, sectionLabel, sectionOccurrence } = params;
+  const removal = replaceFirstScoped(
+    zshrcContent,
+    sectionLabel,
+    config.generatePattern(existingKey),
+    () => "",
+    (line) => config.matchesDisplayLine(line, existingKey),
+    sectionOccurrence ?? 0,
+  );
+  if (!removal.found) {
+    throw new Error(scopedFailureMessage(removal.reason, config.itemTypeCapitalized, existingKey));
+  }
+  return removal.content;
+}

--- a/extensions/zshrc-manager/src/lib/history.ts
+++ b/extensions/zshrc-manager/src/lib/history.ts
@@ -32,15 +32,21 @@ interface HistoryEntry {
 }
 
 /**
- * Saves the current state to history before making a change
+ * Saves a restore point to history.
  *
- * @param description Description of the upcoming change
+ * The entry's `previousContent` is the undo target. Callers that have
+ * already mutated the file MUST pass the pre-change snapshot explicitly —
+ * reading the file after a write would record the new content and turn
+ * undo into a no-op.
+ *
+ * @param description Description of the change
+ * @param previousContent Pre-change file content; read from disk when omitted
  * @returns Promise resolving to true if history was saved successfully, false otherwise
  */
-export async function saveToHistory(description: string): Promise<boolean> {
+export async function saveToHistory(description: string, previousContent?: string): Promise<boolean> {
   log.history.debug(`Saving to history: "${description}"`);
   try {
-    const currentContent = await readZshrcFileRaw();
+    const currentContent = previousContent ?? (await readZshrcFileRaw());
     const filePath = getZshrcPath();
 
     // Get existing history

--- a/extensions/zshrc-manager/src/lib/import-export.ts
+++ b/extensions/zshrc-manager/src/lib/import-export.ts
@@ -115,9 +115,6 @@ export async function importAliasesFromJson(json: string, sectionLabel?: string)
       );
     }
 
-    // Save history before modifying
-    await saveToHistory(`Import ${data.aliases.length} aliases`);
-
     const zshrcContent = await readZshrcFileRaw();
 
     // Generate alias lines with proper escaping
@@ -136,6 +133,10 @@ export async function importAliasesFromJson(json: string, sectionLabel?: string)
 
     await writeZshrcFile(updatedContent);
     clearCache(getZshrcPath());
+
+    // Record history after the write, with the pre-change snapshot as
+    // the undo target
+    await saveToHistory(`Import ${data.aliases.length} aliases`, zshrcContent);
 
     await showToast({
       style: Toast.Style.Success,
@@ -184,9 +185,6 @@ export async function importExportsFromJson(json: string, sectionLabel?: string)
       );
     }
 
-    // Save history before modifying
-    await saveToHistory(`Import ${data.exports.length} exports`);
-
     const zshrcContent = await readZshrcFileRaw();
 
     // Generate export lines with proper escaping
@@ -205,6 +203,10 @@ export async function importExportsFromJson(json: string, sectionLabel?: string)
 
     await writeZshrcFile(updatedContent);
     clearCache(getZshrcPath());
+
+    // Record history after the write, with the pre-change snapshot as
+    // the undo target
+    await saveToHistory(`Import ${data.exports.length} exports`, zshrcContent);
 
     await showToast({
       style: Toast.Style.Success,

--- a/extensions/zshrc-manager/src/lib/parse-zshrc.ts
+++ b/extensions/zshrc-manager/src/lib/parse-zshrc.ts
@@ -5,8 +5,8 @@
  * detect aliases and exports, and categorize entries by type.
  */
 
-import { PARSING_CONSTANTS, FILE_CONSTANTS } from "../constants";
-import { countAllPatterns } from "./pattern-registry";
+import { FILE_CONSTANTS } from "../constants";
+import { countAllPatterns, extractEntries, type RegistryEntries } from "./pattern-registry";
 import { detectSectionMarker, updateSectionContext, type SectionContext } from "./section-detector";
 
 import { EntryType } from "../types/enums";
@@ -16,22 +16,6 @@ import { EntryType } from "../types/enums";
  * Lines longer than this are skipped to prevent ReDoS attacks.
  */
 const MAX_SAFE_LINE_LENGTH = FILE_CONSTANTS.MAX_LINE_LENGTH;
-
-/**
- * Strategy for parsing an entry type
- */
-interface EntryParserStrategy {
-  /** Pattern to match */
-  pattern: RegExp;
-  /** Entry type */
-  type: EntryType;
-  /** Extract entry-specific data from match */
-  extract: (match: RegExpMatchArray, rawLine: string) => Record<string, unknown>;
-  /** Validate that match has required groups */
-  validate: (match: RegExpMatchArray) => boolean;
-  /** Whether this can produce multiple entries from one line */
-  multiEntry?: boolean;
-}
 
 /**
  * Base interface for all zshrc entries
@@ -293,99 +277,47 @@ const entryFactories = {
 } as const;
 
 /**
- * Defines all entry parsing strategies
+ * Builds a per-line index of the registry's extraction so section context
+ * can be attached while walking the file. One line can carry several
+ * entries (array declarations, or an `export PATH=…` that is both an
+ * export and a PATH declaration).
  */
-const ENTRY_PARSERS: EntryParserStrategy[] = [
-  {
-    pattern: PARSING_CONSTANTS.PATTERNS.ALIAS,
-    type: EntryType.ALIAS,
-    validate: (match) => Boolean(match[1] && match[2]),
-    extract: (match) => ({ name: match[1], command: match[2] }),
-  },
-  {
-    pattern: PARSING_CONSTANTS.PATTERNS.EXPORT,
-    type: EntryType.EXPORT,
-    validate: (match) => Boolean(match[1] && match[2]),
-    extract: (match) => ({ variable: match[1], value: match[2] }),
-  },
-  {
-    pattern: PARSING_CONSTANTS.PATTERNS.EVAL,
-    type: EntryType.EVAL,
-    validate: (match) => Boolean(match[1]),
-    extract: (match) => ({ command: match[1] }),
-  },
-  {
-    pattern: PARSING_CONSTANTS.PATTERNS.SETOPT,
-    type: EntryType.SETOPT,
-    validate: (match) => Boolean(match[1]),
-    extract: (match) => ({ option: match[1] }),
-  },
-  {
-    pattern: PARSING_CONSTANTS.PATTERNS.PLUGIN,
-    type: EntryType.PLUGIN,
-    validate: (match) => Boolean(match[1]),
-    extract: (match) => ({ name: match[1] }),
-    multiEntry: true,
-  },
-  {
-    pattern: PARSING_CONSTANTS.PATTERNS.FUNCTION,
-    type: EntryType.FUNCTION,
-    validate: (match) => Boolean(match[1]),
-    extract: (match) => ({ name: match[1] }),
-  },
-  {
-    pattern: PARSING_CONSTANTS.PATTERNS.SOURCE,
-    type: EntryType.SOURCE,
-    validate: (match) => Boolean(match[1]),
-    extract: (match) => ({ path: match[1] }),
-  },
-  {
-    pattern: PARSING_CONSTANTS.PATTERNS.AUTOLOAD,
-    type: EntryType.AUTOLOAD,
-    validate: (match) => Boolean(match[1]),
-    extract: (match) => ({ function: match[1] }),
-  },
-  {
-    pattern: PARSING_CONSTANTS.PATTERNS.FPATH,
-    type: EntryType.FPATH,
-    validate: (match) => Boolean(match[1]),
-    extract: (match) => ({ directories: [match[1]] }),
-    multiEntry: true,
-  },
-  {
-    pattern: PARSING_CONSTANTS.PATTERNS.PATH,
-    type: EntryType.PATH,
-    validate: (match) => Boolean(match[1]),
-    extract: (match) => ({ value: match[1] }),
-  },
-  {
-    pattern: PARSING_CONSTANTS.PATTERNS.THEME,
-    type: EntryType.THEME,
-    validate: (match) => Boolean(match[1]),
-    extract: (match) => ({ name: match[1] }),
-  },
-  {
-    pattern: PARSING_CONSTANTS.PATTERNS.COMPLETION,
-    type: EntryType.COMPLETION,
-    validate: () => true,
-    extract: () => ({ command: "compinit" }),
-  },
-  {
-    pattern: PARSING_CONSTANTS.PATTERNS.HISTORY,
-    type: EntryType.HISTORY,
-    validate: (match) => Boolean(match[1]),
-    extract: (match, rawLine) => {
-      const variable = rawLine.match(/^(?:\s*)(HIST[A-Z_]*)\s*=/)?.[1] || "HIST";
-      return { variable, value: match[1] };
-    },
-  },
-  {
-    pattern: PARSING_CONSTANTS.PATTERNS.KEYBINDING,
-    type: EntryType.KEYBINDING,
-    validate: (match) => Boolean(match[1]),
-    extract: (match) => ({ command: match[1] }),
-  },
-];
+function buildEntriesByLine(extracted: RegistryEntries): Map<number, Array<(base: BaseEntryData) => ZshEntry>> {
+  const byLine = new Map<number, Array<(base: BaseEntryData) => ZshEntry>>();
+  const add = (line: number, build: (base: BaseEntryData) => ZshEntry) => {
+    const list = byLine.get(line) ?? [];
+    list.push(build);
+    byLine.set(line, list);
+  };
+
+  for (const e of extracted.aliases)
+    add(e.line, (b) => entryFactories[EntryType.ALIAS](b, { name: e.name, command: e.command }));
+  for (const e of extracted.exports)
+    add(e.line, (b) => entryFactories[EntryType.EXPORT](b, { variable: e.variable, value: e.value }));
+  for (const e of extracted.evals) add(e.line, (b) => entryFactories[EntryType.EVAL](b, { command: e.command }));
+  for (const e of extracted.setopts) add(e.line, (b) => entryFactories[EntryType.SETOPT](b, { option: e.option }));
+  for (const e of extracted.plugins) add(e.line, (b) => entryFactories[EntryType.PLUGIN](b, { name: e.name }));
+  for (const e of extracted.functions) add(e.line, (b) => entryFactories[EntryType.FUNCTION](b, { name: e.name }));
+  for (const e of extracted.sources) add(e.line, (b) => entryFactories[EntryType.SOURCE](b, { path: e.path }));
+  for (const e of extracted.autoloads)
+    add(e.line, (b) => entryFactories[EntryType.AUTOLOAD](b, { function: e.function }));
+  for (const e of extracted.fpathEntries)
+    add(e.line, (b) => entryFactories[EntryType.FPATH](b, { directories: [e.entry] }));
+  for (const e of extracted.pathEntries) add(e.line, (b) => entryFactories[EntryType.PATH](b, { value: e.entry }));
+  for (const e of extracted.themes) add(e.line, (b) => entryFactories[EntryType.THEME](b, { name: e.name }));
+  for (const e of extracted.completions)
+    add(e.line, (b) => entryFactories[EntryType.COMPLETION](b, { command: e.command }));
+  for (const e of extracted.history)
+    add(e.line, (b) => entryFactories[EntryType.HISTORY](b, { variable: e.variable, value: e.value }));
+  for (const e of extracted.keybindings)
+    add(e.line, (b) =>
+      entryFactories[EntryType.KEYBINDING](b, {
+        command: b.originalLine.replace(/^\s*bindkey\s+/, "").trim(),
+      }),
+    );
+
+  return byLine;
+}
 
 /**
  * Parses zshrc content into structured entries
@@ -420,6 +352,10 @@ export function parseZshrc(content: string): ReadonlyArray<ZshEntry> {
     functionLevel: 0,
   };
 
+  // One extraction pass over the whole content — the registry is the
+  // single parser; this function only attaches section context.
+  const entriesByLine = buildEntriesByLine(extractEntries(content));
+
   for (let index = 0; index < lines.length; index += 1) {
     const rawLine = lines[index];
     if (!rawLine) continue;
@@ -448,40 +384,14 @@ export function parseZshrc(content: string): ReadonlyArray<ZshEntry> {
       continue;
     }
 
-    // Try each parser strategy in order
-    let matched = false;
-    for (const parser of ENTRY_PARSERS) {
-      const match = rawLine.match(parser.pattern);
-      if (match && parser.validate(match)) {
-        const baseData = createBaseEntryData(index + 1, rawLine, context.currentSection);
-        const specificData = parser.extract(match, rawLine);
-
-        // Handle multi-entry types (plugins, fpath) with type-safe factories
-        if (parser.multiEntry && parser.type === EntryType.PLUGIN && match[1]) {
-          const pluginList = match[1].split(/\s+/).filter((p) => p.trim());
-          for (const plugin of pluginList) {
-            entries.push(entryFactories[EntryType.PLUGIN](baseData, { name: plugin.trim() }));
-          }
-        } else if (parser.multiEntry && parser.type === EntryType.FPATH && match[1]) {
-          const directories = match[1].split(/\s+/).filter((d) => d.trim());
-          for (const dir of directories) {
-            entries.push(entryFactories[EntryType.FPATH](baseData, { directories: [dir.trim()] }));
-          }
-        } else {
-          // Use type-safe factory based on entry type
-          const factory = entryFactories[parser.type];
-          if (factory) {
-            entries.push(factory(baseData, specificData as never));
-          }
-        }
-
-        matched = true;
-        break;
+    const builders = entriesByLine.get(index + 1);
+    if (builders && builders.length > 0) {
+      const baseData = createBaseEntryData(index + 1, rawLine, context.currentSection);
+      for (const build of builders) {
+        entries.push(build(baseData));
       }
-    }
-
-    // If no parser matched, add as OTHER using type-safe factory
-    if (!matched) {
+    } else {
+      // No registry match — track the line as OTHER
       const baseData = createBaseEntryData(index + 1, rawLine, context.currentSection);
       entries.push(entryFactories[EntryType.OTHER](baseData));
     }

--- a/extensions/zshrc-manager/src/lib/parse-zshrc.ts
+++ b/extensions/zshrc-manager/src/lib/parse-zshrc.ts
@@ -6,7 +6,7 @@
  */
 
 import { FILE_CONSTANTS } from "../constants";
-import { countAllPatterns, extractEntries, type RegistryEntries } from "./pattern-registry";
+import { countAllPatterns, countUnrecognizedLines, extractDetailed, type RegistryEntries } from "./pattern-registry";
 import { detectSectionMarker, updateSectionContext, type SectionContext } from "./section-detector";
 
 import { EntryType } from "../types/enums";
@@ -354,7 +354,8 @@ export function parseZshrc(content: string): ReadonlyArray<ZshEntry> {
 
   // One extraction pass over the whole content — the registry is the
   // single parser; this function only attaches section context.
-  const entriesByLine = buildEntriesByLine(extractEntries(content));
+  const detailed = extractDetailed(content);
+  const entriesByLine = buildEntriesByLine(detailed.entries);
 
   for (let index = 0; index < lines.length; index += 1) {
     const rawLine = lines[index];
@@ -390,8 +391,10 @@ export function parseZshrc(content: string): ReadonlyArray<ZshEntry> {
       for (const build of builders) {
         entries.push(build(baseData));
       }
-    } else {
-      // No registry match — track the line as OTHER
+    } else if (!detailed.matchedLines.has(index + 1)) {
+      // No registry match — track the line as OTHER. Consumed lines of a
+      // multi-line array (body elements, closing paren) are recognized,
+      // not OTHER; their entries live on the declaration's opening line.
       const baseData = createBaseEntryData(index + 1, rawLine, context.currentSection);
       entries.push(entryFactories[EntryType.OTHER](baseData));
     }
@@ -428,24 +431,11 @@ export function toLogicalSections(content: string): ReadonlyArray<LogicalSection
     // Count all entry types using centralized pattern registry
     const counts = countAllPatterns(joined);
 
-    // Count other entries (non-empty lines that don't match any pattern)
-    const allPatternMatches =
-      counts.aliases +
-      counts.exports +
-      counts.evals +
-      counts.setopts +
-      counts.plugins +
-      counts.functions +
-      counts.sources +
-      counts.autoloads +
-      counts.fpaths +
-      counts.paths +
-      counts.themes +
-      counts.completions +
-      counts.history +
-      counts.keybindings;
-    const totalNonEmptyLines = joined.split("\n").filter((line) => line.trim().length > 0).length;
-    const otherCount = Math.max(0, totalNonEmptyLines - allPatternMatches);
+    // "Other" counts LINES the registry did not recognize — not a
+    // subtraction of entry counts from line counts, which mixes units
+    // (a multi-line plugins array is one recognized construct spanning
+    // several lines yielding several entries).
+    const otherCount = countUnrecognizedLines(joined);
 
     sections.push({
       label: label?.trim() || "Unlabeled",

--- a/extensions/zshrc-manager/src/lib/parse-zshrc.ts
+++ b/extensions/zshrc-manager/src/lib/parse-zshrc.ts
@@ -6,7 +6,13 @@
  */
 
 import { FILE_CONSTANTS } from "../constants";
-import { countAllPatterns, countUnrecognizedLines, extractDetailed, type RegistryEntries } from "./pattern-registry";
+import {
+  countAllPatterns,
+  countUnrecognizedLines,
+  extractDetailed,
+  multilineArrayInteriorLines,
+  type RegistryEntries,
+} from "./pattern-registry";
 import { detectSectionMarker, updateSectionContext, type SectionContext } from "./section-detector";
 
 import { EntryType } from "../types/enums";
@@ -356,6 +362,7 @@ export function parseZshrc(content: string): ReadonlyArray<ZshEntry> {
   // single parser; this function only attaches section context.
   const detailed = extractDetailed(content);
   const entriesByLine = buildEntriesByLine(detailed.entries);
+  const arrayInterior = multilineArrayInteriorLines(content);
 
   for (let index = 0; index < lines.length; index += 1) {
     const rawLine = lines[index];
@@ -378,8 +385,10 @@ export function parseZshrc(content: string): ReadonlyArray<ZshEntry> {
       continue;
     }
 
-    // Check for section markers using enhanced detection
-    const marker = detectSectionMarker(rawLine, index + 1);
+    // Check for section markers using enhanced detection. Lines inside a
+    // multi-line array are never markers — a comment in an array body
+    // that happens to look like a section header must not shift context.
+    const marker = arrayInterior.has(index + 1) ? null : detectSectionMarker(rawLine, index + 1);
     if (marker) {
       context = updateSectionContext(marker, context);
       continue;
@@ -460,12 +469,15 @@ export function toLogicalSections(content: string): ReadonlyArray<LogicalSection
     });
   };
 
+  const arrayInterior = multilineArrayInteriorLines(content);
+
   for (let index = 0; index < lines.length; index += 1) {
     const raw = lines[index];
     if (!raw) continue;
 
-    // Use enhanced section detection
-    const marker = detectSectionMarker(raw, index + 1);
+    // Use enhanced section detection; lines inside a multi-line array
+    // are never markers (see parseZshrc).
+    const marker = arrayInterior.has(index + 1) ? null : detectSectionMarker(raw, index + 1);
     if (marker) {
       // Handle end markers
       if (["custom_end", "dashed_end", "function_end"].includes(marker.type)) {

--- a/extensions/zshrc-manager/src/lib/pattern-registry.ts
+++ b/extensions/zshrc-manager/src/lib/pattern-registry.ts
@@ -88,11 +88,54 @@ export interface RegistryEntries {
 const P = PARSING_CONSTANTS.PATTERNS;
 
 /**
+ * Index just past the `)` matching the `$(` at `start`, or -1 when the
+ * substitution never closes in `text`. The substitution gets its own
+ * quote context (starting unquoted after `$(`): inner quotes never leak
+ * into the caller's quote state, and a `)` inside inner quotes is
+ * content, not the close. `$(` nests, both bare and inside inner double
+ * quotes.
+ */
+function scanSubstitution(text: string, start: number): number {
+  let depth = 1;
+  let quote: '"' | "'" | null = null;
+  for (let i = start + 2; i < text.length; i += 1) {
+    const ch = text[i]!;
+    if (quote === "'") {
+      if (ch === "'") quote = null;
+      continue;
+    }
+    if (ch === "\\") {
+      i += 1;
+      continue;
+    }
+    if (ch === "$" && text[i + 1] === "(") {
+      depth += 1;
+      i += 1;
+      continue;
+    }
+    if (quote === '"') {
+      if (ch === '"') quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === ")") {
+      depth -= 1;
+      if (depth === 0) return i + 1;
+    }
+  }
+  return -1;
+}
+
+/**
  * Tokenizes zsh array body lines into elements, honoring the pieces of
  * zsh syntax that whitespace-splitting gets wrong: inline comments
  * (`#` at start of word) end the line, quoted elements may contain
  * whitespace, and backslashes escape. Quotes are stripped from the
- * returned elements.
+ * returned elements — except inside `$(…)`, whose text (quotes and all)
+ * is the declaration and is kept verbatim.
  */
 export function tokenizeArrayBody(bodyLines: string[]): string[] {
   const tokens: string[] = [];
@@ -102,7 +145,6 @@ export function tokenizeArrayBody(bodyLines: string[]): string[] {
     // a word like foo#bar) is content, not a comment.
     let current = "";
     let quote: '"' | "'" | null = null;
-    let substitutionDepth = 0;
     for (let i = 0; i < line.length; i += 1) {
       const ch = line[i]!;
       if (quote === "'") {
@@ -116,11 +158,17 @@ export function tokenizeArrayBody(bodyLines: string[]): string[] {
       }
       if (ch === "$" && line[i + 1] === "(") {
         // `$(…)` is one word however many spaces the command inside it
-        // has — track depth so whitespace splitting pauses until it
-        // closes. Applies inside double quotes too.
-        substitutionDepth += 1;
-        current += "$(";
-        i += 1;
+        // has, and its text is kept verbatim — inner quotes are part of
+        // the declaration, and never leak into the outer quote state.
+        // Applies inside double quotes too.
+        const end = scanSubstitution(line, i);
+        if (end === -1) {
+          // Unclosed on this line: everything after is inside it.
+          current += line.slice(i);
+          break;
+        }
+        current += line.slice(i, end);
+        i = end - 1;
         continue;
       }
       if (quote === '"') {
@@ -137,7 +185,6 @@ export function tokenizeArrayBody(bodyLines: string[]): string[] {
         } else if (ch === '"') {
           quote = null;
         } else {
-          if (ch === ")" && substitutionDepth > 0) substitutionDepth -= 1;
           current += ch;
         }
         continue;
@@ -154,16 +201,11 @@ export function tokenizeArrayBody(bodyLines: string[]): string[] {
         quote = ch;
         continue;
       }
-      if (ch === ")" && substitutionDepth > 0) {
-        substitutionDepth -= 1;
-        current += ch;
-        continue;
-      }
-      if (ch === "#" && current === "" && substitutionDepth === 0) {
+      if (ch === "#" && current === "") {
         // Comment runs to end of line
         break;
       }
-      if (/\s/.test(ch) && substitutionDepth === 0) {
+      if (/\s/.test(ch)) {
         if (current) {
           tokens.push(current);
           current = "";
@@ -189,7 +231,6 @@ export function tokenizeArrayBody(bodyLines: string[]): string[] {
  */
 function findUnquotedCloseParen(text: string): number {
   let quote: '"' | "'" | null = null;
-  let substitutionDepth = 0;
   for (let i = 0; i < text.length; i += 1) {
     const ch = text[i]!;
     if (quote === "'") {
@@ -203,28 +244,22 @@ function findUnquotedCloseParen(text: string): number {
       continue;
     }
     if (ch === "$" && text[i + 1] === "(") {
-      // `$(…)` nests and may itself contain `$(…)` — both inside and
-      // outside double quotes.
-      substitutionDepth += 1;
-      i += 1;
+      // `$(…)` is skipped as a unit with its own quote context (see
+      // scanSubstitution) — inner quotes and parens are its content.
+      const end = scanSubstitution(text, i);
+      if (end === -1) return -1;
+      i = end - 1;
       continue;
     }
     if (quote === '"') {
       if (ch === '"') quote = null;
-      else if (ch === ")" && substitutionDepth > 0) substitutionDepth -= 1;
       continue;
     }
     if (ch === '"' || ch === "'") {
       quote = ch;
       continue;
     }
-    if (ch === ")") {
-      if (substitutionDepth > 0) {
-        substitutionDepth -= 1;
-        continue;
-      }
-      return i;
-    }
+    if (ch === ")") return i;
   }
   return -1;
 }

--- a/extensions/zshrc-manager/src/lib/pattern-registry.ts
+++ b/extensions/zshrc-manager/src/lib/pattern-registry.ts
@@ -95,19 +95,41 @@ const P = PARSING_CONSTANTS.PATTERNS;
  */
 export function tokenizeArrayBody(bodyLines: string[]): string[] {
   const tokens: string[] = [];
-  for (const raw of bodyLines) {
-    // An inline comment runs to end of line; `#` only starts a comment
-    // at the beginning of a word
-    const commentStart = raw.match(/(^|\s)#/);
-    const line = commentStart?.index !== undefined ? raw.slice(0, commentStart.index) : raw;
-
-    const tokenPattern = /"([^"]*)"|'([^']*)'|(\S+)/g;
-    let match: RegExpExecArray | null;
-    while ((match = tokenPattern.exec(line)) !== null) {
-      const value = match[1] ?? match[2] ?? match[3];
-      if (value && value.trim()) {
-        tokens.push(value.trim());
+  for (const line of bodyLines) {
+    // Single pass tracking quote state: `#` starts a comment only when it
+    // is outside quotes AND begins a word — a `#` inside quotes (or inside
+    // a word like foo#bar) is content, not a comment.
+    let current = "";
+    let quote: '"' | "'" | null = null;
+    for (let i = 0; i < line.length; i += 1) {
+      const ch = line[i]!;
+      if (quote) {
+        if (ch === quote) {
+          quote = null;
+        } else {
+          current += ch;
+        }
+        continue;
       }
+      if (ch === '"' || ch === "'") {
+        quote = ch;
+        continue;
+      }
+      if (ch === "#" && current === "") {
+        // Comment runs to end of line
+        break;
+      }
+      if (/\s/.test(ch)) {
+        if (current) {
+          tokens.push(current);
+          current = "";
+        }
+        continue;
+      }
+      current += ch;
+    }
+    if (current) {
+      tokens.push(current);
     }
   }
   return tokens;

--- a/extensions/zshrc-manager/src/lib/pattern-registry.ts
+++ b/extensions/zshrc-manager/src/lib/pattern-registry.ts
@@ -102,6 +102,7 @@ export function tokenizeArrayBody(bodyLines: string[]): string[] {
     // a word like foo#bar) is content, not a comment.
     let current = "";
     let quote: '"' | "'" | null = null;
+    let substitutionDepth = 0;
     for (let i = 0; i < line.length; i += 1) {
       const ch = line[i]!;
       if (quote === "'") {
@@ -111,6 +112,15 @@ export function tokenizeArrayBody(bodyLines: string[]): string[] {
         } else {
           current += ch;
         }
+        continue;
+      }
+      if (ch === "$" && line[i + 1] === "(") {
+        // `$(…)` is one word however many spaces the command inside it
+        // has — track depth so whitespace splitting pauses until it
+        // closes. Applies inside double quotes too.
+        substitutionDepth += 1;
+        current += "$(";
+        i += 1;
         continue;
       }
       if (quote === '"') {
@@ -127,6 +137,7 @@ export function tokenizeArrayBody(bodyLines: string[]): string[] {
         } else if (ch === '"') {
           quote = null;
         } else {
+          if (ch === ")" && substitutionDepth > 0) substitutionDepth -= 1;
           current += ch;
         }
         continue;
@@ -143,11 +154,16 @@ export function tokenizeArrayBody(bodyLines: string[]): string[] {
         quote = ch;
         continue;
       }
-      if (ch === "#" && current === "") {
+      if (ch === ")" && substitutionDepth > 0) {
+        substitutionDepth -= 1;
+        current += ch;
+        continue;
+      }
+      if (ch === "#" && current === "" && substitutionDepth === 0) {
         // Comment runs to end of line
         break;
       }
-      if (/\s/.test(ch)) {
+      if (/\s/.test(ch) && substitutionDepth === 0) {
         if (current) {
           tokens.push(current);
           current = "";
@@ -164,13 +180,16 @@ export function tokenizeArrayBody(bodyLines: string[]): string[] {
 }
 
 /**
- * Index of the first `)` that actually closes an array — i.e. is neither
- * inside quotes nor backslash-escaped — or -1. Shares its quote and
- * escape semantics with `tokenizeArrayBody`, so termination and
- * tokenization can never disagree about what a quote covers.
+ * Index of the first `)` that actually closes an array — i.e. is not
+ * inside quotes, not backslash-escaped, and not the close of a `$(…)`
+ * command substitution (`path+=($(brew --prefix)/bin)`) — or -1. Shares
+ * its quote and escape semantics with `tokenizeArrayBody`, so
+ * termination and tokenization can never disagree about what a quote
+ * covers.
  */
 function findUnquotedCloseParen(text: string): number {
   let quote: '"' | "'" | null = null;
+  let substitutionDepth = 0;
   for (let i = 0; i < text.length; i += 1) {
     const ch = text[i]!;
     if (quote === "'") {
@@ -183,15 +202,29 @@ function findUnquotedCloseParen(text: string): number {
       i += 1;
       continue;
     }
+    if (ch === "$" && text[i + 1] === "(") {
+      // `$(…)` nests and may itself contain `$(…)` — both inside and
+      // outside double quotes.
+      substitutionDepth += 1;
+      i += 1;
+      continue;
+    }
     if (quote === '"') {
       if (ch === '"') quote = null;
+      else if (ch === ")" && substitutionDepth > 0) substitutionDepth -= 1;
       continue;
     }
     if (ch === '"' || ch === "'") {
       quote = ch;
       continue;
     }
-    if (ch === ")") return i;
+    if (ch === ")") {
+      if (substitutionDepth > 0) {
+        substitutionDepth -= 1;
+        continue;
+      }
+      return i;
+    }
   }
   return -1;
 }

--- a/extensions/zshrc-manager/src/lib/pattern-registry.ts
+++ b/extensions/zshrc-manager/src/lib/pattern-registry.ts
@@ -1,183 +1,358 @@
 /**
- * Centralized pattern registry for zsh parsing
+ * Centralized pattern registry for zsh parsing — the single parser.
  *
- * This module provides a single source of truth for all regex patterns
- * used throughout the application, eliminating duplication and ensuring
- * consistency across parsing functions.
+ * Every surface (type views, statistics, sections, search) derives from
+ * `matchLine` / `extractEntries` here, so counts, search results, and
+ * drill-down views cannot disagree. `countAllPatterns` is a projection
+ * over `extractEntries`, and the legacy `utils/parsers.ts` functions are
+ * thin projections over the same output.
  *
- * All patterns are derived from PARSING_CONSTANTS.PATTERNS to ensure
- * consistency with the main parser.
+ * Every extracted entry carries the 1-based line it was parsed from
+ * (relative to the content handed in), so write paths can eventually
+ * address definitions directly instead of counting occurrences.
  */
 
-import { PARSING_CONSTANTS } from "../constants";
+import { FILE_CONSTANTS, PARSING_CONSTANTS } from "../constants";
+
+/** Position information every registry entry carries. */
+interface Positioned {
+  /** 1-based line number within the parsed content */
+  line: number;
+}
+
+export interface AliasMatch extends Positioned {
+  name: string;
+  command: string;
+}
+export interface ExportMatch extends Positioned {
+  variable: string;
+  value: string;
+}
+export interface EvalMatch extends Positioned {
+  command: string;
+}
+export interface SetoptMatch extends Positioned {
+  option: string;
+}
+export interface PluginMatch extends Positioned {
+  name: string;
+}
+export interface FunctionMatch extends Positioned {
+  name: string;
+}
+export interface SourceMatch extends Positioned {
+  path: string;
+}
+export interface AutoloadMatch extends Positioned {
+  function: string;
+}
+export interface PathLikeMatch extends Positioned {
+  entry: string;
+  type: "export" | "append" | "prepend" | "set";
+}
+export interface ThemeMatch extends Positioned {
+  name: string;
+}
+export interface CompletionMatch extends Positioned {
+  command: string;
+}
+export interface HistoryMatch extends Positioned {
+  variable: string;
+  value: string;
+}
+export interface KeybindingMatch extends Positioned {
+  key: string;
+  command: string;
+  widget?: string | undefined;
+  keymap?: string | undefined;
+}
+
+/** Everything the registry extracted from one piece of content. */
+export interface RegistryEntries {
+  aliases: AliasMatch[];
+  exports: ExportMatch[];
+  evals: EvalMatch[];
+  setopts: SetoptMatch[];
+  plugins: PluginMatch[];
+  functions: FunctionMatch[];
+  sources: SourceMatch[];
+  autoloads: AutoloadMatch[];
+  fpathEntries: PathLikeMatch[];
+  pathEntries: PathLikeMatch[];
+  themes: ThemeMatch[];
+  completions: CompletionMatch[];
+  history: HistoryMatch[];
+  keybindings: KeybindingMatch[];
+}
+
+const P = PARSING_CONSTANTS.PATTERNS;
 
 /**
- * Creates a global regex from a source pattern for counting matches
+ * PATH/FPATH declaration forms. Each variable ("PATH"/"path",
+ * "FPATH"/"fpath") gets the same family of matchers. Order matters:
+ * the first matching form wins for a given line.
  */
-function createGlobalPattern(pattern: RegExp): RegExp {
-  return new RegExp(pattern.source, "gm");
+function matchPathLike(line: string, upper: string, lower: string): PathLikeMatch[] | null {
+  const out = (entry: string, type: PathLikeMatch["type"]): PathLikeMatch[] => [{ entry, type, line: 0 }];
+  const split = (list: string, type: PathLikeMatch["type"]): PathLikeMatch[] =>
+    list
+      .split(/\s+/)
+      .filter((p) => p.trim())
+      .map((p) => ({ entry: p.trim(), type, line: 0 }));
+
+  let m = line.match(
+    new RegExp(
+      `^(?:\\s*)(?:export|(?:typeset|declare)(?:\\s+-[A-Za-z]+)*)\\s+${upper}\\s*=\\s*["']?(.+?)["']?(?:\\s*)$`,
+    ),
+  );
+  if (m?.[1]) return out(m[1], "export");
+
+  m = line.match(new RegExp(`^(?:\\s*)${upper}\\+=\\s*["']?:?(.+?)["']?(?:\\s*)$`));
+  if (m?.[1] && !m[1].startsWith("(")) return out(m[1], "append");
+
+  m = line.match(new RegExp(`^(?:\\s*)${lower}\\+=\\s*\\(([^)]+)\\)(?:\\s*)$`));
+  if (m?.[1]) return split(m[1], "append");
+
+  m = line.match(new RegExp(`^(?:\\s*)${lower}=\\s*\\(([^)]+)\\)(?:\\s*)$`));
+  if (m?.[1]) return split(m[1], "set");
+
+  m = line.match(new RegExp(`^(?:\\s*)${upper}\\s*=\\s*["']?\\$${upper}:(.+?)["']?(?:\\s*)$`));
+  if (m?.[1]) return out(m[1], "append");
+
+  m = line.match(new RegExp(`^(?:\\s*)${upper}\\s*=\\s*["']?(.+?):\\$${upper}["']?(?:\\s*)$`));
+  if (m?.[1]) return out(m[1], "prepend");
+
+  // Plain assignment replaces the whole variable — a "set", like the
+  // array form. (Deliberate unification decision: the count and the
+  // view agree by both listing it.)
+  m = line.match(new RegExp(`^(?:\\s*)${upper}\\s*=\\s*["']?(.+?)["']?(?:\\s*)$`));
+  if (m?.[1] && !m[1].includes(`$${upper}`)) return out(m[1], "set");
+
+  return null;
 }
 
 /**
- * Counts matches of a pattern in content
+ * Structured keybinding forms, ported from the legacy parser. Order
+ * matters: the most specific form wins. Bare mode/flag lines
+ * (`bindkey -e`, `bindkey -v`) deliberately do not match — the
+ * keybindings view has nothing to show for them, and counts must agree
+ * with the view.
  */
-function countMatches(content: string, pattern: RegExp): number {
-  const matches = content.match(createGlobalPattern(pattern));
-  return matches ? matches.length : 0;
+function matchKeybinding(line: string): KeybindingMatch | null {
+  let m = line.match(/^(?:\s*)bindkey\s+-M\s+(\S+)\s+-s\s+(['"])([^'"]+)\2\s+(['"])([^'"]+)\4(?:\s*)$/);
+  if (m?.[1] && m[3] && m[5]) {
+    return { key: m[3], command: m[5].trim(), widget: "string-replacement", keymap: m[1], line: 0 };
+  }
+  m = line.match(/^(?:\s*)bindkey\s+-M\s+(\S+)\s+(['"])([^'"]+)\2\s+(\S+)(?:\s*)$/);
+  if (m?.[1] && m[3] && m[4]) {
+    return { key: m[3], command: m[4].trim(), keymap: m[1], line: 0 };
+  }
+  m = line.match(/^(?:\s*)bindkey\s+-M\s+(\S+)\s+([^'"\s]\S*)\s+(\S+)(?:\s*)$/);
+  if (m?.[1] && m[2] && m[3]) {
+    return { key: m[2], command: m[3].trim(), keymap: m[1], line: 0 };
+  }
+  m = line.match(/^(?:\s*)bindkey\s+-s\s+(['"])([^'"]+)\1\s+(['"])([^'"]+)\3(?:\s*)$/);
+  if (m?.[2] && m[4]) {
+    return { key: m[2], command: m[4].trim(), widget: "string-replacement", line: 0 };
+  }
+  m = line.match(/^(?:\s*)bindkey\s+(?!-[MsrRLlevaAdpN])(['"])([^'"]+)\1\s+(\S+)(?:\s*)$/);
+  if (m?.[2] && m[3]) {
+    return { key: m[2], command: m[3].trim(), line: 0 };
+  }
+  m = line.match(/^(?:\s*)bindkey\s+(?!-[MsrRLlevaAdpN])([^'"\s]\S*)\s+(\S+)(?:\s*)$/);
+  if (m?.[1] && m[2]) {
+    return { key: m[1], command: m[2].trim(), line: 0 };
+  }
+  return null;
+}
+
+const withLine = <T extends Positioned>(entries: T[] | null, line: number): T[] =>
+  (entries ?? []).map((entry) => ({ ...entry, line }));
+
+/**
+ * Extract every recognized construct from content, with line positions.
+ *
+ * A line can legitimately surface in more than one collection —
+ * `export PATH=…` is both an export and a PATH declaration, matching
+ * what the Exports and PATH views have always shown.
+ */
+export function extractEntries(content: string): RegistryEntries {
+  const result: RegistryEntries = {
+    aliases: [],
+    exports: [],
+    evals: [],
+    setopts: [],
+    plugins: [],
+    functions: [],
+    sources: [],
+    autoloads: [],
+    fpathEntries: [],
+    pathEntries: [],
+    themes: [],
+    completions: [],
+    history: [],
+    keybindings: [],
+  };
+
+  const lines = content.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const raw = lines[index];
+    if (!raw || raw.trim().length === 0) continue;
+    // Skip extremely long lines to prevent ReDoS
+    if (raw.length > FILE_CONSTANTS.MAX_LINE_LENGTH) continue;
+    const line = index + 1;
+
+    // Multi-line array declarations (`plugins=(`, `path+=(`, …) — common
+    // in Oh My Zsh configs — are consumed as one declaration attributed
+    // to their opening line.
+    const arrayOpen = raw.match(/^(\s*)(plugins|path|fpath)(\+?)=\s*\(([^)]*)$/);
+    if (arrayOpen && !raw.includes(")")) {
+      const parts: string[] = [arrayOpen[4] ?? ""];
+      let closeIndex = index + 1;
+      while (closeIndex < lines.length) {
+        const bodyLine = lines[closeIndex] ?? "";
+        const closePos = bodyLine.indexOf(")");
+        if (closePos !== -1) {
+          parts.push(bodyLine.slice(0, closePos));
+          break;
+        }
+        parts.push(bodyLine);
+        closeIndex += 1;
+      }
+      if (closeIndex < lines.length) {
+        const elements = parts
+          .join(" ")
+          .split(/\s+/)
+          .filter((p) => p.trim());
+        const variable = arrayOpen[2]!;
+        const type: PathLikeMatch["type"] = arrayOpen[3] === "+" ? "append" : "set";
+        for (const element of elements) {
+          if (variable === "plugins") {
+            result.plugins.push({ name: element.trim(), line });
+          } else if (variable === "path") {
+            result.pathEntries.push({ entry: element.trim(), type, line });
+          } else {
+            result.fpathEntries.push({ entry: element.trim(), type, line });
+          }
+        }
+        index = closeIndex;
+        continue;
+      }
+    }
+
+    let m = raw.match(P.ALIAS);
+    if (m?.[1] && m[2]) {
+      result.aliases.push({ name: m[1], command: m[2], line });
+      continue;
+    }
+
+    // Exports and PATH/FPATH declarations are not exclusive: fall through.
+    m = raw.match(P.EXPORT);
+    if (m?.[1] && m[2]) {
+      result.exports.push({ variable: m[1], value: m[2], line });
+    }
+
+    const pathMatches = matchPathLike(raw, "PATH", "path");
+    if (pathMatches) {
+      result.pathEntries.push(...withLine(pathMatches, line));
+    }
+    const fpathMatches = matchPathLike(raw, "FPATH", "fpath");
+    if (fpathMatches) {
+      result.fpathEntries.push(...withLine(fpathMatches, line));
+    }
+    if (m || pathMatches || fpathMatches) {
+      continue;
+    }
+
+    m = raw.match(P.EVAL);
+    if (m?.[1]) {
+      result.evals.push({ command: m[1], line });
+      continue;
+    }
+
+    m = raw.match(P.SETOPT);
+    if (m?.[1]) {
+      result.setopts.push({ option: m[1], line });
+      continue;
+    }
+
+    m = raw.match(P.PLUGIN);
+    if (m?.[1]) {
+      for (const name of m[1].split(/\s+/).filter((p) => p.trim())) {
+        result.plugins.push({ name: name.trim(), line });
+      }
+      continue;
+    }
+
+    m = raw.match(P.FUNCTION);
+    if (m?.[1]) {
+      result.functions.push({ name: m[1], line });
+      continue;
+    }
+
+    m = raw.match(P.SOURCE);
+    if (m?.[1]) {
+      result.sources.push({ path: m[1], line });
+      continue;
+    }
+
+    m = raw.match(P.AUTOLOAD);
+    if (m?.[1]) {
+      result.autoloads.push({ function: m[1], line });
+      continue;
+    }
+
+    m = raw.match(P.THEME);
+    if (m?.[1]) {
+      result.themes.push({ name: m[1], line });
+      continue;
+    }
+
+    m = raw.match(P.COMPLETION);
+    if (m) {
+      result.completions.push({ command: "compinit", line });
+      continue;
+    }
+
+    m = raw.match(P.HISTORY);
+    if (m?.[1]) {
+      const variable = raw.match(/^(?:\s*)(HIST[A-Z_]*)\s*=/)?.[1] || "HIST";
+      result.history.push({ variable, value: m[1], line });
+      continue;
+    }
+
+    const keybinding = matchKeybinding(raw);
+    if (keybinding) {
+      result.keybindings.push({ ...keybinding, line });
+      continue;
+    }
+  }
+
+  return result;
 }
 
 /**
- * Pattern registry for counting entries in content
- * Uses the same patterns as the main parser to ensure consistency
- */
-const PATTERN_REGISTRY = {
-  /**
-   * Count aliases in content
-   * @param content The content to analyze
-   * @returns Number of alias declarations found
-   */
-  countAliases: (content: string): number => {
-    return countMatches(content, PARSING_CONSTANTS.PATTERNS.ALIAS);
-  },
-
-  /**
-   * Count exports in content
-   * @param content The content to analyze
-   * @returns Number of export declarations found
-   */
-  countExports: (content: string): number => {
-    return countMatches(content, PARSING_CONSTANTS.PATTERNS.EXPORT);
-  },
-
-  /**
-   * Count eval commands in content
-   * @param content The content to analyze
-   * @returns Number of eval commands found
-   */
-  countEvals: (content: string): number => {
-    return countMatches(content, PARSING_CONSTANTS.PATTERNS.EVAL);
-  },
-
-  /**
-   * Count setopt commands in content
-   * @param content The content to analyze
-   * @returns Number of setopt commands found
-   */
-  countSetopts: (content: string): number => {
-    return countMatches(content, PARSING_CONSTANTS.PATTERNS.SETOPT);
-  },
-
-  /**
-   * Count plugin declarations in content
-   * @param content The content to analyze
-   * @returns Number of plugin declarations found
-   */
-  countPlugins: (content: string): number => {
-    return countMatches(content, PARSING_CONSTANTS.PATTERNS.PLUGIN);
-  },
-
-  /**
-   * Count function definitions in content
-   * @param content The content to analyze
-   * @returns Number of function definitions found
-   */
-  countFunctions: (content: string): number => {
-    return countMatches(content, PARSING_CONSTANTS.PATTERNS.FUNCTION);
-  },
-
-  /**
-   * Count source commands in content
-   * @param content The content to analyze
-   * @returns Number of source commands found
-   */
-  countSources: (content: string): number => {
-    return countMatches(content, PARSING_CONSTANTS.PATTERNS.SOURCE);
-  },
-
-  /**
-   * Count autoload commands in content
-   * @param content The content to analyze
-   * @returns Number of autoload commands found
-   */
-  countAutoloads: (content: string): number => {
-    return countMatches(content, PARSING_CONSTANTS.PATTERNS.AUTOLOAD);
-  },
-
-  /**
-   * Count fpath declarations in content
-   * @param content The content to analyze
-   * @returns Number of fpath declarations found
-   */
-  countFpaths: (content: string): number => {
-    return countMatches(content, PARSING_CONSTANTS.PATTERNS.FPATH);
-  },
-
-  /**
-   * Count PATH declarations in content
-   * @param content The content to analyze
-   * @returns Number of PATH declarations found
-   */
-  countPaths: (content: string): number => {
-    return countMatches(content, PARSING_CONSTANTS.PATTERNS.PATH);
-  },
-
-  /**
-   * Count theme declarations in content
-   * @param content The content to analyze
-   * @returns Number of theme declarations found
-   */
-  countThemes: (content: string): number => {
-    return countMatches(content, PARSING_CONSTANTS.PATTERNS.THEME);
-  },
-
-  /**
-   * Count completion commands in content
-   * @param content The content to analyze
-   * @returns Number of completion commands found
-   */
-  countCompletions: (content: string): number => {
-    return countMatches(content, PARSING_CONSTANTS.PATTERNS.COMPLETION);
-  },
-
-  /**
-   * Count history settings in content
-   * @param content The content to analyze
-   * @returns Number of history settings found
-   */
-  countHistory: (content: string): number => {
-    return countMatches(content, PARSING_CONSTANTS.PATTERNS.HISTORY);
-  },
-
-  /**
-   * Count keybinding commands in content
-   * @param content The content to analyze
-   * @returns Number of keybinding commands found
-   */
-  countKeybindings: (content: string): number => {
-    return countMatches(content, PARSING_CONSTANTS.PATTERNS.KEYBINDING);
-  },
-} as const;
-
-/**
- * Count all pattern matches in content
- * @param content The content to analyze
- * @returns Object with counts for each pattern type
+ * Count all pattern matches in content.
+ *
+ * A projection over `extractEntries`, so any count shown anywhere equals
+ * the number of entries the corresponding view lists.
  */
 export function countAllPatterns(content: string) {
+  const entries = extractEntries(content);
   return {
-    aliases: PATTERN_REGISTRY.countAliases(content),
-    exports: PATTERN_REGISTRY.countExports(content),
-    evals: PATTERN_REGISTRY.countEvals(content),
-    setopts: PATTERN_REGISTRY.countSetopts(content),
-    plugins: PATTERN_REGISTRY.countPlugins(content),
-    functions: PATTERN_REGISTRY.countFunctions(content),
-    sources: PATTERN_REGISTRY.countSources(content),
-    autoloads: PATTERN_REGISTRY.countAutoloads(content),
-    fpaths: PATTERN_REGISTRY.countFpaths(content),
-    paths: PATTERN_REGISTRY.countPaths(content),
-    themes: PATTERN_REGISTRY.countThemes(content),
-    completions: PATTERN_REGISTRY.countCompletions(content),
-    history: PATTERN_REGISTRY.countHistory(content),
-    keybindings: PATTERN_REGISTRY.countKeybindings(content),
+    aliases: entries.aliases.length,
+    exports: entries.exports.length,
+    evals: entries.evals.length,
+    setopts: entries.setopts.length,
+    plugins: entries.plugins.length,
+    functions: entries.functions.length,
+    sources: entries.sources.length,
+    autoloads: entries.autoloads.length,
+    fpaths: entries.fpathEntries.length,
+    paths: entries.pathEntries.length,
+    themes: entries.themes.length,
+    completions: entries.completions.length,
+    history: entries.history.length,
+    keybindings: entries.keybindings.length,
   };
 }

--- a/extensions/zshrc-manager/src/lib/pattern-registry.ts
+++ b/extensions/zshrc-manager/src/lib/pattern-registry.ts
@@ -88,10 +88,11 @@ export interface RegistryEntries {
 const P = PARSING_CONSTANTS.PATTERNS;
 
 /**
- * Tokenizes zsh array body lines into elements, honoring the two pieces
- * of zsh syntax that whitespace-splitting gets wrong: inline comments
- * (`#` at start of word) end the line, and quoted elements may contain
- * whitespace. Quotes are stripped from the returned elements.
+ * Tokenizes zsh array body lines into elements, honoring the pieces of
+ * zsh syntax that whitespace-splitting gets wrong: inline comments
+ * (`#` at start of word) end the line, quoted elements may contain
+ * whitespace, and backslashes escape. Quotes are stripped from the
+ * returned elements.
  */
 export function tokenizeArrayBody(bodyLines: string[]): string[] {
   const tokens: string[] = [];
@@ -103,11 +104,38 @@ export function tokenizeArrayBody(bodyLines: string[]): string[] {
     let quote: '"' | "'" | null = null;
     for (let i = 0; i < line.length; i += 1) {
       const ch = line[i]!;
-      if (quote) {
-        if (ch === quote) {
+      if (quote === "'") {
+        // Inside single quotes nothing escapes, not even backslash.
+        if (ch === "'") {
           quote = null;
         } else {
           current += ch;
+        }
+        continue;
+      }
+      if (quote === '"') {
+        if (ch === "\\") {
+          const next = line[i + 1];
+          // Inside double quotes a backslash escapes only these; before
+          // anything else it stays a literal backslash.
+          if (next === '"' || next === "\\" || next === "$" || next === "`") {
+            current += next;
+            i += 1;
+          } else {
+            current += ch;
+          }
+        } else if (ch === '"') {
+          quote = null;
+        } else {
+          current += ch;
+        }
+        continue;
+      }
+      if (ch === "\\") {
+        const next = line[i + 1];
+        if (next !== undefined) {
+          current += next;
+          i += 1;
         }
         continue;
       }
@@ -136,14 +164,47 @@ export function tokenizeArrayBody(bodyLines: string[]): string[] {
 }
 
 /**
- * PATH/FPATH declaration forms. Each variable ("PATH"/"path",
- * "FPATH"/"fpath") gets the same family of matchers. Order matters:
- * the first matching form wins for a given line.
+ * Index of the first `)` that actually closes an array — i.e. is neither
+ * inside quotes nor backslash-escaped — or -1. Shares its quote and
+ * escape semantics with `tokenizeArrayBody`, so termination and
+ * tokenization can never disagree about what a quote covers.
  */
-function matchPathLike(line: string, upper: string, lower: string): PathLikeMatch[] | null {
+function findUnquotedCloseParen(text: string): number {
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i]!;
+    if (quote === "'") {
+      if (ch === "'") quote = null;
+      continue;
+    }
+    if (ch === "\\") {
+      // Skipping the escaped char is right in both remaining states: it
+      // only changes scanning when it hides a quote or a `)`.
+      i += 1;
+      continue;
+    }
+    if (quote === '"') {
+      if (ch === '"') quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === ")") return i;
+  }
+  return -1;
+}
+
+/**
+ * Scalar PATH/FPATH declaration forms. Each variable ("PATH", "FPATH")
+ * gets the same family of matchers. Order matters: the first matching
+ * form wins for a given line. Array forms (`path=(…)`, `fpath+=(…)`) are
+ * handled by the quote-aware array scanner in `extractDetailed`, which
+ * runs before this and consumes those lines.
+ */
+function matchPathLike(line: string, upper: string): PathLikeMatch[] | null {
   const out = (entry: string, type: PathLikeMatch["type"]): PathLikeMatch[] => [{ entry, type, line: 0 }];
-  const split = (list: string, type: PathLikeMatch["type"]): PathLikeMatch[] =>
-    tokenizeArrayBody([list]).map((entry) => ({ entry, type, line: 0 }));
 
   let m = line.match(
     new RegExp(
@@ -154,12 +215,6 @@ function matchPathLike(line: string, upper: string, lower: string): PathLikeMatc
 
   m = line.match(new RegExp(`^(?:\\s*)${upper}\\+=\\s*["']?:?(.+?)["']?(?:\\s*)$`));
   if (m?.[1] && !m[1].startsWith("(")) return out(m[1], "append");
-
-  m = line.match(new RegExp(`^(?:\\s*)${lower}\\+=\\s*\\(([^)]+)\\)(?:\\s*)$`));
-  if (m?.[1]) return split(m[1], "append");
-
-  m = line.match(new RegExp(`^(?:\\s*)${lower}=\\s*\\(([^)]+)\\)(?:\\s*)$`));
-  if (m?.[1]) return split(m[1], "set");
 
   m = line.match(new RegExp(`^(?:\\s*)${upper}\\s*=\\s*["']?\\$${upper}:(.+?)["']?(?:\\s*)$`));
   if (m?.[1]) return out(m[1], "append");
@@ -259,24 +314,43 @@ export function extractDetailed(content: string): DetailedExtraction {
     if (raw.length > FILE_CONSTANTS.MAX_LINE_LENGTH) continue;
     const line = index + 1;
 
-    // Multi-line array declarations (`plugins=(`, `path+=(`, …) — common
-    // in Oh My Zsh configs — are consumed as one declaration attributed
-    // to their opening line.
-    const arrayOpen = raw.match(/^(\s*)(plugins|path|fpath)(\+?)=\s*\(([^)]*)$/);
-    if (arrayOpen && !raw.includes(")")) {
-      const parts: string[] = [arrayOpen[4] ?? ""];
-      let closeIndex = index + 1;
-      while (closeIndex < lines.length) {
-        const bodyLine = lines[closeIndex] ?? "";
-        const closePos = bodyLine.indexOf(")");
-        if (closePos !== -1) {
-          parts.push(bodyLine.slice(0, closePos));
-          break;
+    // Array declarations (`plugins=(git docker)`, `path+=(`, …) —
+    // single-line or spanning several lines as is common in Oh My Zsh
+    // configs — are consumed as one declaration attributed to their
+    // opening line. Close-paren detection is quote-aware, so a `)`
+    // inside a quoted element does not terminate the array.
+    const arrayOpen = raw.match(/^(\s*)(plugins|path|fpath)(\+?)=\s*\((.*)$/);
+    if (arrayOpen) {
+      const firstBody = arrayOpen[4] ?? "";
+      const parts: string[] = [];
+      let closeIndex = -1;
+
+      const sameLineClose = findUnquotedCloseParen(firstBody);
+      if (sameLineClose !== -1) {
+        // Single line — only when nothing but whitespace or a comment
+        // follows the close.
+        const trailing = firstBody.slice(sameLineClose + 1).trim();
+        if (trailing === "" || trailing.startsWith("#")) {
+          parts.push(firstBody.slice(0, sameLineClose));
+          closeIndex = index;
         }
-        parts.push(bodyLine);
-        closeIndex += 1;
+      } else {
+        parts.push(firstBody);
+        let scan = index + 1;
+        while (scan < lines.length) {
+          const bodyLine = lines[scan] ?? "";
+          const closePos = findUnquotedCloseParen(bodyLine);
+          if (closePos !== -1) {
+            parts.push(bodyLine.slice(0, closePos));
+            closeIndex = scan;
+            break;
+          }
+          parts.push(bodyLine);
+          scan += 1;
+        }
       }
-      if (closeIndex < lines.length) {
+
+      if (closeIndex !== -1) {
         const elements = tokenizeArrayBody(parts);
         const variable = arrayOpen[2]!;
         const type: PathLikeMatch["type"] = arrayOpen[3] === "+" ? "append" : "set";
@@ -309,11 +383,11 @@ export function extractDetailed(content: string): DetailedExtraction {
       result.exports.push({ variable: m[1], value: m[2], line });
     }
 
-    const pathMatches = matchPathLike(raw, "PATH", "path");
+    const pathMatches = matchPathLike(raw, "PATH");
     if (pathMatches) {
       result.pathEntries.push(...withLine(pathMatches, line));
     }
-    const fpathMatches = matchPathLike(raw, "FPATH", "fpath");
+    const fpathMatches = matchPathLike(raw, "FPATH");
     if (fpathMatches) {
       result.fpathEntries.push(...withLine(fpathMatches, line));
     }
@@ -330,15 +404,6 @@ export function extractDetailed(content: string): DetailedExtraction {
     m = raw.match(P.SETOPT);
     if (m?.[1]) {
       result.setopts.push({ option: m[1], line });
-      continue;
-    }
-
-    m = raw.match(P.PLUGIN);
-    if (m?.[1]) {
-      for (const name of tokenizeArrayBody([m[1]])) {
-        result.plugins.push({ name, line });
-      }
-      matchedLines.add(line);
       continue;
     }
 

--- a/extensions/zshrc-manager/src/lib/pattern-registry.ts
+++ b/extensions/zshrc-manager/src/lib/pattern-registry.ts
@@ -88,6 +88,32 @@ export interface RegistryEntries {
 const P = PARSING_CONSTANTS.PATTERNS;
 
 /**
+ * Tokenizes zsh array body lines into elements, honoring the two pieces
+ * of zsh syntax that whitespace-splitting gets wrong: inline comments
+ * (`#` at start of word) end the line, and quoted elements may contain
+ * whitespace. Quotes are stripped from the returned elements.
+ */
+export function tokenizeArrayBody(bodyLines: string[]): string[] {
+  const tokens: string[] = [];
+  for (const raw of bodyLines) {
+    // An inline comment runs to end of line; `#` only starts a comment
+    // at the beginning of a word
+    const commentStart = raw.match(/(^|\s)#/);
+    const line = commentStart?.index !== undefined ? raw.slice(0, commentStart.index) : raw;
+
+    const tokenPattern = /"([^"]*)"|'([^']*)'|(\S+)/g;
+    let match: RegExpExecArray | null;
+    while ((match = tokenPattern.exec(line)) !== null) {
+      const value = match[1] ?? match[2] ?? match[3];
+      if (value && value.trim()) {
+        tokens.push(value.trim());
+      }
+    }
+  }
+  return tokens;
+}
+
+/**
  * PATH/FPATH declaration forms. Each variable ("PATH"/"path",
  * "FPATH"/"fpath") gets the same family of matchers. Order matters:
  * the first matching form wins for a given line.
@@ -95,10 +121,7 @@ const P = PARSING_CONSTANTS.PATTERNS;
 function matchPathLike(line: string, upper: string, lower: string): PathLikeMatch[] | null {
   const out = (entry: string, type: PathLikeMatch["type"]): PathLikeMatch[] => [{ entry, type, line: 0 }];
   const split = (list: string, type: PathLikeMatch["type"]): PathLikeMatch[] =>
-    list
-      .split(/\s+/)
-      .filter((p) => p.trim())
-      .map((p) => ({ entry: p.trim(), type, line: 0 }));
+    tokenizeArrayBody([list]).map((entry) => ({ entry, type, line: 0 }));
 
   let m = line.match(
     new RegExp(
@@ -169,6 +192,17 @@ function matchKeybinding(line: string): KeybindingMatch | null {
 const withLine = <T extends Positioned>(entries: T[] | null, line: number): T[] =>
   (entries ?? []).map((entry) => ({ ...entry, line }));
 
+/** Registry extraction plus which physical lines it consumed. */
+export interface DetailedExtraction {
+  entries: RegistryEntries;
+  /**
+   * 1-based numbers of every non-empty line the registry recognized,
+   * including the opening, body, and closing lines of multi-line arrays.
+   * Lines outside this set are what "Other" counts should count.
+   */
+  matchedLines: Set<number>;
+}
+
 /**
  * Extract every recognized construct from content, with line positions.
  *
@@ -176,7 +210,8 @@ const withLine = <T extends Positioned>(entries: T[] | null, line: number): T[] 
  * `export PATH=…` is both an export and a PATH declaration, matching
  * what the Exports and PATH views have always shown.
  */
-export function extractEntries(content: string): RegistryEntries {
+export function extractDetailed(content: string): DetailedExtraction {
+  const matchedLines = new Set<number>();
   const result: RegistryEntries = {
     aliases: [],
     exports: [],
@@ -220,12 +255,12 @@ export function extractEntries(content: string): RegistryEntries {
         closeIndex += 1;
       }
       if (closeIndex < lines.length) {
-        const elements = parts
-          .join(" ")
-          .split(/\s+/)
-          .filter((p) => p.trim());
+        const elements = tokenizeArrayBody(parts);
         const variable = arrayOpen[2]!;
         const type: PathLikeMatch["type"] = arrayOpen[3] === "+" ? "append" : "set";
+        for (let consumed = index; consumed <= closeIndex; consumed += 1) {
+          matchedLines.add(consumed + 1);
+        }
         for (const element of elements) {
           if (variable === "plugins") {
             result.plugins.push({ name: element.trim(), line });
@@ -278,9 +313,10 @@ export function extractEntries(content: string): RegistryEntries {
 
     m = raw.match(P.PLUGIN);
     if (m?.[1]) {
-      for (const name of m[1].split(/\s+/).filter((p) => p.trim())) {
-        result.plugins.push({ name: name.trim(), line });
+      for (const name of tokenizeArrayBody([m[1]])) {
+        result.plugins.push({ name, line });
       }
+      matchedLines.add(line);
       continue;
     }
 
@@ -328,7 +364,40 @@ export function extractEntries(content: string): RegistryEntries {
     }
   }
 
-  return result;
+  // Every entry's own line is a recognized line; multi-line array
+  // body/close lines were added when they were consumed above.
+  for (const collection of Object.values(result)) {
+    for (const entry of collection) {
+      matchedLines.add(entry.line);
+    }
+  }
+
+  return { entries: result, matchedLines };
+}
+
+/** Extract every recognized construct from content, with line positions. */
+export function extractEntries(content: string): RegistryEntries {
+  return extractDetailed(content).entries;
+}
+
+/**
+ * Counts non-empty lines the registry did not recognize — the "Other"
+ * count. Lines are the unit here (unlike the per-entry type counts), so
+ * a recognized multi-line array contributes nothing to Other, however
+ * many elements or physical lines it spans.
+ */
+export function countUnrecognizedLines(content: string): number {
+  const { matchedLines } = extractDetailed(content);
+  const lines = content.split(/\r?\n/);
+  let unrecognized = 0;
+  for (let index = 0; index < lines.length; index += 1) {
+    const raw = lines[index];
+    if (!raw || raw.trim().length === 0) continue;
+    if (!matchedLines.has(index + 1)) {
+      unrecognized += 1;
+    }
+  }
+  return unrecognized;
 }
 
 /**

--- a/extensions/zshrc-manager/src/lib/pattern-registry.ts
+++ b/extensions/zshrc-manager/src/lib/pattern-registry.ts
@@ -302,6 +302,88 @@ function matchKeybinding(line: string): KeybindingMatch | null {
 const withLine = <T extends Positioned>(entries: T[] | null, line: number): T[] =>
   (entries ?? []).map((entry) => ({ ...entry, line }));
 
+/** A recognized array declaration and the physical lines it spans. */
+interface ArrayScan {
+  /** "plugins" | "path" | "fpath" */
+  variable: string;
+  /** `+=` (append) vs `=` (set) */
+  append: boolean;
+  /** Raw body text between the parens, one entry per physical line */
+  parts: string[];
+  /** 0-based index of the line holding the closing paren */
+  closeIndex: number;
+}
+
+/**
+ * Matches an array declaration (`plugins=(git docker)`, `path+=(`, …)
+ * opening at `index` — single-line or spanning several lines as is
+ * common in Oh My Zsh configs. Close-paren detection is quote-aware, so
+ * a `)` inside a quoted element does not terminate the array. Returns
+ * null when the line opens no array or the array never closes.
+ */
+function matchArrayAt(lines: readonly string[], index: number): ArrayScan | null {
+  const raw = lines[index] ?? "";
+  const arrayOpen = raw.match(/^(\s*)(plugins|path|fpath)(\+?)=\s*\((.*)$/);
+  if (!arrayOpen) return null;
+
+  const firstBody = arrayOpen[4] ?? "";
+  const parts: string[] = [];
+  let closeIndex = -1;
+
+  const sameLineClose = findUnquotedCloseParen(firstBody);
+  if (sameLineClose !== -1) {
+    // Single line — only when nothing but whitespace or a comment
+    // follows the close.
+    const trailing = firstBody.slice(sameLineClose + 1).trim();
+    if (trailing === "" || trailing.startsWith("#")) {
+      parts.push(firstBody.slice(0, sameLineClose));
+      closeIndex = index;
+    }
+  } else {
+    parts.push(firstBody);
+    let scan = index + 1;
+    while (scan < lines.length) {
+      const bodyLine = lines[scan] ?? "";
+      const closePos = findUnquotedCloseParen(bodyLine);
+      if (closePos !== -1) {
+        parts.push(bodyLine.slice(0, closePos));
+        closeIndex = scan;
+        break;
+      }
+      parts.push(bodyLine);
+      scan += 1;
+    }
+  }
+
+  if (closeIndex === -1) return null;
+  return { variable: arrayOpen[2]!, append: arrayOpen[3] === "+", parts, closeIndex };
+}
+
+/**
+ * 1-based numbers of the body and closing lines of every multi-line
+ * array. Section detection must ignore these lines: a comment inside an
+ * array that happens to match a section-header format must not split
+ * the array, or per-section counts would disagree with what the
+ * registry (and therefore every view) extracts.
+ */
+export function multilineArrayInteriorLines(content: string): Set<number> {
+  const interior = new Set<number>();
+  const lines = content.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const raw = lines[index];
+    if (!raw || raw.trim().length === 0) continue;
+    if (raw.length > FILE_CONSTANTS.MAX_LINE_LENGTH) continue;
+    const scan = matchArrayAt(lines, index);
+    if (scan && scan.closeIndex > index) {
+      for (let consumed = index + 1; consumed <= scan.closeIndex; consumed += 1) {
+        interior.add(consumed + 1);
+      }
+      index = scan.closeIndex;
+    }
+  }
+  return interior;
+}
+
 /** Registry extraction plus which physical lines it consumed. */
 export interface DetailedExtraction {
   entries: RegistryEntries;
@@ -347,61 +429,26 @@ export function extractDetailed(content: string): DetailedExtraction {
     if (raw.length > FILE_CONSTANTS.MAX_LINE_LENGTH) continue;
     const line = index + 1;
 
-    // Array declarations (`plugins=(git docker)`, `path+=(`, …) —
-    // single-line or spanning several lines as is common in Oh My Zsh
-    // configs — are consumed as one declaration attributed to their
-    // opening line. Close-paren detection is quote-aware, so a `)`
-    // inside a quoted element does not terminate the array.
-    const arrayOpen = raw.match(/^(\s*)(plugins|path|fpath)(\+?)=\s*\((.*)$/);
-    if (arrayOpen) {
-      const firstBody = arrayOpen[4] ?? "";
-      const parts: string[] = [];
-      let closeIndex = -1;
-
-      const sameLineClose = findUnquotedCloseParen(firstBody);
-      if (sameLineClose !== -1) {
-        // Single line — only when nothing but whitespace or a comment
-        // follows the close.
-        const trailing = firstBody.slice(sameLineClose + 1).trim();
-        if (trailing === "" || trailing.startsWith("#")) {
-          parts.push(firstBody.slice(0, sameLineClose));
-          closeIndex = index;
-        }
-      } else {
-        parts.push(firstBody);
-        let scan = index + 1;
-        while (scan < lines.length) {
-          const bodyLine = lines[scan] ?? "";
-          const closePos = findUnquotedCloseParen(bodyLine);
-          if (closePos !== -1) {
-            parts.push(bodyLine.slice(0, closePos));
-            closeIndex = scan;
-            break;
-          }
-          parts.push(bodyLine);
-          scan += 1;
+    // Array declarations — consumed as one declaration attributed to
+    // their opening line (see `matchArrayAt`).
+    const arrayScan = matchArrayAt(lines, index);
+    if (arrayScan) {
+      const elements = tokenizeArrayBody(arrayScan.parts);
+      const type: PathLikeMatch["type"] = arrayScan.append ? "append" : "set";
+      for (let consumed = index; consumed <= arrayScan.closeIndex; consumed += 1) {
+        matchedLines.add(consumed + 1);
+      }
+      for (const element of elements) {
+        if (arrayScan.variable === "plugins") {
+          result.plugins.push({ name: element.trim(), line });
+        } else if (arrayScan.variable === "path") {
+          result.pathEntries.push({ entry: element.trim(), type, line });
+        } else {
+          result.fpathEntries.push({ entry: element.trim(), type, line });
         }
       }
-
-      if (closeIndex !== -1) {
-        const elements = tokenizeArrayBody(parts);
-        const variable = arrayOpen[2]!;
-        const type: PathLikeMatch["type"] = arrayOpen[3] === "+" ? "append" : "set";
-        for (let consumed = index; consumed <= closeIndex; consumed += 1) {
-          matchedLines.add(consumed + 1);
-        }
-        for (const element of elements) {
-          if (variable === "plugins") {
-            result.plugins.push({ name: element.trim(), line });
-          } else if (variable === "path") {
-            result.pathEntries.push({ entry: element.trim(), type, line });
-          } else {
-            result.fpathEntries.push({ entry: element.trim(), type, line });
-          }
-        }
-        index = closeIndex;
-        continue;
-      }
+      index = arrayScan.closeIndex;
+      continue;
     }
 
     let m = raw.match(P.ALIAS);

--- a/extensions/zshrc-manager/src/lib/resolve.ts
+++ b/extensions/zshrc-manager/src/lib/resolve.ts
@@ -14,7 +14,7 @@
 import { readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { parseExports, parsePathEntries } from "../utils/parsers";
+import { parsePathEntries } from "../utils/parsers";
 import { getZshrcPath } from "./zsh";
 
 /** Three-valued answer for facts that may be undecidable. */
@@ -49,15 +49,31 @@ function getConfigContent(): string | null {
   return configContentCache;
 }
 
-/** The raw value of a variable exported in the config, or undefined. */
-function getConfigExport(variable: string): string | undefined {
+/**
+ * The raw value of a variable assigned in the config, or undefined.
+ *
+ * Accepts every declaration form zsh does — `export VAR=…`,
+ * `typeset/declare [-flags] VAR=…`, and a plain `VAR=…` assignment,
+ * which is how `ZSH_CUSTOM` is commonly set.
+ */
+function getConfigAssignment(variable: string): string | undefined {
   const content = getConfigContent();
   if (content === null) {
     return undefined;
   }
+  const regex = new RegExp(
+    `^\\s*(?:(?:export|typeset(?:\\s+-[A-Za-z]+)*|declare(?:\\s+-[A-Za-z]+)*)\\s+)?${variable}=(.*?)\\s*$`,
+    "gm",
+  );
   // Last assignment wins, as it would in the shell.
-  const matches = parseExports(content).filter((entry) => entry.variable === variable);
-  return matches.at(-1)?.value;
+  let value: string | undefined;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(content)) !== null) {
+    if (match[1]) {
+      value = match[1];
+    }
+  }
+  return value;
 }
 
 /**
@@ -70,9 +86,22 @@ function getConfigExport(variable: string): string | undefined {
  */
 export function expandUserPath(raw: string, home: string = homedir()): string | null {
   let trimmed = raw.trim();
-  // Shell operands are often quoted; the quotes are not part of the path.
-  if (trimmed.length >= 2 && (trimmed[0] === '"' || trimmed[0] === "'") && trimmed.endsWith(trimmed[0]!)) {
-    trimmed = trimmed.slice(1, -1);
+  // Shell operands are often quoted; the quotes are not part of the path,
+  // and anything after the closing quote (e.g. an inline comment that a
+  // caller failed to strip) is not either.
+  const quote = trimmed[0];
+  if (quote === '"' || quote === "'") {
+    const close = trimmed.indexOf(quote, 1);
+    if (close === -1) {
+      return null;
+    }
+    trimmed = trimmed.slice(1, close);
+  } else {
+    // For unquoted values, an inline comment is not part of the operand.
+    const hash = trimmed.search(/\s#/);
+    if (hash !== -1) {
+      trimmed = trimmed.slice(0, hash).trimEnd();
+    }
   }
   if (trimmed.length === 0) {
     return null;
@@ -83,7 +112,9 @@ export function expandUserPath(raw: string, home: string = homedir()): string | 
     expanded = home + expanded.slice(1);
   } else if (expanded.startsWith("${HOME}")) {
     expanded = home + expanded.slice("${HOME}".length);
-  } else if (expanded.startsWith("$HOME")) {
+  } else if (/^\$HOME(\/|$)/.test(expanded)) {
+    // The boundary check keeps $HOMEBREW_PREFIX and friends from being
+    // mangled into $HOME + "BREW_PREFIX…".
     expanded = home + expanded.slice("$HOME".length);
   }
 
@@ -233,8 +264,8 @@ export function pluginInstalled(
     return "unknown";
   }
 
-  const zshDecl = env["ZSH"] ?? getConfigExport("ZSH");
-  const customDecl = env["ZSH_CUSTOM"] ?? getConfigExport("ZSH_CUSTOM");
+  const zshDecl = env["ZSH"] ?? getConfigAssignment("ZSH");
+  const customDecl = env["ZSH_CUSTOM"] ?? getConfigAssignment("ZSH_CUSTOM");
 
   const cacheKey = `${name}\0${home}\0${zshDecl ?? ""}\0${customDecl ?? ""}`;
   const cached = pluginCache.get(cacheKey);

--- a/extensions/zshrc-manager/src/lib/scoped-replace.ts
+++ b/extensions/zshrc-manager/src/lib/scoped-replace.ts
@@ -15,6 +15,7 @@
  */
 
 import { detectSectionMarker } from "./section-detector";
+import { multilineArrayInteriorLines } from "./pattern-registry";
 
 interface SectionBounds {
   startLine: number;
@@ -48,9 +49,15 @@ function findSectionInstanceBounds(content: string, label: string, n: number): S
     return null;
   };
 
+  // Lines inside a multi-line array are never markers — must mirror
+  // toLogicalSections, or write-target sections would resolve to
+  // different bounds than the sections the items were parsed from.
+  const arrayInterior = multilineArrayInteriorLines(content);
+
   for (let i = 0; i < lines.length; i += 1) {
     const raw = lines[i];
     if (!raw) continue;
+    if (arrayInterior.has(i + 1)) continue;
     const marker = detectSectionMarker(raw, i + 1);
     if (!marker) continue;
 

--- a/extensions/zshrc-manager/src/lib/section-detector.ts
+++ b/extensions/zshrc-manager/src/lib/section-detector.ts
@@ -6,6 +6,7 @@
  */
 
 import { PARSING_CONSTANTS, getSectionFormatsInOrder } from "../constants";
+import { multilineArrayInteriorLines } from "./pattern-registry";
 
 import type { SectionMarkerType } from "../types/enums";
 
@@ -157,9 +158,13 @@ export function analyzeSectionMarkers(content: string): SectionMarker[] {
     functionLevel: 0,
   };
 
+  // Lines inside a multi-line array are never markers — a comment in an
+  // array body that matches a section-header format must not register.
+  const arrayInterior = multilineArrayInteriorLines(content);
+
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
-    if (line) {
+    if (line && !arrayInterior.has(i + 1)) {
       const marker = detectSectionMarker(line, i + 1);
 
       if (marker) {
@@ -206,9 +211,11 @@ export function groupContentIntoSections(content: string): Array<{
     functionLevel: 0,
   };
 
+  const arrayInterior = multilineArrayInteriorLines(content);
+
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
-    if (line) {
+    if (line && !arrayInterior.has(i + 1)) {
       const marker = detectSectionMarker(line, i + 1);
 
       if (marker) {
@@ -319,11 +326,12 @@ export function findSectionBounds(
   const lines = content.split(/\r?\n/);
   let sectionStartLine: number | null = null;
   let sectionEndLine: number | null = null;
+  const arrayInterior = multilineArrayInteriorLines(content);
 
   // Find the section start
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
-    if (!line) continue;
+    if (!line || arrayInterior.has(i + 1)) continue;
     const marker = detectSectionMarker(line, i + 1);
 
     if (marker && marker.name === sectionLabel) {
@@ -342,7 +350,7 @@ export function findSectionBounds(
   // Find the section end (next section start or end marker)
   for (let i = sectionStartLine; i < lines.length; i++) {
     const line = lines[i];
-    if (!line) continue;
+    if (!line || arrayInterior.has(i + 1)) continue;
     const marker = detectSectionMarker(line, i + 1);
 
     if (marker) {

--- a/extensions/zshrc-manager/src/lib/section-writer.ts
+++ b/extensions/zshrc-manager/src/lib/section-writer.ts
@@ -300,9 +300,10 @@ export async function addAliasesToZshrc(
 
     lines.splice(insertLine, 0, ...insertContent);
 
-    // Save to history before writing for undo support
-    await saveToHistory(`Add ${aliases.length} aliases to "${existingSection.marker.name}"`);
     await writeZshrcFile(lines.join("\n"));
+    // Record history after the write, with the pre-change snapshot as
+    // the undo target
+    await saveToHistory(`Add ${aliases.length} aliases to "${existingSection.marker.name}"`, content);
 
     return {
       success: true,
@@ -326,9 +327,10 @@ export async function addAliasesToZshrc(
     // Append to content and write
     const newContent = content + newSection.join("\n");
 
-    // Save to history before writing for undo support
-    await saveToHistory(`Create section "${displayName}" with ${aliases.length} aliases`);
     await writeZshrcFile(newContent);
+    // Record history after the write, with the pre-change snapshot as
+    // the undo target
+    await saveToHistory(`Create section "${displayName}" with ${aliases.length} aliases`, content);
 
     return {
       success: true,
@@ -375,9 +377,10 @@ export async function addSingleAliasToZshrc(
 
       lines.splice(insertLine, 0, ...insertContent);
 
-      // Save to history before writing for undo support
-      await saveToHistory(`Add alias "${alias.name}" to "${existingSection.marker.name}"`);
       await writeZshrcFile(lines.join("\n"));
+      // Record history after the write, with the pre-change snapshot as
+      // the undo target
+      await saveToHistory(`Add alias "${alias.name}" to "${existingSection.marker.name}"`, content);
 
       return {
         success: true,
@@ -407,9 +410,10 @@ export async function addSingleAliasToZshrc(
 
     const newContent = content + newSection.join("\n");
 
-    // Save to history before writing for undo support
-    await saveToHistory(`Add alias "${alias.name}" (create "${collectionName}" section)`);
     await writeZshrcFile(newContent);
+    // Record history after the write, with the pre-change snapshot as
+    // the undo target
+    await saveToHistory(`Add alias "${alias.name}" (create "${collectionName}" section)`, content);
 
     return {
       success: true,
@@ -421,9 +425,10 @@ export async function addSingleAliasToZshrc(
   const appendContent = alias.description ? `\n# ${alias.description}\n${aliasLine}\n` : `\n${aliasLine}\n`;
   const newContent = content + appendContent;
 
-  // Save to history before writing for undo support
-  await saveToHistory(`Add alias "${alias.name}"`);
   await writeZshrcFile(newContent);
+  // Record history after the write, with the pre-change snapshot as
+  // the undo target
+  await saveToHistory(`Add alias "${alias.name}"`, content);
 
   return {
     success: true,

--- a/extensions/zshrc-manager/src/lib/toggle-item.ts
+++ b/extensions/zshrc-manager/src/lib/toggle-item.ts
@@ -76,10 +76,7 @@ export async function toggleItem(key: string, config: EditItemConfig): Promise<b
     lines[foundIndex] = newLine;
     const updatedContent = lines.join("\n");
 
-    // Save to history before writing
     const action = isCurrentlyCommented ? "Enable" : "Disable";
-    await saveToHistory(`${action} ${config.itemType} "${key}"`);
-
     await writeZshrcFile(updatedContent);
     clearCache(getZshrcPath());
 
@@ -88,6 +85,10 @@ export async function toggleItem(key: string, config: EditItemConfig): Promise<b
     if (verify !== updatedContent) {
       throw new Error("Write verification failed: content mismatch after toggle");
     }
+
+    // Record history after the verified write, with the pre-change
+    // snapshot as the undo target
+    await saveToHistory(`${action} ${config.itemType} "${key}"`, zshrcContent);
 
     const newState = !isCurrentlyCommented;
     await showToast({

--- a/extensions/zshrc-manager/src/utils/parsers.ts
+++ b/extensions/zshrc-manager/src/utils/parsers.ts
@@ -117,7 +117,9 @@ export function parseFunctions(content: string): ReadonlyArray<{ name: string }>
  * @returns Array of source objects with path
  */
 export function parseSources(content: string): ReadonlyArray<{ path: string }> {
-  const regex = /^(?:\s*)source\s+(.+?)(?:\s*)$/gm;
+  // Capture only the operand: a quoted string, or an unquoted token —
+  // an inline `# comment` after the operand is not part of the path.
+  const regex = /^(?:\s*)source\s+("(?:[^"\\]|\\.)*"|'[^']*'|[^\s#]+)/gm;
   const result: Array<{ path: string }> = [];
   let match: RegExpExecArray | null;
   while ((match = regex.exec(content)) !== null) {

--- a/extensions/zshrc-manager/src/utils/parsers.ts
+++ b/extensions/zshrc-manager/src/utils/parsers.ts
@@ -1,10 +1,15 @@
 /**
- * Utility functions for parsing zshrc content
+ * Utility functions for parsing zshrc content.
  *
- * @deprecated Use the centralized pattern registry in src/lib/pattern-registry.ts
- * and the main parser in src/lib/parse-zshrc.ts instead of these individual functions.
- * These functions are kept for backward compatibility but will be removed in a future version.
+ * These are thin projections over the pattern registry
+ * (src/lib/pattern-registry.ts), which is the single parser. Every view,
+ * statistic, and search surface derives from the same extraction, so
+ * counts and lists cannot disagree. The legacy return shapes are
+ * preserved; line positions live on the registry output for callers
+ * that need them.
  */
+
+import { extractEntries } from "../lib/pattern-registry";
 
 /**
  * Parses aliases from zshrc content
@@ -12,15 +17,7 @@
  * @returns Array of alias objects with name and command
  */
 export function parseAliases(content: string): ReadonlyArray<{ name: string; command: string }> {
-  const regex = /^(?:\s*)alias\s+([A-Za-z0-9_.:-]+)=(?:'|")(.*?)(?:'|")(?:\s*)$/gm;
-  const result: Array<{ name: string; command: string }> = [];
-  let match: RegExpExecArray | null;
-  while ((match = regex.exec(content)) !== null) {
-    if (match[1] && match[2]) {
-      result.push({ name: match[1], command: match[2] });
-    }
-  }
-  return result;
+  return extractEntries(content).aliases.map(({ name, command }) => ({ name, command }));
 }
 
 /**
@@ -29,15 +26,7 @@ export function parseAliases(content: string): ReadonlyArray<{ name: string; com
  * @returns Array of export objects with variable and value
  */
 export function parseExports(content: string): ReadonlyArray<{ variable: string; value: string }> {
-  const regex = /^(?:\s*)(?:export|typeset\s+-x)\s+([A-Za-z_][A-Za-z0-9_]*)=(.*?)(?:\s*)$/gm;
-  const result: Array<{ variable: string; value: string }> = [];
-  let match: RegExpExecArray | null;
-  while ((match = regex.exec(content)) !== null) {
-    if (match[1] && match[2]) {
-      result.push({ variable: match[1], value: match[2] });
-    }
-  }
-  return result;
+  return extractEntries(content).exports.map(({ variable, value }) => ({ variable, value }));
 }
 
 /**
@@ -46,15 +35,7 @@ export function parseExports(content: string): ReadonlyArray<{ variable: string;
  * @returns Array of eval objects with command
  */
 export function parseEvals(content: string): ReadonlyArray<{ command: string }> {
-  const regex = /^(?:\s*)eval\s+(.+?)(?:\s*)$/gm;
-  const result: Array<{ command: string }> = [];
-  let match: RegExpExecArray | null;
-  while ((match = regex.exec(content)) !== null) {
-    if (match[1]) {
-      result.push({ command: match[1] });
-    }
-  }
-  return result;
+  return extractEntries(content).evals.map(({ command }) => ({ command }));
 }
 
 /**
@@ -63,15 +44,7 @@ export function parseEvals(content: string): ReadonlyArray<{ command: string }> 
  * @returns Array of setopt objects with option
  */
 export function parseSetopts(content: string): ReadonlyArray<{ option: string }> {
-  const regex = /^(?:\s*)setopt\s+(.+?)(?:\s*)$/gm;
-  const result: Array<{ option: string }> = [];
-  let match: RegExpExecArray | null;
-  while ((match = regex.exec(content)) !== null) {
-    if (match[1]) {
-      result.push({ option: match[1] });
-    }
-  }
-  return result;
+  return extractEntries(content).setopts.map(({ option }) => ({ option }));
 }
 
 /**
@@ -80,18 +53,7 @@ export function parseSetopts(content: string): ReadonlyArray<{ option: string }>
  * @returns Array of plugin names
  */
 export function parsePlugins(content: string): ReadonlyArray<{ name: string }> {
-  const regex = /^(?:\s*)plugins\s*=\s*\(([^)]+)\)(?:\s*)$/gm;
-  const result: Array<{ name: string }> = [];
-  let match: RegExpExecArray | null;
-  while ((match = regex.exec(content)) !== null) {
-    if (match[1]) {
-      const pluginList = match[1].split(/\s+/).filter((p) => p.trim());
-      pluginList.forEach((plugin) => {
-        result.push({ name: plugin.trim() });
-      });
-    }
-  }
-  return result;
+  return extractEntries(content).plugins.map(({ name }) => ({ name }));
 }
 
 /**
@@ -100,15 +62,7 @@ export function parsePlugins(content: string): ReadonlyArray<{ name: string }> {
  * @returns Array of function names
  */
 export function parseFunctions(content: string): ReadonlyArray<{ name: string }> {
-  const regex = /^(?:\s*)([A-Za-z_][A-Za-z0-9_]*)\s*\(\s*\)\s*\{(?:\s*)$/gm;
-  const result: Array<{ name: string }> = [];
-  let match: RegExpExecArray | null;
-  while ((match = regex.exec(content)) !== null) {
-    if (match[1]) {
-      result.push({ name: match[1] });
-    }
-  }
-  return result;
+  return extractEntries(content).functions.map(({ name }) => ({ name }));
 }
 
 /**
@@ -117,86 +71,20 @@ export function parseFunctions(content: string): ReadonlyArray<{ name: string }>
  * @returns Array of source objects with path
  */
 export function parseSources(content: string): ReadonlyArray<{ path: string }> {
-  // Capture only the operand: a quoted string, or an unquoted token —
-  // an inline `# comment` after the operand is not part of the path.
-  const regex = /^(?:\s*)source\s+("(?:[^"\\]|\\.)*"|'[^']*'|[^\s#]+)/gm;
-  const result: Array<{ path: string }> = [];
-  let match: RegExpExecArray | null;
-  while ((match = regex.exec(content)) !== null) {
-    if (match[1]) {
-      result.push({ path: match[1] });
-    }
-  }
-  return result;
+  return extractEntries(content).sources.map(({ path }) => ({ path }));
 }
 
 /**
  * Parses PATH modifications from zshrc content
- * Matches: export PATH="...", path+=(...), PATH="..."
+ * Matches: export/typeset/declare PATH=..., PATH+=..., path+=(...), path=(...),
+ * PATH="$PATH:...", PATH="...:$PATH", and plain PATH=... assignments
  * @param content The raw content to parse
- * @returns Array of PATH objects with entry and type (export, append, prepend)
+ * @returns Array of PATH objects with entry and type (export, append, prepend, set)
  */
 export function parsePathEntries(
   content: string,
 ): ReadonlyArray<{ entry: string; type: "export" | "append" | "prepend" | "set" }> {
-  const result: Array<{ entry: string; type: "export" | "append" | "prepend" | "set" }> = [];
-
-  // Match export PATH="...", typeset -x PATH="...", declare -x PATH="..."
-  const exportRegex = /^(?:\s*)(?:export|(?:typeset|declare)(?:\s+-[A-Za-z]+)*)\s+PATH\s*=\s*["']?(.+?)["']?(?:\s*)$/gm;
-  let match: RegExpExecArray | null;
-  while ((match = exportRegex.exec(content)) !== null) {
-    if (match[1]) {
-      result.push({ entry: match[1], type: "export" });
-    }
-  }
-
-  // Match PATH+=:/dir and PATH+="/dir" - string append
-  const stringAppendRegex = /^(?:\s*)PATH\+=\s*["']?:?(.+?)["']?(?:\s*)$/gm;
-  while ((match = stringAppendRegex.exec(content)) !== null) {
-    if (match[1] && !match[1].startsWith("(")) {
-      result.push({ entry: match[1], type: "append" });
-    }
-  }
-
-  // Match path+=(...) - zsh array append
-  const appendRegex = /^(?:\s*)path\+=\s*\(([^)]+)\)(?:\s*)$/gm;
-  while ((match = appendRegex.exec(content)) !== null) {
-    if (match[1]) {
-      const paths = match[1].split(/\s+/).filter((p) => p.trim());
-      paths.forEach((p) => {
-        result.push({ entry: p.trim(), type: "append" });
-      });
-    }
-  }
-
-  // Match path=(...) - zsh array set (replaces entire path)
-  const setRegex = /^(?:\s*)path=\s*\(([^)]+)\)(?:\s*)$/gm;
-  while ((match = setRegex.exec(content)) !== null) {
-    if (match[1]) {
-      const paths = match[1].split(/\s+/).filter((p) => p.trim());
-      paths.forEach((p) => {
-        result.push({ entry: p.trim(), type: "set" });
-      });
-    }
-  }
-
-  // Match PATH="$PATH:..."
-  const pathModifyRegex = /^(?:\s*)PATH\s*=\s*["']?\$PATH:(.+?)["']?(?:\s*)$/gm;
-  while ((match = pathModifyRegex.exec(content)) !== null) {
-    if (match[1]) {
-      result.push({ entry: match[1], type: "append" });
-    }
-  }
-
-  // Match PATH="...:$PATH"
-  const pathPrependRegex = /^(?:\s*)PATH\s*=\s*["']?(.+?):\$PATH["']?(?:\s*)$/gm;
-  while ((match = pathPrependRegex.exec(content)) !== null) {
-    if (match[1]) {
-      result.push({ entry: match[1], type: "prepend" });
-    }
-  }
-
-  return result;
+  return extractEntries(content).pathEntries.map(({ entry, type }) => ({ entry, type }));
 }
 
 /**
@@ -207,56 +95,7 @@ export function parsePathEntries(
 export function parseFpathEntries(
   content: string,
 ): ReadonlyArray<{ entry: string; type: "export" | "append" | "prepend" | "set" }> {
-  const result: Array<{ entry: string; type: "export" | "append" | "prepend" | "set" }> = [];
-
-  // Match export FPATH="..."
-  const exportRegex = /^(?:\s*)export\s+FPATH\s*=\s*["']?(.+?)["']?(?:\s*)$/gm;
-  let match: RegExpExecArray | null;
-  while ((match = exportRegex.exec(content)) !== null) {
-    if (match[1]) {
-      result.push({ entry: match[1], type: "export" });
-    }
-  }
-
-  // Match fpath+=(...) - zsh array append
-  const appendRegex = /^(?:\s*)fpath\+=\s*\(([^)]+)\)(?:\s*)$/gm;
-  while ((match = appendRegex.exec(content)) !== null) {
-    if (match[1]) {
-      const paths = match[1].split(/\s+/).filter((p) => p.trim());
-      paths.forEach((p) => {
-        result.push({ entry: p.trim(), type: "append" });
-      });
-    }
-  }
-
-  // Match fpath=(...) - zsh array set (replaces entire fpath)
-  const setRegex = /^(?:\s*)fpath=\s*\(([^)]+)\)(?:\s*)$/gm;
-  while ((match = setRegex.exec(content)) !== null) {
-    if (match[1]) {
-      const paths = match[1].split(/\s+/).filter((p) => p.trim());
-      paths.forEach((p) => {
-        result.push({ entry: p.trim(), type: "set" });
-      });
-    }
-  }
-
-  // Match FPATH="$FPATH:..."
-  const fpathModifyRegex = /^(?:\s*)FPATH\s*=\s*["']?\$FPATH:(.+?)["']?(?:\s*)$/gm;
-  while ((match = fpathModifyRegex.exec(content)) !== null) {
-    if (match[1]) {
-      result.push({ entry: match[1], type: "append" });
-    }
-  }
-
-  // Match FPATH="...:$FPATH" - prepend pattern
-  const fpathPrependRegex = /^(?:\s*)FPATH\s*=\s*["']?(.+?):\$FPATH["']?(?:\s*)$/gm;
-  while ((match = fpathPrependRegex.exec(content)) !== null) {
-    if (match[1]) {
-      result.push({ entry: match[1], type: "prepend" });
-    }
-  }
-
-  return result;
+  return extractEntries(content).fpathEntries.map(({ entry, type }) => ({ entry, type }));
 }
 
 /**
@@ -281,85 +120,10 @@ export interface KeybindingResult {
  * @returns Array of keybinding objects with key, command, optional widget, and optional keymap
  */
 export function parseKeybindings(content: string): ReadonlyArray<KeybindingResult> {
-  const result: Array<KeybindingResult> = [];
-  const seen = new Set<string>();
-
-  // Helper to add unique results (avoid duplicates from multiple regex matches)
-  const addResult = (entry: KeybindingResult) => {
-    const key = `${entry.keymap || ""}:${entry.key}:${entry.command}:${entry.widget || ""}`;
-    if (!seen.has(key)) {
-      seen.add(key);
-      result.push(entry);
-    }
-  };
-
-  // Match bindkey -M keymap -s "key" "replacement" (keymap-specific string replacement)
-  // Uses separate patterns for quoted and unquoted keys to avoid greedy matching
-  const keymapStringQuotedRegex = /^(?:\s*)bindkey\s+-M\s+(\S+)\s+-s\s+(['"])([^'"]+)\2\s+(['"])([^'"]+)\4(?:\s*)$/gm;
-  let match: RegExpExecArray | null;
-  while ((match = keymapStringQuotedRegex.exec(content)) !== null) {
-    if (match[1] && match[3] && match[5]) {
-      addResult({
-        key: match[3],
-        command: match[5].trim(),
-        widget: "string-replacement",
-        keymap: match[1],
-      });
-    }
-  }
-
-  // Match bindkey -M keymap "key" command (keymap-specific binding with quoted key)
-  const keymapQuotedRegex = /^(?:\s*)bindkey\s+-M\s+(\S+)\s+(['"])([^'"]+)\2\s+(\S+)(?:\s*)$/gm;
-  while ((match = keymapQuotedRegex.exec(content)) !== null) {
-    if (match[1] && match[3] && match[4]) {
-      addResult({
-        key: match[3],
-        command: match[4].trim(),
-        keymap: match[1],
-      });
-    }
-  }
-
-  // Match bindkey -M keymap key command (keymap-specific binding with unquoted key)
-  // Unquoted key must not start with a quote
-  const keymapUnquotedRegex = /^(?:\s*)bindkey\s+-M\s+(\S+)\s+([^'"\s]\S*)\s+(\S+)(?:\s*)$/gm;
-  while ((match = keymapUnquotedRegex.exec(content)) !== null) {
-    if (match[1] && match[2] && match[3]) {
-      addResult({
-        key: match[2],
-        command: match[3].trim(),
-        keymap: match[1],
-      });
-    }
-  }
-
-  // Match bindkey -s "key" "replacement" (string replacement with quoted args)
-  const bindkeyStringQuotedRegex = /^(?:\s*)bindkey\s+-s\s+(['"])([^'"]+)\1\s+(['"])([^'"]+)\3(?:\s*)$/gm;
-  while ((match = bindkeyStringQuotedRegex.exec(content)) !== null) {
-    if (match[2] && match[4]) {
-      addResult({ key: match[2], command: match[4].trim(), widget: "string-replacement" });
-    }
-  }
-
-  // Match bindkey "key" command (basic with quoted key)
-  // Exclude all known bindkey flags: -M (keymap), -s (string), -r (remove), -R (range),
-  // -L (list), -l (widgets), -e (emacs), -v (viins), -a (vicmd), -d (delete), -p (prefix), -N (new widget)
-  const bindkeyQuotedRegex = /^(?:\s*)bindkey\s+(?!-[MsrRLlevaAdpN])(['"])([^'"]+)\1\s+(\S+)(?:\s*)$/gm;
-  while ((match = bindkeyQuotedRegex.exec(content)) !== null) {
-    if (match[2] && match[3]) {
-      addResult({ key: match[2], command: match[3].trim() });
-    }
-  }
-
-  // Match bindkey key command (basic with unquoted key, must not have flags)
-  // Unquoted key must not start with a quote
-  // Exclude all known bindkey flags (same as above)
-  const bindkeyUnquotedRegex = /^(?:\s*)bindkey\s+(?!-[MsrRLlevaAdpN])([^'"\s]\S*)\s+(\S+)(?:\s*)$/gm;
-  while ((match = bindkeyUnquotedRegex.exec(content)) !== null) {
-    if (match[1] && match[2]) {
-      addResult({ key: match[1], command: match[2].trim() });
-    }
-  }
-
-  return result;
+  return extractEntries(content).keybindings.map(({ key, command, widget, keymap }) => ({
+    key,
+    command,
+    widget,
+    keymap,
+  }));
 }

--- a/extensions/zshrc-manager/vitest.config.ts
+++ b/extensions/zshrc-manager/vitest.config.ts
@@ -16,11 +16,14 @@ export default defineConfig({
       exclude: ["src/**/*.d.ts", "src/__tests__/**", "src/**/*.test.{ts,tsx}", "src/**/*.spec.{ts,tsx}"],
       // Ratchet: set just below current coverage so regressions fail while
       // `npm run validate` stays green. Raise as coverage grows.
+      // Current: ~70 lines/statements. The remaining gap to the aspirational
+      // 75 is the ten type views and the collections code, which the
+      // unified-home redesign deletes — deliberately not gold-plated.
       thresholds: {
         branches: 85,
-        functions: 70,
-        lines: 56,
-        statements: 56,
+        functions: 80,
+        lines: 69,
+        statements: 69,
       },
     },
   },


### PR DESCRIPTION
### 🤖 Disclosure

This extension was developed with AI assistance (Claude Code, Cursor, CodeRabbitAI and Greptile), with my guidance on architecture, requirements, and testing. All code was reviewed and validated by me, including manual testing in Raycast.

## Description

The extension carried two independently written parser systems: ten standalone regex extractors feeding the type views, and a pattern-registry parser feeding sections and statistics. Any construct matched by one and not the other made the counts users see disagree with the lists behind them — most visibly, multi-line `plugins=(…)` arrays (Oh My Zsh's default layout) were counted by one surface and missed by the other. This PR unifies all parsing on a single registry, brings the file-writing code — the highest-risk, least-tested code in the extension — under component tests, and fixes an undo bug the new tests exposed. It also carries three small resolved-facts fixes that missed the previous PR's merge window.

### Bug fixes

- **Undo now actually reverts adds and edits.** History entries for add/edit operations recorded the post-change file as their restore point, so undoing them silently restored the state you were trying to revert. Every write now records the pre-change snapshot, and only after the write is verified, so a failed write can no longer leave a restore point for a change that never happened.
- **Counts match lists everywhere.** Statistics, section counts, and the type views all derive from one parser; multi-line `plugins=(…)`/`path+=(…)`/`fpath=(…)` arrays parse on every surface; PATH/FPATH declarations are recognized in all supported forms (`export`/`typeset -x`/`declare -x`, `+=` append, array forms, `$PATH`-relative, plain assignment); keybinding counts no longer include bare mode lines (`bindkey -e`) the Keybindings view has nothing to show for.
- **Array parsing follows zsh quoting.** Quoted elements may contain whitespace, parentheses, and escaped quotes; `$(…)` command substitutions stay one element with their text kept verbatim (nested and quoted forms included); inline comments inside array bodies are ignored. And a comment inside a multi-line array that happens to match a section-header format (`## group`, `# Section: X`) no longer splits the array — previously that skewed per-section counts, and on the write side could have let "add to section" insert a line into the middle of the array.
- Sources with quoted operands or trailing inline comments resolve correctly in the `Source Exists` fact; plugin install checks honor `ZSH_CUSTOM`/`ZSH` declared as plain (unexported) assignments; `$HOMEBREW_PREFIX`-style variables are no longer mis-expanded as `$HOME`.

### Technical Highlights

- `pattern-registry.ts` is now the single parser: `extractEntries()` returns typed entries for all 14 construct types, each carrying its line position. The legacy `utils/parsers.ts` functions and `parseZshrc` are thin projections over it. Where the two old parsers disagreed, each construct's behavior was decided explicitly and tested — never the silent union.
- Three invariant test layers: a property test (every view entry appears in registry output exactly once, over a corpus exercising every decision), a golden-count test (statistics == view counts == section counts), and occurrence-targeting tests (duplicate definitions in same-labeled sections are addressed individually; same-section duplicates are refused unchanged).
- Array bodies are tokenized by a small quote-aware scanner shared between element extraction, array-termination detection, and section detection (single/double quotes, backslash escapes, `$(…)` with its own quote context) — one semantics, so no two surfaces can disagree about what a quote covers. Deliberately not a shell interpreter: parameter expansion, `$'…'` quoting, and multi-line quoted elements are out of scope; unrecognized lines degrade to the "Other" count rather than being guessed at.
- The 701-line `edit-item-form.tsx` is split along form/preview/submit boundaries: pure content computation lives in `edit-item-write.ts`, shared by save, delete, and the diff preview — so the preview provably shows exactly what a save writes.
- 90 new tests (1,240 total): array-tokenization ground truth (quoting, escapes, command substitution, section-like comments in arrays), every form flow (create, edit, move, cancel, confirm-guard, fail-closed refusals, write-verification failure, delete ordering), the shared list controller, backup restore/delete and history undo/clear including cancelled paths, and the collections write path. Raycast components are mocked; assertions target the extension's own behavior — the exact content written, writes blocked on cancel, refusals leaving the file untouched.
- Coverage gate ratcheted: lines/statements 56 → 69 (actual ~70), functions 70 → 80. The remaining gap to 75 is the ten type views and collections browser, which the upcoming redesign replaces — deliberately not gold-plated.
- No new dependencies, no new commands, no UI changes.

### Actual Count

<img width="1551" height="984" alt="actual" src="https://github.com/user-attachments/assets/73e70cc0-e79e-4286-9317-533ee52dc7a1" />

### Before Fix

<img width="741" height="453" alt="before" src="https://github.com/user-attachments/assets/b567a024-34a1-46be-8c11-0b6b6f06e8af" />

### After Fix

<img width="734" height="455" alt="after" src="https://github.com/user-attachments/assets/d2a19f98-96c1-4538-aade-efe79d248707" />

## Screencast

No new captures — this PR is internal (parsing, tests, write-path correctness) with no visual changes; the existing `metadata/` set remains accurate.

## How to Test

No special hardware or credentials needed — a zsh setup with a few aliases suffices.

1. `npm ci && npm test` — 1,240 tests including the new parser-unification and write-path suites
2. `npm run dev`, open the extension: pick any section in the view switcher and compare its counts against the corresponding type view — they now always agree. If your `plugins=(…)` array spans multiple lines (the Oh My Zsh default), that's the case that used to disagree.
3. Add or edit an alias, then use Undo (⌘Z from the main view, or the History view): the change is actually reverted — previously undo of an add/edit was a silent no-op.
4. Edit an alias and press ⌘⇧P (Preview Changes): the diff shown is computed by the same code path as the save.

## Checklist

- [x] I read the [Prepare an Extension for Store](https://developers.raycast.com/basics/prepare-an-extension-for-store) guidelines
- [x] I read the [Publish an Extension](https://developers.raycast.com/basics/publish-an-extension) guidelines
- [x] Ran `npm run build` and tested the build in Raycast
- [x] All assets used are in the `assets` folder; README media outside `metadata/`
- [x] `npm run lint` passes

