### PR TITLE
Update YouTrack extension: add live search and autocomplete

### DIFF
--- a/extensions/youtrack/CHANGELOG.md
+++ b/extensions/youtrack/CHANGELOG.md
@@ -1,6 +1,6 @@
 # YouTrack Changelog
 
-## [Update] - {PR_MERGE_DATE}
+## [Update] - 2026-08-14
 
 - Add server-side issue search with YouTrack query suggestions
 

--- a/extensions/youtrack/CHANGELOG.md
+++ b/extensions/youtrack/CHANGELOG.md
@@ -1,5 +1,9 @@
 # YouTrack Changelog
 
+## [Update] - {PR_MERGE_DATE}
+
+- Add server-side issue search with YouTrack query suggestions
+
 ## [Update] - 2025-08-08
 
 - Bugfixes and improvements

--- a/extensions/youtrack/package-lock.json
+++ b/extensions/youtrack/package-lock.json
@@ -8,6 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.101.1",
+        "@raycast/utils": "^2.2.0",
         "beautiful-react-hooks": "^5.0.3",
         "lodash": "^4.17.21",
         "youtrack-client": "^0.5.3"
@@ -15,7 +16,6 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",
         "@eslint/js": "^9.31.0",
-        "@raycast/utils": "^2.2.0",
         "@types/lodash": "^4.17.20",
         "@types/node": "22.13.14",
         "@types/react": "19.1.8",
@@ -1226,7 +1226,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.0.tgz",
       "integrity": "sha512-K7ffrYh9bktLqrXVP/+QjcxwFoibJ9ADaTyoHEJMON7Qqq05/uJC4hw+q0Gr15pHi8X0w6kTzv3r2cBe8OEWMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -1649,7 +1648,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.14.tgz",
       "integrity": "sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -1710,7 +1708,6 @@
       "integrity": "sha512-kVIaQE9vrN9RLCQMQ3iyRlVJpTiDUY6woHGb30JDkfJErqrQEmtdWH3gV0PBAfGZgQXoqzXOO0T3K6ioApbbAA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.37.0",
         "@typescript-eslint/types": "8.37.0",
@@ -2080,7 +2077,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2103,6 +2099,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -2372,7 +2369,8 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -2637,6 +2635,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -2655,6 +2654,7 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
       "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2813,6 +2813,7 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2821,7 +2822,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3114,7 +3114,6 @@
       "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3176,7 +3175,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -3720,6 +3718,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -3750,6 +3749,7 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -4037,6 +4037,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -4821,6 +4822,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4830,6 +4832,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -5230,7 +5233,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5271,6 +5273,7 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -5341,6 +5344,7 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
       "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cookie": "^1.0.1",
         "set-cookie-parser": "^2.6.0"
@@ -5605,7 +5609,8 @@
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "7.7.1",
@@ -5623,7 +5628,8 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -6086,7 +6092,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6167,7 +6172,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6278,7 +6284,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6352,7 +6357,6 @@
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6953,7 +6957,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6967,7 +6970,6 @@
       "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.6",

--- a/extensions/youtrack/package.json
+++ b/extensions/youtrack/package.json
@@ -271,5 +271,8 @@
     "test": "vitest",
     "publish": "npx @raycast/api@latest publish"
   },
