### PR TITLE
Escape user input in PyPI search query and URL

### DIFF
--- a/extensions/python/CHANGELOG.md
+++ b/extensions/python/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Python Changelog
 
-## [Fix Search Query Escaping] - {PR_MERGE_DATE}
+## [Fix Search Query Escaping] - 2026-08-05
 
 - Escape user input before interpolating it into the search query and URL.
 

--- a/extensions/python/CHANGELOG.md
+++ b/extensions/python/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Python Changelog
 
+## [Fix Search Query Escaping] - {PR_MERGE_DATE}
+
+- Escape user input before interpolating it into the search query and URL.
+
 ## [Maintenance] - 2026-01-15
 
 - Add support for Windows platform.

--- a/extensions/python/package.json
+++ b/extensions/python/package.json
@@ -9,7 +9,8 @@
     "Developer Tools"
   ],
   "contributors": [
-    "muhammadrizo"
+    "muhammadrizo",
+    "benjaminkifle"
   ],
   "license": "MIT",
   "commands": [

--- a/extensions/python/src/search-pypi.tsx
+++ b/extensions/python/src/search-pypi.tsx
@@ -11,15 +11,20 @@ interface DoltPackageRow {
   version: string;
 }
 
+function escapeSqlString(term: string): string {
+  return term.replace(/\\/g, "\\\\").replace(/'/g, "''");
+}
+
 export default function PackageList() {
   const [searchTerm, setSearchTerm] = useState<string>("");
   const abortable = useRef<AbortController | undefined>(undefined);
 
   const { isLoading, data, revalidate } = usePromise(
     async (): Promise<Package[]> => {
-      const url = `https://www.dolthub.com/api/v1alpha1/iloveitaly/pypi/main?q=SELECT+*+FROM+%60projects%60+WHERE+name+LIKE+%27${searchTerm}%25%27+LIMIT+50%3B`;
+      const query = `SELECT * FROM \`projects\` WHERE name LIKE '${escapeSqlString(searchTerm)}%' LIMIT 50;`;
+      const url = `https://www.dolthub.com/api/v1alpha1/iloveitaly/pypi/main?q=${encodeURIComponent(query)}`;
       const response = await fetch(url);
-      const packageJsonResponse = (await response.json()) as { rows: DoltPackageRow[] };
+      const packageJsonResponse = (await response.json()) as { rows?: DoltPackageRow[] };
 
       /*
       {
@@ -65,7 +70,7 @@ export default function PackageList() {
         }
        */
 
-      return packageJsonResponse["rows"].map((row: DoltPackageRow) => {
+      return (packageJsonResponse.rows ?? []).map((row: DoltPackageRow) => {
         return {
           name: row.name,
           description: row.summary,
@@ -111,7 +116,7 @@ export default function PackageList() {
                 actions={
                   <ActionPanel>
                     <Action.OpenInBrowser
-                      url={`https://pypi.org/search?q=${searchTerm}`}
+                      url={`https://pypi.org/search?q=${encodeURIComponent(searchTerm)}`}
                       title="View PyPI Search Results"
                     />
                   </ActionPanel>


### PR DESCRIPTION
## Description

The search term was interpolated directly into both a SQL string literal and a
URL query parameter, with no escaping for either context.

**Broken SQL.** A typed apostrophe closed the string literal early. Searching
`it's` produced:

    SELECT * FROM `projects` WHERE name LIKE 'it's%' LIMIT 50;

which the API rejects with `syntax error at position 47 near 's'`. More
seriously, the same gap allows arbitrary SQL to be grafted onto the query —
a search term of `' OR '1'='1` produced valid, executing SQL rather than a
search string.

**Broken URLs.** Characters like `&` and `#` terminated the query parameter
early, so the server received truncated SQL with no `LIMIT` clause.

### Fix

The query is now built first and passed through `encodeURIComponent` as a
single unit, with `'` and `\` escaped for the SQL string context beforehand.
The original hand-encoded the *static* parts of the URL (`%60`, `%27`, `%3B`)
but had no way to encode the interpolated term, which is the root of both
problems.

`%` and `_` are deliberately **not** escaped, so existing wildcard behavior
is unchanged.

The "View PyPI Search Results" action had the same unescaped interpolation
and is now encoded too.

This does not change how results are returned — it only fixes queries that
were previously malformed.

### Testing

| Search | Result |
| --- | --- |
| `fastapi` | 50 results — unchanged |
| `100%` | 17 results — unchanged |
| `typing_ext` | unchanged |
| `it's` | valid SQL instead of a server-side syntax error |

`npm run lint` and `npm run build` both pass.

## Screencast

No visible UI change — this fixes malformed queries, and successful searches
look identical before and after.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
