### PR TITLE
[Tempo] Prefill remaining estimate

### DIFF
--- a/extensions/tempo/CHANGELOG.md
+++ b/extensions/tempo/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Tempo Changelog
 
-## [Prefill Remaining Estimate] - {PR_MERGE_DATE}
+## [Prefill Remaining Estimate] - 2026-08-05
 
 - Prefill the editable remaining estimate from the selected Jira issue
 

--- a/extensions/tempo/CHANGELOG.md
+++ b/extensions/tempo/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Tempo Changelog
 
+## [Prefill Remaining Estimate] - {PR_MERGE_DATE}
+
+- Prefill the editable remaining estimate from the selected Jira issue
+
 ## [Add Remaining Estimate Validation] - 2026-06-22
 
 - Add validation for remaining estimate field based on global configuration

--- a/extensions/tempo/src/add-worklog.tsx
+++ b/extensions/tempo/src/add-worklog.tsx
@@ -12,7 +12,7 @@ import {
   LaunchType,
 } from "@raycast/api";
 import { showFailureToast, useCachedState } from "@raycast/utils";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { fetchFromTempoAPI } from "./services/tempo.service";
 import {
   getAssignedIssues,
@@ -246,6 +246,7 @@ function WorklogForm({ issueKey, onSuccess }: { issueKey: string; onSuccess: () 
   const [useTimeRange, setUseTimeRange] = useCachedState<boolean>(USE_TIME_RANGE_STORAGE_KEY, false);
   const [isRemainingEstimateRequired, setIsRemainingEstimateRequired] = useState(false);
   const [remainingEstimate, setRemainingEstimate] = useState("");
+  const hasEditedRemainingEstimate = useRef(false);
 
   // Fetch details of the selected issue
   useEffect(() => {
@@ -256,7 +257,11 @@ function WorklogForm({ issueKey, onSuccess }: { issueKey: string; onSuccess: () 
         .then((issue) => {
           setIssue(issue);
           const remainingEstimateSeconds = issue?.fields.timetracking?.remainingEstimateSeconds;
-          setRemainingEstimate(remainingEstimateSeconds === undefined ? "" : formatDuration(remainingEstimateSeconds));
+          if (!hasEditedRemainingEstimate.current) {
+            setRemainingEstimate(
+              remainingEstimateSeconds === undefined ? "" : formatDuration(remainingEstimateSeconds),
+            );
+          }
         })
         .catch((error) => {
           console.error("Failed to load issue:", error);
@@ -486,7 +491,10 @@ function WorklogForm({ issueKey, onSuccess }: { issueKey: string; onSuccess: () 
           placeholder="Required: 1h, 1h30m, 30m"
           info="Required by your Tempo workspace. Enter the estimated remaining time after this worklog."
           value={remainingEstimate}
-          onChange={setRemainingEstimate}
+          onChange={(value) => {
+            hasEditedRemainingEstimate.current = true;
+            setRemainingEstimate(value);
+          }}
         />
       )}
       <Form.Dropdown id="date" title="Date" value={selectedDate} onChange={setSelectedDate}>

--- a/extensions/tempo/src/add-worklog.tsx
+++ b/extensions/tempo/src/add-worklog.tsx
@@ -245,6 +245,7 @@ function WorklogForm({ issueKey, onSuccess }: { issueKey: string; onSuccess: () 
   const [selectedDate, setSelectedDate] = useState<string>(formatDateToString(new Date()));
   const [useTimeRange, setUseTimeRange] = useCachedState<boolean>(USE_TIME_RANGE_STORAGE_KEY, false);
   const [isRemainingEstimateRequired, setIsRemainingEstimateRequired] = useState(false);
+  const [remainingEstimate, setRemainingEstimate] = useState("");
 
   // Fetch details of the selected issue
   useEffect(() => {
@@ -252,7 +253,11 @@ function WorklogForm({ issueKey, onSuccess }: { issueKey: string; onSuccess: () 
       setIsLoading(true);
 
       const issuePromise = getIssueByKey(issueKey)
-        .then(setIssue)
+        .then((issue) => {
+          setIssue(issue);
+          const remainingEstimateSeconds = issue?.fields.timetracking?.remainingEstimateSeconds;
+          setRemainingEstimate(remainingEstimateSeconds === undefined ? "" : formatDuration(remainingEstimateSeconds));
+        })
         .catch((error) => {
           console.error("Failed to load issue:", error);
         });
@@ -480,6 +485,8 @@ function WorklogForm({ issueKey, onSuccess }: { issueKey: string; onSuccess: () 
           title="Remaining Estimate"
           placeholder="Required: 1h, 1h30m, 30m"
           info="Required by your Tempo workspace. Enter the estimated remaining time after this worklog."
+          value={remainingEstimate}
+          onChange={setRemainingEstimate}
         />
       )}
       <Form.Dropdown id="date" title="Date" value={selectedDate} onChange={setSelectedDate}>

--- a/extensions/tempo/src/services/jira-issues.service.ts
+++ b/extensions/tempo/src/services/jira-issues.service.ts
@@ -21,6 +21,9 @@ export interface JiraIssue {
       key: string;
       name: string;
     };
+    timetracking?: {
+      remainingEstimateSeconds?: number;
+    };
   };
 }
 
@@ -139,7 +142,7 @@ export async function getIssueByKey(issueKey: string): Promise<JiraIssue | null>
     const authToken = getJiraAuthToken();
 
     const response = await fetch(
-      `${jiraBaseUrl}/rest/api/3/issue/${issueKey}?fields=summary,status,issuetype,project`,
+      `${jiraBaseUrl}/rest/api/3/issue/${issueKey}?fields=summary,status,issuetype,project,timetracking`,
       {
         headers: {
           Authorization: `Basic ${authToken}`,


### PR DESCRIPTION
## Description

Fixes #29959.

The selected Jira issue request now includes timetracking data. Its numeric remainingEstimateSeconds value is formatted with the existing Tempo duration helper and used to initialize the controlled Remaining Estimate field, so the current estimate appears automatically and remains editable.

## Screencast

Not included; this requires authenticated Jira and Tempo accounts.

## Checklist

- [x] I read the extension guidelines
- [x] I read the documentation about publishing
- [x] I ran npm run build and tested this distribution build in Raycast
- [x] I checked that files in the assets folder are used by the extension itself
- [x] I checked that assets used in the README are located outside the metadata folder if they were not generated with the metadata tool

Validation: npm run lint and npm run build pass. A focused round-trip check verifies Jira estimate seconds format to a Tempo duration and parse back without loss.