### PR TITLE
fix(issue-bot): look up the extension with Object.entries

### DIFF
--- a/scripts/bots/issue-bot.ts
+++ b/scripts/bots/issue-bot.ts
@@ -64,7 +64,7 @@ export default async ({ github, context }: API) => {
       newMatchGitHub.exec(context.payload.issue.body) || oldMatchGithub.exec(context.payload.issue.body) || [];
     extensionFolder = x;
 
-    extension = Object.values(extensionName2Folder).find(([_, folder]) => folder === extensionFolder)?.[0];
+    extension = Object.entries(extensionName2Folder).find(([, folder]) => folder === extensionFolder)?.[0];
 
     if (!extension) {
       console.log(`could not find the extension in the body`);


### PR DESCRIPTION
## Description

Fixes raycastbot commenting "We could not find the extension related to this issue" on issues
that link their extension by GitHub URL.

Fixes #29795

## Problem

`extensionName2Folder` maps `owner/name` to a folder name:

```json
{ "tiulpin/youtrack": "youtrack" }
```

The lookup in `issue-bot.ts` iterates it with `Object.values`:

```ts
extension = Object.values(extensionName2Folder).find(([_, folder]) => folder === extensionFolder)?.[0];
```

`Object.values` returns the folder strings, not `[key, value]` pairs. Strings are iterable, so
`([_, folder])` destructures one into its first two characters — for `"youtrack"` that is
`_ = "y"`, `folder = "o"`. TypeScript accepts this, because destructuring a `string` that way
yields `string`, so the comparison type-checks while comparing a single character against a
folder name.

`folder === extensionFolder` is therefore never true, `find` returns `undefined`, and the bot
takes the not-found path: it posts the "could not find the extension" comment and applies
`status: stalled`.

Verified against the checked-in `.github/extensionName2Folder.json` (3148 entries), for the
legacy issue body from #3156 and the current one:

```
folder parsed : "youtrack"
Object.values  : undefined      -> bot comments "could not find" + labels stalled
Object.entries : tiulpin/youtrack
```

One note on scope: the issue describes this as a legacy-link problem, but both branches feed the
same lookup, so a current `### Extension` + GitHub URL body fails the same way. Only
`raycast.com` links are unaffected — they take the other branch, which indexes the map by key
directly.

## Fix

```diff
-    extension = Object.values(extensionName2Folder).find(([_, folder]) => folder === extensionFolder)?.[0];
+    extension = Object.entries(extensionName2Folder).find(([, folder]) => folder === extensionFolder)?.[0];
```

`Object.entries` produces the `[name, folder]` pairs the destructuring already assumed, so
`?.[0]` yields the extension name. `tsc --noEmit -p scripts/bots/tsconfig.json` passes.

## Related, not changed here

`pr-bot.ts:557` has the identical `Object.values` call in `extensionLabel`. I left it out of this
PR because fixing it is not equivalent: `extension` is currently always `undefined` there, so the
function always falls through to `label = extension: ${extensionFolder}`. Switching to
`Object.entries` activates the `if (extension)` branch, which contains a second mismatch —
`names` holds bare names while `extension` is `owner/name`, so
`names.filter((x) => x === extension)` cannot match either, and the duplicate-name
disambiguation it guards still would not work. That changes label output, which seemed like your
call rather than mine. Happy to follow up with it if you want it in the same shape.
