### PR TITLE
Add Touch ID authentication to Flush DNS

### DIFF
--- a/extensions/flush-dns/CHANGELOG.md
+++ b/extensions/flush-dns/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Flush DNS Changelog
 
-## [Touch ID Authentication] - {PR_MERGE_DATE}
+## [Touch ID Authentication] - 2026-08-12
 
 - Added Touch ID authentication for macOS DNS flushing while retaining the administrator password fallback ([#13104](https://github.com/raycast/extensions/issues/13104)).
 

--- a/extensions/flush-dns/CHANGELOG.md
+++ b/extensions/flush-dns/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Flush DNS Changelog
 
+## [Touch ID Authentication] - {PR_MERGE_DATE}
+
+- Added Touch ID authentication for macOS DNS flushing while retaining the administrator password fallback ([#13104](https://github.com/raycast/extensions/issues/13104)).
+
 ## [macOS 26+ Support] - 2026-01-04
 
 - Added support for macOS Tahoe (26) and later versions.

--- a/extensions/flush-dns/README.md
+++ b/extensions/flush-dns/README.md
@@ -3,3 +3,37 @@
 Flush the DNS cache
 
 Works for macOS 10.6+ and Windows
+
+## macOS Cache Coverage
+
+On modern macOS, Flush DNS clears both OS-level host-resolution caches:
+
+- `/usr/bin/dscacheutil -flushcache` clears the Directory Service/libinfo cache.
+- `/usr/bin/killall -HUP mDNSResponder` purges the separate `mDNSResponder` DNS-reply cache.
+
+Browsers and other applications may maintain additional caches that this extension does not clear.
+
+## Authenticate with Touch ID on macOS
+
+Flushing the macOS caches requires administrator privileges. Flush DNS uses Touch ID when `sudo` is configured with the `pam_tid.so` PAM module. This configuration applies to `sudo` globally, not only to Raycast.
+
+### macOS Sonoma (14) and Later
+
+1. Copy Apple's local sudo template:
+   ```bash
+   sudo cp /etc/pam.d/sudo_local.template /etc/pam.d/sudo_local
+   ```
+2. Uncomment this line in `/etc/pam.d/sudo_local`:
+   ```text
+   auth       sufficient     pam_tid.so
+   ```
+
+### macOS Ventura (13) and Earlier
+
+Add this line to the `auth` entries in `/etc/pam.d/sudo`:
+
+```text
+auth       sufficient     pam_tid.so
+```
+
+macOS updates may overwrite `/etc/pam.d/sudo`. If Touch ID is unavailable or not enabled for `sudo`, Flush DNS retains the existing administrator password prompt. Cancelling or failing a Touch ID attempt stops the flush instead of opening a second password prompt.

--- a/extensions/flush-dns/package.json
+++ b/extensions/flush-dns/package.json
@@ -38,7 +38,8 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
-    "publish": "npx @raycast/api@latest publish"
+    "publish": "npx @raycast/api@latest publish",
+    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test tests/*.test.ts"
   },
   "version": "1.0.0",
   "platforms": [

--- a/extensions/flush-dns/src/index.ts
+++ b/extensions/flush-dns/src/index.ts
@@ -1,36 +1,10 @@
 import { confirmAlert, showHUD } from "@raycast/api";
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { platform } from "node:os";
+import { getMacOSCommandsForVersion } from "./macOSCommands";
+import { runWithPrivileges, type PrivilegedCommand } from "./sudoSupport";
 
-type ShellType = string | undefined;
-
-interface CommandSet {
-  commands: Record<string, string>;
-  shell: ShellType;
-}
-
-const OS_COMMANDS = {
-  darwin: {
-    commands: {
-      dscacheutil: "/usr/bin/dscacheutil -flushcache",
-      mDNSResponder: "/usr/bin/killall -HUP mDNSResponder",
-      mdnsflushcache: "/usr/bin/discoveryutil mdnsflushcache",
-    },
-    shell: "/bin/bash",
-  },
-  win32: {
-    commands: {
-      ipconfig: "ipconfig /flushdns",
-    },
-    shell: undefined, // Uses cmd.exe by default
-  },
-} as const satisfies Record<string, CommandSet>;
-
-type SupportedPlatform = "darwin" | "win32";
-
-interface Win32Commands {
-  ipconfig: string;
-}
+const WINDOWS_COMMAND = "ipconfig /flushdns";
 
 export default async function main() {
   const osPlatform = platform();
@@ -40,88 +14,50 @@ export default async function main() {
     return;
   }
 
-  const osCommandSet = OS_COMMANDS[osPlatform as SupportedPlatform];
-
-  let command: string;
-  let shell: ShellType;
-
-  switch (osPlatform) {
-    case "darwin": {
-      const macResult = await getMacOSCommands(osCommandSet);
-      if (!macResult) return;
-
-      command = macResult.command;
-      shell = macResult.shell;
-      break;
-    }
-
-    case "win32": {
-      const { ipconfig } = osCommandSet.commands as Win32Commands;
-      command = ipconfig;
-      shell = osCommandSet.shell;
-      break;
-    }
-
-    default:
-      await showHUD("🚫 Unsupported OS");
-      return;
-  }
-
-  console.log(`🚀 Executing DNS flush command: ${command} in shell: ${shell}`);
-
   try {
-    execSync(command, { shell, stdio: "ignore" });
+    if (osPlatform === "darwin") {
+      const commands = await getMacOSCommands();
+      if (!commands) return;
+
+      const commandSummary = commands.map((command) => [command.executable, ...command.args].join(" ")).join("; ");
+      console.log(`🚀 Executing privileged DNS flush commands: ${commandSummary}`);
+      await runWithPrivileges(commands);
+    } else {
+      console.log(`🚀 Executing DNS flush command: ${WINDOWS_COMMAND}`);
+      execSync(WINDOWS_COMMAND, { stdio: "ignore" });
+    }
+
     await showHUD("✅ DNS Cache Flushed Successfully");
   } catch (error) {
     await handleExecutionError(error, osPlatform);
   }
 }
 
-async function getMacOSCommands(osCommandSet: CommandSet): Promise<{ command: string; shell: ShellType } | null> {
+async function getMacOSCommands(): Promise<readonly PrivilegedCommand[] | null> {
   try {
-    const osVersion = execSync("sw_vers -productVersion").toString().trim();
+    const osVersion = execFileSync("/usr/bin/sw_vers", ["-productVersion"]).toString().trim();
+    const commands = getMacOSCommandsForVersion(osVersion);
 
-    const [major] = osVersion.split(".").map(Number);
-
-    let runCommands: string[];
-
-    if (Number.isNaN(major)) {
-      throw new Error(`Unparsable macOS version: ${osVersion}`);
+    if (commands) {
+      return commands;
     }
 
-    // macOS 11+ (Big Sur → future)
-    if (major >= 11) {
-      runCommands = ["dscacheutil", "mDNSResponder"];
-    }
-    // macOS 10.4 - 10.15.7
-    else if (major === 10) {
-      const minor = Number(osVersion.split(".")[1]);
+    const confirmed = await confirmAlert({
+      title: `⚠️ OS Version ${osVersion} Not Tested`,
+      message: "Attempt to flush DNS cache anyway?",
+      primaryAction: { title: "Flush DNS" },
+    });
 
-      if (minor >= 10) {
-        runCommands = ["mDNSResponder"];
-      } else if (minor === 6) {
-        runCommands = ["dscacheutil"];
-      } else {
-        runCommands = ["mdnsflushcache"];
-      }
-    } else {
-      const confirmed = await confirmAlert({
-        title: `⚠️ OS Version ${osVersion} Not Tested`,
-        message: "Attempt to flush DNS cache anyway?",
-        primaryAction: { title: "Flush DNS" },
-      });
+    if (!confirmed) return null;
 
-      if (!confirmed) return null;
-      runCommands = ["dscacheutil", "mDNSResponder"];
+    const fallbackCommands = getMacOSCommandsForVersion("11");
+    if (!fallbackCommands) {
+      throw new Error("Unable to select modern macOS DNS flush commands");
     }
 
-    const commandList = runCommands.map((key) => osCommandSet.commands[key]).join("; ");
-    return {
-      command: `osascript -e 'do shell script "${commandList}" with administrator privileges'`,
-      shell: osCommandSet.shell,
-    };
-  } catch (e) {
-    console.error("❌ Error determining macOS version:", e);
+    return fallbackCommands;
+  } catch (error) {
+    console.error("❌ Error determining macOS version:", error);
     await showHUD("Failed to determine macOS version");
     return null;
   }
@@ -131,7 +67,7 @@ async function handleExecutionError(error: unknown, os: string) {
   let errorMessage = "⚠️ Error flushing DNS cache";
 
   if (typeof error === "object" && error !== null && "stderr" in error) {
-    const stderr = (error as { stderr?: Buffer }).stderr?.toString() || "";
+    const stderr = (error as { stderr?: Buffer | string }).stderr?.toString() || "";
     if (stderr) {
       console.error(".Stderr:", stderr);
       if (os === "win32" && stderr.includes("The requested operation requires elevation")) {

--- a/extensions/flush-dns/src/macOSCommands.ts
+++ b/extensions/flush-dns/src/macOSCommands.ts
@@ -1,0 +1,35 @@
+import type { PrivilegedCommand } from "./sudoSupport";
+
+const MACOS_COMMANDS = {
+  dscacheutil: { executable: "/usr/bin/dscacheutil", args: ["-flushcache"] },
+  mDNSResponder: { executable: "/usr/bin/killall", args: ["-HUP", "mDNSResponder"] },
+  mdnsflushcache: { executable: "/usr/bin/discoveryutil", args: ["mdnsflushcache"] },
+} as const satisfies Record<string, PrivilegedCommand>;
+
+export function getMacOSCommandsForVersion(osVersion: string): readonly PrivilegedCommand[] | null {
+  const [major] = osVersion.split(".").map(Number);
+
+  if (Number.isNaN(major)) {
+    throw new Error(`Unparsable macOS version: ${osVersion}`);
+  }
+
+  if (major >= 11) {
+    return [MACOS_COMMANDS.dscacheutil, MACOS_COMMANDS.mDNSResponder];
+  }
+
+  if (major === 10) {
+    const minor = Number(osVersion.split(".")[1]);
+
+    if (minor >= 10) {
+      return [MACOS_COMMANDS.mDNSResponder];
+    }
+
+    if (minor === 6) {
+      return [MACOS_COMMANDS.dscacheutil];
+    }
+
+    return [MACOS_COMMANDS.mdnsflushcache];
+  }
+
+  return null;
+}

--- a/extensions/flush-dns/src/sudoSupport.ts
+++ b/extensions/flush-dns/src/sudoSupport.ts
@@ -1,0 +1,60 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { promisify } from "node:util";
+
+export interface PrivilegedCommand {
+  executable: string;
+  args: readonly string[];
+}
+
+interface PrivilegeRunnerDependencies {
+  exists(path: string): boolean;
+  read(path: string): string;
+  execute(executable: string, args: readonly string[], timeout?: number): Promise<void>;
+}
+
+const TOUCH_ID_PATTERN = /^auth\s+sufficient\s+pam_tid\.so$/m;
+const SUDO_LOCAL_PATH = "/etc/pam.d/sudo_local";
+const SUDO_PATH = "/etc/pam.d/sudo";
+const execFile = promisify(execFileCallback);
+const APPLE_SCRIPT = `on run argv
+  do shell script item 1 of argv with prompt "Flush DNS requires administrator privileges" with administrator privileges
+end run`;
+
+function quoteForShell(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+export function createPrivilegeRunner(dependencies: PrivilegeRunnerDependencies) {
+  return async function runWithPrivileges(commands: readonly PrivilegedCommand[]): Promise<void> {
+    const pamPath = dependencies.exists(SUDO_LOCAL_PATH) ? SUDO_LOCAL_PATH : SUDO_PATH;
+    let touchIdActive = false;
+
+    try {
+      touchIdActive = TOUCH_ID_PATTERN.test(dependencies.read(pamPath));
+    } catch {
+      // Fall back to the existing administrator password prompt when PAM configuration cannot be read.
+    }
+
+    if (!touchIdActive) {
+      const commandList = commands
+        .map((command) => [command.executable, ...command.args].map(quoteForShell).join(" "))
+        .join("; ");
+
+      await dependencies.execute("/usr/bin/osascript", ["-e", APPLE_SCRIPT, "--", commandList], 60_000);
+      return;
+    }
+
+    for (const command of commands) {
+      await dependencies.execute("/usr/bin/sudo", [command.executable, ...command.args]);
+    }
+  };
+}
+
+export const runWithPrivileges = createPrivilegeRunner({
+  exists: existsSync,
+  read: (path) => readFileSync(path, "utf8"),
+  execute: async (executable, args, timeout) => {
+    await execFile(executable, [...args], timeout === undefined ? undefined : { timeout });
+  },
+});

--- a/extensions/flush-dns/tests/macOSCommands.test.ts
+++ b/extensions/flush-dns/tests/macOSCommands.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { getMacOSCommandsForVersion } from "../src/macOSCommands.ts";
+
+describe("getMacOSCommandsForVersion", () => {
+  test("selects both OS-level cache commands on modern macOS", () => {
+    assert.deepEqual(getMacOSCommandsForVersion("27.0"), [
+      { executable: "/usr/bin/dscacheutil", args: ["-flushcache"] },
+      { executable: "/usr/bin/killall", args: ["-HUP", "mDNSResponder"] },
+    ]);
+  });
+
+  const legacyCases = [
+    ["10.15.7", [{ executable: "/usr/bin/killall", args: ["-HUP", "mDNSResponder"] }]],
+    ["10.6.8", [{ executable: "/usr/bin/dscacheutil", args: ["-flushcache"] }]],
+    ["10.9.5", [{ executable: "/usr/bin/discoveryutil", args: ["mdnsflushcache"] }]],
+  ] as const;
+
+  for (const [version, expected] of legacyCases) {
+    test(`preserves the legacy command mapping for macOS ${version}`, () => {
+      assert.deepEqual(getMacOSCommandsForVersion(version), expected);
+    });
+  }
+
+  test("returns null for an untested major version", () => {
+    assert.equal(getMacOSCommandsForVersion("9.5"), null);
+  });
+
+  test("rejects an unparsable version", () => {
+    assert.throws(() => getMacOSCommandsForVersion("unknown"), /Unparsable macOS version: unknown/);
+  });
+});

--- a/extensions/flush-dns/tests/sudoSupport.test.ts
+++ b/extensions/flush-dns/tests/sudoSupport.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { createPrivilegeRunner, type PrivilegedCommand } from "../src/sudoSupport.ts";
+
+const COMMANDS: readonly PrivilegedCommand[] = [
+  { executable: "/usr/bin/dscacheutil", args: ["-flushcache"] },
+  { executable: "/usr/bin/killall", args: ["-HUP", "mDNSResponder"] },
+];
+
+describe("createPrivilegeRunner", () => {
+  test("runs every command in order through sudo when Touch ID is active", async () => {
+    const calls: Array<{ executable: string; args: readonly string[]; timeout?: number }> = [];
+    const runWithPrivileges = createPrivilegeRunner({
+      exists: () => true,
+      read: () => "auth       sufficient     pam_tid.so\n",
+      execute: async (executable, args, timeout) => {
+        calls.push({ executable, args, timeout });
+      },
+    });
+
+    await runWithPrivileges(COMMANDS);
+
+    assert.deepEqual(calls, [
+      {
+        executable: "/usr/bin/sudo",
+        args: ["/usr/bin/dscacheutil", "-flushcache"],
+        timeout: undefined,
+      },
+      {
+        executable: "/usr/bin/sudo",
+        args: ["/usr/bin/killall", "-HUP", "mDNSResponder"],
+        timeout: undefined,
+      },
+    ]);
+  });
+
+  test("uses one AppleScript password prompt when the Touch ID rule is commented out", async () => {
+    const calls: Array<{ executable: string; args: readonly string[]; timeout?: number }> = [];
+    const runWithPrivileges = createPrivilegeRunner({
+      exists: () => true,
+      read: () => "# auth       sufficient     pam_tid.so\n",
+      execute: async (executable, args, timeout) => {
+        calls.push({ executable, args, timeout });
+      },
+    });
+
+    await runWithPrivileges(COMMANDS);
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].executable, "/usr/bin/osascript");
+    assert.equal(calls[0].timeout, 60_000);
+    assert.equal(calls[0].args[0], "-e");
+    assert.match(calls[0].args[1], /do shell script item 1 of argv/);
+    assert.deepEqual(calls[0].args.slice(2), [
+      "--",
+      "'/usr/bin/dscacheutil' '-flushcache'; '/usr/bin/killall' '-HUP' 'mDNSResponder'",
+    ]);
+  });
+
+  test("reads the standard sudo PAM file when sudo_local is missing", async () => {
+    const readPaths: string[] = [];
+    const calls: Array<{ executable: string; args: readonly string[] }> = [];
+    const runWithPrivileges = createPrivilegeRunner({
+      exists: () => false,
+      read: (path) => {
+        readPaths.push(path);
+        return "auth sufficient pam_tid.so\n";
+      },
+      execute: async (executable, args) => {
+        calls.push({ executable, args });
+      },
+    });
+
+    await runWithPrivileges(COMMANDS);
+
+    assert.deepEqual(readPaths, ["/etc/pam.d/sudo"]);
+    assert.equal(calls[0].executable, "/usr/bin/sudo");
+  });
+
+  test("uses the password fallback when the PAM configuration cannot be read", async () => {
+    const calls: Array<{ executable: string; args: readonly string[] }> = [];
+    const runWithPrivileges = createPrivilegeRunner({
+      exists: () => true,
+      read: () => {
+        throw new Error("permission denied");
+      },
+      execute: async (executable, args) => {
+        calls.push({ executable, args });
+      },
+    });
+
+    await runWithPrivileges(COMMANDS);
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].executable, "/usr/bin/osascript");
+  });
+
+  test("does not open the password fallback after sudo authentication fails", async () => {
+    const calls: string[] = [];
+    const authenticationError = new Error("Touch ID cancelled");
+    const runWithPrivileges = createPrivilegeRunner({
+      exists: () => true,
+      read: () => "auth sufficient pam_tid.so\n",
+      execute: async (executable) => {
+        calls.push(executable);
+        throw authenticationError;
+      },
+    });
+
+    await assert.rejects(runWithPrivileges(COMMANDS), authenticationError);
+    assert.deepEqual(calls, ["/usr/bin/sudo"]);
+  });
+});


### PR DESCRIPTION
## Description

Adds optional Touch ID authorization for privileged DNS flushing on macOS.

- Detects an active `pam_tid.so` rule in `/etc/pam.d/sudo_local`, falling back to `/etc/pam.d/sudo`.
- Runs the selected cache commands sequentially through `/usr/bin/sudo` using exact executable and argument arrays when Touch ID is configured.
- Stops after Touch ID cancellation or a `sudo` failure without opening a surprise password prompt.
- Retains the existing one-dialog AppleScript administrator-password fallback when Touch ID is unavailable, with a 60-second timeout.
- Preserves the existing Windows and legacy macOS command selection while documenting the separate Directory Service and `mDNSResponder` cache layers.

Closes #13104.

## Screencast

Not included. Manually verified in Raycast Beta on macOS 27: the local development command presented Touch ID and completed both modern macOS cache commands.

## Validation

- `npm test` — 11 tests passed
- `npm run lint`
- `npm run build`
- `git diff --check`
- Raycast Beta Touch ID happy-path test

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
