### PR TITLE
[Porkbun] domain status as Dot and domain in tooltip

### DIFF
--- a/extensions/porkbun/CHANGELOG.md
+++ b/extensions/porkbun/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Porkbun Changelog
 
+## [Domain Status as Dot] - {PR_MERGE_DATE}
+
+- "Retrieve All Domains" command collapses the STATUS as `Dot` to save space and the full domain is also added to `tooltip` (ref: [Issue #27326](https://github.com/raycast/extensions/issues/27326))
+
 ## [Retrieve Account Balance] - 2026-06-04
 
 - Add new command to check account credit balance

--- a/extensions/porkbun/CHANGELOG.md
+++ b/extensions/porkbun/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Porkbun Changelog
 
-## [Domain Status as Dot] - {PR_MERGE_DATE}
+## [Domain Status as Dot] - 2026-08-07
 
 - "Retrieve All Domains" command collapses the STATUS as `Dot` to save space and the full domain is also added to `tooltip` (ref: [Issue #27326](https://github.com/raycast/extensions/issues/27326))
 

--- a/extensions/porkbun/src/retrieve-all-domains.tsx
+++ b/extensions/porkbun/src/retrieve-all-domains.tsx
@@ -95,14 +95,12 @@ export default function RetrieveAllDomains() {
           filteredDomains.map((item) => (
             <List.Item
               key={item.domain}
-              title={item.domain}
+              title={{ value: item.domain, tooltip: item.domain }}
               icon={getFavicon(`https://${item.domain}`, { fallback: Icon.Globe })}
               accessories={[
                 {
-                  tag: {
-                    value: `status: ${item.status}`,
-                    color: item.status === "ACTIVE" ? Color.Green : Color.Yellow,
-                  },
+                  icon: { source: Icon.Dot, tintColor: item.status === "ACTIVE" ? Color.Green : Color.Yellow },
+                  tooltip: item.status,
                 },
               ]}
               actions={


### PR DESCRIPTION
## Description

- "Retrieve All Domains" command collapses the STATUS as `Dot` to save space and the full domain is also added to `tooltip` (close #27326)

## Screenshot

<img width="2000" height="1250" alt="porkbun 2026-08-07 at 11 45 58" src="https://github.com/user-attachments/assets/52b21ca3-105b-4024-9e4f-f1718423ea37" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
