### PR TITLE
Enhance Pins with group launch and import workflows

### DIFF
--- a/extensions/pins/CHANGELOG.md
+++ b/extensions/pins/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Pins Changelog
 
-## [1.10.0 - Group Quicklinks and URL Workflows] - {PR_MERGE_DATE}
+## [1.10.0 - Group Quicklinks and URL Workflows] - 2026-08-14
 
 - Added a no-view command for opening all pins in a group.
 - Added actions to create a Quicklink or copy a deeplink for a group.

--- a/extensions/pins/CHANGELOG.md
+++ b/extensions/pins/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Pins Changelog
 
-## [1.10.0 - Group Quicklinks and URL Workflows] - 2026-08-06
+## [1.10.0 - Group Quicklinks and URL Workflows] - {PR_MERGE_DATE}
 
 - Added a no-view command for opening all pins in a group.
 - Added actions to create a Quicklink or copy a deeplink for a group.

--- a/extensions/pins/CHANGELOG.md
+++ b/extensions/pins/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Pins Changelog
 
+## [1.10.0 - Group Quicklinks and URL Workflows] - 2026-08-06
+
+- Added a no-view command for opening all pins in a group.
+- Added actions to create a Quicklink or copy a deeplink for a group.
+- Added an optional preferred browser per group, with per-pin application settings taking precedence.
+- Added fast bulk import for newline-separated URLs into a selected group.
+
 ## [1.9.0 - Pin Aliases & Per-Group Display Setting] - 2024-07-21
 
 - Added setting for pin aliases.

--- a/extensions/pins/README.md
+++ b/extensions/pins/README.md
@@ -13,6 +13,9 @@ A Raycast extension for pinning anything with a path or URL to the menu bar, wit
 - Pin current browser tab, Finder selection, frontmost document, etc. with a single click
 - Customize pin icons
 - Create groups and subgroups to organize pins into
+- Open groups from Quicklinks or deeplinks without showing the Pins interface
+- Choose an optional preferred browser for each group
+- Bulk-import newline-separated URLs into a group
 - Customize group icons
 - Edit pins and groups as desired
 - Move/rearrange pins and groups as desired
@@ -27,6 +30,7 @@ A Raycast extension for pinning anything with a path or URL to the menu bar, wit
 - Show Pins - Initiates the menu bar extra
 - View Pins - Lists all pins, allows you to edit existing or rearrange existing pins
 - View Groups - Lists all groups, allows you to edit existing groups
+- Open Pin Group - Opens every pin in a group without showing a view (used by group Quicklinks and deeplinks)
 - New Pin - Creates a new pin with a given name, URL/path, icon, and group assignment
 - New Group - Creates a new group with a given name and icon
 - Export Pin Data - Copies a JSON representation of your pins and groups to the clipboard

--- a/extensions/pins/package-lock.json
+++ b/extensions/pins/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "pins",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pins",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
         "@raycast/api": "^1.77.1",
-        "@raycast/utils": "^1.16.1",
+        "@raycast/utils": "^1.19.1",
         "@types/papaparse": "^5.3.8",
         "@types/xml-js": "^1.0.0",
         "papaparse": "^5.4.1",
