### PR TITLE
Update voiceink extension

### DIFF
--- a/extensions/voiceink/CHANGELOG.md
+++ b/extensions/voiceink/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Fix Empty History and Silent Copy Actions] - {PR_MERGE_DATE}
+
+- Read the transcription table's columns before querying it, instead of assuming them from the selected database source
+- Fix an empty history on current VoiceInk versions, which renamed the `powerModeName` and `powerModeEmoji` columns to `modeName` and `modeEmoji`
+- Confirm the copy and paste actions with a HUD, while still keeping the transcription text out of the render tree
+
 ## [Render Stability] - 2026-08-03
 
 - Prevent large transcription histories from overflowing Raycast's render payload

--- a/extensions/voiceink/CHANGELOG.md
+++ b/extensions/voiceink/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Fix Empty History and Restore Copy Confirmation] - {PR_MERGE_DATE}
+## [Fix Empty History and Restore Copy Confirmation] - 2026-08-12
 
 - Read the transcription table's columns before querying it, instead of assuming them from the selected database source
 - Fix an empty history on current VoiceInk versions, which renamed the `powerModeName` and `powerModeEmoji` columns to `modeName` and `modeEmoji`

--- a/extensions/voiceink/CHANGELOG.md
+++ b/extensions/voiceink/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## [Fix Empty History and Silent Copy Actions] - {PR_MERGE_DATE}
+## [Fix Empty History and Restore Copy Confirmation] - {PR_MERGE_DATE}
 
 - Read the transcription table's columns before querying it, instead of assuming them from the selected database source
 - Fix an empty history on current VoiceInk versions, which renamed the `powerModeName` and `powerModeEmoji` columns to `modeName` and `modeEmoji`
-- Confirm the copy and paste actions with a HUD, while still keeping the transcription text out of the render tree
+- Restore the copy and paste confirmation lost in the previous release, without putting transcription text back into the render tree
 
 ## [Render Stability] - 2026-08-03
 

--- a/extensions/voiceink/package.json
+++ b/extensions/voiceink/package.json
@@ -5,6 +5,9 @@
   "description": "Quick access to your VoiceInk transcriptions",
   "icon": "extension-icon.png",
   "author": "metrovoc",
+  "contributors": [
+    "pasquale.salza"
+  ],
   "categories": [
     "Productivity"
   ],

--- a/extensions/voiceink/src/components/TranscriptionDetail.tsx
+++ b/extensions/voiceink/src/components/TranscriptionDetail.tsx
@@ -1,5 +1,6 @@
-import { Action, ActionPanel, Clipboard, Detail, Icon } from "@raycast/api";
+import { Action, ActionPanel, Detail, Icon } from "@raycast/api";
 import type { Transcription } from "../lib/types";
