### PR TITLE
Update finder-file-actions extension

### DIFF
--- a/extensions/finder-file-actions/CHANGELOG.md
+++ b/extensions/finder-file-actions/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Finder File Actions Changelog
 
-## [Finder-native undo and filename handling] - {PR_MERGE_DATE}
+## [Finder-native undo and filename handling] - 2026-08-07
 
 - Fixed "Create Text File" treating a typed filename as an extension and creating names such as `untitled.notes`
 - Added Finder-native undo for Move to Folder and Copy to Folder

--- a/extensions/finder-file-actions/CHANGELOG.md
+++ b/extensions/finder-file-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Finder File Actions Changelog
 
+## [Finder-native undo and filename handling] - {PR_MERGE_DATE}
+
+- Fixed "Create Text File" treating a typed filename as an extension and creating names such as `untitled.notes`
+- Added Finder-native undo for Move to Folder and Copy to Folder
+- Updated @raycast/api to 1.104.24 and @raycast/utils to 2.2.7
+
 ## [Pinned folder custom names] - 2026-05-28
 
 - Added custom names for pinned folders

--- a/extensions/finder-file-actions/README.md
+++ b/extensions/finder-file-actions/README.md
@@ -1,53 +1,61 @@
 # Finder File Actions
 
-A Raycast extension that provides various actions for files selected in Finder.
+File operations for macOS Finder via [Raycast](https://raycast.com).
+
+[Install from the Raycast Store](https://www.raycast.com/pa1ar/finder-file-actions)
+
+![Commands](metadata/finder-file-actions-3.png)
 
 ## Commands
 
 ### Move to Folder
 
-Quickly move or copy selected files in Finder to a destination folder of your choice. Alfred users will be familiar with this functionality.
+Move selected Finder files to any folder via Spotlight search.
 
-#### Features
+![Move to Folder](metadata/finder-file-actions-1.png)
 
-- Move or copy one or more files selected in Finder to any folder
-- Fast and reliable folder search using macOS Spotlight (`mdfind`)
-- Smart sorting of search results based on relevance and recency
-- Pin frequently used folders for quick access
-- Recently used folders history
-- Folder navigation in case you don't know the exact folder name
-- Indication of the selected files
-- Visual feedback for successful/failed operations
-- Metadata display (last used date, modification date, file type)
+![Navigation](metadata/finder-file-actions-2.png)
 
-#### Performance
+- Spotlight search to find any folder on your Mac
+- Navigate into subfolders, go up levels
+- Pin frequently used folders
+- Recent folders remembered
+- Batch operations with multiple files
+- Streaming for large files (10MB+) with progress tracking
 
-- Concurrent file operations (up to 3 streams at a time)
-- Streaming for large files with minimal memory usage
-- Progress tracking for both individual files and batches
-- Continues on errors (failing files don't stop the batch)
-- Smart folder history management
+### Copy to Folder
 
-#### Usage
+Same as Move to Folder, but copies instead of moving.
 
-1. Select one or more files in Finder
-2. Trigger the "Move to Folder" or "Copy to Folder" command in Raycast
-3. Search for your destination folder or navigate through directories
-4. Press Enter to navigate to a folder, Cmd+Return to move/copy files
+### Create Folder
 
-#### Keyboard Shortcuts
+Create a new folder in the current Finder directory. Optional name argument (defaults to "untitled folder"). Follows macOS naming convention for duplicates ("name", "name 2", "name 3").
 
-- `Enter`: Navigate to the selected folder
-- `Cmd+Return`: Move files to the selected folder
-- `Cmd+Shift+Return`: Copy files to the selected folder
-- `Cmd+Shift+D`: Toggle details view
-- `Cmd+Shift+P`: Pin/Unpin folder
-- `Cmd+Shift+R`: Remove folder from recent history
+### Wrap in Folder
 
-## Installation
+Create a new folder and move the selected Finder files into it.
 
-Install from the [Raycast Store](https://www.raycast.com/pa1ar/finder-file-actions), or search for "Finder File Actions" in Raycast.
+![Wrap in Folder](metadata/finder-file-actions-5.png)
+
+### Create Text File
+
+Create a text file with an optional filename. Names without an extension default to `.txt`. Auto-fills with clipboard content when available.
+
+![Create Text File](metadata/finder-file-actions-4.png)
+
+## Keyboard Shortcuts
+
+- `Enter` - navigate to folder
+- `Cmd+Return` - move files here
+- `Cmd+Shift+Return` - copy files here
+- `Cmd+Shift+D` - toggle details
+- `Cmd+Shift+P` - pin/unpin folder
+- `Cmd+Shift+R` - remove from recent
+
+## Install
+
+[Raycast Store](https://www.raycast.com/pa1ar/finder-file-actions) or search "Finder File Actions" in Raycast.
 
 ## Credits
 
-This extension is based on the [Folder Search](https://www.raycast.com/GastroGeek/folder-search) extension originally created by [GastroGeek](https://www.raycast.com/GastroGeek). The folder searching functionality was adapted from the original extension, while adding new capabilities for file operations.
+Folder search adapted from [Folder Search](https://www.raycast.com/GastroGeek/folder-search) by [GastroGeek](https://www.raycast.com/GastroGeek).

--- a/extensions/finder-file-actions/docs/plans/completed/2026-07-27-finder-native-undo.md
+++ b/extensions/finder-file-actions/docs/plans/completed/2026-07-27-finder-native-undo.md
@@ -1,0 +1,29 @@
+# Finder-native undo
+
+Craft issue: `1SS-325` (`8766f0a4-8513-3d91-8a75-5a41c44aa5ba`)
+
+## Outcome
+
+Moves and copies initiated by Finder File Actions on macOS are performed by Finder, so Finder can expose them through its native Undo command.
+
+## Scope
+
+- Add a Finder operation adapter for batched move and copy commands.
+- Use Finder-backed operations from the Move to Folder and Copy to Folder flows.
+- Preserve existing collision confirmation and result reporting.
+- Fail explicitly when Finder cannot perform an operation so native undo is never silently lost.
+- Add unit tests for routing, AppleScript escaping, and failure behavior.
+
+## Proof of done
+
+- Finder shows an Undo Move or Undo Copy action after a successful FFA operation.
+- Command-Z in Finder reverses the operation in a disposable test fixture.
+- `bun run lint`, `bun test`, and `bun run build` pass.
+
+## Notes
+
+- Finder undo is Finder-scoped and temporary, not a global system undo stack.
+- Runtime proof: the development command moved a selected file to Desktop, Finder exposed `Undo Move of “runtime-test.txt”`, and one Command-Z restored it.
+- Batched move and copy operations each produce one Finder undo entry.
+- Finder undo restores the moved source after an overwrite, but does not restore the replaced destination item. The confirmation and result toast disclose this limitation.
+- Cross-volume behavior remains unverified.

--- a/extensions/finder-file-actions/package-lock.json
+++ b/extensions/finder-file-actions/package-lock.json
@@ -7,8 +7,8 @@
       "name": "finder-file-actions",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.104.11",
-        "@raycast/utils": "^2.2.3",
+        "@raycast/api": "^1.104.24",
+        "@raycast/utils": "^2.2.7",
         "binary-split": "^1.0.5",
         "fs-extra": "^11.3.4",
         "run-applescript": "^7.1.0",
@@ -1994,16 +1994,16 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.104.11",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.11.tgz",
-      "integrity": "sha512-UaLyWDlgtgyruTVclcJ1RAJjRWKc/ISw+WQAzTHui4qpY3olaaXWrE/dox6/7Cd3mFZtkQ6grhdUiYTBsUUfuw==",
+      "version": "1.104.24",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.24.tgz",
+      "integrity": "sha512-Jppfyi1T7wcGXZFxpzXuvNAKUPQ+BQkKC0N3rJBz1epp/z22SH9aLA23YZRk/ickGwEm6DI/7OY7Jin8dD53Sg==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.8.4",
         "@oclif/plugin-autocomplete": "^3.2.40",
         "@oclif/plugin-help": "^6.2.37",
         "@oclif/plugin-not-found": "^3.2.74",
-        "@types/node": "22.13.10",
+        "@types/node": "22.19.17",
         "@types/react": "19.0.10",
         "esbuild": "^0.27.3",
         "react": "19.0.0"
@@ -2012,10 +2012,10 @@
         "ray": "bin/run.js"
       },
       "engines": {
-        "node": ">=22.14.0"
+        "node": ">=22.22.2"
       },
       "peerDependencies": {
-        "@types/node": "22.13.10",
+        "@types/node": "22.19.17",
         "@types/react": "19.0.10",
         "react-devtools": "6.1.1"
       },
@@ -2032,12 +2032,12 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@types/node": {
-      "version": "22.13.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
-      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@raycast/api/node_modules/@types/react": {
@@ -2059,9 +2059,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/@raycast/eslint-config": {
@@ -2097,9 +2097,9 @@
       }
     },
     "node_modules/@raycast/utils": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.3.tgz",
-      "integrity": "sha512-YwqleVl0Wk/FOq+672gtvswuwMqjNqIr+c63FhouTEHc1LJ3zaohLSkW4+UcfBjPU8HySKQm+kJqZW1iOM9fnA==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.7.tgz",
+      "integrity": "sha512-1jV9tKLluP0Av/ICcl/yvVzCj7mY6F3wnKsh8SJpy/Fsqq/LCFXcI6TgMabIJ45AaDVhEV+JH9jS1lJSwBgiMw==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"

--- a/extensions/finder-file-actions/package.json
+++ b/extensions/finder-file-actions/package.json
@@ -85,8 +85,8 @@
       "icon": "create-text-file.png",
       "arguments": [
         {
-          "name": "extension",
-          "placeholder": "txt",
+          "name": "filename",
+          "placeholder": "untitled.txt",
           "type": "text",
           "required": false
         }
@@ -112,8 +112,8 @@
     }
   ],
   "dependencies": {
-    "@raycast/api": "^1.104.11",
-    "@raycast/utils": "^2.2.3",
+    "@raycast/api": "^1.104.24",
+    "@raycast/utils": "^2.2.7",
     "binary-split": "^1.0.5",
     "fs-extra": "^11.3.4",
     "run-applescript": "^7.1.0",

--- a/extensions/finder-file-actions/src/common/finder-file-operations.ts
+++ b/extensions/finder-file-actions/src/common/finder-file-operations.ts
@@ -1,0 +1,40 @@
+import { runAppleScript } from "run-applescript";
+
+export type FinderFileOperation = "move" | "copy";
+
+export function escapeAppleScriptString(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+export function buildFinderFileOperationScript(
+  operation: FinderFileOperation,
+  sourcePaths: string[],
+  destinationPath: string,
+  replacing: boolean,
+): string {
+  if (sourcePaths.length === 0) {
+    throw new Error("No source files provided");
+  }
+
+  const sources = sourcePaths
+    .map((sourcePath) => `(POSIX file "${escapeAppleScriptString(sourcePath)}") as alias`)
+    .join(", ");
+  const command = operation === "move" ? "move" : "duplicate";
+
+  return `
+    set sourceItems to {${sources}}
+    set destinationFolder to (POSIX file "${escapeAppleScriptString(destinationPath)}") as alias
+    tell application "Finder"
+      ${command} sourceItems to destinationFolder replacing ${replacing}
+    end tell
+  `;
+}
+
+export async function performFinderFileOperation(
+  operation: FinderFileOperation,
+  sourcePaths: string[],
+  destinationPath: string,
+  replacing: boolean,
+): Promise<void> {
+  await runAppleScript(buildFinderFileOperationScript(operation, sourcePaths, destinationPath, replacing));
+}

--- a/extensions/finder-file-actions/src/common/text-file-name.ts
+++ b/extensions/finder-file-actions/src/common/text-file-name.ts
@@ -1,0 +1,29 @@
+import path from "path";
+
+export interface TextFileName {
+  baseName: string;
+  extension?: string;
+}
+
+export function parseTextFileName(rawInput?: string): TextFileName {
+  const input = path.basename(rawInput?.trim() || "");
+
+  if (!input || input === "." || input === "..") {
+    return { baseName: "untitled", extension: "txt" };
+  }
+
+  const dotIndex = input.lastIndexOf(".");
+
+  if (dotIndex > 0) {
+    return {
+      baseName: input.slice(0, dotIndex),
+      extension: input.slice(dotIndex + 1) || undefined,
+    };
+  }
+
+  if (dotIndex === 0) {
+    return { baseName: input };
+  }
+
+  return { baseName: input, extension: "txt" };
+}

--- a/extensions/finder-file-actions/src/create-text-file.tsx
+++ b/extensions/finder-file-actions/src/create-text-file.tsx
@@ -3,11 +3,10 @@ import path from "path";
 
 import { isFinderFrontmost, getCurrentFinderDirectory, selectInFinder, generateUniqueName } from "./common/finder";
 import { fsAsync } from "./common/fs-async";
+import { parseTextFileName } from "./common/text-file-name";
 
 export default async function CreateTextFile(props: LaunchProps<{ arguments: Arguments.CreateTextFile }>) {
-  const rawExt = props.arguments.extension?.trim() || "txt";
-  // strip leading dot if user typed ".md" instead of "md"
-  const extension = rawExt.replace(/^\./, "");
+  const { baseName, extension } = parseTextFileName(props.arguments.filename);
 
   const frontmost = await isFinderFrontmost();
   if (!frontmost) {
@@ -31,7 +30,7 @@ export default async function CreateTextFile(props: LaunchProps<{ arguments: Arg
   }
 
   // generate unique filename
-  const uniqueName = await generateUniqueName(targetDir, "untitled", extension);
+  const uniqueName = await generateUniqueName(targetDir, baseName, extension);
   const filePath = path.join(targetDir, uniqueName);
 
   // write the file

--- a/extensions/finder-file-actions/src/move-to-folder.tsx
+++ b/extensions/finder-file-actions/src/move-to-folder.tsx
@@ -29,6 +29,7 @@ import { folderName, lastUsedSort, fixDoubleConcat, pinnedFolderName } from "./c
 import { fsAsync } from "./common/fs-async";
 import { CacheManager } from "./common/cache-manager";
 import { isFinderFrontmost } from "./common/finder";
+import { FinderFileOperation, performFinderFileOperation } from "./common/finder-file-operations";
 
 interface RecentFolder extends SpotlightSearchResult {
   lastUsed: Date;
@@ -311,8 +312,10 @@ export default function Command(props: LaunchProps) {
     }
   }, [searchText, folders]);
 
-  // Move files to selected folder
-  async function moveFilesToFolder(destinationPath: string) {
+  async function transferFilesToFolder(destinationPath: string, operation: FinderFileOperation) {
+    const verb = operation === "move" ? "move" : "copy";
+    const pastTense = operation === "move" ? "Moved" : "Copied";
+
     // Check if destination folder exists
     if (!(await fsAsync.exists(destinationPath))) {
       console.error(`Destination folder does not exist: ${destinationPath}`);
@@ -333,76 +336,48 @@ export default function Command(props: LaunchProps) {
         throw new Error("Destination is not a folder");
       }
 
-      let successCount = 0;
-      let failCount = 0;
+      const filesToTransfer: string[] = [];
+      let replacing = false;
 
-      // Process files in batches for better performance
-      const results = await fsAsync.batchProcess(
-        selectedFiles,
-        async (filePath) => {
-          try {
-            const fileName = path.basename(filePath);
-            const destFilePath = path.join(destinationPath, fileName);
+      for (const filePath of selectedFiles) {
+        const fileName = path.basename(filePath);
+        const destFilePath = path.join(destinationPath, fileName);
 
-            // Check if file already exists at destination
-            if (await fsAsync.exists(destFilePath)) {
-              const overwrite = await confirmAlert({
-                title: "Overwrite the existing file?",
-                message: fileName + " already exists in " + destinationPath,
-              });
-
-              if (!overwrite) {
-                return { success: false, skipped: true };
-              }
-
-              if (filePath === destFilePath) {
-                await showHUD("The source and destination file are the same");
-                return { success: false, skipped: true };
-              }
-            }
-
-            // Move the file with progress tracking
-            const result = await fsAsync.moveFile(filePath, destFilePath, {
-              overwrite: true,
-              onProgress: (percent) => {
-                // Update progress toast for large files
-                if (percent % 10 === 0) {
-                  // Update every 10%
-                  showToast({
-                    title: `Moving ${fileName}`,
-                    message: `${Math.round(percent)}% complete`,
-                    style: Toast.Style.Animated,
-                  });
-                }
-              },
-            });
-
-            return result;
-          } catch (error) {
-            console.error(`Error moving file ${filePath}:`, error);
-            return { success: false, error };
-          }
-        },
-        {
-          concurrency: 3,
-          onProgress: (completed, total) => {
-            showToast({
-              title: `Moving Files`,
-              message: `${completed}/${total} files processed`,
-              style: Toast.Style.Animated,
-            });
-          },
-        },
-      );
-
-      // Count successes and failures
-      results.forEach((result) => {
-        if (result.success) {
-          successCount++;
-        } else if (!("skipped" in result && result.skipped)) {
-          failCount++;
+        if (filePath === destFilePath) {
+          await showHUD("The source and destination file are the same");
+          continue;
         }
+
+        if (await fsAsync.exists(destFilePath)) {
+          const overwrite = await confirmAlert({
+            title: "Overwrite the existing file?",
+            message:
+              fileName + " already exists in " + destinationPath + "\n\nFinder Undo won't restore the replaced item.",
+          });
+          if (!overwrite) continue;
+          replacing = true;
+        }
+
+        filesToTransfer.push(filePath);
+      }
+
+      if (filesToTransfer.length === 0) {
+        showToast({
+          title: `Failed to ${verb} files`,
+          message: "No files were selected for the operation",
+          style: Toast.Style.Failure,
+        });
+        return;
+      }
+
+      await showToast({
+        title: `${operation === "move" ? "Moving" : "Copying"} Files`,
+        message: `${filesToTransfer.length} file${filesToTransfer.length === 1 ? "" : "s"}`,
+        style: Toast.Style.Animated,
       });
+
+      await performFinderFileOperation(operation, filesToTransfer, destinationPath, replacing);
+      const successCount = filesToTransfer.length;
 
       // Update recent folders with this destination
       const destinationFolder =
@@ -429,182 +404,32 @@ export default function Command(props: LaunchProps) {
         }
       }
 
-      // Show success/failure toast
-      if (successCount > 0) {
-        showToast({
-          title: `Moved ${successCount} file${successCount !== 1 ? "s" : ""}`,
-          message: failCount > 0 ? `Failed to move ${failCount} file${failCount !== 1 ? "s" : ""}` : "",
-          style: failCount > 0 ? Toast.Style.Failure : Toast.Style.Success,
-        });
+      showToast({
+        title: `${pastTense} ${successCount} file${successCount !== 1 ? "s" : ""}`,
+        message: replacing ? "Finder Undo won't restore replaced items" : "Undo is available in Finder",
+        style: Toast.Style.Success,
+      });
 
-        // Close the window after successful move
-        popToRoot({ clearSearchBar: true });
-        closeMainWindow({ clearRootSearch: true });
-      } else {
-        showToast({
-          title: "Failed to move files",
-          message: "No files were moved successfully",
-          style: Toast.Style.Failure,
-        });
-      }
+      popToRoot({ clearSearchBar: true });
+      closeMainWindow({ clearRootSearch: true });
     } catch (error) {
-      console.error("Error moving files:", error);
+      console.error(`Error ${verb}ing files:`, error);
       showToast({
         title: "Error",
-        message: "Failed to move files",
+        message: `Failed to ${verb} files`,
         style: Toast.Style.Failure,
       });
+    } finally {
+      setIsLoading(false);
     }
-
-    setIsLoading(false);
   }
 
-  // Copy files to selected folder
+  async function moveFilesToFolder(destinationPath: string) {
+    await transferFilesToFolder(destinationPath, "move");
+  }
+
   async function copyFilesToFolder(destinationPath: string) {
-    // Check if destination folder exists
-    if (!(await fsAsync.exists(destinationPath))) {
-      console.error(`Destination folder does not exist: ${destinationPath}`);
-      showToast({
-        title: "Error",
-        message: `Destination folder does not exist: ${path.basename(destinationPath)}`,
-        style: Toast.Style.Failure,
-      });
-      return;
-    }
-
-    setIsLoading(true);
-
-    try {
-      // Verify destination folder exists and is a directory
-      const stats = await fsAsync.getStats(destinationPath);
-      if (!stats?.isDirectory) {
-        throw new Error("Destination is not a folder");
-      }
-
-      let successCount = 0;
-      let failCount = 0;
-
-      // Process files in batches for better performance
-      const results = await fsAsync.batchProcess(
-        selectedFiles,
-        async (filePath) => {
-          try {
-            const fileName = path.basename(filePath);
-            const destFilePath = path.join(destinationPath, fileName);
-
-            // Check if file already exists at destination
-            if (await fsAsync.exists(destFilePath)) {
-              const overwrite = await confirmAlert({
-                title: "Overwrite the existing file?",
-                message: fileName + " already exists in " + destinationPath,
-              });
-
-              if (!overwrite) {
-                return { success: false, skipped: true };
-              }
-
-              if (filePath === destFilePath) {
-                await showHUD("The source and destination file are the same");
-                return { success: false, skipped: true };
-              }
-            }
-
-            // Copy the file with progress tracking
-            const result = await fsAsync.copyFile(filePath, destFilePath, {
-              overwrite: true,
-              onProgress: (percent) => {
-                // Update progress toast for large files
-                if (percent % 10 === 0) {
-                  // Update every 10%
-                  showToast({
-                    title: `Copying ${fileName}`,
-                    message: `${Math.round(percent)}% complete`,
-                    style: Toast.Style.Animated,
-                  });
-                }
-              },
-            });
-
-            return result;
-          } catch (error) {
-            console.error(`Error copying file ${filePath}:`, error);
-            return { success: false, error };
-          }
-        },
-        {
-          concurrency: 3,
-          onProgress: (completed, total) => {
-            showToast({
-              title: `Copying Files`,
-              message: `${completed}/${total} files processed`,
-              style: Toast.Style.Animated,
-            });
-          },
-        },
-      );
-
-      // Count successes and failures
-      results.forEach((result) => {
-        if (result.success) {
-          successCount++;
-        } else if (!("skipped" in result && result.skipped)) {
-          failCount++;
-        }
-      });
-
-      // Update recent folders with this destination
-      const destinationFolder =
-        folders.find((f) => f.path === destinationPath) || recentFolders.find((f) => f.path === destinationPath);
-
-      if (destinationFolder) {
-        addToRecentFolders(destinationFolder);
-      } else if (destinationPath === currentPath) {
-        // If the destination is the current navigation path, add it to recent folders
-        const stats = await fsAsync.getStats(destinationPath);
-        if (stats?.isDirectory) {
-          const navFolder: SpotlightSearchResult = {
-            path: destinationPath,
-            kMDItemFSName: path.basename(destinationPath),
-            kMDItemKind: "Folder",
-            kMDItemFSSize: 0,
-            kMDItemFSCreationDate: stats.birthtime,
-            kMDItemContentModificationDate: stats.mtime,
-            kMDItemLastUsedDate: stats.atime,
-            kMDItemUseCount: 0,
-          };
-
-          addToRecentFolders(navFolder);
-        }
-      }
-
-      // Show success/failure toast
-      if (successCount > 0) {
-        showToast({
-          title: `Copied ${successCount} file${successCount !== 1 ? "s" : ""}`,
-          message: failCount > 0 ? `Failed to copy ${failCount} file${failCount !== 1 ? "s" : ""}` : "",
-          style: failCount > 0 ? Toast.Style.Failure : Toast.Style.Success,
-        });
-
-        // Close the window after successful copy
-        popToRoot({ clearSearchBar: true });
-        closeMainWindow({ clearRootSearch: true });
-      } else {
-        showToast({
-          title: "Failed to copy files",
-          message: "No files were copied successfully",
-          style: Toast.Style.Failure,
-        });
-      }
-    } catch (error) {
-      console.error("Error copying files:", error);
-      showToast({
-        title: "Error",
-        message: "Failed to copy files",
-        style: Toast.Style.Failure,
-      });
-    }
-
-    setIsLoading(false);
+    await transferFilesToFolder(destinationPath, "copy");
   }
 
   // Load folder contents

--- a/extensions/finder-file-actions/src/tests/create-text-file.test.ts
+++ b/extensions/finder-file-actions/src/tests/create-text-file.test.ts
@@ -4,6 +4,7 @@ import fs from "fs-extra";
 import { createTestDirectory, cleanupTestDirectory } from "./utils/test-helpers";
 import { generateUniqueName } from "../common/finder";
 import { fsAsync } from "../common/fs-async";
+import { parseTextFileName } from "../common/text-file-name";
 
 describe("Create Text File", () => {
   let testDir: string;
@@ -14,6 +15,20 @@ describe("Create Text File", () => {
 
   afterEach(async () => {
     await cleanupTestDirectory(testDir);
+  });
+
+  describe("parseTextFileName", () => {
+    it.each([
+      [undefined, { baseName: "untitled", extension: "txt" }],
+      ["", { baseName: "untitled", extension: "txt" }],
+      ["notes", { baseName: "notes", extension: "txt" }],
+      ["notes.md", { baseName: "notes", extension: "md" }],
+      ["notes.v2.md", { baseName: "notes.v2", extension: "md" }],
+      [".gitignore", { baseName: ".gitignore" }],
+      ["notes.", { baseName: "notes" }],
+    ])("parses %s", (input, expected) => {
+      expect(parseTextFileName(input)).toEqual(expected);
+    });
   });
 
   describe("generateUniqueName with extension", () => {

--- a/extensions/finder-file-actions/src/tests/finder-file-operations.test.ts
+++ b/extensions/finder-file-actions/src/tests/finder-file-operations.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "@jest/globals";
+import { buildFinderFileOperationScript, escapeAppleScriptString } from "../common/finder-file-operations";
+
+describe("Finder file operations", () => {
+  it("escapes quotes and backslashes in paths", () => {
+    expect(escapeAppleScriptString('/tmp/a "quoted" \\ file')).toBe('/tmp/a \\"quoted\\" \\\\ file');
+  });
+
+  it("builds one Finder move command for the whole batch", () => {
+    const script = buildFinderFileOperationScript("move", ["/tmp/a.txt", "/tmp/b.txt"], "/tmp/destination", false);
+
+    expect(script).toContain(
+      'set sourceItems to {(POSIX file "/tmp/a.txt") as alias, (POSIX file "/tmp/b.txt") as alias}',
+    );
+    expect(script).toContain("move sourceItems to destinationFolder replacing false");
+  });
+
+  it("uses Finder duplicate for copy operations", () => {
+    const script = buildFinderFileOperationScript("copy", ["/tmp/a.txt"], "/tmp/destination", true);
+
+    expect(script).toContain("duplicate sourceItems to destinationFolder replacing true");
+  });
+
+  it("rejects empty batches", () => {
+    expect(() => buildFinderFileOperationScript("move", [], "/tmp/destination", false)).toThrow(
+      "No source files provided",
+    );
+  });
+});


### PR DESCRIPTION
## Description

- Run Move to Folder and Copy to Folder through Finder so the operations are registered in macOS native undo history.
- Treat Create Text File input as a filename. Bare names receive `.txt`, explicit extensions and dotfiles are preserved.
- Include the previously merged pinned-folder custom-name contribution in the standalone source.

## Testing

- `bun test`: 65 passed
- `bun run lint`
- `bun run build`
- Verified in Raycast that `notes` creates `notes.txt`
- Verified in Raycast that Finder restores a moved file with Command-Z

## Screencast

Not included because both changes affect operation behavior rather than command layout.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
