### PR TITLE
fix(downdetector): handle 403 from search URL by falling through to status page

### DIFF
--- a/extensions/downdetector/CHANGELOG.md
+++ b/extensions/downdetector/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Fixes] - 2026-08-04
+
+### Fixed
+
+- Search no longer fails with HTTP 403 when Downdetector's `/search/` endpoint is blocked by Cloudflare; the extension now falls through to the direct `/status/{slug}` lookup.
+
 ## [Initial Release] - 2026-07-28
 
 ### Added

--- a/extensions/downdetector/CHANGELOG.md
+++ b/extensions/downdetector/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Fixes] - 2026-08-04
+## [Fixes] - {PR_MERGE_DATE}
 
 ### Fixed
 

--- a/extensions/downdetector/CHANGELOG.md
+++ b/extensions/downdetector/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Fixes] - {PR_MERGE_DATE}
+## [Fixes] - 2026-08-04
 
 ### Fixed
 

--- a/extensions/downdetector/src/api.ts
+++ b/extensions/downdetector/src/api.ts
@@ -464,7 +464,7 @@ export async function searchServices(query: string): Promise<Service[]> {
       html = res.body;
       break;
     }
-    if (res.status !== 404) throw new Error(`HTTP ${res.status} — ${url}`);
+    if (res.status !== 404 && res.status !== 403) throw new Error(`HTTP ${res.status} — ${url}`);
   }
 
   // Last resort: try the status page directly from the slugified query

--- a/extensions/downdetector/src/api.ts
+++ b/extensions/downdetector/src/api.ts
@@ -464,7 +464,8 @@ export async function searchServices(query: string): Promise<Service[]> {
       html = res.body;
       break;
     }
-    if (res.status !== 404 && res.status !== 403) throw new Error(`HTTP ${res.status} — ${url}`);
+    if (res.status !== 404 && res.status !== 403)
+      throw new Error(`HTTP ${res.status} — ${url}`);
   }
 
   // Last resort: try the status page directly from the slugified query


### PR DESCRIPTION
## Description

Fixes the downdetector extension failing with a 403 when searching for services.

Fixes #29864

## Problem

The `/search/?q=` endpoint on downdetector.com now returns HTTP 403 (Cloudflare block). The search fallback logic only treated 404 as "try next path" — a 403 caused an immediate throw, preventing the extension from reaching the direct `/status/{slug}` lookup which still works fine.

## Fix

One-character change: treat 403 the same as 404 in the search path fallback loop.

```diff
- if (res.status !== 404) throw new Error(`HTTP ${res.status} — ${url}`);
+ if (res.status !== 404 && res.status !== 403) throw new Error(`HTTP ${res.status} — ${url}`);
```

This lets the extension fall through the search path alternatives and eventually resolve via the direct status page URL.

## Test Plan

- Search for any service (e.g., "github") → no longer throws 403, resolves via `/status/github/`
- Invalid service names still produce the expected "Service introuvable" error
- Services that DO work via search still work (no behavior change for 200/404)