+import { copyAndConfirm, pasteToActiveApp } from "../lib/clipboard";
 import { cfTimeToDate, formatDuration, getDisplayText } from "../lib/database";
 
 interface Props {
@@ -32,19 +33,19 @@ export function TranscriptionDetail({ transcription }: Props) {
       }
       actions={
         <ActionPanel>
-          <Action title="Copy Text" icon={Icon.Clipboard} onAction={() => Clipboard.copy(displayText)} />
+          <Action title="Copy Text" icon={Icon.Clipboard} onAction={() => copyAndConfirm(displayText)} />
           {transcription.enhancedText && transcription.text !== transcription.enhancedText && (
             <Action
               title="Copy Original Text"
               icon={Icon.Clipboard}
-              onAction={() => Clipboard.copy(transcription.text)}
+              onAction={() => copyAndConfirm(transcription.text)}
               shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
             />
           )}
           <Action
             title="Paste Text"
             icon={Icon.TextCursor}
-            onAction={() => Clipboard.paste(displayText)}
+            onAction={() => pasteToActiveApp(displayText)}
             shortcut={{ modifiers: ["cmd", "shift"], key: "v" }}
           />
         </ActionPanel>

--- a/extensions/voiceink/src/components/TranscriptionItem.tsx
+++ b/extensions/voiceink/src/components/TranscriptionItem.tsx
@@ -1,5 +1,6 @@
-import { Action, ActionPanel, Clipboard, Color, Icon, List, useNavigation } from "@raycast/api";
+import { Action, ActionPanel, Color, Icon, List, useNavigation } from "@raycast/api";
 import type { Transcription } from "../lib/types";
+import { copyAndConfirm, pasteToActiveApp } from "../lib/clipboard";
 import { formatRelativeTime, getDisplayText, truncateText } from "../lib/database";
 import { TranscriptionDetail } from "./TranscriptionDetail";
 
@@ -21,19 +22,19 @@ export function TranscriptionItem({ transcription }: Props) {
       actions={
         <ActionPanel>
           <ActionPanel.Section>
-            <Action title="Copy Text" icon={Icon.Clipboard} onAction={() => Clipboard.copy(displayText)} />
+            <Action title="Copy Text" icon={Icon.Clipboard} onAction={() => copyAndConfirm(displayText)} />
             {hasEnhancement && (
               <Action
                 title="Copy Original Text"
                 icon={Icon.Clipboard}
-                onAction={() => Clipboard.copy(transcription.text)}
+                onAction={() => copyAndConfirm(transcription.text)}
                 shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
               />
             )}
             <Action
               title="Paste Text"
               icon={Icon.TextCursor}
-              onAction={() => Clipboard.paste(displayText)}
+              onAction={() => pasteToActiveApp(displayText)}
               shortcut={{ modifiers: ["cmd", "shift"], key: "v" }}
             />
           </ActionPanel.Section>

--- a/extensions/voiceink/src/lib/clipboard.ts
+++ b/extensions/voiceink/src/lib/clipboard.ts
@@ -1,0 +1,15 @@
+import { Clipboard, closeMainWindow, showHUD } from "@raycast/api";
+
+// The transcription text is passed through a callback rather than an action's
+// `content` prop on purpose: props end up in Raycast's serialized render tree,
+// and a hundred full transcriptions there is what used to break it. showHUD
+// still confirms the action and closes the window.
+export async function copyAndConfirm(text: string): Promise<void> {
+  await Clipboard.copy(text);
+  await showHUD("Copied to Clipboard");
+}
+
+export async function pasteToActiveApp(text: string): Promise<void> {
+  await closeMainWindow();
+  await Clipboard.paste(text);
+}

--- a/extensions/voiceink/src/lib/database.ts
+++ b/extensions/voiceink/src/lib/database.ts
@@ -13,6 +13,32 @@ const DB_PATHS = {
 // Core Foundation epoch: 2001-01-01 00:00:00 UTC
 const CF_EPOCH = 978307200;
 
+// The columns each field has lived in, most recent first. VoiceInk renamed
+// powerModeName/powerModeEmoji to modeName/modeEmoji, which SwiftData applies
+// to the store as a column rename, so the same install can use either name
+// depending on the version that last migrated it. VoiceInk CE uses modeName.
+const COLUMN_CANDIDATES = {
+  id: ["ZID"],
+  text: ["ZTEXT"],
+  enhancedText: ["ZENHANCEDTEXT"],
+  timestamp: ["ZTIMESTAMP"],
+  duration: ["ZDURATION"],
+  modelName: ["ZTRANSCRIPTIONMODELNAME"],
+  powerModeName: ["ZMODENAME", "ZPOWERMODENAME"],
+  powerModeEmoji: ["ZMODEEMOJI", "ZPOWERMODEEMOJI"],
+  status: ["ZTRANSCRIPTIONSTATUS"],
+} as const;
+
+type Field = keyof typeof COLUMN_CANDIDATES;
+
+// Lists the columns of the transcription table so the history query can be
+// built from what the database actually has.
+export const SCHEMA_QUERY = "SELECT name FROM pragma_table_info('ZTRANSCRIPTION')";
+
+export interface SchemaColumn {
+  name: string;
+}
+
 export interface DatabaseInfo {
   path: string;
   available: boolean;
@@ -47,15 +73,10 @@ export function getDatabaseInfo(): DatabaseInfo {
     case "custom":
       if (prefs.customDatabasePath) {
         const customPath = expandTilde(prefs.customDatabasePath);
-        const customSource = customPath.includes("com.prakashjoshipax.VoiceInk")
-          ? "official"
-          : customPath.includes("com.metrovoc.VoiceInk")
-            ? "ce"
-            : "custom";
         return {
           path: customPath,
           available: existsSync(customPath),
-          source: customSource,
+          source: "custom",
         };
       }
       return { path: "", available: false, source: "none" };
@@ -104,40 +125,62 @@ export function formatDuration(seconds: number): string {
   return `${mins}m ${secs}s`;
 }
 
-export function buildQuery(limit: number, searchTerm?: string, source: DatabaseInfo["source"] = "custom"): string {
-  const modeColumns =
-    source === "official"
-      ? "ZPOWERMODENAME as powerModeName, ZPOWERMODEEMOJI as powerModeEmoji"
-      : source === "ce"
-        ? "ZMODENAME as powerModeName, ZMODEEMOJI as powerModeEmoji"
-        : "NULL as powerModeName, NULL as powerModeEmoji";
+function resolveColumns(columns: string[]): Partial<Record<Field, string>> {
+  const available = new Set(columns);
+  const resolved: Partial<Record<Field, string>> = {};
+
+  for (const field of Object.keys(COLUMN_CANDIDATES) as Field[]) {
+    resolved[field] = COLUMN_CANDIDATES[field].find((candidate) => available.has(candidate));
+  }
+
+  return resolved;
+}
+
+function selectAs(column: string | undefined, alias: string): string {
+  return `${column ?? "NULL"} as ${alias}`;
+}
+
+export function buildQuery(limit: number, searchTerm: string | undefined, columns: string[]): string {
+  const resolved = resolveColumns(columns);
+
+  // Z_PK is Core Data's own primary key, so it is there even if ZID is not.
+  const idColumn = resolved.id ? `hex(${resolved.id})` : "CAST(Z_PK AS TEXT)";
+  const selectList = [
+    `${idColumn} as id`,
+    selectAs(resolved.text, "text"),
+    selectAs(resolved.enhancedText, "enhancedText"),
+    selectAs(resolved.timestamp, "timestamp"),
+    selectAs(resolved.duration, "duration"),
+    selectAs(resolved.modelName, "modelName"),
+    selectAs(resolved.powerModeName, "powerModeName"),
+    selectAs(resolved.powerModeEmoji, "powerModeEmoji"),
+  ].join(",\n      ");
 
   const baseQuery = `
     SELECT
-      hex(ZID) as id,
-      ZTEXT as text,
-      ZENHANCEDTEXT as enhancedText,
-      ZTIMESTAMP as timestamp,
-      ZDURATION as duration,
-      ZTRANSCRIPTIONMODELNAME as modelName,
-      ${modeColumns}
+      ${selectList}
     FROM ZTRANSCRIPTION
-    WHERE ZTRANSCRIPTIONSTATUS = 'completed'
+    WHERE ${resolved.status ? `${resolved.status} = 'completed'` : "1 = 1"}
   `;
 
+  const searchableColumns = [resolved.text, resolved.enhancedText].filter((column): column is string =>
+    Boolean(column)
+  );
+
   let searchClause = "";
-  if (searchTerm) {
+  if (searchTerm && searchableColumns.length > 0) {
     const words = searchTerm.trim().split(/\s+/).filter(Boolean);
     if (words.length > 0) {
       const conditions = words.map((word) => {
         const escaped = escapeSqlString(word);
-        return `(ZTEXT LIKE '%${escaped}%' ESCAPE '\\' OR ZENHANCEDTEXT LIKE '%${escaped}%' ESCAPE '\\')`;
+        const matches = searchableColumns.map((column) => `${column} LIKE '%${escaped}%' ESCAPE '\\'`);
+        return `(${matches.join(" OR ")})`;
       });
       searchClause = ` AND ${conditions.join(" AND ")}`;
     }
   }
 
-  return `${baseQuery}${searchClause} ORDER BY ZTIMESTAMP DESC LIMIT ${limit}`;
+  return `${baseQuery}${searchClause} ORDER BY ${resolved.timestamp ?? "Z_PK"} DESC LIMIT ${limit}`;
 }
 
 function escapeSqlString(str: string): string {

--- a/extensions/voiceink/src/search-transcriptions.tsx
+++ b/extensions/voiceink/src/search-transcriptions.tsx
@@ -1,26 +1,49 @@
 import { useState } from "react";
 import { Action, ActionPanel, List, Icon, openExtensionPreferences } from "@raycast/api";
 import { useSQL } from "@raycast/utils";
-import { getDatabaseInfo, buildQuery, normalizeTranscriptions } from "./lib/database";
+import { getDatabaseInfo, buildQuery, normalizeTranscriptions, SCHEMA_QUERY } from "./lib/database";
+import type { SchemaColumn } from "./lib/database";
 import type { Transcription } from "./lib/types";
 import { TranscriptionItem } from "./components/TranscriptionItem";
 
 const DISPLAY_LIMIT = 100;
+const PERMISSION_PRIMING = "VoiceInk stores your transcription history in a local database.";
 
 export default function SearchTranscriptions() {
   const [searchText, setSearchText] = useState("");
   const dbInfo = getDatabaseInfo();
 
-  const query = buildQuery(DISPLAY_LIMIT, searchText || undefined, dbInfo.source);
   const queryDatabasePath = dbInfo.available ? dbInfo.path : "/dev/null";
 
-  const { isLoading, data, error, permissionView } = useSQL<Transcription>(queryDatabasePath, query, {
+  // VoiceInk renames columns between versions, so read the schema first and
+  // only ask for columns this database has.
+  const {
+    isLoading: isLoadingSchema,
+    data: schemaColumns,
+    error: schemaError,
+    permissionView: schemaPermissionView,
+  } = useSQL<SchemaColumn>(queryDatabasePath, SCHEMA_QUERY, {
     execute: dbInfo.available,
-    permissionPriming: "VoiceInk stores your transcription history in a local database.",
+    permissionPriming: PERMISSION_PRIMING,
+    failureToastOptions: {
+      title: "Failed to read the transcriptions database",
+    },
+  });
+
+  const columns = schemaColumns?.map((column) => column.name);
+  const query = buildQuery(DISPLAY_LIMIT, searchText || undefined, columns ?? []);
+
+  const { isLoading, data, error, permissionView } = useSQL<Transcription>(queryDatabasePath, query, {
+    execute: dbInfo.available && columns !== undefined,
+    permissionPriming: PERMISSION_PRIMING,
     failureToastOptions: {
       title: "Failed to load transcriptions",
     },
   });
+
+  if (schemaPermissionView) {
+    return schemaPermissionView;
+  }
 
   if (permissionView) {
     return permissionView;
@@ -44,18 +67,20 @@ export default function SearchTranscriptions() {
   }
 
   const transcriptions = normalizeTranscriptions(data || []);
+  const loadError = schemaError ?? error;
+  const isLoadingAny = isLoadingSchema || isLoading;
 
   return (
     <List
-      isLoading={isLoading}
+      isLoading={isLoadingAny}
       filtering={false}
       onSearchTextChange={setSearchText}
       searchBarPlaceholder="Search transcriptions..."
       throttle
     >
-      {error ? (
-        <List.EmptyView icon={Icon.Warning} title="Unable to Read Transcriptions" description={error.message} />
-      ) : transcriptions.length === 0 && !isLoading ? (
+      {loadError ? (
+        <List.EmptyView icon={Icon.Warning} title="Unable to Read Transcriptions" description={loadError.message} />
+      ) : transcriptions.length === 0 && !isLoadingAny ? (
         <List.EmptyView
           icon={searchText ? Icon.MagnifyingGlass : Icon.Message}
           title={searchText ? "No Results" : "No Transcriptions"}


### PR DESCRIPTION
## Description

Two fixes to the Search Transcriptions command.

**Empty history on current VoiceInk versions.** VoiceInk renamed `powerModeName`/`powerModeEmoji` to `modeName`/`modeEmoji` via `@Attribute(originalName:)` in [Transcription.swift](https://github.com/Beingpax/VoiceInk/blob/main/VoiceInk/Models/Transcription.swift), back in May. SwiftData applies that as a column rename, so any store opened by a build since then has `ZMODENAME`/`ZMODEEMOJI`. `buildQuery` still asked for `ZPOWERMODENAME` whenever the source was `official`, so the statement failed to prepare with `no such column: ZPOWERMODENAME` and the list came back empty. Reproduced against VoiceInk 2.1.

The column name does not depend on which VoiceInk you run, but on which version last opened that particular store — an official store that has not been reopened since the rename still has the old names. So rather than swap one hardcoded name for another, the command now reads `pragma_table_info('ZTRANSCRIPTION')` first and builds the query from the columns the database actually has, taking the first known name for each field. Migrated stores, unmigrated stores and VoiceInk CE all work, and a future rename degrades to a missing badge instead of an empty list. This also removes the heuristic that inferred the schema from the bundle id in a custom path, which is where the wrong assumption lived.

**Copy and paste stopped confirming.** Until #29928 these were `Action.CopyToClipboard` and `Action.Paste`, which show a HUD and close the window for free. That PR moved them to plain `Action` callbacks to keep transcription text out of the serialized render tree — worth keeping — but the confirmation went with it: copying looked like it did nothing, and pasting fired with the Raycast window still frontmost. The helpers in `src/lib/clipboard.ts` restore both behaviours explicitly, so the text still travels through a callback rather than a prop. The comment there records why, so it does not get undone again.

Tested against a real VoiceInk 2.1 store and a synthetic pre-rename store: both return rows with the mode badge populated. A column set without the mode columns still returns rows, with an empty badge. Multi-word search and `LIKE` escaping are unchanged. `npm run build` and `ray lint` are clean, and the build was loaded in Raycast to confirm the list populates and both actions confirm.

## Screencast

N/A

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
