### PR TITLE
Update bitbucket extension

### DIFF
--- a/extensions/bitbucket/CHANGELOG.md
+++ b/extensions/bitbucket/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Bitbucket Changelog
 
-## [Update] - {PR_MERGE_DATE}
+## [Update] - 2026-08-22
 
 - Added Search All Open Pull Requests command to browse open PRs across the workspace
 

--- a/extensions/bitbucket/CHANGELOG.md
+++ b/extensions/bitbucket/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bitbucket Changelog
 
+## [Update] - {PR_MERGE_DATE}
+
+- Added Search All Open Pull Requests command to browse open PRs across the workspace
+
 ## [Update] - 2025-11-17
 
 - Update shortcuts to be consistent across MacOS and Windows

--- a/extensions/bitbucket/package.json
+++ b/extensions/bitbucket/package.json
@@ -12,7 +12,8 @@
     "arpitdalal",
     "litomore",
     "AaronMoat",
-    "0xdhrv"
+    "0xdhrv",
+    "siuhinnn"
   ],
   "license": "MIT",
   "commands": [
@@ -28,6 +29,13 @@
       "title": "Search My Open Pull Requests",
       "subtitle": "Bitbucket",
       "description": "Showing open pull requests for the current user",
+      "mode": "view"
+    },
+    {
+      "name": "searchAllPullRequests",
+      "title": "Search All Open Pull Requests",
+      "subtitle": "Bitbucket",
+      "description": "Showing all open pull requests in the workspace",
       "mode": "view"
     }
   ],

