### PR TITLE
Update snippetsurfer extension

### DIFF
--- a/extensions/snippetsurfer/CHANGELOG.md
+++ b/extensions/snippetsurfer/CHANGELOG.md
@@ -1,6 +1,6 @@
 # SnippetSurfer Changelog
 
-## [Enhancements] - {PR_MERGE_DATE}
+## [Enhancements] - 2026-08-07
 - Add "Hide Folder in List" preference to hide the folder path next to each snippet, giving long snippet names more room.
 
 ## [Enhancements] - 2026-04-22

--- a/extensions/snippetsurfer/CHANGELOG.md
+++ b/extensions/snippetsurfer/CHANGELOG.md
@@ -1,5 +1,8 @@
 # SnippetSurfer Changelog
 
+## [Enhancements] - {PR_MERGE_DATE}
+- Add "Hide Folder in List" preference to hide the folder path next to each snippet, giving long snippet names more room.
+
 ## [Enhancements] - 2026-04-22
 - Add "Paste first code block" preference to copy/paste only the first code block from a snippet instead of the full content.
 - Fix nested code fence rendering in README.

--- a/extensions/snippetsurfer/package.json
+++ b/extensions/snippetsurfer/package.json
@@ -6,7 +6,8 @@
   "icon": "command-icon.png",
   "author": "astronight",
   "contributors": [
-    "stevenokuto"
+    "stevenokuto",
+    "ridemountainpig"
   ],
   "categories": [
     "Developer Tools"
@@ -51,6 +52,15 @@
         }
       ],
       "title": "Select primary action"
+    },
+    {
+      "name": "hideFolderInList",
+      "description": "Hide the folder path next to each snippet in the list to give long snippet names more room.",
+      "type": "checkbox",
+      "required": false,
+      "default": false,
+      "title": "Hide Folder in List",
+      "label": "Hide folder"
     },
     {
       "name": "pasteContentScope",

--- a/extensions/snippetsurfer/src/search-snippets.tsx
+++ b/extensions/snippetsurfer/src/search-snippets.tsx
@@ -26,6 +26,7 @@ export default function Command() {
         ...previous,
         primaryAction: preferences["primaryAction"],
         pasteContentScope: preferences["pasteContentScope"] ?? "pasteScopeFull",
+        hideFolderInList: preferences["hideFolderInList"] ?? false,
       }));
     };
     fetch();
@@ -186,7 +187,9 @@ export default function Command() {
               id={i.id}
               key={i.id}
               title={i.name}
-              accessories={[{ icon: Icon.Folder, text: i.folder && i.folder !== "." ? i.folder : "" }]}
+              accessories={
+                !state.hideFolderInList && i.folder && i.folder !== "." ? [{ icon: Icon.Folder, text: i.folder }] : []
+              }
               keywords={[i.folder, ...i.content.content.split(" ").concat(i.content.rawMetadata.split(" "))]}
               icon={Icon.Document}
               detail={<SnippetContent snippet={i} />}

--- a/extensions/snippetsurfer/src/types/index.d.ts
+++ b/extensions/snippetsurfer/src/types/index.d.ts
@@ -24,5 +24,6 @@ export interface State {
   selectedFilter?: string;
   primaryAction?: string;
   pasteContentScope?: string;
+  hideFolderInList?: boolean;
   paths?: string[];
 }


### PR DESCRIPTION
## Description
- Add "Hide Folder in List" preference to hide the folder path next to each snippet, giving long snippet names more room. Close #29972.
<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
