### PR TITLE
fix(google-meet): launch the resolved application instead of matching by name

### DIFF
--- a/extensions/google-meet/CHANGELOG.md
+++ b/extensions/google-meet/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Google Meet Changelog
 
+## [Fix Browser Launch] - {PR_MERGE_DATE}
+
+- Fix meetings opening in the wrong application when the chosen browser's name is a substring of another installed app's name. The creation URL was opened by passing the browser's display name to `open()`, which has to match that name back to an application — and `Dia` matches `Obsidian`, so meetings opened in Obsidian, launching it even when it wasn't running. The resolved `Application` is now passed instead, so the exact bundle is opened. The browser's name is still what selects the adapter and addresses the app in AppleScript, which needs the name macOS installs it under.
+
 ## [Fix Brave Support] - 2026-08-05
 
 - Fix Brave being rejected with "isn't a supported browser". macOS installs Brave as `Brave Browser.app` and reports it under that name, but the supported-browser list held `Brave`, so the exact-match check added in the previous release failed for it.

--- a/extensions/google-meet/CHANGELOG.md
+++ b/extensions/google-meet/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Meet Changelog
 
-## [Fix Browser Launch] - {PR_MERGE_DATE}
+## [Fix Browser Launch] - 2026-08-06
 
 - Fix meetings opening in the wrong application when the chosen browser's name is a substring of another installed app's name. The creation URL was opened by passing the browser's display name to `open()`, which has to match that name back to an application — and `Dia` matches `Obsidian`, so meetings opened in Obsidian, launching it even when it wasn't running. The resolved `Application` is now passed instead, so the exact bundle is opened. The browser's name is still what selects the adapter and addresses the app in AppleScript, which needs the name macOS installs it under.
 

--- a/extensions/google-meet/src/services/create-meeting.ts
+++ b/extensions/google-meet/src/services/create-meeting.ts
@@ -67,8 +67,8 @@ export async function createMeeting(options: CreateMeetingOptions): Promise<Crea
   // browser mode.
   const pwaApp = launchTarget === "pwa" ? await resolvePwaApp() : undefined;
 
-  const browserName = await resolveCreationBrowser();
-  const adapter = getAdapterForBrowser(browserName);
+  const browser = await resolveCreationBrowser();
+  const adapter = getAdapterForBrowser(browser.name);
   const creationUrl = buildCreationUrl(options.profile);
 
   const previousClipboardText = adapter.usesClipboardFallback
@@ -76,7 +76,7 @@ export async function createMeeting(options: CreateMeetingOptions): Promise<Crea
     : undefined;
 
   try {
-    await open(creationUrl, browserName);
+    await open(creationUrl, browser.application);
 
     const rawUrl = await waitForMeetingUrl(() => adapter.getCandidateUrls(), {
       timeoutMs: getPollTimeoutMs(),

--- a/extensions/google-meet/src/services/launch-target.ts
+++ b/extensions/google-meet/src/services/launch-target.ts
@@ -19,20 +19,36 @@ export function getLaunchTarget(): LaunchTarget {
 }
 
 /**
+ * A resolved browser, carrying both identities it's needed under:
+ *
+ * - `application` launches it. Passing the resolved application rather than
+ *   its display name means the exact bundle is opened; a name has to be
+ *   matched back to an app, and short browser names are substrings of
+ *   unrelated apps (`Dia` matches `Obsidian`), which opens the wrong one.
+ * - `name` scripts it. AppleScript addresses an app by the name macOS
+ *   installs it under (`tell application "Brave Browser"`), and the adapter
+ *   for a browser family is selected from that same name.
+ */
+export type CreationBrowser = {
+  application: Application;
+  name: SupportedBrowsers;
+};
+
+/**
  * Determines which real, scriptable browser should open the meeting
  * creation URL. Used for both launch targets: even in PWA mode the meeting
  * is created and its URL is read through a real browser first, since PWA
  * wrapper apps aren't reliably scriptable — see `browser-adapters/pwa.ts`.
  */
-export async function resolveCreationBrowser(): Promise<SupportedBrowsers> {
+export async function resolveCreationBrowser(): Promise<CreationBrowser> {
   const { preferredBrowser } = getPreferenceValues<Preferences>();
   if (preferredBrowser?.name && isSupportedBrowserName(preferredBrowser.name)) {
-    return preferredBrowser.name;
+    return { application: preferredBrowser, name: preferredBrowser.name };
   }
 
   const defaultApplication = await getDefaultApplication(meetCreationUrl);
   if (isSupportedBrowserName(defaultApplication.name)) {
-    return defaultApplication.name;
+    return { application: defaultApplication, name: defaultApplication.name };
   }
 
   throw new MeetError("UNSUPPORTED_BROWSER", {


### PR DESCRIPTION
## Description

Meetings can open in the wrong application. On my machine every command opened Obsidian — launching it even when it was quit — instead of Dia, my default browser.

The cause is that the creation URL is opened by passing the browser's display name to `open()`:

```ts
const browserName = await resolveCreationBrowser(); // "Dia"
await open(creationUrl, browserName);
```

`open()` has to match that name back to an installed application, and short browser names are substrings of unrelated app names — `Dia` is a substring of `Obsi**dia**n`. Setting "Set preferred browser" to Dia explicitly made no difference, because the same string is what gets resolved either way. Switching the preference to Google Chrome worked, since that name collides with nothing.

This is only reachable since #29481, which introduced `getDefaultApplication()` + name-based resolution. Before that the app argument was left `undefined` when no preferred browser was set, so Launch Services routed the URL by its own default and returned the right browser.

### The fix

`resolveCreationBrowser()` already has the full `Application` from both of its sources — the `appPicker` preference and `getDefaultApplication()` — and was discarding everything but `.name`. It now returns both identities, because they do two different jobs:

- **`application`** launches the browser. Passing the resolved `Application` targets the exact bundle, so no name matching happens.
- **`name`** scripts it. AppleScript addresses an app by the name macOS installs it under (`tell application "Brave Browser"`), and `getAdapterForBrowser()` selects the browser family from that same name.

This leaves the `supportedBrowsers` name matching from #29981 fully intact — that fix is about the scripting identity, which still needs the exact installed name. The change only stops the *launch* target from being re-derived from a display name.

It also brings the browser path in line with the PWA path, which already passes an `Application` to `open()` (`browser-adapters/pwa.ts`).

## Screencast

Straightforward two-file change with no UI surface, so no screencast. Verified manually with Dia set as the default browser, in both branches of `resolveCreationBrowser()`:

- **"Set preferred browser" set to Dia** — before: Obsidian launched, no meeting, no error toast. After: Dia opens `meet.google.com/new`, the link is detected and copied.
- **"Set preferred browser" left empty** (falls through to `getDefaultApplication()`) — same result. This is the path that originally broke.

`npm run build` and `npx ray lint` both pass.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