@@ -401,13 +401,13 @@
       }
     },
     "node_modules/@raycast/utils": {
-      "version": "1.16.1",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-1.19.1.tgz",
+      "integrity": "sha512-/udUGcTZCgZZwzesmjBkqG5naQZTD/ZLHbqRwkWcF+W97vf9tr9raxKyQjKsdZ17OVllw2T3sHBQsVUdEmCm2g==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
         "cross-fetch": "^3.1.6",
         "dequal": "^2.0.3",
-        "media-typer": "^1.1.0",
         "object-hash": "^3.0.0",
         "signal-exit": "^4.0.2",
         "stream-chain": "^2.2.5",
@@ -706,13 +706,6 @@
       "version": "0.0.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/content-type": {
-      "version": "1.0.5",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/cross-fetch": {
       "version": "3.1.8",
@@ -1382,13 +1375,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/media-typer": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/merge2": {

--- a/extensions/pins/package.json
+++ b/extensions/pins/package.json
@@ -551,5 +551,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/pins/package.json
+++ b/extensions/pins/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "pins",
   "title": "Pins",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Create pins for paths and URLs and display them in the menu bar",
   "keywords": [
     "pin",
@@ -21,7 +21,8 @@
   "icon": "command-icon.png",
   "author": "HelloImSteven",
   "contributors": [
-    "pernielsentikaer"
+    "pernielsentikaer",
+    "matheuscoelho3006"
   ],
   "categories": [
     "Productivity",
@@ -326,6 +327,20 @@
       ]
     },
     {
+      "name": "open-pin-group",
+      "title": "Open Pin Group",
+      "description": "Open all pins in a group",
+      "mode": "no-view",
+      "arguments": [
+        {
+          "name": "groupId",
+          "type": "text",
+          "required": true,
+          "placeholder": "Group ID"
+        }
+      ]
+    },
+    {
       "name": "copy-pins",
       "title": "Export Pin Data",
       "description": "Export pins and groups in JSON, CSV, TOML, YAML, or XML format",
@@ -514,7 +529,7 @@
   "dependencies": {
     "@iarna/toml": "^2.2.5",
     "@raycast/api": "^1.77.1",
-    "@raycast/utils": "^1.16.1",
+    "@raycast/utils": "^1.19.1",
     "@types/papaparse": "^5.3.8",
     "@types/xml-js": "^1.0.0",
     "papaparse": "^5.4.1",

--- a/extensions/pins/src/components/BulkImportUrlsForm.tsx
+++ b/extensions/pins/src/components/BulkImportUrlsForm.tsx
@@ -9,28 +9,47 @@ type BulkImportUrlsFormProps = {
   onImported: () => Promise<void>;
 };
 
+/**
+ * Normalizes a URL while preserving any explicit URL scheme supported by Pins.
+ * @param input The URL to normalize.
+ * @returns The normalized URL, or undefined if the value is invalid.
+ */
 const normalizeUrl = (input: string) => {
   const trimmed = input.trim();
   if (!trimmed) return undefined;
 
-  const candidate = /^[a-zA-Z][a-zA-Z\d+.-]*:\/\//.test(trimmed) ? trimmed : `https://${trimmed}`;
+  const hasExplicitScheme = /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(trimmed);
+  const looksLikeHostWithPort = /^(?:localhost|(?:\d{1,3}\.){3}\d{1,3}|[^/:\s]+\.[^/:\s]+):\d+(?:[/?#]|$)/i.test(
+    trimmed,
+  );
+  const candidate = hasExplicitScheme && !looksLikeHostWithPort ? trimmed : `https://${trimmed}`;
   try {
     const url = new URL(candidate);
-    if (url.protocol != "http:" && url.protocol != "https:") return undefined;
     return url.toString();
   } catch {
     return undefined;
   }
 };
 
+/**
+ * Creates a concise default pin title from a URL.
+ * @param url The normalized URL.
+ * @returns A title of at most 80 characters.
+ */
 const titleFromUrl = (url: string) => {
   const parsed = new URL(url);
   const hostname = parsed.hostname.replace(/^www\./, "");
   const pathname = parsed.pathname.replace(/^\/+|\/+$/g, "");
-  const title = pathname ? `${hostname}/${pathname}` : hostname;
+  const title = hostname ? (pathname ? `${hostname}/${pathname}` : hostname) : `${parsed.protocol}${parsed.pathname}`;
   return title.length > 80 ? `${title.slice(0, 77)}...` : title;
 };
 
+/**
+ * Form for importing newline-separated URLs into a group.
+ * @param props.group The target group.
+ * @param props.onImported The function to call after importing pins.
+ * @returns A form view.
+ */
 export default function BulkImportUrlsForm({ group, onImported }: BulkImportUrlsFormProps) {
   const { pop } = useNavigation();
 

--- a/extensions/pins/src/components/BulkImportUrlsForm.tsx
+++ b/extensions/pins/src/components/BulkImportUrlsForm.tsx
@@ -1,0 +1,109 @@
+import { Action, ActionPanel, Form, Icon, showToast, Toast, useNavigation } from "@raycast/api";
+
+import { Group } from "../lib/Groups";
+import { createNewPins, getPins } from "../lib/Pins";
+import { Visibility } from "../lib/constants";
+
+type BulkImportUrlsFormProps = {
+  group: Group;
+  onImported: () => Promise<void>;
+};
+
+const normalizeUrl = (input: string) => {
+  const trimmed = input.trim();
+  if (!trimmed) return undefined;
+
+  const candidate = /^[a-zA-Z][a-zA-Z\d+.-]*:\/\//.test(trimmed) ? trimmed : `https://${trimmed}`;
+  try {
+    const url = new URL(candidate);
+    if (url.protocol != "http:" && url.protocol != "https:") return undefined;
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+};
+
+const titleFromUrl = (url: string) => {
+  const parsed = new URL(url);
+  const hostname = parsed.hostname.replace(/^www\./, "");
+  const pathname = parsed.pathname.replace(/^\/+|\/+$/g, "");
+  const title = pathname ? `${hostname}/${pathname}` : hostname;
+  return title.length > 80 ? `${title.slice(0, 77)}...` : title;
+};
+
+export default function BulkImportUrlsForm({ group, onImported }: BulkImportUrlsFormProps) {
+  const { pop } = useNavigation();
+
+  return (
+    <Form
+      navigationTitle={`Import URLs into ${group.name}`}
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm
+            title="Import URLs"
+            icon={Icon.Download}
+            onSubmit={async (values) => {
+              const lines = String(values.urls || "")
+                .split(/\r?\n/)
+                .map((line) => line.trim())
+                .filter(Boolean);
+
+              if (lines.length == 0) {
+                await showToast({ style: Toast.Style.Failure, title: "No URLs provided" });
+                return;
+              }
+
+              const normalized = lines.map(normalizeUrl);
+              const invalidCount = normalized.filter((url) => url == undefined).length;
+              const uniqueUrls = [...new Set(normalized.filter((url): url is string => url != undefined))];
+              const storedPins = await getPins();
+              const existingUrls = new Set(
+                storedPins.filter((pin) => pin.group == group.name).map((pin) => normalizeUrl(pin.url) || pin.url),
+              );
+              const newUrls = uniqueUrls.filter((url) => !existingUrls.has(url));
+              const duplicateCount =
+                uniqueUrls.length - newUrls.length + (normalized.length - invalidCount - uniqueUrls.length);
+
+              if (newUrls.length == 0) {
+                await showToast({
+                  style: Toast.Style.Failure,
+                  title: "No new URLs to import",
+                  message:
+                    invalidCount > 0 ? `${invalidCount} invalid URL${invalidCount == 1 ? "" : "s"} skipped` : undefined,
+                });
+                return;
+              }
+
+              await createNewPins(
+                newUrls.map((url) => ({
+                  name: titleFromUrl(url),
+                  url,
+                  icon: "Favicon / File Icon",
+                  group: group.name,
+                  application: "None",
+                  visibility: Visibility.USE_PARENT,
+                })),
+              );
+              await onImported();
+
+              const details = [
+                invalidCount > 0 ? `${invalidCount} invalid skipped` : undefined,
+                duplicateCount > 0 ? `${duplicateCount} duplicate${duplicateCount == 1 ? "" : "s"} skipped` : undefined,
+              ].filter(Boolean);
+
+              await showToast({
+                style: Toast.Style.Success,
+                title: `Imported ${newUrls.length} pin${newUrls.length == 1 ? "" : "s"}`,
+                message: details.length > 0 ? details.join("; ") : undefined,
+              });
+              pop();
+            }}
+          />
+        </ActionPanel>
+      }
+    >
+      <Form.TextArea id="urls" title="URLs" placeholder="Paste one URL per line..." autoFocus />
+      <Form.Description text="Missing schemes are treated as HTTPS. Invalid and duplicate URLs are skipped." />
+    </Form>
+  );
+}

--- a/extensions/pins/src/components/BulkImportUrlsForm.tsx
+++ b/extensions/pins/src/components/BulkImportUrlsForm.tsx
@@ -3,6 +3,7 @@ import { Action, ActionPanel, Form, Icon, showToast, Toast, useNavigation } from
 import { Group } from "../lib/Groups";
 import { createNewPins, getPins } from "../lib/Pins";
 import { Visibility } from "../lib/constants";
+import { hasURLScheme } from "../lib/utils";
 
 type BulkImportUrlsFormProps = {
   group: Group;
@@ -18,16 +19,32 @@ const normalizeUrl = (input: string) => {
   const trimmed = input.trim();
   if (!trimmed) return undefined;
 
-  const hasExplicitScheme = /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(trimmed);
   const looksLikeHostWithPort = /^(?:localhost|(?:\d{1,3}\.){3}\d{1,3}|[^/:\s]+\.[^/:\s]+):\d+(?:[/?#]|$)/i.test(
     trimmed,
   );
-  const candidate = hasExplicitScheme && !looksLikeHostWithPort ? trimmed : `https://${trimmed}`;
+  const candidate = hasURLScheme(trimmed) && !looksLikeHostWithPort ? trimmed : `https://${trimmed}`;
   try {
-    const url = new URL(candidate);
-    return url.toString();
+    new URL(candidate.replace(/{{[\s\S]*}}/g, "pins-placeholder"));
+    return candidate;
   } catch {
     return undefined;
+  }
+};
+
+/**
+ * Produces a canonical key for URL comparisons without changing the stored URL.
+ * @param url The URL to canonicalize.
+ * @returns A canonical comparison key, or undefined if the URL is invalid.
+ */
+const canonicalizeUrl = (url: string) => {
+  const normalized = normalizeUrl(url);
+  if (!normalized) return undefined;
+  if (normalized.includes("{{")) return `placeholder:${normalized}`;
+
+  try {
+    return new URL(normalized).toString();
+  } catch {
+    return normalized;
   }
 };
 
@@ -37,11 +54,16 @@ const normalizeUrl = (input: string) => {
  * @returns A title of at most 80 characters.
  */
 const titleFromUrl = (url: string) => {
-  const parsed = new URL(url);
-  const hostname = parsed.hostname.replace(/^www\./, "");
-  const pathname = parsed.pathname.replace(/^\/+|\/+$/g, "");
-  const title = hostname ? (pathname ? `${hostname}/${pathname}` : hostname) : `${parsed.protocol}${parsed.pathname}`;
-  return title.length > 80 ? `${title.slice(0, 77)}...` : title;
+  try {
+    const parsed = new URL(url);
+    const hostname = parsed.hostname.replace(/^www\./, "");
+    const encodedPathname = parsed.pathname.replace(/^\/+|\/+$/g, "");
+    const pathname = decodeURI(encodedPathname);
+    const title = hostname ? (pathname ? `${hostname}/${pathname}` : hostname) : `${parsed.protocol}${pathname}`;
+    return title.length > 80 ? `${title.slice(0, 77)}...` : title;
+  } catch {
+    return url.length > 80 ? `${url.slice(0, 77)}...` : url;
+  }
 };
 
 /**
@@ -74,14 +96,24 @@ export default function BulkImportUrlsForm({ group, onImported }: BulkImportUrls
 
               const normalized = lines.map(normalizeUrl);
               const invalidCount = normalized.filter((url) => url == undefined).length;
-              const uniqueUrls = [...new Set(normalized.filter((url): url is string => url != undefined))];
+              const uniqueUrls = new Map<string, string>();
+              for (const url of normalized) {
+                if (!url) continue;
+                const canonicalUrl = canonicalizeUrl(url);
+                if (canonicalUrl && !uniqueUrls.has(canonicalUrl)) uniqueUrls.set(canonicalUrl, url);
+              }
+
               const storedPins = await getPins();
               const existingUrls = new Set(
-                storedPins.filter((pin) => pin.group == group.name).map((pin) => normalizeUrl(pin.url) || pin.url),
+                storedPins
+                  .filter((pin) => pin.group == group.name)
+                  .map((pin) => canonicalizeUrl(pin.url))
+                  .filter((url): url is string => url != undefined),
               );
-              const newUrls = uniqueUrls.filter((url) => !existingUrls.has(url));
-              const duplicateCount =
-                uniqueUrls.length - newUrls.length + (normalized.length - invalidCount - uniqueUrls.length);
+              const newUrls = [...uniqueUrls.entries()]
+                .filter(([canonicalUrl]) => !existingUrls.has(canonicalUrl))
+                .map(([, url]) => url);
+              const duplicateCount = normalized.length - invalidCount - newUrls.length;
 
               if (newUrls.length == 0) {
                 await showToast({

--- a/extensions/pins/src/components/GroupForm.tsx
+++ b/extensions/pins/src/components/GroupForm.tsx
@@ -87,7 +87,7 @@ export default function GroupForm(props: { group?: Group; groups?: Group[]; setG
                   iconColor: values.iconColorField,
                   visibility: values.visibilityField,
                   menubarDisplay: values.menubarDisplayField,
-                  browser: values.browserField == "None" ? undefined : values.browserField,
+                  preferredBrowser: values.preferredBrowserField == "None" ? undefined : values.preferredBrowserField,
                 });
                 await launchCommand({
                   name: "view-groups",
@@ -107,7 +107,7 @@ export default function GroupForm(props: { group?: Group; groups?: Group[]; setG
                     iconColor: values.iconColorField,
                     visibility: values.visibilityField,
                     menubarDisplay: values.menubarDisplayField,
-                    browser: values.browserField == "None" ? undefined : values.browserField,
+                    preferredBrowser: values.preferredBrowserField == "None" ? undefined : values.preferredBrowserField,
                   },
                   setGroups as (groups: Group[]) => void,
                   pop,
@@ -165,12 +165,21 @@ export default function GroupForm(props: { group?: Group; groups?: Group[]; setG
       </Form.Dropdown>
 
       <Form.Dropdown
-        id="browserField"
+        id="preferredBrowserField"
         title="Preferred Browser"
         info="The browser used for URL pins in this group when a pin does not have its own Open With setting."
-        defaultValue={targetGroup.browser || "None"}
+        defaultValue={targetGroup.preferredBrowser || "None"}
       >
         <Form.Dropdown.Item key="None" title="Use Global Preferred Browser" value="None" icon={Icon.Globe} />
+        {targetGroup.preferredBrowser &&
+        !browsers.some((browser) => (browser.bundleId || browser.path) == targetGroup.preferredBrowser) ? (
+          <Form.Dropdown.Item
+            key={targetGroup.preferredBrowser}
+            title={`Previously Selected (${targetGroup.preferredBrowser})`}
+            value={targetGroup.preferredBrowser}
+            icon={Icon.Globe}
+          />
+        ) : null}
         {browsers.map((browser) => (
           <Form.Dropdown.Item
             key={browser.bundleId || browser.path}

--- a/extensions/pins/src/components/GroupForm.tsx
+++ b/extensions/pins/src/components/GroupForm.tsx
@@ -1,8 +1,10 @@
 import {
   Action,
   ActionPanel,
+  Application,
   Color,
   Form,
+  getApplications,
   Icon,
   LaunchType,
   environment,
@@ -18,7 +20,7 @@ import {
   modifyGroup,
   useGroups,
 } from "../lib/Groups";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { getIcon } from "../lib/icons";
 import { SORT_STRATEGY, Visibility } from "../lib/constants";
 import { usePins } from "../lib/Pins";
@@ -38,6 +40,7 @@ export default function GroupForm(props: { group?: Group; groups?: Group[]; setG
   const [nameError, setNameError] = useState<string | undefined>();
   const [parentID, setParentID] = useState<number | undefined>(group?.parent);
   const [parentError, setParentError] = useState<string | undefined>();
+  const [browsers, setBrowsers] = useState<Application[]>([]);
   const { groups } = useGroups();
   const { pop } = useNavigation();
 
@@ -53,6 +56,12 @@ export default function GroupForm(props: { group?: Group; groups?: Group[]; setG
       : group;
 
   const parent = group?.parent ? groups.find((g) => g.id == group.parent) : undefined;
+
+  useEffect(() => {
+    getApplications("https://example.com")
+      .then(setBrowsers)
+      .catch(() => setBrowsers([]));
+  }, []);
 
   return (
     <Form
@@ -78,6 +87,7 @@ export default function GroupForm(props: { group?: Group; groups?: Group[]; setG
                   iconColor: values.iconColorField,
                   visibility: values.visibilityField,
                   menubarDisplay: values.menubarDisplayField,
+                  browser: values.browserField == "None" ? undefined : values.browserField,
                 });
                 await launchCommand({
                   name: "view-groups",
@@ -97,6 +107,7 @@ export default function GroupForm(props: { group?: Group; groups?: Group[]; setG
                     iconColor: values.iconColorField,
                     visibility: values.visibilityField,
                     menubarDisplay: values.menubarDisplayField,
+                    browser: values.browserField == "None" ? undefined : values.browserField,
                   },
                   setGroups as (groups: Group[]) => void,
                   pop,
@@ -151,6 +162,23 @@ export default function GroupForm(props: { group?: Group; groups?: Group[]; setG
             />
           );
         })}
+      </Form.Dropdown>
+
+      <Form.Dropdown
+        id="browserField"
+        title="Preferred Browser"
+        info="The browser used for URL pins in this group when a pin does not have its own Open With setting."
+        defaultValue={targetGroup.browser || "None"}
+      >
+        <Form.Dropdown.Item key="None" title="Use Global Preferred Browser" value="None" icon={Icon.Globe} />
+        {browsers.map((browser) => (
+          <Form.Dropdown.Item
+            key={browser.bundleId || browser.path}
+            title={browser.name}
+            value={browser.bundleId || browser.path}
+            icon={{ fileIcon: browser.path }}
+          />
+        ))}
       </Form.Dropdown>
 
       <Form.Dropdown

--- a/extensions/pins/src/components/actions/CopyGroupActionsSubmenu.tsx
+++ b/extensions/pins/src/components/actions/CopyGroupActionsSubmenu.tsx
@@ -7,10 +7,16 @@ import { Group, getGroupStatistics } from "../../lib/Groups";
  * @param props.group The group to copy information about.
  * @param props.groups The list of groups to use for statistics.
  * @param props.pins The list of pins to use for statistics.
+ * @param props.deeplink The deeplink used to open the group.
  * @returns A submenu component.
  */
-export default function CopyGroupActionsSubmenu(props: { group: Group; groups: Group[]; pins: Pin[] }) {
-  const { group, groups, pins } = props;
+export default function CopyGroupActionsSubmenu(props: {
+  group: Group;
+  groups: Group[];
+  pins: Pin[];
+  deeplink: string;
+}) {
+  const { group, groups, pins, deeplink } = props;
 
   return (
     <ActionPanel.Submenu title="Clipboard Actions" icon={Icon.Clipboard}>
@@ -24,6 +30,7 @@ export default function CopyGroupActionsSubmenu(props: { group: Group; groups: G
         content={group.id.toString()}
         shortcut={{ modifiers: ["cmd", "shift"], key: "i" }}
       />
+      <Action.CopyToClipboard title="Copy Group Deeplink" content={deeplink} />
       <Action
         title="Copy Group JSON"
         icon={Icon.Clipboard}

--- a/extensions/pins/src/import-data.tsx
+++ b/extensions/pins/src/import-data.tsx
@@ -179,7 +179,7 @@ const importCSVData = async (data: string[][], importMethod: string) => {
           indices.menubarDisplay == -1
             ? undefined
             : (row[indices.menubarDisplay] as GroupDisplaySetting) || GroupDisplaySetting.USE_PARENT,
-        browser: indices.browser == undefined ? undefined : row[indices.browser],
+        preferredBrowser: indices.preferredBrowser == undefined ? undefined : row[indices.preferredBrowser],
       };
     });
     await importJSONData({ groups: newGroups }, importMethod);

--- a/extensions/pins/src/import-data.tsx
+++ b/extensions/pins/src/import-data.tsx
@@ -179,6 +179,7 @@ const importCSVData = async (data: string[][], importMethod: string) => {
           indices.menubarDisplay == -1
             ? undefined
             : (row[indices.menubarDisplay] as GroupDisplaySetting) || GroupDisplaySetting.USE_PARENT,
+        browser: indices.browser == undefined ? undefined : row[indices.browser],
       };
     });
     await importJSONData({ groups: newGroups }, importMethod);

--- a/extensions/pins/src/lib/Groups.ts
+++ b/extensions/pins/src/lib/Groups.ts
@@ -64,12 +64,27 @@ export type Group = {
    * How the group should be displayed in the menubar.
    */
   menubarDisplay?: GroupDisplaySetting;
+
+  /**
+   * The browser identifier to use for URL pins in this group when the pin has no application override.
+   */
+  browser?: string;
 };
 
 /**
  * The keys of an {@link Group} object.
  */
-export const GroupKeys = ["name", "icon", "id", "parent", "sortStrategy", "iconColor", "dateCreated", "visibility"];
+export const GroupKeys = [
+  "name",
+  "icon",
+  "id",
+  "parent",
+  "sortStrategy",
+  "iconColor",
+  "dateCreated",
+  "visibility",
+  "browser",
+];
 
 /**
  * Checks if an object is a group.

--- a/extensions/pins/src/lib/Groups.ts
+++ b/extensions/pins/src/lib/Groups.ts
@@ -68,7 +68,7 @@ export type Group = {
   /**
    * The browser identifier to use for URL pins in this group when the pin has no application override.
    */
-  browser?: string;
+  preferredBrowser?: string;
 };
 
 /**
@@ -83,7 +83,7 @@ export const GroupKeys = [
   "iconColor",
   "dateCreated",
   "visibility",
-  "browser",
+  "preferredBrowser",
 ];
 
 /**

--- a/extensions/pins/src/lib/Pins.ts
+++ b/extensions/pins/src/lib/Pins.ts
@@ -395,7 +395,7 @@ export const openPin = async (
           if (target.match(/^[a-zA-Z](?![%])[a-zA-Z0-9+.-]+?:.*/g)) {
             const groupBrowser = targetApplication
               ? undefined
-              : (await getGroups()).find((group) => group.name == pin.group)?.browser;
+              : (await getGroups()).find((group) => group.name == pin.group)?.preferredBrowser;
 
             // Prefer the pin's application, then its group's browser, then the global preferred browser.
             await open(encodeURI(target), targetApplication || groupBrowser || preferences.preferredBrowser);

--- a/extensions/pins/src/lib/Pins.ts
+++ b/extensions/pins/src/lib/Pins.ts
@@ -25,7 +25,13 @@ import {
 } from "@raycast/api";
 import { useEffect, useState } from "react";
 import { SORT_FN, StorageKey, SORT_STRATEGY, Visibility, PinAction } from "./constants";
-import { objectFromNonNullableEntriesOfObject, runCommand, runCommandInTerminal } from "./utils";
+import {
+  encodeURIOnce,
+  hasURLScheme,
+  objectFromNonNullableEntriesOfObject,
+  runCommand,
+  runCommandInTerminal,
+} from "./utils";
 import { ExtensionPreferences } from "./preferences";
 import * as fs from "fs";
 import * as os from "os";
@@ -179,6 +185,26 @@ export const PinKeys = [
  */
 export const getPins = async () => {
   return (await getStorage(StorageKey.LOCAL_PINS)) as Pin[];
+};
+
+/**
+ * Checks whether a pin is disabled directly or by a disabled group or ancestor.
+ * @param pin The pin to check.
+ * @param groups The complete list of groups.
+ * @returns Whether the pin is disabled.
+ */
+export const isPinDisabled = (pin: Pin, groups: Group[]) => {
+  if (pin.visibility == Visibility.DISABLED) return true;
+
+  let group = groups.find((candidate) => candidate.name == pin.group);
+  const visitedGroupIDs = new Set<string>();
+  while (group && !visitedGroupIDs.has(group.id.toString())) {
+    if (group.visibility == Visibility.DISABLED) return true;
+    visitedGroupIDs.add(group.id.toString());
+    group = groups.find((candidate) => candidate.id == group?.parent);
+  }
+
+  return false;
 };
 
 /**
@@ -338,19 +364,37 @@ export const usePins = () => {
  * Opens a pin.
  * @param pin The pin to open.
  * @param preferences The extension preferences object.
+ * @param context Values made available to placeholders.
+ * @param groups A previously loaded list of groups.
+ * @returns Whether the pin opened successfully.
  */
 export const openPin = async (
   pin: Pin,
   preferences: { preferredBrowser?: Application },
   context?: { [key: string]: unknown },
+  groups?: Group[],
 ) => {
   const startDate = new Date();
+  let resolvedGroups = groups;
+  const getResolvedGroups = async () => {
+    resolvedGroups = resolvedGroups || (await getGroups());
+    return resolvedGroups;
+  };
+
+  let opened = false;
   try {
+    const disabledByGroup = pin.group && pin.group != "None" ? isPinDisabled(pin, await getResolvedGroups()) : false;
+    if (pin.visibility == Visibility.DISABLED || disabledByGroup) {
+      await showToast({ title: `${pin.name || "Pin"} is disabled`, style: Toast.Style.Failure });
+      return false;
+    }
+
     if (pin.fragment) {
       // Copy the text fragment to the clipboard
       await Clipboard.copy(pin.url);
       await showToast({ title: "Copied To Clipboard" });
       await setStorage(StorageKey.LAST_OPENED_PIN, pin.id);
+      opened = true;
     } else {
       // Convert LocalData objects to strings
       const filteredContext = objectFromNonNullableEntriesOfObject(context || {});
@@ -388,18 +432,21 @@ export const openPin = async (
           if (fs.existsSync(target)) {
             await open(path.resolve(target), targetApplication);
             await setStorage(StorageKey.LAST_OPENED_PIN, pin.id);
+            opened = true;
           } else {
             throw new Error("File does not exist.");
           }
         } else {
-          if (target.match(/^[a-zA-Z](?![%])[a-zA-Z0-9+.-]+?:.*/g)) {
-            const groupBrowser = targetApplication
-              ? undefined
-              : (await getGroups()).find((group) => group.name == pin.group)?.preferredBrowser;
+          if (hasURLScheme(target)) {
+            const groupBrowser =
+              targetApplication || !pin.group || pin.group == "None"
+                ? undefined
+                : (await getResolvedGroups()).find((group) => group.name == pin.group)?.preferredBrowser;
 
             // Prefer the pin's application, then its group's browser, then the global preferred browser.
-            await open(encodeURI(target), targetApplication || groupBrowser || preferences.preferredBrowser);
+            await open(encodeURIOnce(target), targetApplication || groupBrowser || preferences.preferredBrowser);
             await setStorage(StorageKey.LAST_OPENED_PIN, pin.id);
+            opened = true;
           } else {
             // Open Terminal command in the default Terminal application
             await setStorage(StorageKey.LAST_OPENED_PIN, pin.id);
@@ -410,6 +457,7 @@ export const openPin = async (
               // Run the Terminal command in a new Terminal tab
               await runCommandInTerminal(target);
             }
+            opened = true;
           }
         }
       }
@@ -421,7 +469,10 @@ export const openPin = async (
       message: (error as Error).message,
       style: Toast.Style.Failure,
     });
+    return false;
   }
+
+  if (!opened) return false;
 
   const endDate = new Date();
   const timeElapsed = endDate.getTime() - startDate.getTime();
@@ -445,6 +496,7 @@ export const openPin = async (
     },
     false,
   );
+  return true;
 };
 
 /**
@@ -481,8 +533,9 @@ export const createNewPins = async (attributesList: Partial<Pin>[]) => {
   if (attributesList.length == 0) return [];
 
   const storedPins = await getPins();
-  const usedIDs = new Set(storedPins.map((pin) => pin.id));
-  let nextID = ((await getStorage(StorageKey.NEXT_PIN_ID))[0] as number) || 1;
+  const usedIDs = new Set(storedPins.map((pin) => Number(pin.id)).filter((id) => Number.isInteger(id) && id > 0));
+  const storedNextID = Number((await getStorage(StorageKey.NEXT_PIN_ID))[0]);
+  let nextID = Number.isInteger(storedNextID) && storedNextID > 0 ? storedNextID : 1;
 
   const newPins = attributesList.map((attributes) => {
     while (usedIDs.has(nextID)) nextID++;

--- a/extensions/pins/src/lib/Pins.ts
+++ b/extensions/pins/src/lib/Pins.ts
@@ -393,8 +393,12 @@ export const openPin = async (
           }
         } else {
           if (target.match(/^[a-zA-Z](?![%])[a-zA-Z0-9+.-]+?:.*/g)) {
-            // Open the URL in the target application (fallback to preferred browser, then default browser)
-            await open(encodeURI(target), targetApplication || preferences.preferredBrowser);
+            const groupBrowser = targetApplication
+              ? undefined
+              : (await getGroups()).find((group) => group.name == pin.group)?.browser;
+
+            // Prefer the pin's application, then its group's browser, then the global preferred browser.
+            await open(encodeURI(target), targetApplication || groupBrowser || preferences.preferredBrowser);
             await setStorage(StorageKey.LAST_OPENED_PIN, pin.id);
           } else {
             // Open Terminal command in the default Terminal application
@@ -465,30 +469,46 @@ export const getNextPinID = async () => {
  * @returns The new pin object.
  */
 export const createNewPin = async (attributes: Partial<Pin>) => {
-  // Get the stored pins
+  return (await createNewPins([attributes]))[0];
+};
+
+/**
+ * Creates multiple pins in a single storage update.
+ * @param attributesList The attributes of the new pins.
+ * @returns The newly created pin objects.
+ */
+export const createNewPins = async (attributesList: Partial<Pin>[]) => {
+  if (attributesList.length == 0) return [];
+
   const storedPins = await getPins();
-  const newID = await getNextPinID();
+  const usedIDs = new Set(storedPins.map((pin) => pin.id));
+  let nextID = ((await getStorage(StorageKey.NEXT_PIN_ID))[0] as number) || 1;
 
-  // Add the new pin to the list of stored pins
-  const newData = [...storedPins];
-  const newPin = {
-    ...attributes,
-    name: attributes.name?.toString() || "New Pin",
-    url: attributes.url?.toString() || "",
-    icon: attributes.icon?.toString() || "Favicon / File Icon",
-    group: attributes.group?.toString() || "None",
-    application: attributes.application?.toString() || "None",
-    id: newID,
-    expireDate: attributes.expireDate ? new Date(attributes.expireDate as string).toUTCString() : undefined,
-    dateCreated: new Date().toUTCString(),
-    visibility: attributes.visibility || Visibility.VISIBLE,
-    expirationAction: attributes.expirationAction || PinAction.DELETE,
-  } as Pin;
-  newData.push(newPin);
+  const newPins = attributesList.map((attributes) => {
+    while (usedIDs.has(nextID)) nextID++;
 
-  // Update the stored pins
-  await setStorage(StorageKey.LOCAL_PINS, newData);
-  return newPin;
+    const newPin = {
+      ...attributes,
+      name: attributes.name?.toString() || "New Pin",
+      url: attributes.url?.toString() || "",
+      icon: attributes.icon?.toString() || "Favicon / File Icon",
+      group: attributes.group?.toString() || "None",
+      application: attributes.application?.toString() || "None",
+      id: nextID,
+      expireDate: attributes.expireDate ? new Date(attributes.expireDate as string).toUTCString() : undefined,
+      dateCreated: new Date().toUTCString(),
+      visibility: attributes.visibility || Visibility.VISIBLE,
+      expirationAction: attributes.expirationAction || PinAction.DELETE,
+    } as Pin;
+
+    usedIDs.add(nextID);
+    nextID++;
+    return newPin;
+  });
+
+  await setStorage(StorageKey.NEXT_PIN_ID, [nextID]);
+  await setStorage(StorageKey.LOCAL_PINS, [...storedPins, ...newPins]);
+  return newPins;
 };
 
 /**

--- a/extensions/pins/src/lib/openPinGroup.ts
+++ b/extensions/pins/src/lib/openPinGroup.ts
@@ -21,7 +21,9 @@ export const openPinGroup = async (groupId: string | number): Promise<OpenPinGro
 
   const groupPins = getMemberPins(group, groups, pins);
   const preferences = getPreferenceValues<ExtensionPreferences>();
-  await Promise.all(groupPins.map((pin) => openPin(pin, preferences)));
+  for (const pin of groupPins) {
+    await openPin(pin, preferences);
+  }
 
   return { group, opened: groupPins.length };
 };

--- a/extensions/pins/src/lib/openPinGroup.ts
+++ b/extensions/pins/src/lib/openPinGroup.ts
@@ -1,0 +1,26 @@
+import { getPreferenceValues } from "@raycast/api";
+
+import { getGroups, getMemberPins, Group } from "./Groups";
+import { getPins, openPin } from "./Pins";
+import { ExtensionPreferences } from "./preferences";
+
+export type OpenPinGroupResult = {
+  group?: Group;
+  opened: number;
+};
+
+/**
+ * Opens all direct member pins of a group.
+ * @param groupId The ID of the group to open.
+ */
+export const openPinGroup = async (groupId: string | number): Promise<OpenPinGroupResult> => {
+  const [groups, pins] = await Promise.all([getGroups(), getPins()]);
+  const group = groups.find((candidate) => candidate.id.toString() == groupId.toString());
+  if (!group) return { opened: 0 };
+
+  const groupPins = getMemberPins(group, groups, pins);
+  const preferences = getPreferenceValues<ExtensionPreferences>();
+  await Promise.all(groupPins.map((pin) => openPin(pin, preferences)));
+
+  return { group, opened: groupPins.length };
+};

--- a/extensions/pins/src/lib/openPinGroup.ts
+++ b/extensions/pins/src/lib/openPinGroup.ts
@@ -12,6 +12,7 @@ export type OpenPinGroupResult = {
 /**
  * Opens all direct member pins of a group.
  * @param groupId The ID of the group to open.
+ * @returns The matched group and number of opened pins.
  */
 export const openPinGroup = async (groupId: string | number): Promise<OpenPinGroupResult> => {
   const [groups, pins] = await Promise.all([getGroups(), getPins()]);

--- a/extensions/pins/src/lib/openPinGroup.ts
+++ b/extensions/pins/src/lib/openPinGroup.ts
@@ -1,12 +1,15 @@
 import { getPreferenceValues } from "@raycast/api";
 
 import { getGroups, getMemberPins, Group } from "./Groups";
-import { getPins, openPin } from "./Pins";
+import { getPins, isPinDisabled, openPin } from "./Pins";
 import { ExtensionPreferences } from "./preferences";
 
 export type OpenPinGroupResult = {
   group?: Group;
   opened: number;
+  failed: number;
+  skippedDisabled: number;
+  total: number;
 };
 
 /**
@@ -17,13 +20,27 @@ export type OpenPinGroupResult = {
 export const openPinGroup = async (groupId: string | number): Promise<OpenPinGroupResult> => {
   const [groups, pins] = await Promise.all([getGroups(), getPins()]);
   const group = groups.find((candidate) => candidate.id.toString() == groupId.toString());
-  if (!group) return { opened: 0 };
+  if (!group) return { opened: 0, failed: 0, skippedDisabled: 0, total: 0 };
 
   const groupPins = getMemberPins(group, groups, pins);
   const preferences = getPreferenceValues<ExtensionPreferences>();
+  let opened = 0;
+  let failed = 0;
+  let skippedDisabled = 0;
   for (const pin of groupPins) {
-    await openPin(pin, preferences);
+    if (isPinDisabled(pin, groups)) {
+      skippedDisabled++;
+      continue;
+    }
+
+    try {
+      if (await openPin(pin, preferences, undefined, groups)) opened++;
+      else failed++;
+    } catch (error) {
+      console.error(error);
+      failed++;
+    }
   }
 
-  return { group, opened: groupPins.length };
+  return { group, opened, failed, skippedDisabled, total: groupPins.length };
 };

--- a/extensions/pins/src/lib/utils.tsx
+++ b/extensions/pins/src/lib/utils.tsx
@@ -61,6 +61,24 @@ export const cutoff = (str: string, cutoff: number) => {
 };
 
 /**
+ * Checks whether a string starts with a valid URL scheme.
+ * @param value The string to check.
+ * @returns Whether the string starts with a URL scheme.
+ */
+export const hasURLScheme = (value: string) => {
+  return /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(value);
+};
+
+/**
+ * Encodes a URI without double-encoding valid percent-encoded octets.
+ * @param value The URI to encode.
+ * @returns The encoded URI.
+ */
+export const encodeURIOnce = (value: string) => {
+  return encodeURI(value).replace(/%25([\da-fA-F]{2})/g, "%$1");
+};
+
+/**
  * Pluralizes a string based on a count.
  * @param str The string to pluralize.
  * @param count The count to base the pluralization on.

--- a/extensions/pins/src/open-pin-group.ts
+++ b/extensions/pins/src/open-pin-group.ts
@@ -14,8 +14,31 @@ export default async function OpenPinGroupCommand(props: LaunchProps<{ arguments
     return;
   }
 
-  if (result.opened == 0) {
+  if (result.total == 0) {
     await showHUD(`“${result.group.name}” has no pins`);
+    return;
+  }
+
+  if (result.skippedDisabled == result.total) {
+    await showHUD(`All ${result.total} pin${result.total == 1 ? " is" : "s are"} disabled in “${result.group.name}”`);
+    return;
+  }
+
+  if (result.opened == 0) {
+    const details = [
+      result.failed > 0 ? `${result.failed} failed` : undefined,
+      result.skippedDisabled > 0 ? `${result.skippedDisabled} disabled` : undefined,
+    ].filter(Boolean);
+    await showHUD(`No pins opened from “${result.group.name}”${details.length > 0 ? ` (${details.join(", ")})` : ""}`);
+    return;
+  }
+
+  if (result.failed > 0 || result.skippedDisabled > 0) {
+    const details = [
+      result.failed > 0 ? `${result.failed} failed` : undefined,
+      result.skippedDisabled > 0 ? `${result.skippedDisabled} disabled` : undefined,
+    ].filter(Boolean);
+    await showHUD(`Opened ${result.opened}/${result.total} pins from “${result.group.name}” (${details.join(", ")})`);
     return;
   }
 

--- a/extensions/pins/src/open-pin-group.ts
+++ b/extensions/pins/src/open-pin-group.ts
@@ -1,0 +1,19 @@
+import { LaunchProps, showHUD } from "@raycast/api";
+
+import { openPinGroup } from "./lib/openPinGroup";
+
+export default async function OpenPinGroupCommand(props: LaunchProps<{ arguments: Arguments.OpenPinGroup }>) {
+  const result = await openPinGroup(props.arguments.groupId);
+
+  if (!result.group) {
+    await showHUD("Pin group not found");
+    return;
+  }
+
+  if (result.opened == 0) {
+    await showHUD(`“${result.group.name}” has no pins`);
+    return;
+  }
+
+  await showHUD(`Opened ${result.opened} pin${result.opened == 1 ? "" : "s"} from “${result.group.name}”`);
+}

--- a/extensions/pins/src/open-pin-group.ts
+++ b/extensions/pins/src/open-pin-group.ts
@@ -2,6 +2,10 @@ import { LaunchProps, showHUD } from "@raycast/api";
 
 import { openPinGroup } from "./lib/openPinGroup";
 
+/**
+ * Raycast command for opening every direct member pin of a group without showing a view.
+ * @param props The command launch arguments.
+ */
 export default async function OpenPinGroupCommand(props: LaunchProps<{ arguments: Arguments.OpenPinGroup }>) {
   const result = await openPinGroup(props.arguments.groupId);
 

--- a/extensions/pins/src/view-groups.tsx
+++ b/extensions/pins/src/view-groups.tsx
@@ -7,9 +7,11 @@ import {
   Alert,
   getPreferenceValues,
   Keyboard,
+  LaunchType,
   LocalStorage,
   showToast,
 } from "@raycast/api";
+import { createDeeplink, DeeplinkType } from "@raycast/utils";
 import { setStorage, getStorage } from "./lib/storage";
 import { Direction, StorageKey } from "./lib/constants";
 import { Group, deleteGroup, useGroups } from "./lib/Groups";
@@ -27,6 +29,7 @@ import { useEffect, useState } from "react";
 import CopyGroupActionsSubmenu from "./components/actions/CopyGroupActionsSubmenu";
 import { ExtensionPreferences, ViewGroupsPreferences } from "./lib/preferences";
 import { pluralize } from "./lib/utils";
+import BulkImportUrlsForm from "./components/BulkImportUrlsForm";
 
 /**
  * Action to create a new group. Opens a form view with blank/default fields.
@@ -66,7 +69,7 @@ const moveGroup = async (index: number, dir: Direction, setGroups: React.Dispatc
  */
 export default function ViewGroupsCommand() {
   const { groups, setGroups, revalidateGroups } = useGroups();
-  const { pins } = usePins();
+  const { pins, revalidatePins } = usePins();
   const [examplesInstalled, setExamplesInstalled] = useState<boolean>(true);
   const preferences = getPreferenceValues<ExtensionPreferences & ViewGroupsPreferences>();
 
@@ -96,6 +99,12 @@ export default function ViewGroupsCommand() {
       <List.EmptyView title="No Groups Found" icon="no-view.png" />
       {((groups as Group[]) || []).map((group, index) => {
         const groupPins = pins.filter((pin: Pin) => pin.group == group.name);
+        const deeplink = createDeeplink({
+          type: DeeplinkType.Extension,
+          command: "open-pin-group",
+          launchType: LaunchType.Background,
+          arguments: { groupId: group.id.toString() },
+        });
         const maxID = Math.max(...groups.map((group) => group.id));
         const accessories: List.Item.Accessory[] = [];
         if (preferences.showVisibility) addVisibilityAccessory(group, accessories, true);
@@ -123,6 +132,17 @@ export default function ViewGroupsCommand() {
                         }),
                       );
                     }}
+                  />
+                  <Action.CreateQuicklink
+                    title="Create Group Quicklink"
+                    icon={Icon.Link}
+                    quicklink={{ name: `Open ${group.name}`, link: deeplink }}
+                  />
+                  <Action.CopyToClipboard title="Copy Group Deeplink" content={deeplink} icon={Icon.Clipboard} />
+                  <Action.Push
+                    title="Import URLs"
+                    icon={Icon.Download}
+                    target={<BulkImportUrlsForm group={group} onImported={revalidatePins} />}
                   />
                   <Action.Push
                     title="Edit"

--- a/extensions/pins/src/view-groups.tsx
+++ b/extensions/pins/src/view-groups.tsx
@@ -133,22 +133,22 @@ export default function ViewGroupsCommand() {
                       );
                     }}
                   />
-                  <Action.CreateQuicklink
-                    title="Create Group Quicklink"
-                    icon={Icon.Link}
-                    quicklink={{ name: `Open ${group.name}`, link: deeplink }}
-                  />
-                  <Action.CopyToClipboard title="Copy Group Deeplink" content={deeplink} icon={Icon.Clipboard} />
-                  <Action.Push
-                    title="Import URLs"
-                    icon={Icon.Download}
-                    target={<BulkImportUrlsForm group={group} onImported={revalidatePins} />}
-                  />
                   <Action.Push
                     title="Edit"
                     icon={Icon.Pencil}
                     target={<GroupForm group={group} setGroups={setGroups as (groups: Group[]) => void} />}
                     shortcut={Keyboard.Shortcut.Common.Edit}
+                  />
+                  <Action.CreateQuicklink
+                    title="Create Group Quicklink"
+                    icon={Icon.Link}
+                    shortcut={{ modifiers: ["cmd", "shift"], key: "q" }}
+                    quicklink={{ name: `Open ${group.name}`, link: deeplink }}
+                  />
+                  <Action.Push
+                    title="Import URLs"
+                    icon={Icon.Download}
+                    target={<BulkImportUrlsForm group={group} onImported={revalidatePins} />}
                   />
 
                   <Action
@@ -259,7 +259,7 @@ export default function ViewGroupsCommand() {
                     kind="groups"
                   />
                 ) : null}
-                <CopyGroupActionsSubmenu group={group} groups={groups} pins={pins} />
+                <CopyGroupActionsSubmenu group={group} groups={groups} pins={pins} deeplink={deeplink} />
               </ActionPanel>
             }
           />

--- a/extensions/pins/src/view-groups.tsx
+++ b/extensions/pins/src/view-groups.tsx
@@ -15,7 +15,7 @@ import { createDeeplink, DeeplinkType } from "@raycast/utils";
 import { setStorage, getStorage } from "./lib/storage";
 import { Direction, StorageKey } from "./lib/constants";
 import { Group, deleteGroup, useGroups } from "./lib/Groups";
-import { Pin, openPin, usePins } from "./lib/Pins";
+import { Pin, usePins } from "./lib/Pins";
 import {
   addIDAccessory,
   addParentGroupAccessory,
@@ -30,6 +30,7 @@ import CopyGroupActionsSubmenu from "./components/actions/CopyGroupActionsSubmen
 import { ExtensionPreferences, ViewGroupsPreferences } from "./lib/preferences";
 import { pluralize } from "./lib/utils";
 import BulkImportUrlsForm from "./components/BulkImportUrlsForm";
+import { openPinGroup } from "./lib/openPinGroup";
 
 /**
  * Action to create a new group. Opens a form view with blank/default fields.
@@ -126,11 +127,7 @@ export default function ViewGroupsCommand() {
                     title={`Open ${groupPins.length} ${pluralize("Pin", groupPins.length)}`}
                     icon={Icon.ChevronRight}
                     onAction={async () => {
-                      await Promise.all(
-                        groupPins.map(async (pin) => {
-                          await openPin(pin, preferences);
-                        }),
-                      );
+                      await openPinGroup(group.id);
                     }}
                   />
                   <Action.Push


### PR DESCRIPTION
## Description

Adds the group-focused workflows requested in the review of #25026 to the existing Pins extension:

- adds an `Open Pin Group` no-view command that targets groups by stable ID;
- adds group actions to create a Quicklink or copy a background deeplink;
- adds an optional preferred browser per group, with the precedence `pin application > group browser > global preferred browser`;
- adds a fast newline-separated URL import flow inside `View Groups`, including HTTPS normalization, support for Pins' custom URL schemes, and invalid/duplicate URL handling.

The new `preferredBrowser` group field is optional, so existing stored groups remain compatible without a migration. Browser bundle IDs are stored instead of local application paths to keep exported group data portable, and a saved browser is preserved if it is temporarily unavailable. Bulk-created pins are persisted in a single storage update.

Review follow-ups preserve Pins placeholders and existing percent-encoded URLs during bulk import, normalize imported pin IDs before allocation, skip disabled pins and groups, and report partial group-launch failures accurately.

This consolidates the useful Link Groups workflows into Pins instead of publishing a second extension with the same core outcome.

## Validation

- `npm run lint`
- `npm run build`

## Screencast

Not included yet; this is a draft PR.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build`
- [x] I ran `npm run lint`
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
