### PR TITLE
Update try extension

### DIFF
--- a/extensions/try/CHANGELOG.md
+++ b/extensions/try/CHANGELOG.md
@@ -1,6 +1,6 @@
 # try Changelog
 
-## [Fixes] - {PR_MERGE_DATE}
+## [Fixes] - 2026-08-07
 
 - The "Created" confirmation now clears itself instead of staying on screen after you leave Raycast
 - Renamed "Delete" to "Move to Trash", which is what it always did — directories go to the system Trash and can be restored from there

--- a/extensions/try/CHANGELOG.md
+++ b/extensions/try/CHANGELOG.md
@@ -1,5 +1,12 @@
 # try Changelog
 
+## [Fixes] - {PR_MERGE_DATE}
+
+- The "Created" confirmation now clears itself instead of staying on screen after you leave Raycast
+- Renamed "Delete" to "Move to Trash", which is what it always did — directories go to the system Trash and can be restored from there
+- Removed the confirmation prompt's incorrect "This cannot be undone" warning
+- Moving a directory to the Trash no longer asks for confirmation, and confirms with a HUD once it completes
+
 ## [Improvements] - 2026-06-19
 
 - Clone now runs asynchronously with a live progress toast, so the UI no longer freezes during the clone

--- a/extensions/try/CHANGELOG.md
+++ b/extensions/try/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Renamed "Delete" to "Move to Trash", which is what it always did — directories go to the system Trash and can be restored from there
 - Removed the confirmation prompt's incorrect "This cannot be undone" warning
 - Moving a directory to the Trash no longer asks for confirmation, and confirms with a HUD once it completes
+- Copy Path now uses Raycast's standard shortcut for copying a path, ⌘⇧, (was ⌘⇧C)
 
 ## [Improvements] - 2026-06-19
 

--- a/extensions/try/README.md
+++ b/extensions/try/README.md
@@ -35,7 +35,7 @@ Press `⌘+G` to clone a git repository. Supports:
 - **Open With** - Open directory with default app (updates last accessed time)
 - **Show in Finder** - Reveal in Finder
 - **Copy Path** - Copy directory path to clipboard
-- **Delete** - Remove directory (with confirmation)
+- **Move to Trash** - Move directory to the system Trash, where it can be restored
 
 ## Configuration
 

--- a/extensions/try/package-lock.json
+++ b/extensions/try/package-lock.json
@@ -487,9 +487,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -568,9 +568,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1127,9 +1127,9 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.104.19",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.19.tgz",
-      "integrity": "sha512-SAVg56BAzxZGy/OPQ0jekUG3pJaoX5pCqleALvFo9JRE7P2tvKoglWnYRcIJArRhLlvV8FtFNMDafd+NNwXXCw==",
+      "version": "1.104.24",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.24.tgz",
+      "integrity": "sha512-Jppfyi1T7wcGXZFxpzXuvNAKUPQ+BQkKC0N3rJBz1epp/z22SH9aLA23YZRk/ickGwEm6DI/7OY7Jin8dD53Sg==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.8.4",
@@ -1620,15 +1620,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/callsites": {
@@ -1980,9 +1980,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2171,9 +2171,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -2419,9 +2419,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/extensions/try/src/components/CreateForm.tsx
+++ b/extensions/try/src/components/CreateForm.tsx
@@ -1,7 +1,13 @@
 import { Form, ActionPanel, Action, showToast, Toast, useNavigation } from "@raycast/api";
 import { useState } from "react";
+import { setTimeout as delay } from "timers/promises";
 import { basename } from "path";
 import { createTryDirectory, generateDatePrefix } from "../lib/utils";
