### PR TITLE
Add Tendem MCP server to the registry

### DIFF
--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Model Context Protocol Registry Changelog
 
-## [Add Tendem MCP Server] - {PR_MERGE_DATE}
+## [Add Tendem MCP Server] - 2026-08-06
 
 Add Tendem to the official registry: delegate tasks to vetted human experts (research, competitive analysis, fact-checking, copywriting, editing, design review, presentation polish, data cleaning and list building). Tendem's orchestrator scopes the task and quotes a transparent price, and the expert's verified results come back as markdown plus files. Remote Streamable HTTP MCP server via mcp-remote with OAuth 2.0 sign-in; an API key alternative is available for headless use.
 

--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Model Context Protocol Registry Changelog
 
+## [Add Tendem MCP Server] - {PR_MERGE_DATE}
+
+Add Tendem to the official registry: delegate tasks to vetted human experts (research, competitive analysis, fact-checking, copywriting, editing, design review, presentation polish, data cleaning and list building). Tendem's orchestrator scopes the task and quotes a transparent price, and the expert's verified results come back as markdown plus files. Remote Streamable HTTP MCP server via mcp-remote with OAuth 2.0 sign-in; an API key alternative is available for headless use.
+
 ## [Add JobYap MCP Server] - 2026-08-03
 
 Add JobYap to the official registry: search job postings aggregated from companies' official careers sites — salaries, locations, and a community discussion thread on every job. Remote Streamable HTTP MCP server via mcp-remote; no auth required.

--- a/extensions/model-context-protocol-registry/README.md
+++ b/extensions/model-context-protocol-registry/README.md
@@ -84,6 +84,7 @@ To add a new MCP registry to the registry, you need to create a new entry in the
 | [Agentcard](https://agentcard.sh) | Prepaid virtual cards for AI agents. Fund a wallet, set spend caps and human approvals, and your agent mints a one-time virtual card for each purchase that works at any merchant. Connects to the remote Agentcard MCP server over OAuth 2.0. |
 | [UseMyContext](https://usemycontext.ai) | The personal context layer for AI: one user-owned profile plus files, read by any MCP client so you never re-introduce yourself. 8 tools for profile, file search and reads, cited answers from your documents, and exact table queries. Connects to the remote UseMyContext server over OAuth 2.1. |
 | [JobYap](https://jobyap.com/agents) | Search job postings aggregated from companies' official careers sites — salaries, locations, and a community discussion thread on every job. Remote Streamable HTTP MCP server; no auth required. |
+| [Tendem](https://github.com/Toloka/tendem-mcp) | Delegate tasks to vetted human experts - research, competitive analysis, fact-checking, copywriting, editing, design review, presentation polish, data cleaning and list building. Submit a task in natural language; Tendem's orchestrator scopes it and quotes a transparent price, and after explicit approval a vetted human expert executes it and returns verified results as markdown plus files. Remote Streamable HTTP MCP server with OAuth 2.0 sign-in on first use. |
 
 ### Community MCP Servers
 

--- a/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
+++ b/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
@@ -811,6 +811,18 @@ export const OFFICIAL_ENTRIES: RegistryEntry[] = [
       args: ["-y", "mcp-remote", "https://mcp.jobyap.com/mcp"],
     },
   },
+  {
+    name: "tendem",
+    title: "Tendem",
+    description:
+      "Delegate tasks to vetted human experts - research, competitive analysis, fact-checking, copywriting, editing, design review, presentation polish, data cleaning and list building. Submit a task in natural language; Tendem's orchestrator scopes it and quotes a transparent price, and after explicit approval a vetted human expert executes it and returns verified results as markdown plus files. Remote Streamable HTTP MCP server with OAuth 2.0 sign-in on first use.",
+    icon: "https://framerusercontent.com/images/EGNlwavPB2tW8etz63vecfpJu0.png",
+    homepage: "https://github.com/Toloka/tendem-mcp",
+    configuration: {
+      command: "npx",
+      args: ["-y", "mcp-remote", "https://mcp.tendem.ai/mcp?utm_hash=66fdb1535f"],
+    },
+  },
 ];
 
 export const COMMUNITY_ENTRIES: RegistryEntry[] = [


### PR DESCRIPTION
## Description

Adds **Tendem** to the official MCP server registry (`OFFICIAL_ENTRIES`). Submitted by the maintainers of the server.

Tendem is a hybrid AI + human task service. The agent submits a task in natural language; Tendem's orchestrator scopes it and quotes a transparent price, and after explicit approval a vetted human expert executes it and returns verified results as markdown plus files. Useful for research, competitive analysis, fact-checking, copywriting, editing, design review, presentation polish, data cleaning and list building.

- **Endpoint:** `https://mcp.tendem.ai/mcp` — remote Streamable HTTP, wired up via `mcp-remote` like the other hosted entries (Circleback, Glif, JobYap).
- **Auth:** OAuth 2.0 on first use, so no API key goes into the config. A `Authorization: ApiKey <token>` header is available for headless use.
- **Source / homepage:** https://github.com/Toloka/tendem-mcp
- **Also listed in** the official MCP Registry as `io.github.Toloka/tendem-mcp`.
- **Tools:** `create_task`, `get_task`, `get_contract`, `approve_task`, `cancel_task`, `get_task_result`, `list_tasks`, `read_chat`, `send_message`, `get_account`, `get_file_upload_url`.

## Checklist

- [x] Added the entry to `src/registries/builtin/entries.ts` (`OFFICIAL_ENTRIES`)
- [x] Added a `CHANGELOG.md` entry using `{PR_MERGE_DATE}`
- [x] Updated the generated server table in `README.md`
- [x] Icon is a stable hosted PNG (Tendem's own logo asset)
