### PR TITLE
fix(google-chrome-profiles): don't open a window for the previously used profile on cold start

### DIFF
--- a/extensions/google-chrome-profiles/CHANGELOG.md
+++ b/extensions/google-chrome-profiles/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Chrome Profiles Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-08-12
 
 - Fix opening a profile while Chrome is closed producing two windows: the requested profile, plus one for whichever profile was used last. The Bring to Front / New Tab / Open URL path began with `tell application "Google Chrome" to activate`, which launches Chrome with no arguments; a flagless Chrome restores every profile listed in `profile.last_active_profiles` (Local State), so the previous profile's window appeared before System Events ever clicked the Profiles menu. Branch on whether the browser is already running: when it is, the Profiles-menu click is unchanged and keeps the focus / add-a-tab / find-an-existing-tab semantics; when it is not, do a single cold start into the requested profile with `/usr/bin/open -n -a <bundle> --args --profile-directory=<dir> --new-window [url]`. `--profile-directory` is the profile a cold Chrome boots into, which is what suppresses the session restore.
 - Fix the New Window action holding an `osascript` subprocess open for the browser's entire lifetime. It exec'd Chrome's inner Mach-O binary directly, so `do shell script` never returned; it now shares the `/usr/bin/open` helper above, which returns as soon as Launch Services takes the request. `BrowserConfig.binaryPath` becomes `appPath` accordingly, since `open -a` expects the `.app` bundle.

--- a/extensions/google-chrome-profiles/CHANGELOG.md
+++ b/extensions/google-chrome-profiles/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Google Chrome Profiles Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Fix opening a profile while Chrome is closed producing two windows: the requested profile, plus one for whichever profile was used last. The Bring to Front / New Tab / Open URL path began with `tell application "Google Chrome" to activate`, which launches Chrome with no arguments; a flagless Chrome restores every profile listed in `profile.last_active_profiles` (Local State), so the previous profile's window appeared before System Events ever clicked the Profiles menu. Branch on whether the browser is already running: when it is, the Profiles-menu click is unchanged and keeps the focus / add-a-tab / find-an-existing-tab semantics; when it is not, do a single cold start into the requested profile with `/usr/bin/open -n -a <bundle> --args --profile-directory=<dir> --new-window [url]`. `--profile-directory` is the profile a cold Chrome boots into, which is what suppresses the session restore.
+- Fix the New Window action holding an `osascript` subprocess open for the browser's entire lifetime. It exec'd Chrome's inner Mach-O binary directly, so `do shell script` never returned; it now shares the `/usr/bin/open` helper above, which returns as soon as Launch Services takes the request. `BrowserConfig.binaryPath` becomes `appPath` accordingly, since `open -a` expects the `.app` bundle.
+
 ## [Fix] - 2026-07-14
 
 - Fix profile actions still failing in the store build after the 2026-05-26 detached-spawn fix. `showHUD` was awaited *before* spawning the detached `osascript` subprocess; `showHUD` closes the main window, which starts the extension process teardown, so in the distribution build the Node process could be killed before the `spawn` call ever ran — the HUD appeared but no Chrome action happened. (Dev mode keeps the process alive, which is why this never reproduced under `npm run dev`.) Spawn the detached subprocess first, then show the HUD; skip the HUD when the spawn failed so the failure toast stays visible.

--- a/extensions/google-chrome-profiles/package.json
+++ b/extensions/google-chrome-profiles/package.json
@@ -10,7 +10,8 @@
     "jschmidtcordeiro",
     "NirRosh",
     "josh_carty",
