### PR TITLE
[Search npm] Add npmx.dev search results provider

### DIFF
--- a/extensions/search-npm/CHANGELOG.md
+++ b/extensions/search-npm/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Search npm Changelog
 
-## [Add search results provider] - {PR_MERGE_DATE}
+## [Add search results provider] - 2026-08-06
 
 - Add an npmx.dev option for external package search results
 

--- a/extensions/search-npm/CHANGELOG.md
+++ b/extensions/search-npm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Search npm Changelog
 
+## [Add search results provider] - 2026-08-04
+
+- Add an npmx.dev option for external package search results
+
 ## [Update] - 2026-08-03
 
 - Adjusted list icon colors to reduce visual clutter

--- a/extensions/search-npm/CHANGELOG.md
+++ b/extensions/search-npm/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Search npm Changelog
 
-## [Add search results provider] - 2026-08-04
+## [Add search results provider] - {PR_MERGE_DATE}
 
 - Add an npmx.dev option for external package search results
 

--- a/extensions/search-npm/package.json
+++ b/extensions/search-npm/package.json
@@ -151,11 +151,29 @@
       "value": "30"
     },
     {
+      "name": "searchResultsProvider",
+      "type": "dropdown",
+      "data": [
+        {
+          "title": "npmjs.com",
+          "value": "npmjs"
+        },
+        {
+          "title": "npmx.dev",
+          "value": "npmx"
+        }
+      ],
+      "title": "Search Results Provider",
+      "description": "The website used for external package search results",
+      "required": false,
+      "default": "npmjs"
+    },
+    {
       "name": "showLinkToSearchResultsInListView",
       "type": "checkbox",
       "label": "Show link in list view",
-      "title": "Show link to npmjs.com results in list view",
-      "description": "Show link to npmjs.com search results in list view",
+      "title": "Show external search results in list view",
+      "description": "Show a link to the selected search results provider in list view",
       "required": false,
       "value": true,
       "default": true

--- a/extensions/search-npm/src/index.tsx
+++ b/extensions/search-npm/src/index.tsx
@@ -17,9 +17,15 @@ export default function PackageList() {
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState<string>("");
   const [history, setHistory] = useCachedState<HistoryItem[]>("history", []);
   const [favorites, fetchFavorites] = useFavorites();
-  const { historyCount, showLinkToSearchResultsInListView, size } = getPreferenceValues<Preferences.Index>();
+  const { historyCount, searchResultsProvider, showLinkToSearchResultsInListView, size } =
+    getPreferenceValues<Preferences.Index>();
   const [total, setTotal] = useState(0);
   const pageSize = Math.max(1, Number.parseInt(size, 10) || 20);
+  const searchResultsProviderName = searchResultsProvider === "npmx" ? "npmx.dev" : "npmjs.com";
+  const searchResultsUrl =
+    searchResultsProvider === "npmx"
+      ? `https://npmx.dev/search?${new URLSearchParams({ q: searchTerm })}`
+      : `https://www.npmjs.com/search?${new URLSearchParams({ q: searchTerm })}`;
 
   // If the search term is empty or only 1 character - the request will always result in 'Bad Request' error, so there's no reason to make it
   const canSearch = Boolean(debouncedSearchTerm) && debouncedSearchTerm.length > 1;
@@ -112,13 +118,13 @@ export default function PackageList() {
             <>
               {showLinkToSearchResultsInListView ? (
                 <List.Item
-                  title={`View search results for "${searchTerm}" on npmjs.com`}
+                  title={`View search results for "${searchTerm}" on ${searchResultsProviderName}`}
                   icon={{ source: Icon.MagnifyingGlass, tintColor: Color.SecondaryText }}
                   actions={
                     <ActionPanel>
                       <Action.OpenInBrowser
-                        url={`https://www.npmjs.com/search?q=${searchTerm}`}
-                        title="View npm Search Results"
+                        url={searchResultsUrl}
+                        title={`View ${searchResultsProviderName} Search Results`}
                       />
                     </ActionPanel>
                   }


### PR DESCRIPTION
## Description

Fixes #29692.

Add a Search Results Provider preference for npmjs.com and npmx.dev. The optional external-results row now reflects the selected provider and builds an encoded provider-specific search URL, while npmjs.com remains the default.

## Screencast

Not included; this adds one standard dropdown preference and updates the existing external-results row.

## Checklist

- [x] I read the extension guidelines
- [x] I read the documentation about publishing
- [x] I ran npm run build and tested this distribution build in Raycast
- [x] I checked that files in the assets folder are used by the extension itself
- [x] I checked that assets used in the README are located outside the metadata folder if they were not generated with the metadata tool

Validation: npm run lint and npm run build pass. A focused assertion verifies special-character query encoding.