### PR TITLE
[github]: Added GitHub CLI clone option

### DIFF
--- a/extensions/github/CHANGELOG.md
+++ b/extensions/github/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GitHub Changelog
 
-## [Clone with GitHub CLI] - {PR_MERGE_DATE}
+## [Clone with GitHub CLI] - 2026-08-06
 
 - Added a "Clone Tool" choice to the "Clone with Options" flow, letting you clone repositories with the GitHub CLI (`gh repo clone`) instead of plain `git clone`, using your existing `gh` authentication and configuration.
 - The Git method remains the default, and the target directory and branch options are preserved when using GitHub CLI.

--- a/extensions/github/CHANGELOG.md
+++ b/extensions/github/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Added a "Clone Tool" choice to the "Clone with Options" flow, letting you clone repositories with the GitHub CLI (`gh repo clone`) instead of plain `git clone`, using your existing `gh` authentication and configuration.
 - The Git method remains the default, and the target directory and branch options are preserved when using GitHub CLI.
 - Shows actionable guidance when the GitHub CLI is not installed or not authenticated.
+- Security: clone commands are now spawned without a shell, so branches and paths containing shell characters are handled safely.
+- Fixed `gh` detection for installations in Homebrew or other directories that are missing from Raycast's PATH.
 
 ## [Show README in repository actions] - 2026-08-03
 

--- a/extensions/github/CHANGELOG.md
+++ b/extensions/github/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GitHub Changelog
 
-## [Clone with GitHub CLI] - 2026-08-05
+## [Clone with GitHub CLI] - {PR_MERGE_DATE}
 
 - Added a "Clone Tool" choice to the "Clone with Options" flow, letting you clone repositories with the GitHub CLI (`gh repo clone`) instead of plain `git clone`, using your existing `gh` authentication and configuration.
 - The Git method remains the default, and the target directory and branch options are preserved when using GitHub CLI.

--- a/extensions/github/CHANGELOG.md
+++ b/extensions/github/CHANGELOG.md
@@ -1,5 +1,11 @@
 # GitHub Changelog
 
+## [Clone with GitHub CLI] - 2026-08-05
+
+- Added a "Clone Tool" choice to the "Clone with Options" flow, letting you clone repositories with the GitHub CLI (`gh repo clone`) instead of plain `git clone`, using your existing `gh` authentication and configuration.
+- The Git method remains the default, and the target directory and branch options are preserved when using GitHub CLI.
+- Shows actionable guidance when the GitHub CLI is not installed or not authenticated.
+
 ## [Show README in repository actions] - 2026-08-03
 
 - Added a "Show Readme" action to the Search Repositories, My Latest Repositories, and My Starred Repositories commands that renders the repository's README inside Raycast, with relative links and images resolved to absolute URLs.
@@ -37,6 +43,7 @@
 - Added an `API` section showing the current GitHub API rate limit (remaining / total, with reset time tooltip).
 - Added a `Refresh Frequency` preference (15 minutes / 30 minutes / 1 hour / 2 hours, default 30 minutes) so users can balance freshness against GitHub API quota usage.
 - Each organization is now a submenu with quick access to **Open Profile**, **Repositories**, **People** and **Projects** instead of just opening the organization homepage.
+- `PRs Authored`, `Issues Authored`, `Open PRs` and `Open Issues` are now submenus listing the 5 most recently updated items (each clickable to jump straight to GitHub), with a `View All` shortcut at the bottom. This is intentionally a thin convenience for users who keep only the _Stats_ menu bar enabled — the dedicated _My Pull Requests Menu Bar_ and _My Issues Menu Bar_ commands remain the recommended surfaces when you need filters, sorting, or full PR/Issue triage workflow (see the README).
 - `PRs Authored`, `Issues Authored`, `Open PRs` and `Open Issues` are now submenus listing the 5 most recently updated items (each clickable to jump straight to GitHub), with a `View All` shortcut at the bottom. This is intentionally a thin convenience for users who keep only the *Stats* menu bar enabled — the dedicated *My Pull Requests Menu Bar* and *My Issues Menu Bar* commands remain the recommended surfaces when you need filters, sorting, or full PR/Issue triage workflow (see the README).
 
 ## [Download Repository Command] - 2026-04-28

