### PR TITLE
[Ray Code] Support home-relative workspace paths

### DIFF
--- a/extensions/ray-code/CHANGELOG.md
+++ b/extensions/ray-code/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Ray Code Changelog
 
-## [Expand Home Directory Paths] - {PR_MERGE_DATE}
+## [Expand Home Directory Paths] - 2026-08-07
 
 - Expand `~` in the configured workspace path before resolving it
 

--- a/extensions/ray-code/CHANGELOG.md
+++ b/extensions/ray-code/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Ray Code Changelog
 
+## [Expand Home Directory Paths] - {PR_MERGE_DATE}
+
+- Expand `~` in the configured workspace path before resolving it
+
 ## [Fix the issue with accessing the user shell properly] - 2026-01-02
 
 - `process.env.SHELL` is undefined, use the shell-env package instead

--- a/extensions/ray-code/src/utils/path.ts
+++ b/extensions/ray-code/src/utils/path.ts
@@ -1,0 +1,14 @@
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+export const expandHomePath = (inputPath: string) => {
+  if (inputPath === "~") {
+    return homedir();
+  }
+
+  if (inputPath.startsWith("~/")) {
+    return resolve(homedir(), inputPath.slice(2));
+  }
+
+  return inputPath;
+};

--- a/extensions/ray-code/src/utils/path.ts
+++ b/extensions/ray-code/src/utils/path.ts
@@ -6,7 +6,7 @@ export const expandHomePath = (inputPath: string) => {
     return homedir();
   }
 
-  if (inputPath.startsWith("~/")) {
+  if (inputPath.startsWith("~/") || inputPath.startsWith("~\\")) {
     return resolve(homedir(), inputPath.slice(2));
   }
 

--- a/extensions/ray-code/src/utils/workspace.ts
+++ b/extensions/ray-code/src/utils/workspace.ts
@@ -1,5 +1,6 @@
 import { getPreferenceValues } from "@raycast/api";
 import { resolve, relative } from "node:path";
+import { expandHomePath } from "./path";
 
 export const getWorkspaceRoot = () => {
   const preferences = getPreferenceValues<Preferences>();
@@ -8,7 +9,7 @@ export const getWorkspaceRoot = () => {
     throw new Error("Workspace root directory is not configured. Please set it in the extension preferences.");
   }
 
-  return resolve(preferences.workspaceRoot);
+  return resolve(expandHomePath(preferences.workspaceRoot));
 };
 
 export const isAutoEditEnabled = () => {


### PR DESCRIPTION
## Description
Closes #29659.

  ### Reproduction

  1. Selected a folder inside the home directory as Ray Code’s workspace.
  2. Asked Ray Code to list the workspace files.
  3. The `list-dir` tool received the correct relative path `"."`, but failed with:

     ```text
     ENOENT: no such file or directory, scandir '/~/ray-code-repro'

  4. Selecting /tmp/ray-code-repro-control as the workspace succeeded, isolating the failure to home-relative paths.

### Root Cause

  Diagnostic logging showed:

  rawWorkspaceRoot: `~/ray-code-repro`
  cwd: /
  resolvedWorkspaceRoot: `/~/ray-code-repro`

Raycast v2 returned the directory preference using `~`, but Node’s `path.resolve()` treats `~` as a literal directory instead of expanding it to the user’s home directory.

### Changes
  - Added a small helper that expands `~` and `~/...` using `os.homedir()`.
  - Expanded the configured workspace path before resolving it.
  - Preserved the existing workspace-containment validation.
  - Updated the Ray Code CHANGELOG.

### Verification
  - Confirmed the original `~/...` workspace failed before the change.
  - Confirmed the same workspace successfully listed files in the workspace after the change.
  - Confirmed absolute workspace paths remain unchanged.
  - Verified paths containing spaces and unsupported ~username syntax.
  - Ran the TypeScript check, formatting checks, and Raycast distribution build successfully.

## Screencast
NA

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist
- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