-    "smpeotn"
+    "smpeotn",
+    "radek_cabaj"
   ],
   "license": "MIT",
   "commands": [

--- a/extensions/google-chrome-profiles/src/util/types.ts
+++ b/extensions/google-chrome-profiles/src/util/types.ts
@@ -85,19 +85,24 @@ export type GoogleChromeBookmarkFile = {
 export interface BrowserConfig {
   readonly appName: string;
   readonly dataPath: string;
-  readonly binaryPath: string;
+  /**
+   * The `.app` bundle, passed to `open -a`. Not the inner Mach-O binary:
+   * `open` resolves the bundle through Launch Services, which is what makes
+   * the browser come to the front and the command return immediately.
+   */
+  readonly appPath: string;
 }
 
 export const BROWSERS: Record<string, BrowserConfig> = {
   chrome: {
     appName: "Google Chrome",
     dataPath: "Library/Application Support/Google/Chrome",
-    binaryPath: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    appPath: "/Applications/Google Chrome.app",
   },
   "chrome-canary": {
     appName: "Google Chrome Canary",
     dataPath: "Library/Application Support/Google/Chrome Canary",
-    binaryPath: "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+    appPath: "/Applications/Google Chrome Canary.app",
   },
 };
 

--- a/extensions/google-chrome-profiles/src/util/util.ts
+++ b/extensions/google-chrome-profiles/src/util/util.ts
@@ -263,12 +263,48 @@ const runDetachedAppleScript = (script: string): boolean => {
 };
 
 /**
+ * An AppleScript `do shell script` line that launches the browser directly
+ * into `profileDirectory`, optionally at `url`.
+ *
+ * Each piece is load-bearing:
+ *
+ * - `/usr/bin/open` rather than the inner binary: `open` returns as soon as
+ *   Launch Services has taken the request, so the detached `osascript` is not
+ *   held open for the browser's entire lifetime, and the browser is properly
+ *   activated.
+ * - `-n`: the browser's singleton lock makes the second process hand its
+ *   command line to the already-running instance and exit, so this opens a
+ *   window in the requested profile instead of starting a second browser.
+ * - `--profile-directory`: on a *cold* start this is the profile the browser
+ *   boots into. A bare `activate` boots it into the last-used profile
+ *   instead, which is what produced a stray window for the previous profile.
+ * - `--new-window`: without it the browser appends a tab to an existing
+ *   window of that profile rather than opening a window.
+ */
+const launchInProfileCommand = (browser: BrowserConfig, profileDirectory: string, url?: string): string => {
+  const parts = [
+    `"/usr/bin/open -n -a " & quoted form of "${escapeAppleScriptString(browser.appPath)}"`,
+    `" --args --profile-directory=" & quoted form of "${escapeAppleScriptString(profileDirectory)}"`,
+    `" --new-window"`,
+  ];
+  if (url) {
+    parts.push(`" " & quoted form of "${escapeAppleScriptString(url)}"`);
+  }
+  return `do shell script ${parts.join(" & ")}`;
+};
+
+/**
  * Run the script that opens Google Chrome.
  *
  * - `ChromeAction.Focus`: focuses the existing profile window (or opens it if not open)
  * - `ChromeAction.NewTab`: focuses the profile window, then opens a new blank tab
  * - `ChromeAction.NewWindow`: opens a new window for the profile
  * - `ChromeAction.openUrl(url)`: focuses the profile window, then opens the URL in a new tab
+ *
+ * When the browser is not running, every action collapses to a single cold
+ * start into the requested profile (see `launchInProfileCommand`) — there is
+ * no window to focus or add a tab to yet, and going through the Profiles menu
+ * would first have to boot the browser into the last-used profile.
  *
  * @param profile The Chrome profile to open
  * @param target The action to perform
@@ -288,16 +324,8 @@ export const openGoogleChrome = async (
   const action = target.action;
   const url = action === "openUrl" ? target.url : undefined;
 
-  const escapedProfileDirectory = escapeAppleScriptString(profile.directory);
-  const escapedBinaryPath = escapeAppleScriptString(browser.binaryPath);
-
   if (action === "newWindow") {
-    const newWindowScript = `
-      set theAppPath to quoted form of "${escapedBinaryPath}"
-      set theProfile to quoted form of "${escapedProfileDirectory}"
-      do shell script theAppPath & " --profile-directory=" & theProfile & " --new-window"
-    `;
-    if (runDetachedAppleScript(newWindowScript)) {
+    if (runDetachedAppleScript(launchInProfileCommand(browser, profile.directory))) {
       await didSpawn();
     }
     return;
@@ -309,7 +337,13 @@ export const openGoogleChrome = async (
 
   // Use menu bar item 8 for Profiles menu (language-independent position)
   // Chrome menu bar: 1=Apple, 2=Chrome, 3=File, 4=Edit, 5=View, 6=History, 7=Bookmarks, 8=Profiles, 9=Tab, 10=Window, 11=Help
-  const script = `
+  //
+  // The Profiles menu only exists once the browser is up, so this whole path
+  // assumes a running browser. Cold-starting it here is not an option: the
+  // `activate` below would boot it into the *last-used* profile and leave that
+  // window behind next to the one the menu click opens. The `else` branch
+  // below cold-starts into the requested profile in one step instead.
+  const menuScript = `
     tell application "${escapedAppName}" to activate
     tell application "System Events"
       tell process "${escapedAppName}"
@@ -374,6 +408,16 @@ export const openGoogleChrome = async (
     `
         : ""
     }
+  `;
+
+  // `is running` is the one way to ask about an application without launching
+  // it — `tell application ... to activate` would start it as a side effect.
+  const script = `
+    if application "${escapedAppName}" is running then
+      ${menuScript}
+    else
+      ${launchInProfileCommand(browser, profile.directory, url)}
+    end if
   `;
 
   if (runDetachedAppleScript(script)) {


### PR DESCRIPTION
## Description

Opening a profile while Chrome is **closed** produces two windows: the profile you asked for, plus one for whichever profile was used last.

I hit this daily — quit Chrome on profile X, ask the extension for profile Y, and get a stray X window every time alongside the Y window I wanted.

### Cause

The Bring to Front / New Tab / Open URL path starts with:

```applescript
tell application "Google Chrome" to activate
```

`activate` launches Chrome with **no arguments**. A flagless Chrome restores every profile listed in `profile.last_active_profiles` (in `Local State`), so the previously used profile's window is already on screen before System Events ever clicks the Profiles menu. The menu click then adds the requested profile as a second window.

The Profiles menu is only reachable once Chrome is up, so this path can't avoid cold-starting it — and cold-starting it via `activate` is exactly what goes wrong.

### Fix

Branch on whether the browser is already running:

- **Running** — unchanged. The Profiles-menu click still gives the existing focus / add-a-tab / find-an-existing-tab semantics.
- **Not running** — a single cold start straight into the requested profile:

```
/usr/bin/open -n -a <bundle> --args --profile-directory=<dir> --new-window [url]
```

`--profile-directory` is the profile a cold Chrome boots into, which is what suppresses the session restore. With no window to focus or add a tab to, all three actions collapse to this same cold start; `openUrl` passes the URL as the trailing argument.

`is running` is used because it's the one way to ask about an application without launching it as a side effect.

### Also fixed

The **New Window** action previously exec'd Chrome's inner Mach-O binary directly, so `do shell script` never returned and the detached `osascript` stayed alive for the browser's entire session. It now shares the `/usr/bin/open` helper, which returns as soon as Launch Services accepts the request. `BrowserConfig.binaryPath` becomes `appPath` accordingly, since `open -a` expects the `.app` bundle rather than the executable inside it.

## Testing

Two profiles (`Default`, `Profile 1`), with `last_active_profiles` containing both. For each case Chrome was fully quit first, then the profile that was **not** last used was requested. Profiles actually loaded were confirmed via `lsof` on the browser process rather than by eyeballing windows:

| | Chrome argv | profiles loaded | windows |
|---|---|---|---|
| Before (`activate`) | `…/Google Chrome` (no flags) | `Default` + `Profile 1` | 2 |
| After | `…/Google Chrome --profile-directory=Profile 1 --new-window` | `Profile 1` only | 1 |

Also re-checked with Chrome already running: Bring to Front raises the existing window, New Tab adds a tab rather than a window, and Open URL still jumps to a matching tab when one exists.

`ray lint` and `ray build` both pass.

### Note

One case this cannot address: if a profile has *"Continue where you left off"* set, Chrome restores it on any cold start regardless of `--profile-directory`. That's Chrome's startup behaviour and is out of scope here.