### PR TITLE
fix(prism-launcher): icons broken on Windows

### DIFF
--- a/extensions/prism-launcher/CHANGELOG.md
+++ b/extensions/prism-launcher/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Prism Launcher Changelog
 
+## [Bugfix] - {PR_MERGE_DATE}
+
+Fixed broken icon on Windows
+
 ## [New Addition] - 2026-04-01
 
 - Added support for showing live server status in the servers list

--- a/extensions/prism-launcher/CHANGELOG.md
+++ b/extensions/prism-launcher/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Prism Launcher Changelog
 
-## [Bugfix] - {PR_MERGE_DATE}
+## [Bugfix] - 2026-08-06
 
 Fixed broken icon on Windows
 

--- a/extensions/prism-launcher/src/commands/join-server.tsx
+++ b/extensions/prism-launcher/src/commands/join-server.tsx
@@ -4,7 +4,6 @@ import {
   Clipboard,
   closeMainWindow,
   Color,
-  environment,
   Icon,
   Keyboard,
   List,
@@ -12,7 +11,6 @@ import {
   PopToRootType,
 } from "@raycast/api";
 import { usePromise } from "@raycast/utils";
-import * as path from "path";
 import { useState } from "react";
 import { Unless, When } from "react-if";
 import useAsyncEffect from "use-async-effect";
@@ -205,7 +203,7 @@ export default function JoinServer() {
             title={instance.name}
             accessories={instance.favorite ? [{ icon: Icon.Star, tooltip: "Favorited" }] : []}
             icon={{
-              source: instance.icon ?? path.join(environment.assetsPath, "instance-icon.png"),
+              source: instance.icon ?? "instance-icon.png",
             }}
             actions={
               <ActionPanel>

--- a/extensions/prism-launcher/src/commands/manage-instances.tsx
+++ b/extensions/prism-launcher/src/commands/manage-instances.tsx
@@ -2,7 +2,6 @@ import {
   Action,
   ActionPanel,
   closeMainWindow,
-  environment,
   Icon,
   Keyboard,
   List,
@@ -13,7 +12,6 @@ import {
   Toast,
 } from "@raycast/api";
 import { usePromise } from "@raycast/utils";
-import * as path from "path";
 import { useState } from "react";
 import { Unless, When } from "react-if";
 import useAsyncEffect from "use-async-effect";
@@ -83,7 +81,7 @@ export default function ManageInstances() {
             title={instance.name}
             accessories={instance.favorite ? [{ icon: Icon.Star, tooltip: "Favorited" }] : []}
             icon={{
-              source: instance.icon ?? path.join(environment.assetsPath, "instance-icon.png"),
+              source: instance.icon ?? "instance-icon.png",
             }}
             actions={
               <ActionPanel>

--- a/extensions/prism-launcher/src/utils/prism.ts
+++ b/extensions/prism-launcher/src/utils/prism.ts
@@ -3,9 +3,17 @@ import * as fs from "fs-extra";
 import * as async from "modern-async";
 import * as path from "path";
 import nbt from "prismarine-nbt";
+import { pathToFileURL } from "url";
 import type { Instance, Server } from "../types";
 import { getPreferences } from "./preferences";
 import { getShortcutTargetPath } from "./powershell";
+
+/**
+ * Convert a local filesystem path to a `file://` URL that Raycast's `Image.source`
+ */
+function toFileUrl(p: string | undefined): string | undefined {
+  return p ? pathToFileURL(p).href : undefined;
+}
 
 export const isWin = process.platform === "win32";
 export const isMac = process.platform === "darwin";
@@ -97,7 +105,7 @@ export async function loadInstances(favoriteIds: string[], onlyWithServers: bool
     return {
       name: instanceCfg.get("General", "name", instanceId),
       id: instanceId,
-      icon: iconPath,
+      icon: toFileUrl(iconPath),
       favorite: favoriteIds.includes(instanceId),
       ...(onlyWithServers ? { hasServers } : {}),
     };


### PR DESCRIPTION
## Description

Fixes: Instance (and per-server) icons do not render when running Windows.
## Fix

Two changes

1. In `src/utils/prism.ts`, convert the local file path to a `file://` URL via
   Node's built-in `url.pathToFileURL`. This is the cross-platform correct
   form Raycast expects:

   - Windows: `file:///C:/Users/foo/.../icon.png`
   - macOS:   `file:///Users/foo/.../icon.png`

2. In `src/commands/manage-instances.tsx` and `src/commands/join-server.tsx`,
   replace `path.join(environment.assetsPath, "instance-icon.png")` with the
   relative asset path `"instance-icon.png"`, which is the form documented by
   the Raycast API for referencing bundled assets. Removes the now-unused
   `environment` and `path` imports.

## Screencast

Not included

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