-  "packageManager": "pnpm@8.9.2+sha512.b9d35fe91b2a5854dadc43034a3e7b2e675fa4b56e20e8e09ef078fa553c18f8aed44051e7b36e8b8dd435f97eb0c44c4ff3b44fc7c6fa7d21e1fac17bbe661e"
+  "packageManager": "pnpm@8.9.2+sha512.b9d35fe91b2a5854dadc43034a3e7b2e675fa4b56e20e8e09ef078fa553c18f8aed44051e7b36e8b8dd435f97eb0c44c4ff3b44fc7c6fa7d21e1fac17bbe661e",
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/youtrack/package.json
+++ b/extensions/youtrack/package.json
@@ -239,6 +239,7 @@
   ],
   "dependencies": {
     "@raycast/api": "^1.101.1",
+    "@raycast/utils": "^2.2.0",
     "beautiful-react-hooks": "^5.0.3",
     "lodash": "^4.17.21",
     "youtrack-client": "^0.5.3"
@@ -246,7 +247,6 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.31.0",
-    "@raycast/utils": "^2.2.0",
     "@types/lodash": "^4.17.20",
     "@types/node": "22.13.14",
     "@types/react": "19.1.8",

--- a/extensions/youtrack/src/api/youtrack-api-fields.ts
+++ b/extensions/youtrack/src/api/youtrack-api-fields.ts
@@ -6,6 +6,7 @@ import type {
   Project,
   ProjectCustomField,
   Schema,
+  SearchSuggestions,
   StateBundleElement,
   Tag,
   User,
@@ -81,6 +82,12 @@ export const issueWorkItemFields = withDefaultFields([
 export const commandListFields = withDefaultFields([
   { commands: ["error", "description"] },
 ]) satisfies Schema<CommandList>;
+
+export const searchSuggestionsFields = withDefaultFields([
+  {
+    suggestions: ["completionStart", "completionEnd", "description", "group", "option", "prefix", "suffix"],
+  },
+]) satisfies Schema<SearchSuggestions>;
 
 export const commentFields = withDefaultFields([
   "text",

--- a/extensions/youtrack/src/api/youtrack-api-types.ts
+++ b/extensions/youtrack/src/api/youtrack-api-types.ts
@@ -7,6 +7,7 @@ import type {
   issueWorkItemFields,
   userFields,
   commandListFields,
+  searchSuggestionsFields,
   commentFields,
 } from "./youtrack-api-fields";
 
@@ -18,6 +19,7 @@ export type WorkItemFields = typeof workItemFields;
 export type IssueWorkItemFields = typeof issueWorkItemFields;
 export type UserFields = typeof userFields;
 export type CommandListFields = typeof commandListFields;
+export type SearchSuggestionsFields = typeof searchSuggestionsFields;
 
 export type ReducedApiIssue = Pick<
   Issue,

--- a/extensions/youtrack/src/api/youtrack-api.ts
+++ b/extensions/youtrack/src/api/youtrack-api.ts
@@ -6,6 +6,7 @@ import type {
   IssueExtended,
   IssueTag,
   Project,
+  SearchSuggestion,
   User,
   WorkItem,
 } from "../interfaces";
@@ -20,6 +21,7 @@ import type {
   ReducedApiIssue,
   IssueWorkItemFields,
   UserFields,
+  SearchSuggestionsFields,
   IssueComment,
 } from "./youtrack-api-types";
 import {
@@ -30,6 +32,7 @@ import {
   issuesFields,
   issueWorkItemFields,
   projectFields,
+  searchSuggestionsFields,
   tagsFields,
   userFields,
   workItemFields,
@@ -79,6 +82,31 @@ export class YouTrackApi {
           })) ?? [],
       project: { name: issue.project!.name!, shortName: issue.project!.shortName!, id: issue.project!.id },
     }));
+  }
+
+  async fetchSearchSuggestions(query: string): Promise<SearchSuggestion[]> {
+    const data = await this.yt.Search.getSearchSuggestions<SearchSuggestionsFields>(
+      { query, caret: query.length },
+      { fields: searchSuggestionsFields },
+    );
+
+    return data.suggestions.flatMap((suggestion) => {
+      if (suggestion.completionStart === null || suggestion.completionEnd === null || suggestion.option === null) {
+        return [];
+      }
+
+      return [
+        {
+          completionStart: suggestion.completionStart,
+          completionEnd: suggestion.completionEnd,
+          description: suggestion.description ?? "",
+          group: suggestion.group ?? "",
+          option: suggestion.option,
+          prefix: suggestion.prefix ?? "",
+          suffix: suggestion.suffix ?? "",
+        },
+      ];
+    });
   }
 
   async fetchProjects(limit: number): Promise<Project[]> {

--- a/extensions/youtrack/src/browse-state.test.ts
+++ b/extensions/youtrack/src/browse-state.test.ts
@@ -1,0 +1,66 @@
+import { getBrowseEmptyViewState } from "./browse-state";
+
+const emptyState = {
+  hasSearchText: true,
+  isLoading: false,
+  issueCount: 0,
+  suggestionCount: 0,
+};
+
+describe("getBrowseEmptyViewState", () => {
+  test("should surface issue failures with a retry target", () => {
+    expect(
+      getBrowseEmptyViewState({
+        ...emptyState,
+        issuesError: new Error("Authentication failed"),
+      }),
+    ).toEqual({
+      title: "Failed to Load Issues",
+      description: "Authentication failed",
+      retry: "issues",
+    });
+  });
+
+  test("should surface suggestion failures when no results are available", () => {
+    expect(
+      getBrowseEmptyViewState({
+        ...emptyState,
+        suggestionsError: new Error("Suggestions unavailable"),
+      }),
+    ).toEqual({
+      title: "Failed to Load Search Suggestions",
+      description: "Suggestions unavailable",
+      retry: "suggestions",
+    });
+  });
+
+  test("should keep suggestion failures nonfatal when issues are available", () => {
+    expect(
+      getBrowseEmptyViewState({
+        ...emptyState,
+        issueCount: 1,
+        suggestionsError: new Error("Suggestions unavailable"),
+      }),
+    ).toBeNull();
+  });
+
+  test("should ignore a stale suggestion failure after search text is cleared", () => {
+    expect(
+      getBrowseEmptyViewState({
+        ...emptyState,
+        hasSearchText: false,
+        suggestionsError: new Error("Suggestions unavailable"),
+      }),
+    ).toEqual({
+      title: "No Issues Found",
+      description: "No issues match your configured query.",
+    });
+  });
+
+  test("should reserve the no-results message for successful empty responses", () => {
+    expect(getBrowseEmptyViewState(emptyState)).toEqual({
+      title: "No Issues Found",
+      description: "Try another YouTrack search query.",
+    });
+  });
+});

--- a/extensions/youtrack/src/browse-state.ts
+++ b/extensions/youtrack/src/browse-state.ts
@@ -1,0 +1,41 @@
+export interface BrowseEmptyViewState {
+  title: string;
+  description: string;
+  retry?: "issues" | "suggestions";
+}
+
+interface BrowseEmptyViewInput {
+  hasSearchText: boolean;
+  isLoading: boolean;
+  issueCount: number;
+  suggestionCount: number;
+  issuesError?: Error;
+  suggestionsError?: Error;
+}
+
+export function getBrowseEmptyViewState(input: BrowseEmptyViewInput): BrowseEmptyViewState | null {
+  if (input.isLoading || input.issueCount > 0 || input.suggestionCount > 0) {
+    return null;
+  }
+
+  if (input.issuesError) {
+    return {
+      title: "Failed to Load Issues",
+      description: input.issuesError.message,
+      retry: "issues",
+    };
+  }
+
+  if (input.hasSearchText && input.suggestionsError) {
+    return {
+      title: "Failed to Load Search Suggestions",
+      description: input.suggestionsError.message,
+      retry: "suggestions",
+    };
+  }
+
+  return {
+    title: "No Issues Found",
+    description: input.hasSearchText ? "Try another YouTrack search query." : "No issues match your configured query.",
+  };
+}

--- a/extensions/youtrack/src/browse.tsx
+++ b/extensions/youtrack/src/browse.tsx
@@ -1,11 +1,12 @@
-import { useCallback, useEffect, useState } from "react";
-import { getPreferenceValues, List, showToast, Toast } from "@raycast/api";
+import { useCallback, useState } from "react";
+import { Action, ActionPanel, getPreferenceValues, Icon, List, showToast, Toast } from "@raycast/api";
+import { useCachedPromise } from "@raycast/utils";
 import { IssueListItem } from "./components/IssueListItem";
-import { getEmptyIssue } from "./utils";
-import type { State, Issue, WorkItem, Command } from "./interfaces";
-import _ from "lodash";
-import { loadCache, saveCache } from "./cache";
+import { applySearchSuggestion } from "./utils";
+import type { Command, Issue, SearchSuggestion, WorkItem } from "./interfaces";
 import { YouTrackApi } from "./api/youtrack-api";
+import { fetchIssueSearchResults } from "./issue-search";
+import { getBrowseEmptyViewState } from "./browse-state";
 
 interface Preferences {
   instance: string;
@@ -14,65 +15,73 @@ interface Preferences {
   maxIssues: number;
 }
 
+function fetchIssues(query: string, maxIssues: number, suppressBadRequest: boolean): Promise<Issue[]> {
+  return fetchIssueSearchResults(query, maxIssues, suppressBadRequest, (issueQuery, issueLimit) =>
+    YouTrackApi.getInstance().fetchIssues(issueQuery, issueLimit),
+  );
+}
+
+function fetchSearchSuggestions(query: string): Promise<SearchSuggestion[]> {
+  return YouTrackApi.getInstance().fetchSearchSuggestions(query);
+}
+
+function SearchSuggestionListItem(props: {
+  query: string;
+  suggestion: SearchSuggestion;
+  onApply: (query: string) => void;
+}) {
+  const completedQuery = applySearchSuggestion(props.query, props.suggestion);
+
+  return (
+    <List.Item
+      icon={Icon.MagnifyingGlass}
+      title={completedQuery}
+      subtitle={props.suggestion.description || undefined}
+      accessories={props.suggestion.group ? [{ text: props.suggestion.group }] : undefined}
+      actions={
+        <ActionPanel>
+          <Action
+            icon={Icon.MagnifyingGlass}
+            title="Apply Search Suggestion"
+            onAction={() => props.onApply(completedQuery)}
+          />
+        </ActionPanel>
+      }
+    />
+  );
+}
+
 export default function Command() {
   const prefs = getPreferenceValues<Preferences>();
   const youTrackApi = YouTrackApi.getInstance();
+  const [searchText, setSearchText] = useState("");
+  const hasSearchText = searchText.trim().length > 0;
+  const effectiveQuery = hasSearchText ? searchText : prefs.query;
+  const maxIssues = Number(prefs.maxIssues);
 
-  const [state, setState] = useState<State>({ isLoading: true, items: [], project: null });
+  const {
+    data: items,
+    error: issuesError,
+    isLoading: isLoadingIssues,
+    mutate: mutateIssues,
+    revalidate: revalidateIssues,
+  } = useCachedPromise(fetchIssues, [effectiveQuery, maxIssues, hasSearchText], {
+    initialData: [],
+    keepPreviousData: true,
+    failureToastOptions: { title: "Failed loading issues" },
+  });
 
-  useEffect(() => {
-    try {
-      setState({ isLoading: false, items: [], project: null });
-    } catch (error) {
-      setState((previous) => ({
-        ...previous,
-        error: error instanceof Error ? error : new Error("Something went wrong"),
-        isLoading: false,
-        items: [getEmptyIssue()],
-      }));
-    }
-  }, []);
-
-  useEffect(() => {
-    async function fetchItems() {
-      setState((previous) => ({ ...previous, isLoading: true }));
-      try {
-        const cache = await loadCache<Issue>("youtrack-issues");
-
-        if (cache.length) {
-          setState((previous) => ({ ...previous, items: cache, isLoading: true }));
-        }
-
-        const feed = await youTrackApi.fetchIssues(prefs.query, Number(prefs.maxIssues));
-        if (cache.length && _.isEqual(cache, feed)) {
-          setState((previous) => ({ ...previous, isLoading: false }));
-          return;
-        }
-
-        setState((previous) => ({ ...previous, items: feed, isLoading: false }));
-        await saveCache<Issue>("youtrack-issues", feed);
-      } catch (error) {
-        setState((previous) => ({
-          ...previous,
-          error: error instanceof Error ? error : new Error("Something went wrong"),
-          isLoading: false,
-          items: [],
-        }));
-      }
-    }
-
-    fetchItems();
-  }, [prefs.maxIssues, prefs.query, youTrackApi]);
-
-  useEffect(() => {
-    if (state.error) {
-      showToast({
-        style: Toast.Style.Failure,
-        title: "Failed loading issues",
-        message: state.error.message,
-      });
-    }
-  }, [state.error]);
+  const {
+    data: fetchedSuggestions,
+    error: suggestionsError,
+    isLoading: isLoadingSuggestions,
+    revalidate: revalidateSuggestions,
+  } = useCachedPromise(fetchSearchSuggestions, [searchText], {
+    execute: hasSearchText,
+    initialData: [],
+    failureToastOptions: { title: "Failed loading search suggestions" },
+  });
+  const suggestions = hasSearchText ? fetchedSuggestions : [];
 
   const getIssueDetails = useCallback(
     async (issue: Issue) => {
@@ -109,15 +118,10 @@ export default function Command() {
   const deleteIssueCb = useCallback(
     async (issueId: string) => {
       try {
-        await youTrackApi.deleteIssue(issueId);
-        setState((previous) => ({
-          ...previous,
-          items: previous.items.filter((item) => item.id !== issueId),
-        }));
-        await saveCache(
-          "youtrack-issues",
-          state.items.filter((item) => item.id !== issueId),
-        );
+        await mutateIssues(youTrackApi.deleteIssue(issueId), {
+          optimisticUpdate: (currentItems) => currentItems.filter((item) => item.id !== issueId),
+          shouldRevalidateAfter: false,
+        });
         showToast({
           style: Toast.Style.Success,
           title: "Issue deleted",
@@ -131,26 +135,74 @@ export default function Command() {
         });
       }
     },
-    [state.items, youTrackApi],
+    [mutateIssues, youTrackApi],
   );
 
+  const isLoading = isLoadingIssues || (hasSearchText && isLoadingSuggestions);
+  const emptyViewState = getBrowseEmptyViewState({
+    hasSearchText,
+    isLoading,
+    issueCount: items.length,
+    suggestionCount: suggestions.length,
+    issuesError,
+    suggestionsError,
+  });
+
   return (
-    <List isLoading={(!state.items && !state.error) || state.isLoading}>
-      {state.items?.map((item, index) => (
-        <IssueListItem
-          key={item.id}
-          item={item}
-          index={index}
-          instance={prefs.instance}
-          resolved={item.resolved}
-          getIssueDetailsCb={() => getIssueDetails(item)}
-          createWorkItemCb={(workItem: WorkItem) => createWorkItemCb(item, workItem)}
-          applyCommandCb={(command: Command) => applyCommandCb(item, command)}
-          getCommandSuggestions={(command: string) => getCommandSuggestions(item, command)}
-          getLastCommentCb={() => getLastCommentCb(item.id)}
-          deleteIssueCb={() => deleteIssueCb(item.id)}
+    <List
+      isLoading={isLoading}
+      searchText={searchText}
+      onSearchTextChange={setSearchText}
+      searchBarPlaceholder="Search YouTrack issues"
+      filtering={false}
+      throttle
+    >
+      {suggestions.length > 0 ? (
+        <List.Section title="Search Suggestions">
+          {suggestions.map((suggestion, index) => (
+            <SearchSuggestionListItem
+              key={`${suggestion.completionStart}-${suggestion.completionEnd}-${suggestion.option}-${index}`}
+              query={searchText}
+              suggestion={suggestion}
+              onApply={setSearchText}
+            />
+          ))}
+        </List.Section>
+      ) : null}
+      <List.Section title="Issues">
+        {items.map((item, index) => (
+          <IssueListItem
+            key={item.id}
+            item={item}
+            index={index}
+            instance={prefs.instance}
+            resolved={item.resolved}
+            getIssueDetailsCb={() => getIssueDetails(item)}
+            createWorkItemCb={(workItem: WorkItem) => createWorkItemCb(item, workItem)}
+            applyCommandCb={(command: Command) => applyCommandCb(item, command)}
+            getCommandSuggestions={(command: string) => getCommandSuggestions(item, command)}
+            getLastCommentCb={() => getLastCommentCb(item.id)}
+            deleteIssueCb={() => deleteIssueCb(item.id)}
+          />
+        ))}
+      </List.Section>
+      {emptyViewState ? (
+        <List.EmptyView
+          icon={emptyViewState.retry ? Icon.Warning : Icon.MagnifyingGlass}
+          title={emptyViewState.title}
+          description={emptyViewState.description}
+          actions={
+            emptyViewState.retry ? (
+              <ActionPanel>
+                <Action
+                  title="Retry"
+                  onAction={emptyViewState.retry === "issues" ? revalidateIssues : revalidateSuggestions}
+                />
+              </ActionPanel>
+            ) : undefined
+          }
         />
-      ))}
+      ) : null}
     </List>
   );
 }

--- a/extensions/youtrack/src/interfaces.ts
+++ b/extensions/youtrack/src/interfaces.ts
@@ -15,13 +15,6 @@ export interface Project {
   name: string;
 }
 
-export interface State {
-  isLoading: boolean;
-  items: Issue[];
-  project: string | null;
-  error?: Error;
-}
-
 export interface Attachment {
   name: string | null;
   url: string | null;
@@ -101,6 +94,16 @@ export interface ParsedCommand {
 
 export interface CommandSuggestions {
   commands: ParsedCommand[];
+}
+
+export interface SearchSuggestion {
+  completionStart: number;
+  completionEnd: number;
+  description: string;
+  group: string;
+  option: string;
+  prefix: string;
+  suffix: string;
 }
 
 export interface CustomField {

--- a/extensions/youtrack/src/issue-search.test.ts
+++ b/extensions/youtrack/src/issue-search.test.ts
@@ -1,0 +1,33 @@
+import type { Issue } from "./interfaces";
+import { fetchIssueSearchResults } from "./issue-search";
+
+const issue = { id: "DEMO-1" } as Issue;
+
+describe("fetchIssueSearchResults", () => {
+  test("should return fetched issues", async () => {
+    const fetchIssues = vi.fn().mockResolvedValue([issue]);
+
+    await expect(fetchIssueSearchResults("State: Open", 50, true, fetchIssues)).resolves.toEqual([issue]);
+    expect(fetchIssues).toHaveBeenCalledWith("State: Open", 50);
+  });
+
+  test("should treat a bad request as an empty intermediate search", async () => {
+    const fetchIssues = vi.fn().mockRejectedValue(new Error("Error: 400 Bad Request"));
+
+    await expect(fetchIssueSearchResults("State: ", 50, true, fetchIssues)).resolves.toEqual([]);
+  });
+
+  test("should surface a bad request from the configured query", async () => {
+    const error = new Error("Error: 400 Bad Request");
+    const fetchIssues = vi.fn().mockRejectedValue(error);
+
+    await expect(fetchIssueSearchResults("State: ", 50, false, fetchIssues)).rejects.toBe(error);
+  });
+
+  test("should surface all other search failures", async () => {
+    const error = new Error("Error: 500 Internal Server Error");
+    const fetchIssues = vi.fn().mockRejectedValue(error);
+
+    await expect(fetchIssueSearchResults("State: Open", 50, true, fetchIssues)).rejects.toBe(error);
+  });
+});

--- a/extensions/youtrack/src/issue-search.ts
+++ b/extensions/youtrack/src/issue-search.ts
@@ -1,0 +1,22 @@
+import type { Issue } from "./interfaces";
+
+type FetchIssues = (query: string, maxIssues: number) => Promise<Issue[]>;
+
+const BAD_REQUEST_ERROR_MESSAGE = "Error: 400 Bad Request";
+
+export async function fetchIssueSearchResults(
+  query: string,
+  maxIssues: number,
+  suppressBadRequest: boolean,
+  fetchIssues: FetchIssues,
+): Promise<Issue[]> {
+  try {
+    return await fetchIssues(query, maxIssues);
+  } catch (error) {
+    // youtrack-client 0.5.3 discards the response status and exposes only this message.
+    if (suppressBadRequest && error instanceof Error && error.message === BAD_REQUEST_ERROR_MESSAGE) {
+      return [];
+    }
+    throw error;
+  }
+}

--- a/extensions/youtrack/src/utils.test.ts
+++ b/extensions/youtrack/src/utils.test.ts
@@ -1,5 +1,58 @@
-import type { IssueTag } from "./interfaces";
-import { getTagsToAdd, prepareFavorites, isDurationValid, stripHtmlTags } from "./utils";
+import type { IssueTag, SearchSuggestion } from "./interfaces";
+import { applySearchSuggestion, getTagsToAdd, prepareFavorites, isDurationValid, stripHtmlTags } from "./utils";
+
+const searchSuggestion = (overrides: Partial<SearchSuggestion> = {}): SearchSuggestion => ({
+  completionStart: 0,
+  completionEnd: 0,
+  description: "",
+  group: "",
+  option: "State",
+  prefix: "",
+  suffix: ": ",
+  ...overrides,
+});
+
+describe("applySearchSuggestion", () => {
+  test("should insert a suggestion at the completion position", () => {
+    expect(
+      applySearchSuggestion(
+        "State: ",
+        searchSuggestion({ completionStart: 7, completionEnd: 7, option: "Open", suffix: "" }),
+      ),
+    ).toBe("State: Open");
+  });
+
+  test("should replace a partial token", () => {
+    expect(applySearchSuggestion("Stat", searchSuggestion({ completionEnd: 4 }))).toBe("State: ");
+  });
+
+  test("should apply a suggestion prefix and suffix", () => {
+    expect(
+      applySearchSuggestion(
+        "State: Veri",
+        searchSuggestion({
+          completionStart: 7,
+          completionEnd: 11,
+          option: "Verified",
+          prefix: "{",
+          suffix: "}",
+        }),
+      ),
+    ).toBe("State: {Verified}");
+  });
+
+  test("should preserve query text outside the completion range", () => {
+    const query = "project: TEST Stat created: today";
+    const completionStart = query.indexOf("Stat");
+
+    expect(
+      applySearchSuggestion(
+        query,
+        searchSuggestion({ completionStart, completionEnd: completionStart + "Stat".length, suffix: ":" }),
+      ),
+    ).toBe("project: TEST State: created: today");
+  });
+});
 
 describe("getTagsToAdd", () => {
   test("should prepare selected tags to 'IssueTag[]' before submitting issue", () => {

--- a/extensions/youtrack/src/utils.ts
+++ b/extensions/youtrack/src/utils.ts
@@ -1,20 +1,7 @@
 import type { DurationPresentation } from "youtrack-client";
-import type { Comment, CustomField, EnumValue, Issue, IssueExtended, IssueTag, Project } from "./interfaces";
+import type { Comment, CustomField, EnumValue, IssueExtended, IssueTag, Project, SearchSuggestion } from "./interfaces";
 
 type PreparedFavorites = { cached: Project[]; toFetch: string[] };
-export function getEmptyIssue(): Issue {
-  return {
-    id: "",
-    summary: "Connecting to YouTrack...",
-    date: "",
-    created: "",
-    description: "",
-    resolved: false,
-    project: null,
-    customFields: [],
-  };
-}
-
 export const issueStates = {
   ISSUE_RESOLVED: "Resolved",
   ISSUE_OPEN: "Open",
@@ -131,4 +118,9 @@ export function getPriorityFieldValue(customFields: CustomField[]): EnumValue | 
 
 export function getUserAvatar(avatarUrl: string, host: string): string {
   return isURL(avatarUrl) ? avatarUrl : `${host}${avatarUrl}`;
+}
+
+export function applySearchSuggestion(query: string, suggestion: SearchSuggestion): string {
+  const completion = `${suggestion.prefix}${suggestion.option}${suggestion.suffix}`;
+  return `${query.slice(0, suggestion.completionStart)}${completion}${query.slice(suggestion.completionEnd)}`;
 }


### PR DESCRIPTION
## Description

Adds live server-side issue search and YouTrack query autocomplete to the Browse Issues command.

- replaces local filtering of the configured issue list with controlled, server-backed search
- displays YouTrack search-assist suggestions above matching issues and applies the API-provided completion ranges
- preserves the configured query as the default when the search field is empty
- keeps autocomplete usable for incomplete queries such as `State: ` without showing the issue endpoint's expected HTTP 400 as a failure toast
- continues surfacing configured-query, authentication, authorization, network, and server failures

Previously, Browse Issues always fetched the query saved in preferences, so users could only filter that fixed result set locally. This implements the global search workflow requested in #3156.

The incomplete-query toast occurred because applying a field suggestion immediately sent the partial query to the issues endpoint. YouTrack correctly rejected that intermediate grammar while the independent search-assist endpoint still returned value suggestions. Interactive issue-query 400s are now treated as an editable empty-result state; other errors are rethrown.

## Validation

- 18 Vitest tests, including interactive 400 suppression and non-400/configured-query propagation
- TypeScript `--noEmit`
- ESLint
- Prettier on all changed files
- prescribed `npm run build` distribution build
- authenticated manual testing of the final Raycast distribution: field suggestions, the incomplete `state: ` flow without a 400 toast, value suggestions, applied state values, and live matching issues
- `git diff --check`

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
