### PR TITLE
CI: upgrade setup-node to v7

### DIFF
--- a/.github/workflows/generate-code-owners.yml
+++ b/.github/workflows/generate-code-owners.yml
@@ -92,7 +92,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.22.2
       - name: Generate

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -21,7 +21,7 @@ jobs:
             scripts/
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.22.2
 

--- a/.github/workflows/sync-api-docs.yml
+++ b/.github/workflows/sync-api-docs.yml
@@ -20,7 +20,7 @@ jobs:
             scripts/
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.22.2
 

--- a/.github/workflows/sync-utils-docs.yml
+++ b/.github/workflows/sync-utils-docs.yml
@@ -18,7 +18,7 @@ jobs:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.22.2
 
@@ -73,7 +73,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.22.2
 


### PR DESCRIPTION
## Description

Upgrade the five `actions/setup-node` steps in the code-owner and documentation workflows from v4 to v7.

Upstream already changed the Node.js toolchain used by these jobs from 20.15.1 to 22.22.2. This keeps that repository-wide 22.22.2 pin unchanged, while `actions/setup-node@v7` itself runs on Node 24 and removes the remaining Node 20-based action runtime.

Closes #29754.

## Validation

- Actionlint 1.7.12 on all four changed workflow files
- `git diff --check upstream/main...HEAD`
- Verified five `actions/setup-node@v7` references, zero remaining v4 references in these files, and five unchanged `node-version: 22.22.2` pins

## Screencast

Not applicable; this is a CI workflow-only change.

## Checklist

- [x] Extension build and Raycast runtime testing are not applicable
- [x] No extension assets, dependencies, documentation, or README files changed
