### PR TITLE
[is-it-alive] Add OutageDeck status provider

### DIFF
--- a/extensions/is-it-alive/CHANGELOG.md
+++ b/extensions/is-it-alive/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Is It Alive? Changelog
 
-## [OutageDeck Support] - {PR_MERGE_DATE}
+## [OutageDeck Support] - 2026-08-21
 
 - Add OutageDeck provider URLs for normalized vendor-published status, service details, and active incidents across cloud and SaaS providers
 

--- a/extensions/is-it-alive/CHANGELOG.md
+++ b/extensions/is-it-alive/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [OutageDeck Support] - {PR_MERGE_DATE}
 
-- Add OutageDeck provider URLs for normalized live status, service details, and active incidents across more than 170 cloud and SaaS providers
+- Add OutageDeck provider URLs for normalized vendor-published status, service details, and active incidents across cloud and SaaS providers
 
 ## [Statuspage Uptime Accuracy] - 2026-07-26
 

--- a/extensions/is-it-alive/CHANGELOG.md
+++ b/extensions/is-it-alive/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Is It Alive? Changelog
 
+## [OutageDeck Support] - {PR_MERGE_DATE}
+
+- Add OutageDeck provider URLs for normalized live status, service details, and active incidents across more than 170 cloud and SaaS providers
+
 ## [Statuspage Uptime Accuracy] - 2026-07-26
 
 - Fix Statuspage 90-day uptime drift (e.g. claude.ai showing ~59% vs the site's ~99.4%) by using Statuspage's embedded per-second outage data instead of counting any incident day as full downtime

--- a/extensions/is-it-alive/README.md
+++ b/extensions/is-it-alive/README.md
@@ -62,7 +62,7 @@ The RSS fallback is checked last and covers pages whose APIs and HTML are blocke
 
 The AWS adapter reads the Health Dashboard's public `currentevents` endpoint (UTF-16 JSON) plus the 12-month `historyevents.json` S3 export. Components cover service–region pairs that have reported events; services with no events in the window don't appear.
 
-The OutageDeck adapter accepts any `outagedeck.com/providers/{slug}` URL and reads the keyless public API. It provides a consistent status, service breakdown, and active-incident shape for more than 170 cloud and SaaS providers, including sources that do not expose a Statuspage-compatible endpoint.
+The OutageDeck adapter accepts any `outagedeck.com/providers/{slug}` URL and reads the keyless public API. It provides a consistent vendor-published status, service breakdown, and active-incident shape for cloud and SaaS providers, based on their official status feeds.
 
 The Salesforce Trust adapter uses the public `api.status.salesforce.com/v1` API and covers any product page on [status.salesforce.com](https://status.salesforce.com) (Heroku, Tableau, Mulesoft, Slack, …). Add `https://status.salesforce.com/products/{Product}` to monitor one product; the bare domain maps to the core Salesforce Services product. `status.heroku.com` is deprecated in favor of Salesforce Trust, so it maps to the Heroku product automatically.
 

--- a/extensions/is-it-alive/README.md
+++ b/extensions/is-it-alive/README.md
@@ -32,11 +32,12 @@
 
 ## Supported status pages
 
-The extension auto-detects the provider when you add a URL. Detection order: **Railway → AWS → Salesforce Trust → Google Cloud → AI Studio → incident.io → Better Stack → Instatus → Statuspage → Checkly → Uptime.com → RSS**.
+The extension auto-detects the provider when you add a URL. Detection order: **Railway → OutageDeck → AWS → Salesforce Trust → Google Cloud → AI Studio → incident.io → Better Stack → Instatus → Statuspage → Checkly → Uptime.com → RSS**.
 
 | Provider          | Examples                                                       | Detection                             |
 | ----------------- | -------------------------------------------------------------- | ------------------------------------- |
 | **Railway**       | [status.railway.com](https://status.railway.com)               | Hostname match                        |
+| **OutageDeck**    | [outagedeck.com/providers/github](https://outagedeck.com/providers/github) | Provider URL; normalized public API |
 | **AWS**           | [health.aws.amazon.com](https://health.aws.amazon.com/health/status) | Hostname match                 |
 | **Salesforce Trust** | [status.salesforce.com/products/Heroku](https://status.salesforce.com/products/Heroku), [status.heroku.com](https://status.heroku.com) | Hostname match |
 | **Google Cloud**  | [status.cloud.google.com](https://status.cloud.google.com), `status.cloud.google.com/products/vertex-gemini-api` | Hostname match |
@@ -60,6 +61,8 @@ Uptime.com status pages embed their full state as React props in the page HTML; 
 The RSS fallback is checked last and covers pages whose APIs and HTML are blocked (e.g. status.x.ai sits behind a Cloudflare challenge but keeps `/feed.xml` reachable). It is incident-only: components are derived from incident titles, day history marks incident days, and no uptime percentage is available.
 
 The AWS adapter reads the Health Dashboard's public `currentevents` endpoint (UTF-16 JSON) plus the 12-month `historyevents.json` S3 export. Components cover service–region pairs that have reported events; services with no events in the window don't appear.
+
+The OutageDeck adapter accepts any `outagedeck.com/providers/{slug}` URL and reads the keyless public API. It provides a consistent status, service breakdown, and active-incident shape for more than 170 cloud and SaaS providers, including sources that do not expose a Statuspage-compatible endpoint.
 
 The Salesforce Trust adapter uses the public `api.status.salesforce.com/v1` API and covers any product page on [status.salesforce.com](https://status.salesforce.com) (Heroku, Tableau, Mulesoft, Slack, …). Add `https://status.salesforce.com/products/{Product}` to monitor one product; the bare domain maps to the core Salesforce Services product. `status.heroku.com` is deprecated in favor of Salesforce Trust, so it maps to the Heroku product automatically.
 
@@ -105,6 +108,7 @@ src/
     incident-io.ts       # incident.io proxy API
     instatus.ts          # Instatus public /summary.json API
     railway.ts           # Railway status API
+    outagedeck.ts        # OutageDeck normalized public API
     rss.ts               # generic RSS feed fallback (e.g. status.x.ai)
     aistudio.ts          # Google AI Studio / Gemini API incidents RPC
     googlecloud.ts       # Google Cloud Service Health incidents/products JSON

--- a/extensions/is-it-alive/src/adapters/index.ts
+++ b/extensions/is-it-alive/src/adapters/index.ts
@@ -13,6 +13,7 @@ import { checklyAdapter } from "@/adapters/checkly";
 import { googleCloudAdapter } from "@/adapters/googlecloud";
 import { incidentIoAdapter } from "@/adapters/incident-io";
 import { instatusAdapter } from "@/adapters/instatus";
+import { outagedeckAdapter } from "@/adapters/outagedeck";
 import { railwayAdapter } from "@/adapters/railway";
 import { rssAdapter } from "@/adapters/rss";
 import { salesforceAdapter } from "@/adapters/salesforce";
@@ -34,6 +35,7 @@ const adapters: Record<SiteProvider, StatusAdapter> = {
   uptimecom: uptimecomAdapter,
   googlecloud: googleCloudAdapter,
   aistudio: aiStudioAdapter,
+  outagedeck: outagedeckAdapter,
 };
 
 export function getAdapter(provider: SiteProvider): StatusAdapter {
@@ -45,6 +47,11 @@ export async function detectProvider(siteUrl: string): Promise<SiteProvider> {
 
   if (isRailwayHost(normalized)) {
     return "railway";
+  }
+
+  const isOutageDeck = await outagedeckAdapter.detect?.(normalized);
+  if (isOutageDeck) {
+    return "outagedeck";
   }
 
   const isAws = await awsAdapter.detect?.(normalized);
@@ -103,7 +110,7 @@ export async function detectProvider(siteUrl: string): Promise<SiteProvider> {
   }
 
   throw new Error(
-    "Unsupported status page. Try Statuspage, Better Stack, incident.io, Instatus, Checkly, an RSS status feed, or status.railway.app",
+    "Unsupported status page. Try OutageDeck, Statuspage, Better Stack, incident.io, Instatus, Checkly, an RSS status feed, or status.railway.app",
   );
 }
 

--- a/extensions/is-it-alive/src/adapters/outagedeck.ts
+++ b/extensions/is-it-alive/src/adapters/outagedeck.ts
@@ -24,11 +24,12 @@ function providerSlug(siteUrl: string): string | null {
   }
 
   const segments = url.pathname.split("/").filter(Boolean);
-  if (segments[0] === "providers" && segments[1]) {
+  if (segments.length === 2 && segments[0] === "providers" && segments[1]) {
     return decodeURIComponent(segments[1]);
   }
 
   if (
+    segments.length === 4 &&
     segments[0] === "api" &&
     segments[1] === "v1" &&
     segments[2] === "providers" &&

--- a/extensions/is-it-alive/src/adapters/outagedeck.ts
+++ b/extensions/is-it-alive/src/adapters/outagedeck.ts
@@ -16,6 +16,7 @@ import { normalizeSiteUrl } from "@/lib/url";
 
 const OUTAGEDECK_ORIGIN = "https://outagedeck.com";
 const OUTAGEDECK_HOSTS = new Set(["outagedeck.com", "www.outagedeck.com"]);
+const PROVIDER_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 function providerSlug(siteUrl: string): string | null {
   const url = new URL(normalizeSiteUrl(siteUrl));
@@ -24,21 +25,26 @@ function providerSlug(siteUrl: string): string | null {
   }
 
   const segments = url.pathname.split("/").filter(Boolean);
-  if (segments.length === 2 && segments[0] === "providers" && segments[1]) {
-    return decodeURIComponent(segments[1]);
-  }
+  let encodedSlug: string | undefined;
 
-  if (
+  if (segments.length === 2 && segments[0] === "providers" && segments[1]) {
+    encodedSlug = segments[1];
+  } else if (
     segments.length === 4 &&
     segments[0] === "api" &&
     segments[1] === "v1" &&
     segments[2] === "providers" &&
     segments[3]
   ) {
-    return decodeURIComponent(segments[3]);
+    encodedSlug = segments[3];
   }
 
-  return null;
+  if (!encodedSlug) {
+    return null;
+  }
+
+  const slug = decodeURIComponent(encodedSlug);
+  return PROVIDER_SLUG_PATTERN.test(slug) ? slug : null;
 }
 
 function statusToIndicator(status: string): StatusIndicator {

--- a/extensions/is-it-alive/src/adapters/outagedeck.ts
+++ b/extensions/is-it-alive/src/adapters/outagedeck.ts
@@ -1,0 +1,160 @@
+import type {
+  ComponentStatusValue,
+  FetchSnapshotInput,
+  StatusAdapter,
+  StatusIncident,
+  StatusIndicator,
+  StatusSnapshot,
+} from "@/types";
+import type {
+  OutageDeckIncident,
+  OutageDeckProviderResponse,
+  OutageDeckService,
+} from "@/types/outagedeck";
+import { fetchJson } from "@/lib/fetch-json";
+import { normalizeSiteUrl } from "@/lib/url";
+
+const OUTAGEDECK_ORIGIN = "https://outagedeck.com";
+const OUTAGEDECK_HOSTS = new Set(["outagedeck.com", "www.outagedeck.com"]);
+
+function providerSlug(siteUrl: string): string | null {
+  const url = new URL(normalizeSiteUrl(siteUrl));
+  if (!OUTAGEDECK_HOSTS.has(url.hostname)) {
+    return null;
+  }
+
+  const segments = url.pathname.split("/").filter(Boolean);
+  if (segments[0] === "providers" && segments[1]) {
+    return decodeURIComponent(segments[1]);
+  }
+
+  if (
+    segments[0] === "api" &&
+    segments[1] === "v1" &&
+    segments[2] === "providers" &&
+    segments[3]
+  ) {
+    return decodeURIComponent(segments[3]);
+  }
+
+  return null;
+}
+
+function statusToIndicator(status: string): StatusIndicator {
+  switch (status) {
+    case "operational":
+      return "none";
+    case "degraded":
+    case "maintenance":
+    case "unknown":
+      return "minor";
+    case "partial_outage":
+      return "major";
+    case "major_outage":
+      return "critical";
+    default:
+      return "minor";
+  }
+}
+
+function statusToComponent(status: string): ComponentStatusValue | string {
+  switch (status) {
+    case "operational":
+      return "operational";
+    case "degraded":
+      return "degraded_performance";
+    case "partial_outage":
+      return "partial_outage";
+    case "major_outage":
+      return "major_outage";
+    case "maintenance":
+      return "under_maintenance";
+    default:
+      return "unknown";
+  }
+}
+
+function mapIncident(
+  incident: OutageDeckIncident,
+  services: OutageDeckService[],
+): StatusIncident {
+  const componentIdsBySlug = new Map(
+    services.map((service) => [service.slug, service.id]),
+  );
+  const affectedComponentIds = (incident.affectedServices ?? [])
+    .map((service) => componentIdsBySlug.get(service.slug))
+    .filter((id): id is string => Boolean(id));
+
+  return {
+    id: incident.id,
+    name: incident.title,
+    status: incident.status,
+    impact: incident.severity,
+    updatedAt: incident.updatedAt || incident.startedAt,
+    body: incident.summary,
+    affectedComponentIds:
+      affectedComponentIds.length > 0 ? affectedComponentIds : undefined,
+  };
+}
+
+export const outagedeckAdapter: StatusAdapter = {
+  async detect(siteUrl: string): Promise<boolean> {
+    try {
+      return providerSlug(siteUrl) !== null;
+    } catch {
+      return false;
+    }
+  },
+
+  async fetchSnapshot(input: FetchSnapshotInput): Promise<StatusSnapshot> {
+    const normalized = normalizeSiteUrl(input.url);
+    const fetchedAt = new Date().toISOString();
+
+    try {
+      const slug = providerSlug(normalized);
+      if (!slug) {
+        throw new Error("Not an OutageDeck provider URL");
+      }
+
+      const response = await fetchJson<OutageDeckProviderResponse>(
+        `${OUTAGEDECK_ORIGIN}/api/v1/providers/${encodeURIComponent(slug)}`,
+      );
+      const { data } = response;
+      if (!data?.currentStatus || !data.name) {
+        throw new Error("Invalid OutageDeck provider response");
+      }
+
+      const services = data.services ?? [];
+      const pageUrl = data.links?.html
+        ? new URL(data.links.html, OUTAGEDECK_ORIGIN).toString()
+        : normalized;
+
+      return {
+        pageName: data.name,
+        pageUrl,
+        overallDescription: data.currentStatus.headline,
+        indicator: statusToIndicator(data.currentStatus.code),
+        components: services.map((service) => ({
+          id: service.id,
+          name: service.name,
+          status: statusToComponent(service.status),
+        })),
+        incidents: (data.activeIncidents ?? []).map((incident) =>
+          mapIncident(incident, services),
+        ),
+        fetchedAt,
+      };
+    } catch (error) {
+      return {
+        pageName: new URL(normalized).hostname,
+        pageUrl: normalized,
+        overallDescription: "Failed to fetch",
+        indicator: "none",
+        components: [],
+        incidents: [],
+        fetchedAt,
+        error: error instanceof Error ? error.message : "Unknown error",
+      };
+    }
+  },
+};

--- a/extensions/is-it-alive/src/types/index.ts
+++ b/extensions/is-it-alive/src/types/index.ts
@@ -11,7 +11,8 @@ export type SiteProvider =
   | "salesforce"
   | "uptimecom"
   | "googlecloud"
-  | "aistudio";
+  | "aistudio"
+  | "outagedeck";
 
 export type StatusIndicator = "none" | "minor" | "major" | "critical";
 

--- a/extensions/is-it-alive/src/types/outagedeck.ts
+++ b/extensions/is-it-alive/src/types/outagedeck.ts
@@ -1,0 +1,49 @@
+export type OutageDeckStatus =
+  | "operational"
+  | "degraded"
+  | "partial_outage"
+  | "major_outage"
+  | "maintenance"
+  | "unknown";
+
+export interface OutageDeckService {
+  id: string;
+  slug: string;
+  name: string;
+  status: OutageDeckStatus | string;
+}
+
+export interface OutageDeckIncident {
+  id: string;
+  slug: string;
+  title: string;
+  summary?: string;
+  status: string;
+  severity: string;
+  startedAt: string;
+  updatedAt: string;
+  affectedServices?: Array<{
+    slug: string;
+    name: string;
+  }>;
+}
+
+export interface OutageDeckProviderResponse {
+  data: {
+    id: string;
+    slug: string;
+    name: string;
+    currentStatus: {
+      code: OutageDeckStatus | string;
+      label: string;
+      headline: string;
+      summary: string;
+      capturedAt: string;
+    };
+    services?: OutageDeckService[];
+    activeIncidents?: OutageDeckIncident[];
+    links?: {
+      html?: string;
+    };
+  };
+}

--- a/extensions/is-it-alive/tests/outagedeck.test.ts
+++ b/extensions/is-it-alive/tests/outagedeck.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { outagedeckAdapter } from "@/adapters/outagedeck";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("outagedeckAdapter", () => {
+  it("detects provider page and API URLs without matching other pages", async () => {
+    await expect(
+      outagedeckAdapter.detect?.("https://outagedeck.com/providers/github"),
+    ).resolves.toBe(true);
+    await expect(
+      outagedeckAdapter.detect?.(
+        "https://outagedeck.com/api/v1/providers/github",
+      ),
+    ).resolves.toBe(true);
+    await expect(
+      outagedeckAdapter.detect?.("https://outagedeck.com/developers/api"),
+    ).resolves.toBe(false);
+    await expect(
+      outagedeckAdapter.detect?.("https://status.example.com/providers/github"),
+    ).resolves.toBe(false);
+  });
+
+  it("maps provider status, components, and active incidents", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: {
+            id: "provider_github",
+            slug: "github",
+            name: "GitHub",
+            currentStatus: {
+              code: "partial_outage",
+              label: "Partial Outage",
+              headline: "GitHub is experiencing a partial outage",
+              summary: "GitHub Actions is degraded.",
+              capturedAt: "2026-08-05T02:00:00Z",
+            },
+            services: [
+              {
+                id: "service_github_actions",
+                slug: "github-actions",
+                name: "GitHub Actions",
+                status: "degraded",
+              },
+              {
+                id: "service_github_api",
+                slug: "github-api",
+                name: "GitHub API",
+                status: "operational",
+              },
+            ],
+            activeIncidents: [
+              {
+                id: "incident_github_actions",
+                slug: "github-actions-delays",
+                title: "Actions workflow delays",
+                summary: "Some workflow jobs are delayed.",
+                status: "monitoring",
+                severity: "major",
+                startedAt: "2026-08-05T01:00:00Z",
+                updatedAt: "2026-08-05T01:30:00Z",
+                affectedServices: [
+                  { slug: "github-actions", name: "GitHub Actions" },
+                ],
+              },
+            ],
+            links: { html: "/providers/github" },
+          },
+        }),
+        { headers: { "content-type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const snapshot = await outagedeckAdapter.fetchSnapshot({
+      url: "https://outagedeck.com/providers/github",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://outagedeck.com/api/v1/providers/github",
+      { headers: { Accept: "application/json" } },
+    );
+    expect(snapshot.error).toBeUndefined();
+    expect(snapshot.pageName).toBe("GitHub");
+    expect(snapshot.pageUrl).toBe("https://outagedeck.com/providers/github");
+    expect(snapshot.indicator).toBe("major");
+    expect(snapshot.components).toEqual([
+      {
+        id: "service_github_actions",
+        name: "GitHub Actions",
+        status: "degraded_performance",
+      },
+      {
+        id: "service_github_api",
+        name: "GitHub API",
+        status: "operational",
+      },
+    ]);
+    expect(snapshot.incidents[0]).toMatchObject({
+      id: "incident_github_actions",
+      impact: "major",
+      affectedComponentIds: ["service_github_actions"],
+    });
+  });
+
+  it("returns a visible error instead of reporting a failed request healthy", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("Unavailable", {
+          status: 503,
+          headers: { "content-type": "text/plain" },
+        }),
+      ),
+    );
+
+    const snapshot = await outagedeckAdapter.fetchSnapshot({
+      url: "https://outagedeck.com/providers/slack",
+    });
+
+    expect(snapshot.error).toBe("HTTP 503");
+    expect(snapshot.overallDescription).toBe("Failed to fetch");
+    expect(snapshot.components).toEqual([]);
+  });
+});

--- a/extensions/is-it-alive/tests/outagedeck.test.ts
+++ b/extensions/is-it-alive/tests/outagedeck.test.ts
@@ -20,6 +20,16 @@ describe("outagedeckAdapter", () => {
       outagedeckAdapter.detect?.("https://outagedeck.com/developers/api"),
     ).resolves.toBe(false);
     await expect(
+      outagedeckAdapter.detect?.(
+        "https://outagedeck.com/providers/github/actions",
+      ),
+    ).resolves.toBe(false);
+    await expect(
+      outagedeckAdapter.detect?.(
+        "https://outagedeck.com/api/v1/providers/github/incidents",
+      ),
+    ).resolves.toBe(false);
+    await expect(
       outagedeckAdapter.detect?.("https://status.example.com/providers/github"),
     ).resolves.toBe(false);
   });

--- a/extensions/is-it-alive/tests/outagedeck.test.ts
+++ b/extensions/is-it-alive/tests/outagedeck.test.ts
@@ -30,6 +30,16 @@ describe("outagedeckAdapter", () => {
       ),
     ).resolves.toBe(false);
     await expect(
+      outagedeckAdapter.detect?.(
+        "https://outagedeck.com/providers/github%2Factions",
+      ),
+    ).resolves.toBe(false);
+    await expect(
+      outagedeckAdapter.detect?.(
+        "https://outagedeck.com/api/v1/providers/github%5Cactions",
+      ),
+    ).resolves.toBe(false);
+    await expect(
       outagedeckAdapter.detect?.("https://status.example.com/providers/github"),
     ).resolves.toBe(false);
   });


### PR DESCRIPTION
## Description

Adds OutageDeck as a provider adapter for the existing **Is It Alive?** extension. Users can add an `outagedeck.com/providers/{slug}` URL and see normalized vendor-published status, service details, and active incidents for the provider.

- Detects only canonical OutageDeck provider-page and provider-API URLs
- Maps the six documented OutageDeck states into the extension's indicator and component models
- Links incident affected-service slugs back to the displayed components
- Returns the extension's visible error state on HTTP, JSON, or response-shape failures instead of showing a failed request as healthy
- Documents the provider and includes adapter tests for detection, status/incident mapping, and failure behavior

The public API is keyless, permits programmatic access at its published rate limit, and returns data from official provider feeds. I maintain OutageDeck and am disclosing that relationship explicitly.

Validation run from `extensions/is-it-alive`:

- `npm test`: 9 tests passed
- `npm run lint`: Raycast metadata, ESLint, and Prettier checks passed
- `npm run build`: production extension build passed

## Screencast

Not included because this adds an adapter to the existing screens and does not change the UI. The distribution build passed, but Raycast itself is not installed in the environment used for this contribution, so I could not perform the final in-app smoke test.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration): build passed, but the in-app test was unavailable as disclosed above
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