+
+// How long the "Created" confirmation stays up before we dismiss it ourselves.
+// Long enough to read the directory name, short enough that it can't follow the
+// user around the desktop after they leave Raycast.
+const SUCCESS_TOAST_DURATION_MS = 2000;
 
 interface CreateFormProps {
   onSuccess: () => void;
@@ -20,23 +26,35 @@ export function CreateForm({ onSuccess }: CreateFormProps) {
       return;
     }
 
+    let createdPath: string;
     try {
-      const createdPath = createTryDirectory(name);
-      const dirName = basename(createdPath);
-      await showToast({
-        style: Toast.Style.Success,
-        title: "Created",
-        message: dirName,
-      });
-      onSuccess();
-      pop();
+      createdPath = createTryDirectory(name);
     } catch (error) {
       await showToast({
         style: Toast.Style.Failure,
         title: "Failed to create directory",
         message: error instanceof Error ? error.message : String(error),
       });
+      return;
     }
+
+    // Keep the handle so we can dismiss this ourselves. Without it the toast is
+    // fire-and-forget: `pop()` unmounts the form while the toast is still owned by the
+    // command, and once the Raycast window goes away the toast detaches into a floating
+    // overlay that outlives the command that created it.
+    const toast = await showToast({
+      style: Toast.Style.Success,
+      title: "Created",
+      message: basename(createdPath),
+    });
+
+    onSuccess();
+    pop();
+
+    // Best-effort dismissal. The directory already exists by this point, so a failure to
+    // hide must never surface as an error — the toast expires on its own regardless.
+    await delay(SUCCESS_TOAST_DURATION_MS);
+    await toast.hide().catch(() => undefined);
   };
 
   return (

--- a/extensions/try/src/components/TryListItem.tsx
+++ b/extensions/try/src/components/TryListItem.tsx
@@ -24,7 +24,7 @@ export function TryListItem({ directory, onRefresh }: TryListItemProps) {
             <Action.CopyToClipboard
               title="Copy Path"
               content={directory.path}
-              shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+              shortcut={Keyboard.Shortcut.Common.CopyPath}
             />
           </ActionPanel.Section>
           <ActionPanel.Section>

--- a/extensions/try/src/components/TryListItem.tsx
+++ b/extensions/try/src/components/TryListItem.tsx
@@ -1,4 +1,4 @@
-import { List, ActionPanel, Action, Icon, confirmAlert, Alert, showToast, Toast, trash } from "@raycast/api";
+import { List, ActionPanel, Action, Icon, Keyboard, showHUD } from "@raycast/api";
 import { TryDirectory } from "../types";
 import { formatRelativeTime, touchDirectory } from "../lib/utils";
 import { CreateForm } from "./CreateForm";
@@ -10,35 +10,6 @@ interface TryListItemProps {
 }
 
 export function TryListItem({ directory, onRefresh }: TryListItemProps) {
-  const handleDelete = async () => {
-    const confirmed = await confirmAlert({
-      title: "Delete Directory",
-      message: `Are you sure you want to delete "${directory.name}"? This cannot be undone.`,
-      primaryAction: {
-        title: "Delete",
-        style: Alert.ActionStyle.Destructive,
-      },
-    });
-
-    if (confirmed) {
-      try {
-        await trash(directory.path);
-        showToast({
-          style: Toast.Style.Success,
-          title: "Deleted",
-          message: directory.name,
-        });
-        onRefresh();
-      } catch (error) {
-        showToast({
-          style: Toast.Style.Failure,
-          title: "Failed to delete",
-          message: String(error),
-        });
-      }
-    }
-  };
-
   return (
     <List.Item
       icon={Icon.Folder}
@@ -71,12 +42,22 @@ export function TryListItem({ directory, onRefresh }: TryListItemProps) {
             />
           </ActionPanel.Section>
           <ActionPanel.Section>
-            <Action
-              title="Delete"
+            <Action.Trash
+              title="Move to Trash"
               icon={Icon.Trash}
-              style={Action.Style.Destructive}
-              shortcut={{ modifiers: ["ctrl"], key: "x" }}
-              onAction={handleDelete}
+              paths={directory.path}
+              shortcut={Keyboard.Shortcut.Common.Remove}
+              // Action.Trash closes the main window once the move completes, so a Toast
+              // here would detach into a floating overlay — the exact behaviour we just
+              // fixed in CreateForm. showHUD is the primitive meant for post-close
+              // feedback and dismisses itself.
+              //
+              // onTrash is typed `=> void`, so this must not be async: returning a promise
+              // into a void callback leaves any rejection unobserved rather than actionable.
+              onTrash={() => {
+                onRefresh();
+                showHUD(`Moved "${directory.name}" to Trash`).catch(() => undefined);
+              }}
             />
           </ActionPanel.Section>
         </ActionPanel>


### PR DESCRIPTION
## Description

Two fixes to the `try` extension, both about the UI telling the truth about what it just did.

A success toast shown when creating a directory could outlive the command that created it — after the Raycast window closed it detached into a floating overlay and sat on the desktop. The toast handle returned by `showToast` was discarded, so nothing could ever dismiss it deterministically.

Separately, the delete action claimed "This cannot be undone", but it has always called `trash()` — the directory goes to the system Trash and can be restored. The action is now the built-in `Action.Trash`, named for what it actually does.

### Changes

- **Create:** hold the `Toast` handle and dismiss it explicitly after a short read window, so the "Created" confirmation can't follow the user around the desktop.
- **Create:** narrowed the `try`/`catch` to the one call that can fail (`createTryDirectory`), so a failure to dismiss the toast can no longer report a directory that *was* created as a failure.
- **Delete → Move to Trash:** replaced the hand-rolled `confirmAlert` + `trash()` + toast handler with the built-in `Action.Trash`, and renamed the action. Removed the incorrect "This cannot be undone" warning.
  - Note the two behavior changes this carries: `Action.Trash` has no confirmation hook, so the action no longer prompts; and it closes the main window on completion, so confirmation is via `showHUD` rather than a toast (a toast fired as the window closes is exactly the detached-overlay bug above).
- **Shortcuts:** adopted `Keyboard.Shortcut.Common` by semantics.
  - `Common.Remove` for the trash action — identical binding (`⌃X`), no user-visible change.
  - `Common.CopyPath` for Copy Path — **this changes the binding** from `⌘⇧C` (which is `Common.Copy`) to Raycast's standard path-copy shortcut `⌘⇧,`. Called out in the changelog.
- Updated `README.md` to match the renamed action, and refreshed `package-lock.json` (`@raycast/api` 1.104.19 → 1.104.24).

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I ran `npm run lint` and `npx tsc --noEmit` — both clean
- [x] I checked that this change does not break existing commands or remove functionality
- [x] I updated `CHANGELOG.md` per the changelog conventions