--- a/extensions/github/src/components/CheckoutPullRequestForm.tsx
+++ b/extensions/github/src/components/CheckoutPullRequestForm.tsx
@@ -1,4 +1,4 @@
-import { exec } from "node:child_process";
+import { exec, execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -16,7 +16,7 @@ import {
 } from "@raycast/api";
 import { showFailureToast, useForm } from "@raycast/utils";
 
-import { AcceptableCloneProtocol, buildCloneCommand } from "../helpers/repository";
+import { AcceptableCloneProtocol, buildCloneCommandArgs } from "../helpers/repository";
 
 import { PullRequest } from "./PullRequestActions";
 
@@ -45,6 +45,7 @@ export default function CheckoutPullRequestForm({ pullRequest }: CheckoutPullReq
       }
 
       const execAsync = promisify(exec);
+      const execFileAsync = promisify(execFile);
 
       try {
         if (existsSync(targetDir)) {
@@ -72,17 +73,17 @@ export default function CheckoutPullRequestForm({ pullRequest }: CheckoutPullReq
             style: Toast.Style.Animated,
           });
 
-          const branchOption = ["-b", branchName];
-          const cloneCommand = buildCloneCommand(
-            pullRequest.repository.nameWithOwner,
-            repositoryCloneProtocol as AcceptableCloneProtocol,
-            {
-              gitFlags: branchOption,
-              targetDir: targetDir,
-            },
+          await execFileAsync(
+            "git",
+            buildCloneCommandArgs(
+              pullRequest.repository.nameWithOwner,
+              repositoryCloneProtocol as AcceptableCloneProtocol,
+              {
+                gitFlags: ["-b", branchName],
+                targetDir: targetDir,
+              },
+            ),
           );
-
-          await execAsync(cloneCommand);
 
           await showToast({
             style: Toast.Style.Success,

--- a/extensions/github/src/components/CloneRepositoryForm.tsx
+++ b/extensions/github/src/components/CloneRepositoryForm.tsx
@@ -11,8 +11,13 @@ import { ExtendedRepositoryFieldsFragment } from "../generated/graphql";
 import {
   ACCEPTABLE_CLONE_PROTOCOLS,
   AcceptableCloneProtocol,
-  CLONE_PROTOCOLS_TO_LABELS,
+  AcceptableCloneTool,
+  ACCEPTABLE_CLONE_TOOLS,
   buildCloneCommand,
+  buildGhCloneCommand,
+  CLONE_PROTOCOLS_TO_LABELS,
+  CLONE_TOOLS_TO_LABELS,
+  getGhAvailability,
 } from "../helpers/repository";
 
 type CloneRepositoryFormProps = {
@@ -35,13 +40,15 @@ export default function CloneRepositoryForm({ repository }: CloneRepositoryFormP
     [repository],
   );
 
-  const { itemProps, handleSubmit, setValue } = useForm<{
+  const { itemProps, handleSubmit, setValue, values } = useForm<{
     clonePath: string[];
     branch: string;
     cloneProtocol: AcceptableCloneProtocol;
+    cloneTool: AcceptableCloneTool;
   }>({
     initialValues: {
       cloneProtocol: repositoryCloneProtocol,
+      cloneTool: "git",
     },
     async onSubmit(values) {
       const repoName = repository.name;
@@ -54,12 +61,39 @@ export default function CloneRepositoryForm({ repository }: CloneRepositoryFormP
       });
 
       const branchOption = values.branch ? ["-b", values.branch] : [];
-      const cloneCommand = buildCloneCommand(repository.nameWithOwner, values.cloneProtocol, {
-        gitFlags: branchOption,
-        targetDir: targetDir,
-      });
-
       const execAsync = promisify(exec);
+
+      let cloneCommand: string;
+
+      if (values.cloneTool === "gh") {
+        const ghAvailability = await getGhAvailability();
+
+        if (!ghAvailability.available && ghAvailability.reason === "not-installed") {
+          await showFailureToast(undefined, {
+            title: "GitHub CLI is not installed",
+            message: "Install it with `brew install gh` or visit https://cli.github.com, then try again.",
+          });
+          return;
+        }
+
+        if (!ghAvailability.available && ghAvailability.reason === "not-authenticated") {
+          await showFailureToast(undefined, {
+            title: "GitHub CLI is not authenticated",
+            message: "Run `gh auth login` in your terminal to authenticate, then try again.",
+          });
+          return;
+        }
+
+        cloneCommand = buildGhCloneCommand(repository.nameWithOwner, {
+          gitFlags: branchOption,
+          targetDir: targetDir,
+        });
+      } else {
+        cloneCommand = buildCloneCommand(repository.nameWithOwner, values.cloneProtocol, {
+          gitFlags: branchOption,
+          targetDir: targetDir,
+        });
+      }
 
       try {
         await execAsync(cloneCommand);
@@ -117,6 +151,12 @@ export default function CloneRepositoryForm({ repository }: CloneRepositoryFormP
         </ActionPanel>
       }
     >
+      {/* @ts-expect-error value always satisfies AcceptableCloneTool but TypeScript doesn't know that */}
+      <Form.Dropdown {...itemProps.cloneTool} title="Clone Tool">
+        {ACCEPTABLE_CLONE_TOOLS.map((tool) => (
+          <Form.Dropdown.Item key={tool} value={tool} title={CLONE_TOOLS_TO_LABELS[tool]} />
+        ))}
+      </Form.Dropdown>
       <Form.FilePicker
         {...itemProps.clonePath}
         title="Clone Path"
@@ -128,12 +168,21 @@ export default function CloneRepositoryForm({ repository }: CloneRepositoryFormP
       <Form.Dropdown {...itemProps.branch} title="Branch Name">
         {branches?.map((b) => <Form.Dropdown.Item key={b} value={b} title={b} />)}
       </Form.Dropdown>
-      {/* @ts-expect-error value always satisfies AcceptableCloneProtocol but TypeScript doesn't know that */}
-      <Form.Dropdown {...itemProps.cloneProtocol} title="Repository Clone Protocol" storeValue>
-        {ACCEPTABLE_CLONE_PROTOCOLS.map((protocol) => (
-          <Form.Dropdown.Item key={protocol} value={protocol} title={CLONE_PROTOCOLS_TO_LABELS[protocol]} />
-        ))}
-      </Form.Dropdown>
+      {values.cloneTool === "gh" ? (
+        <Form.Description
+          title="Authentication"
+          text="Cloning uses your existing GitHub CLI (gh) authentication and git protocol configuration. Run `gh auth login` in your terminal if you are not authenticated."
+        />
+      ) : (
+        <>
+          {/* @ts-expect-error value always satisfies AcceptableCloneProtocol but TypeScript doesn't know that */}
+          <Form.Dropdown {...itemProps.cloneProtocol} title="Repository Clone Protocol" storeValue>
+            {ACCEPTABLE_CLONE_PROTOCOLS.map((protocol) => (
+              <Form.Dropdown.Item key={protocol} value={protocol} title={CLONE_PROTOCOLS_TO_LABELS[protocol]} />
+            ))}
+          </Form.Dropdown>
+        </>
+      )}
     </Form>
   );
 }

--- a/extensions/github/src/components/CloneRepositoryForm.tsx
+++ b/extensions/github/src/components/CloneRepositoryForm.tsx
@@ -1,4 +1,4 @@
-import { exec } from "child_process";
+import { exec, execFile } from "child_process";
 import path from "path";
 import { promisify } from "util";
 
@@ -13,8 +13,8 @@ import {
   AcceptableCloneProtocol,
   AcceptableCloneTool,
   ACCEPTABLE_CLONE_TOOLS,
-  buildCloneCommand,
-  buildGhCloneCommand,
+  buildCloneCommandArgs,
+  buildGhCloneCommandArgs,
   CLONE_PROTOCOLS_TO_LABELS,
   CLONE_TOOLS_TO_LABELS,
   getGhAvailability,
@@ -62,41 +62,50 @@ export default function CloneRepositoryForm({ repository }: CloneRepositoryFormP
 
       const branchOption = values.branch ? ["-b", values.branch] : [];
       const execAsync = promisify(exec);
+      const execFileAsync = promisify(execFile);
 
-      let cloneCommand: string;
+      let ghExecutable = "gh";
 
       if (values.cloneTool === "gh") {
         const ghAvailability = await getGhAvailability();
 
-        if (!ghAvailability.available && ghAvailability.reason === "not-installed") {
-          await showFailureToast(undefined, {
-            title: "GitHub CLI is not installed",
-            message: "Install it with `brew install gh` or visit https://cli.github.com, then try again.",
-          });
+        if (!ghAvailability.available) {
+          if (ghAvailability.reason === "not-installed") {
+            await showFailureToast(undefined, {
+              title: "GitHub CLI is not installed",
+              message: "Install it with `brew install gh` or visit https://cli.github.com, then try again.",
+            });
+          } else {
+            await showFailureToast(undefined, {
+              title: "GitHub CLI is not authenticated",
+              message: "Run `gh auth login` in your terminal to authenticate, then try again.",
+            });
+          }
           return;
         }
 
-        if (!ghAvailability.available && ghAvailability.reason === "not-authenticated") {
-          await showFailureToast(undefined, {
-            title: "GitHub CLI is not authenticated",
-            message: "Run `gh auth login` in your terminal to authenticate, then try again.",
-          });
-          return;
-        }
-
-        cloneCommand = buildGhCloneCommand(repository.nameWithOwner, {
-          gitFlags: branchOption,
-          targetDir: targetDir,
-        });
-      } else {
-        cloneCommand = buildCloneCommand(repository.nameWithOwner, values.cloneProtocol, {
-          gitFlags: branchOption,
-          targetDir: targetDir,
-        });
+        ghExecutable = ghAvailability.executable;
       }
 
       try {
-        await execAsync(cloneCommand);
+        if (values.cloneTool === "gh") {
+          await execFileAsync(
+            ghExecutable,
+            buildGhCloneCommandArgs(repository.nameWithOwner, {
+              gitFlags: branchOption,
+              targetDir: targetDir,
+            }),
+          );
+        } else {
+          await execFileAsync(
+            "git",
+            buildCloneCommandArgs(repository.nameWithOwner, values.cloneProtocol, {
+              gitFlags: branchOption,
+              targetDir: targetDir,
+            }),
+          );
+        }
+
         await showToast({
           style: Toast.Style.Success,
           title: "Repository cloned successfully",

--- a/extensions/github/src/helpers/repository.ts
+++ b/extensions/github/src/helpers/repository.ts
@@ -1,4 +1,4 @@
-import { exec, execSync } from "node:child_process";
+import { execFile, execFileSync, execSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { promisify } from "node:util";
@@ -68,10 +68,10 @@ export async function cloneAndOpen(repository: ExtendedRepositoryFieldsFragment)
   });
 
   if (!existsSync(clonePath.replace("~", homedir()))) {
-    const cloneCommand = buildCloneCommand(repository.nameWithOwner, repositoryCloneProtocol);
-
     try {
-      execSync(cloneCommand, { cwd: baseClonePath });
+      execFileSync("git", buildCloneCommandArgs(repository.nameWithOwner, repositoryCloneProtocol), {
+        cwd: baseClonePath,
+      });
     } catch (error) {
       toast.style = Toast.Style.Failure;
       toast.title = "Error while cloning the repository";
@@ -178,6 +178,34 @@ export const buildCloneCommand = (
   return cloneCmd;
 };
 
+/**
+ * Build the argument list for a `git clone` execution.
+ *
+ * The command and its arguments are returned separately so they can be spawned
+ * without a shell, preventing user-controlled values (branch, target directory)
+ * from being interpreted as shell syntax.
+ *
+ * @param repoNameWithOwner {string} Repository name with owner.
+ * @param cloneProtocol {AcceptableCloneProtocol} Clone protocol
+ * @param options {Partial<AdditionalCloneFormatOptions>} Optional target directory and git flags.
+ * @returns {string[]} Arguments for `git clone` (without the executable).
+ */
+export const buildCloneCommandArgs = (
+  repoNameWithOwner: string,
+  cloneProtocol: AcceptableCloneProtocol,
+  options?: Partial<AdditionalCloneFormatOptions>,
+): string[] => {
+  const gitFlags = options?.gitFlags ?? [];
+  const targetDir = options?.targetDir ?? "";
+
+  const cloneArgs = ["clone", ...gitFlags, formatRepositoryUrl(repoNameWithOwner, cloneProtocol)];
+  if (targetDir) {
+    cloneArgs.push(targetDir);
+  }
+
+  return cloneArgs;
+};
+
 type AdditionalCloneFormatOptions = {
   /**
    * Target directory for the cloned repository.
@@ -194,43 +222,116 @@ type AdditionalCloneFormatOptions = {
 };
 
 /**
- * Format the clone command using the GitHub CLI.
+ * Build the argument list for a `gh repo clone` execution.
  *
  * The target directory and git flags (e.g. `-b <branch>`) are preserved and
  * forwarded to `git clone`, while authentication, protocol and any other
  * configuration come from the user's existing `gh` setup.
  *
+ * The command and its arguments are returned separately so they can be spawned
+ * without a shell, preventing user-controlled values (branch, target directory)
+ * from being interpreted as shell syntax.
+ *
  * @param repoNameWithOwner {string} Repository name with owner.
  * @param options {Partial<AdditionalCloneFormatOptions>} Optional target directory and git flags.
- * @returns {string} Executable clone command
+ * @returns {string[]} Arguments for `gh repo clone` (without the executable).
  */
-export const buildGhCloneCommand = (
+export const buildGhCloneCommandArgs = (
   repoNameWithOwner: string,
   options?: Partial<AdditionalCloneFormatOptions>,
-): string => {
-  const gitFlags = options?.gitFlags?.join(" ") ?? "";
-  const targetDir = (options?.targetDir ?? "").replace(/"/g, '\\"');
+): string[] => {
+  const gitFlags = options?.gitFlags ?? [];
+  const targetDir = options?.targetDir ?? "";
 
-  let cloneCmd = `gh repo clone ${repoNameWithOwner}`;
-
+  const cloneArgs = ["repo", "clone", repoNameWithOwner];
   if (targetDir) {
-    cloneCmd += ` "${targetDir}"`;
+    cloneArgs.push(targetDir);
+  }
+  if (gitFlags.length > 0) {
+    cloneArgs.push("--", ...gitFlags);
   }
 
-  if (gitFlags) {
-    cloneCmd += ` -- ${gitFlags}`;
-  }
-
-  return cloneCmd;
+  return cloneArgs;
 };
 
 /**
  * Result of checking the availability of the GitHub CLI on the user's machine.
  */
 export type GhAvailability =
-  | { available: true }
-  | { available: false; reason: "not-installed" }
-  | { available: false; reason: "not-authenticated" };
+  | { available: true; executable: string }
+  | { available: false; reason: "not-installed" | "not-authenticated" };
+
+const execFileAsync = promisify(execFile);
+
+const GH_EXECUTABLE_SUFFIXES = ["/gh", "\\gh", "/gh.exe", "\\gh.exe"];
+
+// Patterns matching terminal escape sequences (e.g. iTerm shell integration).
+// Built from character codes so no control characters appear in the source.
+const ESC = String.fromCharCode(27);
+const BEL = String.fromCharCode(7);
+const TERMINAL_OSC_PATTERN = new RegExp(`${ESC}][^${BEL}${ESC}]*(?:${BEL}|${ESC}\\\\)`, "g");
+const TERMINAL_CSI_PATTERN = new RegExp(`${ESC}\\[[0-9;?]*[A-Za-z]`, "g");
+const TERMINAL_CHARSET_PATTERN = new RegExp(`${ESC}\\([0-9A-Za-z]`, "g");
+
+/**
+ * Extract the path to the `gh` executable from a shell `command -v` invocation.
+ *
+ * Terminal escape sequences (e.g. iTerm shell integration) and shell-declared
+ * aliases/functions are filtered out so only a real filesystem path is returned.
+ *
+ * @param output {string} Raw stdout of a `command -v gh` invocation.
+ * @returns {string | undefined} The resolved `gh` path, if any.
+ */
+function extractGhExecutablePath(output: string): string | undefined {
+  const sanitized = output
+    .replace(TERMINAL_OSC_PATTERN, "")
+    .replace(TERMINAL_CSI_PATTERN, "")
+    .replace(TERMINAL_CHARSET_PATTERN, "");
+
+  for (const rawLine of sanitized.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || /^(alias|builtin|function)\s/i.test(line)) {
+      continue;
+    }
+    if (GH_EXECUTABLE_SUFFIXES.some((suffix) => line.endsWith(suffix))) {
+      return line;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Resolve the path to the `gh` executable.
+ *
+ * Raycast's inherited `PATH` omits directories such as Homebrew's
+ * `/opt/homebrew/bin`, so the executable is resolved through the user's shell
+ * (sourcing their profile and rc files) before falling back to a plain `PATH`
+ * lookup.
+ *
+ * @returns {Promise<string>} Absolute path to `gh`, or `"gh"` to rely on `PATH`.
+ */
+async function resolveGhExecutable(): Promise<string> {
+  const shell = process.env.SHELL;
+  if (shell) {
+    for (const flag of ["-l", "-i"]) {
+      try {
+        const { stdout } = await execFileAsync(shell, [flag, "-c", "command -v gh"], {
+          timeout: 5000,
+          maxBuffer: 1024 * 1024,
+        });
+        const resolved = extractGhExecutablePath(stdout.toString());
+        if (resolved) {
+          return resolved;
+        }
+      } catch {
+        // Fall through to the next resolution strategy.
+      }
+    }
+  }
+
+  return "gh";
+}
 
 /**
  * Check whether the GitHub CLI is installed and authenticated on the user's machine.
@@ -238,21 +339,21 @@ export type GhAvailability =
  * @returns {Promise<GhAvailability>} The availability status of the GitHub CLI.
  */
 export async function getGhAvailability(): Promise<GhAvailability> {
-  const execAsync = promisify(exec);
+  const executable = await resolveGhExecutable();
 
   try {
-    await execAsync("gh --version");
+    await execFileAsync(executable, ["--version"]);
   } catch {
     return { available: false, reason: "not-installed" };
   }
 
   try {
-    await execAsync("gh auth status");
+    await execFileAsync(executable, ["auth", "status"]);
   } catch {
     return { available: false, reason: "not-authenticated" };
   }
 
-  return { available: true };
+  return { available: true, executable };
 }
 
 /**

--- a/extensions/github/src/helpers/repository.ts
+++ b/extensions/github/src/helpers/repository.ts
@@ -1,6 +1,7 @@
-import { execSync } from "node:child_process";
+import { exec, execSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
+import { promisify } from "node:util";
 
 import { Color, getPreferenceValues, showToast, Toast } from "@raycast/api";
 import { useCachedState } from "@raycast/utils";
@@ -146,6 +147,13 @@ export const CLONE_PROTOCOLS_TO_LABELS = {
   ssh: "SSH",
 } as const satisfies Record<AcceptableCloneProtocol, string>;
 
+export const ACCEPTABLE_CLONE_TOOLS = ["git", "gh"] as const;
+export type AcceptableCloneTool = (typeof ACCEPTABLE_CLONE_TOOLS)[number];
+export const CLONE_TOOLS_TO_LABELS = {
+  git: "Git",
+  gh: "GitHub CLI",
+} as const satisfies Record<AcceptableCloneTool, string>;
+
 /**
  * Format the clone command based on specified protocol.
  * @param repoNameWithOwner {string} Repository name with owner.
@@ -184,6 +192,68 @@ type AdditionalCloneFormatOptions = {
    */
   gitFlags: string[];
 };
+
+/**
+ * Format the clone command using the GitHub CLI.
+ *
+ * The target directory and git flags (e.g. `-b <branch>`) are preserved and
+ * forwarded to `git clone`, while authentication, protocol and any other
+ * configuration come from the user's existing `gh` setup.
+ *
+ * @param repoNameWithOwner {string} Repository name with owner.
+ * @param options {Partial<AdditionalCloneFormatOptions>} Optional target directory and git flags.
+ * @returns {string} Executable clone command
+ */
+export const buildGhCloneCommand = (
+  repoNameWithOwner: string,
+  options?: Partial<AdditionalCloneFormatOptions>,
+): string => {
+  const gitFlags = options?.gitFlags?.join(" ") ?? "";
+  const targetDir = (options?.targetDir ?? "").replace(/"/g, '\\"');
+
+  let cloneCmd = `gh repo clone ${repoNameWithOwner}`;
+
+  if (targetDir) {
+    cloneCmd += ` "${targetDir}"`;
+  }
+
+  if (gitFlags) {
+    cloneCmd += ` -- ${gitFlags}`;
+  }
+
+  return cloneCmd;
+};
+
+/**
+ * Result of checking the availability of the GitHub CLI on the user's machine.
+ */
+export type GhAvailability =
+  | { available: true }
+  | { available: false; reason: "not-installed" }
+  | { available: false; reason: "not-authenticated" };
+
+/**
+ * Check whether the GitHub CLI is installed and authenticated on the user's machine.
+ *
+ * @returns {Promise<GhAvailability>} The availability status of the GitHub CLI.
+ */
+export async function getGhAvailability(): Promise<GhAvailability> {
+  const execAsync = promisify(exec);
+
+  try {
+    await execAsync("gh --version");
+  } catch {
+    return { available: false, reason: "not-installed" };
+  }
+
+  try {
+    await execAsync("gh auth status");
+  } catch {
+    return { available: false, reason: "not-authenticated" };
+  }
+
+  return { available: true };
+}
 
 /**
  * Format the repository URL based on specified protocol.


### PR DESCRIPTION
Fixes #29787 

## Description

This PR adds support for cloning repositories using **GitHub CLI** (`gh repo clone`) in the existing **Clone with Options** flow of the GitHub extension.

Previously, repositories could only be cloned using `git clone` (HTTPS/SSH). With this change, users can now choose between **Git** and **GitHub CLI** as their clone tool.

### Highlights

- Added a **Clone Tool** dropdown (Git / GitHub CLI) to the Clone with Options form.
- Preserved the existing Git clone flow as the default behavior.
- Added support for cloning via:

  ```bash
  gh repo clone OWNER/REPO DIRECTORY
  ```
- Preserved target directory and branch selection by forwarding the selected branch via `-- -b <branch>`.
- Added actionable guidance when GitHub CLI is unavailable:
  - Suggests installing `gh` if it is not installed.
  - Suggests running `gh auth login` if the user is not authenticated.

This improves the experience for developers who already use GitHub CLI by reusing their existing authentication and Git configuration without changing the current Git workflow.

### Testing

- ✅ `npx tsc --noEmit`
- ✅ `npx ray lint` (0 errors)
- ✅ `npx ray build -e dist`
- ✅ Manually verified:
  - Existing Git clone flow remains unchanged.
  - GitHub CLI clone flow works as expected.
  - Branch forwarding works correctly.
  - Guidance is shown when `gh` is missing or unauthenticated.

## Screencast

<img width="741" height="462" alt="Screenshot 2026-08-05 at 11 58 05 PM" src="https://github.com/user-attachments/assets/6f47369f-60ea-4545-9d02-4cbc092e7eff" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our metadata tool