### PR TITLE
Update karakeep extension

### DIFF
--- a/extensions/karakeep/CHANGELOG.md
+++ b/extensions/karakeep/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Karakeep Changelog
 
-## [2.4.1] - {PR_MERGE_DATE}
+## [2.4.1] - 2026-08-08
 
 - Fixed every bookmark appearing twice after going offline and reconnecting. The pagination prefetch ran even when the server was unreachable, which advanced the page counter while the request failed; the next successful fetch was then appended to the cached rows instead of replacing them. The prefetch now waits for a request that has actually succeeded.
 - Updated `@chrismessina/raycast-logger` to 1.3.0, which hardens credential redaction in logs — including credentials embedded in URLs, and values that previously escaped masking by their runtime type.

--- a/extensions/karakeep/CHANGELOG.md
+++ b/extensions/karakeep/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Karakeep Changelog
 
+## [2.4.1] - {PR_MERGE_DATE}
+
+- Fixed every bookmark appearing twice after going offline and reconnecting. The pagination prefetch ran even when the server was unreachable, which advanced the page counter while the request failed; the next successful fetch was then appended to the cached rows instead of replacing them. The prefetch now waits for a request that has actually succeeded.
+- Updated `@chrismessina/raycast-logger` to 1.3.0, which hardens credential redaction in logs — including credentials embedded in URLs, and values that previously escaped masking by their runtime type.
+- Updated `@raycast/api` to 1.104.24.
+
 ## [2.4.0] - 2026-07-31
 
 ### Offline and Docker recovery

--- a/extensions/karakeep/package-lock.json
+++ b/extensions/karakeep/package-lock.json
@@ -7,8 +7,8 @@
       "name": "karakeep",
       "license": "MIT",
       "dependencies": {
-        "@chrismessina/raycast-logger": "^1.2.2",
-        "@raycast/api": "^1.104.11",
+        "@chrismessina/raycast-logger": "^1.3.0",
+        "@raycast/api": "^1.104.24",
         "@raycast/utils": "^2.2.3"
       },
       "devDependencies": {
@@ -22,9 +22,9 @@
       }
     },
     "node_modules/@chrismessina/raycast-logger": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@chrismessina/raycast-logger/-/raycast-logger-1.2.2.tgz",