--- a/extensions/bitbucket/src/components/pullRequests/searchAllPullRequests.tsx
+++ b/extensions/bitbucket/src/components/pullRequests/searchAllPullRequests.tsx
@@ -15,7 +15,7 @@ export function SearchAllPullRequests() {
   useEffect(() => {
     async function fetchPRs() {
       try {
-        const pullRequests = await getAllOpenPullRequests();
+        const { values: pullRequests, failedRepoCount } = await getAllOpenPullRequests();
 
         const prs =
           pullRequests.map((pr) => ({
@@ -32,6 +32,16 @@ export function SearchAllPullRequests() {
             },
           })) ?? [];
         setState({ pullRequests: prs });
+
+        if (failedRepoCount > 0) {
+          await showToast({
+            style: Toast.Style.Failure,
+            title: "Some repositories failed to load",
+            message: `Could not fetch pull requests from ${failedRepoCount} ${
+              failedRepoCount === 1 ? "repository" : "repositories"
+            }. Results may be incomplete.`,
+          });
+        }
       } catch (error) {
         setState({ error: error instanceof Error ? error : new Error("Something went wrong") });
       }

--- a/extensions/bitbucket/src/components/pullRequests/searchAllPullRequests.tsx
+++ b/extensions/bitbucket/src/components/pullRequests/searchAllPullRequests.tsx
@@ -1,0 +1,81 @@
+import { ActionPanel, List, showToast, Color, Action, Image, Toast } from "@raycast/api";
+import { useState, useEffect } from "react";
+
+import { getAllOpenPullRequests } from "./../../queries";
+import { PullRequest } from "./interface";
+
+interface State {
+  pullRequests?: PullRequest[];
+  error?: Error;
+}
+
+export function SearchAllPullRequests() {
+  const [state, setState] = useState<State>({});
+
+  useEffect(() => {
+    async function fetchPRs() {
+      try {
+        const pullRequests = await getAllOpenPullRequests();
+
+        const prs =
+          pullRequests.map((pr) => ({
+            id: pr.id,
+            title: pr.title,
+            repo: {
+              name: pr.destination?.repository?.name,
+              fullName: pr.destination?.repository?.full_name,
+            },
+            commentCount: pr.comment_count,
+            author: {
+              url: pr.author?.links?.avatar?.href,
+              nickname: pr.author?.nickname,
+            },
+          })) ?? [];
+        setState({ pullRequests: prs });
+      } catch (error) {
+        setState({ error: error instanceof Error ? error : new Error("Something went wrong") });
+      }
+    }
+
+    fetchPRs();
+  }, []);
+
+  if (state.error) {
+    showToast({
+      style: Toast.Style.Failure,
+      title: "Failed loading pull requests",
+      message: state.error.message,
+    });
+  }
+
+  return (
+    <List isLoading={!state.pullRequests && !state.error} searchBarPlaceholder="Search by name...">
+      <List.Section title="Open Pull Requests" subtitle={state.pullRequests?.length + ""}>
+        {state.pullRequests?.map((pr) => (
+          <List.Item
+            key={`${pr.repo.fullName}-${pr.id}`}
+            title={pr.title}
+            subtitle={pr.repo?.fullName}
+            icon={{ source: "icon-pr.png", tintColor: Color.PrimaryText }}
+            actions={
+              <ActionPanel>
+                <ActionPanel.Section>
+                  <Action.OpenInBrowser
+                    title="Open Pull Request in Browser"
+                    url={`https://bitbucket.org/${pr.repo.fullName}/pull-requests/${pr.id}`}
+                  />
+                </ActionPanel.Section>
+              </ActionPanel>
+            }
+            accessories={[
+              {
+                text: `${pr.commentCount} 💬  ·  Created by ${pr.author.nickname}`,
+                icon: { source: pr.author.url, mask: Image.Mask.Circle },
+              },
+            ]}
+          />
+        ))}
+      </List.Section>
+    </List>
+  );
+}

--- a/extensions/bitbucket/src/queries/index.ts
+++ b/extensions/bitbucket/src/queries/index.ts
@@ -270,12 +270,14 @@ export async function getAllOpenPullRequests() {
 
   const perRepo = await mapWithConcurrency(repos, 10, async (repo) => {
     try {
-      return await listOpenPullRequestsForRepo(repo);
+      return { ok: true as const, values: await listOpenPullRequestsForRepo(repo) };
     } catch {
-      return [];
+      return { ok: false as const, values: [] as OpenPullRequest[] };
     }
   });
-  const all = perRepo.flat();
+
+  const failedRepoCount = perRepo.filter((result) => !result.ok).length;
+  const all = perRepo.flatMap((result) => result.values);
 
   all.sort((a, b) => {
     const aTime = a.created_on ? Date.parse(a.created_on) : 0;
@@ -283,5 +285,5 @@ export async function getAllOpenPullRequests() {
     return bTime - aTime;
   });
 
-  return all;
+  return { values: all, failedRepoCount };
 }

--- a/extensions/bitbucket/src/queries/index.ts
+++ b/extensions/bitbucket/src/queries/index.ts
@@ -152,3 +152,130 @@ export async function getMyOpenPullRequests() {
 
   return PullRequestsResponseSchema.parse(await response.json()).values;
 }
+
+type OpenPullRequest = z.infer<typeof PullRequestsResponseSchema>["values"][number] & {
+  created_on?: string;
+};
+
+async function listAllRepositories(): Promise<Schema.Repository[]> {
+  const repos: Schema.Repository[] = [];
+  let page = "1";
+
+  for (;;) {
+    const { data } = await bitbucket.repositories.list({
+      ...defaults,
+      pagelen: 100,
+      sort: "-updated_on",
+      page,
+      fields: ["values.slug", "values.name", "values.full_name", "next"].join(","),
+    });
+
+    repos.push(...((data.values as Schema.Repository[]) ?? []));
+
+    if (!data.next) {
+      break;
+    }
+
+    const nextParams = new URLSearchParams(data.next.split("?")[1]);
+    page = nextParams.get("page") ?? String(Number(page) + 1);
+  }
+
+  return repos;
+}
+
+async function listOpenPullRequestsForRepo(repo: {
+  slug: string;
+  name?: string;
+  full_name?: string;
+}): Promise<OpenPullRequest[]> {
+  const pullRequests: OpenPullRequest[] = [];
+  let page = "1";
+
+  for (;;) {
+    const { data } = await bitbucket.pullrequests.list({
+      ...defaults,
+      repo_slug: repo.slug,
+      pagelen: 50,
+      page,
+      sort: "-created_on",
+      state: "OPEN",
+    });
+
+    for (const pr of data.values ?? []) {
+      const author = pr.author as { nickname?: string; links?: { avatar?: { href?: string } } } | undefined;
+      if (typeof pr.id !== "number" || typeof pr.title !== "string" || typeof author?.nickname !== "string") {
+        continue;
+      }
+
+      pullRequests.push({
+        id: pr.id,
+        title: pr.title,
+        comment_count: (pr.comment_count as number) ?? 0,
+        created_on: pr.created_on,
+        author: {
+          nickname: author.nickname,
+          links: {
+            avatar: {
+              href: author.links?.avatar?.href ?? "",
+            },
+          },
+        },
+        destination: {
+          repository: {
+            name: (pr.destination?.repository?.name as string) ?? repo.name ?? repo.slug,
+            full_name:
+              (pr.destination?.repository?.full_name as string) ??
+              repo.full_name ??
+              `${preferences.workspace}/${repo.slug}`,
+          },
+        },
+      });
+    }
+
+    if (!data.next) {
+      break;
+    }
+
+    const nextParams = new URLSearchParams(data.next.split("?")[1]);
+    page = nextParams.get("page") ?? String(Number(page) + 1);
+  }
+
+  return pullRequests;
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = [];
+  let index = 0;
+
+  async function worker() {
+    while (index < items.length) {
+      const current = index++;
+      results[current] = await mapper(items[current]);
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()));
+  return results;
+}
+
+// Bitbucket has no workspace-wide PR endpoint; iterate repos then fetch open PRs per repo.
+export async function getAllOpenPullRequests() {
+  const repos = (await listAllRepositories()).filter(
+    (repo): repo is Schema.Repository & { slug: string } => typeof repo.slug === "string",
+  );
+
+  const perRepo = await mapWithConcurrency(repos, 10, listOpenPullRequestsForRepo);
+  const all = perRepo.flat();
+
+  all.sort((a, b) => {
+    const aTime = a.created_on ? Date.parse(a.created_on) : 0;
+    const bTime = b.created_on ? Date.parse(b.created_on) : 0;
+    return bTime - aTime;
+  });
+
+  return all;
+}

--- a/extensions/bitbucket/src/queries/index.ts
+++ b/extensions/bitbucket/src/queries/index.ts
@@ -268,7 +268,13 @@ export async function getAllOpenPullRequests() {
     (repo): repo is Schema.Repository & { slug: string } => typeof repo.slug === "string",
   );
 
-  const perRepo = await mapWithConcurrency(repos, 10, listOpenPullRequestsForRepo);
+  const perRepo = await mapWithConcurrency(repos, 10, async (repo) => {
+    try {
+      return await listOpenPullRequestsForRepo(repo);
+    } catch {
+      return [];
+    }
+  });
   const all = perRepo.flat();
 
   all.sort((a, b) => {

--- a/extensions/bitbucket/src/searchAllPullRequests.tsx
+++ b/extensions/bitbucket/src/searchAllPullRequests.tsx
@@ -1,0 +1,3 @@
+import { SearchAllPullRequests } from "./components/pullRequests/searchAllPullRequests";
+
+export default SearchAllPullRequests;


### PR DESCRIPTION
## Description

- Adds a Search All Open Pull Requests command that lists open PRs across the configured workspace (not only PRs you authored).
- Fetches workspace repositories, then loads open PRs per repo with bounded concurrency, and presents them in the same searchable list UI as My Open PRs.

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
