### PR TITLE
[OSS Insight] Fix truncated contributor usernames

### DIFF
--- a/extensions/ossinsight/CHANGELOG.md
+++ b/extensions/ossinsight/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ossinsight Changelog
 
-## [Fix contributor names] - {PR_MERGE_DATE}
+## [Fix contributor names] - 2026-08-05
 
 - Preserve the final character of contributor usernames and ignore empty trailing entries
 

--- a/extensions/ossinsight/CHANGELOG.md
+++ b/extensions/ossinsight/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ossinsight Changelog
 
+## [Fix contributor names] - 2026-08-04
+
+- Preserve the final character of contributor usernames and ignore empty trailing entries
+
 ## [Update] - 2023-08-10
 
 - Updated the UI

--- a/extensions/ossinsight/CHANGELOG.md
+++ b/extensions/ossinsight/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ossinsight Changelog
 
-## [Fix contributor names] - 2026-08-04
+## [Fix contributor names] - {PR_MERGE_DATE}
 
 - Preserve the final character of contributor usernames and ignore empty trailing entries
 

--- a/extensions/ossinsight/package.json
+++ b/extensions/ossinsight/package.json
@@ -69,5 +69,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/ossinsight/src/index.tsx
+++ b/extensions/ossinsight/src/index.tsx
@@ -69,9 +69,10 @@ export default function Command() {
               },
               {
                 icon: Icon.TwoPeople,
-                text: repo.contributor_logins ? repo.contributor_logins.split(",").length + "" : "0",
+                text: repo.contributor_logins ? repo.contributor_logins.split(",").filter(Boolean).length + "" : "0",
                 tooltip:
-                  "Top Contributors" + (repo.contributor_logins ? `: ${repo.contributor_logins.slice(0, -1)}` : ""),
+                  "Top Contributors" +
+                  (repo.contributor_logins ? `: ${repo.contributor_logins.split(",").filter(Boolean).join(",")}` : ""),
               },
             ]}
             actions={


### PR DESCRIPTION
## Description

Fixes #29789.

The contributor tooltip no longer removes the final character from contributor_logins. It now parses the comma-separated list, ignores empty trailing entries, and uses that same parsed list for the count and tooltip.

## Screencast

Not included; this is a focused parsing fix.

## Checklist

- [x] I read the extension guidelines
- [x] I read the documentation about publishing
- [x] I ran npm run build and tested this distribution build in Raycast
- [x] I checked that files in the assets folder are used by the extension itself
- [x] I checked that assets used in the README are located outside the metadata folder if they were not generated with the metadata tool

Validation: npm run lint and npm run build pass. Focused parsing assertions cover values with and without a trailing delimiter.