-      "integrity": "sha512-Btwrfi9aPYZp/Wu1urYSe2eDzEts0HZ/ydJuwX3jyKPSGkxDWISOJVzZ8Ery6TC6FUygcLqN2zU+CqNS0uU2wQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@chrismessina/raycast-logger/-/raycast-logger-1.3.0.tgz",
+      "integrity": "sha512-a7ESBDVijqCBvej0t0zf5h5asIk2HX7UY6SKsZWhwJwi7wl91bGPc3Cxjm8OtIWBgXU+CuS440eKKVDse+2xZw==",
       "license": "MIT",
       "peerDependencies": {
         "@raycast/api": "^1.0.0"
@@ -1124,9 +1124,9 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.104.23",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.23.tgz",
-      "integrity": "sha512-8ZdL9Jhc7C/+nQkUIM78pP0ODPR6wVvPjgg0uU6+n5hEaYABmrCIyA/gFcjfAYjU6EUFV2ZDHp6JNPFjQNyBWQ==",
+      "version": "1.104.24",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.24.tgz",
+      "integrity": "sha512-Jppfyi1T7wcGXZFxpzXuvNAKUPQ+BQkKC0N3rJBz1epp/z22SH9aLA23YZRk/ickGwEm6DI/7OY7Jin8dD53Sg==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.8.4",

--- a/extensions/karakeep/package.json
+++ b/extensions/karakeep/package.json
@@ -274,8 +274,8 @@
     }
   ],
   "dependencies": {
-    "@chrismessina/raycast-logger": "^1.2.2",
-    "@raycast/api": "^1.104.11",
+    "@chrismessina/raycast-logger": "^1.3.0",
+    "@raycast/api": "^1.104.24",
     "@raycast/utils": "^2.2.3"
   },
   "devDependencies": {

--- a/extensions/karakeep/src/apis/index.ts
+++ b/extensions/karakeep/src/apis/index.ts
@@ -37,8 +37,10 @@ export async function fetchWithAuth<T = unknown>(path: string, options: FetchOpt
     // entirely. Log the real code and re-throw the ORIGINAL error so callers
     // can still inspect `error.cause` via isConnectionError().
     if (isConnectionError(error)) {
-      // NOT `code`: the logger's redaction treats that key as a 2FA code and
-      // masks the value to "******", which is how ECONNREFUSED went missing.
+      // `errorCode`, not `code`. raycast-logger 1.2.x masked any key named
+      // `code` as a 2FA code, which is how ECONNREFUSED went missing from the
+      // logs. 1.3.0's head-noun matching no longer does that, but the explicit
+      // name is clearer about what this holds and cannot regress.
       log.error(`${method} ${path} could not connect`, {
         errorCode: getConnectionErrorCode(error) ?? "unknown",
         detail: describeConnectionError(error, apiUrl),

--- a/extensions/karakeep/src/bookmarks.tsx
+++ b/extensions/karakeep/src/bookmarks.tsx
@@ -81,6 +81,8 @@ function AllBookmarksView({
     <BookmarkList
       bookmarks={bookmarks}
       isLoading={isLoading}
+      error={error}
+      hasLiveData={hasLiveData}
       onRefresh={handleRefresh}
       pagination={pagination}
       searchBarPlaceholder={t("searchBookmarks")}
@@ -118,6 +120,8 @@ function ListBookmarksView({
     <BookmarkList
       bookmarks={bookmarks}
       isLoading={isLoading}
+      error={error}
+      hasLiveData={hasLiveData}
       onRefresh={revalidate}
       pagination={pagination}
       searchBarPlaceholder={t("searchBookmarks")}

--- a/extensions/karakeep/src/components/BookmarkList.tsx
+++ b/extensions/karakeep/src/components/BookmarkList.tsx
@@ -17,6 +17,8 @@ interface BookmarkListProps {
   };
   isLoading: boolean;
   error?: Error;
+  /** Whether the rows came from a request that succeeded this session. */
+  hasLiveData?: boolean;
   onRefresh?: () => void;
   searchBarPlaceholder?: string;
   emptyViewTitle?: string;
@@ -47,6 +49,8 @@ function SearchBookmarkList({ searchText }: { searchText: string }) {
     <BookmarkList
       bookmarks={bookmarks}
       isLoading={isLoadingBookmarks}
+      error={error}
+      hasLiveData={hasLiveData}
       onRefresh={revalidateBookmarks}
       searchBarPlaceholder={t("bookmarkList.searchPlaceholder")}
       emptyViewTitle={t("bookmarkList.emptySearch.title")}
@@ -59,6 +63,8 @@ export function BookmarkList({
   bookmarks,
   pagination,
   isLoading,
+  error,
+  hasLiveData,
   onRefresh,
   searchBarPlaceholder,
   emptyViewTitle,
@@ -124,6 +130,10 @@ export function BookmarkList({
     isLoading,
     itemCount: displayInfo.displayBookmarks.length,
     enabled: searchText.trim().length === 0,
+    // Without these the prefetch fires against a dead server and duplicates
+    // the list on reconnect — see raycast/extensions#30021.
+    error,
+    hasLiveData,
   });
 
   useEffect(() => {

--- a/extensions/karakeep/src/hooks/usePrefetchPagination.ts
+++ b/extensions/karakeep/src/hooks/usePrefetchPagination.ts
@@ -19,18 +19,41 @@ export function useEnsureScrollablePagination(options: {
   itemCount: number;
   enabled?: boolean;
   maxPrefetches?: number;
+  /**
+   * The last fetch's error, if any. Required to avoid duplicating the list —
+   * see the offline note below.
+   */
+  error?: unknown;
+  /**
+   * Whether the rows on screen came from a request that actually succeeded this
+   * session (as opposed to being restored from the on-disk cache).
+   */
+  hasLiveData?: boolean;
 }) {
   const prefetchedCount = useRef(0);
   const enabled = options.enabled ?? true;
   const maxPrefetches = options.maxPrefetches ?? 3;
 
   useEffect(() => {
-    const { pagination, isLoading, itemCount } = options;
+    const { pagination, isLoading, itemCount, error, hasLiveData } = options;
     if (!enabled) return;
     if (!pagination || !pagination.hasMore) return;
     if (isLoading) return;
     if (prefetchedCount.current >= maxPrefetches) return;
     if (itemCount <= 0) return;
+
+    // NEVER prefetch against a server we haven't heard from. useCachedPromise
+    // REPLACES on page 0 and CONCATS on page > 0, and onLoadMore increments the
+    // page counter immediately — before the request resolves. So calling it
+    // while offline advances the counter, the request fails, and the next
+    // successful fetch lands as page 1 and is concatenated onto the rows that
+    // were restored from cache. Result: every bookmark twice.
+    //
+    // raycast/extensions#30021: cached list renders once offline, then doubles
+    // on reconnect. `hasLiveData` is the load-bearing half — on a cold offline
+    // start there is no error yet, just restored cache.
+    if (error) return;
+    if (hasLiveData === false) return;
 
     // Heuristic: if we only have up to one page of items, it's likely not scrollable yet.
     if (itemCount <= pagination.pageSize) {
@@ -42,6 +65,8 @@ export function useEnsureScrollablePagination(options: {
     maxPrefetches,
     options.isLoading,
     options.itemCount,
+    options.error,
+    options.hasLiveData,
     options.pagination?.hasMore,
     options.pagination?.pageSize,
     options.pagination?.onLoadMore,

--- a/extensions/karakeep/src/lists.tsx
+++ b/extensions/karakeep/src/lists.tsx
@@ -76,6 +76,8 @@ function ListBookmarksView({ listId, listName }: { listId: string; listName: str
     <BookmarkList
       bookmarks={bookmarks}
       isLoading={isLoading}
+      error={error}
+      hasLiveData={hasLiveData}
       onRefresh={handleRefresh}
       pagination={pagination}
       searchBarPlaceholder={t("list.searchInList", { name: listName })}
@@ -98,6 +100,8 @@ function ArchivedBookmarks() {
     <BookmarkList
       bookmarks={bookmarks}
       isLoading={isLoading}
+      error={error}
+      hasLiveData={hasLiveData}
       onRefresh={revalidate}
       pagination={pagination}
       searchBarPlaceholder={t("list.searchInArchived")}
@@ -120,6 +124,8 @@ function FavoritedBookmarks() {
     <BookmarkList
       bookmarks={bookmarks}
       isLoading={isLoading}
+      error={error}
+      hasLiveData={hasLiveData}
       onRefresh={revalidate}
       pagination={pagination}
       searchBarPlaceholder={t("list.searchInFavorites")}

--- a/extensions/karakeep/src/notes.tsx
+++ b/extensions/karakeep/src/notes.tsx
@@ -59,6 +59,8 @@ export default function Notes() {
     <BookmarkList
       bookmarks={bookmarks}
       isLoading={isLoading}
+      error={error}
+      hasLiveData={hasLiveData}
       onRefresh={revalidate}
       pagination={pagination}
       searchBarPlaceholder={t("notes.searchPlaceholder")}

--- a/extensions/karakeep/src/tags.tsx
+++ b/extensions/karakeep/src/tags.tsx
@@ -26,6 +26,8 @@ function TagBookmarksView({ tagId, tagName }: { tagId: string; tagName: string }
     <BookmarkList
       bookmarks={bookmarks}
       isLoading={isLoading}
+      error={error}
+      hasLiveData={hasLiveData}
       onRefresh={revalidate}
       pagination={pagination}
       searchBarPlaceholder={t("tags.bookmarks.searchInTag", { name: tagName })}


### PR DESCRIPTION
## Description

Fixes #30021 — after going offline and reconnecting, every bookmark rendered twice: once from the cached row (with an empty title) and once from the fresh fetch.

**Cause.** `useCachedPromise` *replaces* results on page 0 and *concatenates* on page > 0, and `onLoadMore` increments the page counter immediately — before the request resolves. `useEnsureScrollablePagination` had no error awareness, so opening the command while the server was unreachable still fired a prefetch: the counter advanced to 1, the request failed, and the next successful fetch landed as page 1 and was concatenated onto the rows restored from the on-disk cache.

**Fix.** The prefetch now requires that a request has actually succeeded. Checking `error` alone is not enough — on a cold offline start there is no error yet, only restored cache — so it also gates on whether the rows on screen came from a live request.

Not a regression from 2.4.0: `usePrefetchPagination.ts` is byte-identical to 2.3.2 and the caching options on the bookmarks hook are unchanged, so this reproduces on 2.3.2 as well.

### Changes

- Pagination prefetch no longer runs against an unreachable server, which is what duplicated the list on reconnect (#30021).
- `@chrismessina/raycast-logger` → 1.3.0 (credential-redaction hardening, including credentials embedded in logged URLs). No API change.
- `@raycast/api` → 1.104.24.

### A note on verification

I could not reproduce the original report on my own machine. My Karakeep runs in local Docker, so stopping it triggers the extension's container-recovery screen, which returns before the bookmark list mounts — the duplication path is unreachable in that setup. It needs a server that becomes unreachable *while the command stays open*, which is the reporter's network-loss scenario.

@erireu — if you're able to check this build against your setup, that would be a big help. The fix is derived from the library's pagination internals and reviewed against the source, but your environment is the one that actually exercises it.

## Checklist

- [X] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [X] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [X] I ran `npm run build` and tested this distribution build in Raycast
- [X] I ran `npm run lint` and `npx tsc --noEmit` — both clean
- [ ] I checked that this change does not break existing commands or remove functionality
- [X] I updated `CHANGELOG.md` per the changelog conventions
