### PR TITLE
fix(google-meet): accept Brave under its real app name

### DIFF
--- a/extensions/google-meet/CHANGELOG.md
+++ b/extensions/google-meet/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Google Meet Changelog
 
+## [Fix Brave Support] - {PR_MERGE_DATE}
+
+- Fix Brave being rejected with "isn't a supported browser". macOS installs Brave as `Brave Browser.app` and reports it under that name, but the supported-browser list held `Brave`, so the exact-match check added in the previous release failed for it.
+
 ## [Reliability Overhaul & PWA Support] - 2026-08-03
 
 - Replace the fixed-delay, unbounded-recursion URL lookup with a single shared `createMeeting` pipeline used by all four commands: it polls for the generated link at a fixed interval with a hard deadline instead of guessing a one-shot sleep, and never casts a missing URL to `string`.

--- a/extensions/google-meet/CHANGELOG.md
+++ b/extensions/google-meet/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Meet Changelog
 
-## [Fix Brave Support] - {PR_MERGE_DATE}
+## [Fix Brave Support] - 2026-08-05
 
 - Fix Brave being rejected with "isn't a supported browser". macOS installs Brave as `Brave Browser.app` and reports it under that name, but the supported-browser list held `Brave`, so the exact-match check added in the previous release failed for it.
 

--- a/extensions/google-meet/src/browser-adapters/index.ts
+++ b/extensions/google-meet/src/browser-adapters/index.ts
@@ -19,7 +19,7 @@ export function getAdapterForBrowser(browserName: SupportedBrowsers): MeetingUrl
     case "Zen":
       return createFirefoxFamilyAdapter(browserName);
     case "Google Chrome":
-    case "Brave":
+    case "Brave Browser":
     case "Microsoft Edge":
     case "Opera":
     case "QQ":

--- a/extensions/google-meet/src/utils/scripts.ts
+++ b/extensions/google-meet/src/utils/scripts.ts
@@ -1,6 +1,9 @@
 export const supportedBrowsers = [
   "Arc",
-  "Brave",
+  // Brave installs as `Brave Browser.app`, so that is the name reported by both
+  // `getDefaultApplication` and the frontmost-process lookup, and the one
+  // AppleScript needs in `tell application`.
+  "Brave Browser",
   "Firefox",
   "Firefox Developer Edition",
   "Google Chrome",


### PR DESCRIPTION
## Description

Fixes the Google Meet extension rejecting Brave as an unsupported browser.

Fixes #29968

## Problem

macOS installs Brave as `Brave Browser.app`, so both `getDefaultApplication` and the
frontmost-process lookup report the name `Brave Browser`. `supportedBrowsers` listed it as
`Brave`, and `resolveCreationBrowser` matches that list exactly:

```ts
function isSupportedBrowserName(name: string): name is SupportedBrowsers {
  return (supportedBrowsers as readonly string[]).includes(name);
}
```

The real name is not in the list, so Create Meet stops with
`"Brave Browser" isn't a supported browser.` — the message quoted in the issue.

This surfaced in 3.x. Before that, `getOpenedBrowser` cast the detected name straight to
`SupportedBrowsers` without checking it, so `Brave Browser` reached
`tell application "Brave Browser"` unchanged and worked. The reliability overhaul replaced
that unchecked cast with a real membership check, which the entry `Brave` fails.

## Fix

Use the actual application name in the list and in the Chromium adapter switch. That name is
also what AppleScript needs in `tell application`, which is why the earlier unchecked path
worked with it.

```diff
-  "Brave",
+  "Brave Browser",
```

`Brave` was never a name macOS reports for this app, so nothing else resolves to it. The
exhaustive `never` check in `getAdapterForBrowser` covers the switch, so the rename is
compile-checked.

Other Chromium browsers in the list are unaffected — their app names already match their
entries.
