### PR TITLE
[Slack] Add expiration argument to Set Status

### DIFF
--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Slack Changelog
 
-## [Add expiration argument to Set Status] - {PR_MERGE_DATE}
+## [Add expiration argument to Set Status] - 2026-08-12
 
 - The **Set Status** command now accepts an optional `expiration` argument — any number of minutes, or `today` / `week` — so a deep link or Quicklink can set a self-clearing status in one step (e.g. `"expiration":"90"` for an hour and a half).
 

--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Slack Changelog
 
+## [Add expiration argument to Set Status] - {PR_MERGE_DATE}
+
+- The **Set Status** command now accepts an optional `expiration` argument — any number of minutes, or `today` / `week` — so a deep link or Quicklink can set a self-clearing status in one step (e.g. `"expiration":"90"` for an hour and a half).
+
 ## [Broadcast Slack thread replies to channels] - 2026-07-21
 
 - Add an optional `replyBroadcast` flag to the `reply-thread` AI tool to also send important thread replies to the channel.

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -113,6 +113,12 @@
           "placeholder": ":rocket:",
           "type": "text",
           "required": false
+        },
+        {
+          "name": "expiration",
+          "placeholder": "Minutes, today, or week",
+          "type": "text",
+          "required": false
         }
       ]
     }

--- a/extensions/slack/src/set-status.tsx
+++ b/extensions/slack/src/set-status.tsx
@@ -6,7 +6,11 @@ import { SLACK_EMOJI_CODE_MAP } from "./constants/emoji.constants";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { type SlackStatusForm, StatusForm } from "./components/set-status/status-form.component";
 import { EmojiPicker } from "./components/set-status/emoji-picker.component";
-import { getDurationOptionFromTimestamp, getTextForExpiration } from "./utils/set-status/expiration.util";
+import {
+  getDurationOptionFromTimestamp,
+  getExpirationTimestamp,
+  getTextForExpiration,
+} from "./utils/set-status/expiration.util";
 import { showToastWithPromise } from "./utils/toast.util";
 import SetAiStatusForm from "./components/set-status/set-ai-status-form.component";
 
@@ -40,8 +44,19 @@ function normalizeEmoji(emoji?: string): string | undefined {
   return EMOJI_NAME_BY_CHAR[trimmed] ?? EMOJI_NAME_BY_CHAR[trimmed.replace(/️/g, "")];
 }
 
+// Accepts what `getExpirationTimestamp` understands: a keyword or a minute count. Returns undefined
+// otherwise, so the caller can report it instead of hitting that helper's NaN-to-"don't clear" path.
+function normalizeExpiration(expiration?: string): string | undefined {
+  const trimmed = expiration?.trim();
+  if (!trimmed) {
+    return "0";
+  }
+
+  return trimmed === "today" || trimmed === "week" || /^\d+$/.test(trimmed) ? trimmed : undefined;
+}
+
 function SlackStatusList(props: LaunchProps<{ arguments: Arguments.SetStatus }>) {
-  const { statusText: statusTextArgument, emoji: emojiArgument } = props.arguments;
+  const { statusText: statusTextArgument, emoji: emojiArgument, expiration: expirationArgument } = props.arguments;
 
   const { data: me, isLoading: isFetchMeLoading } = useMe();
   const {
@@ -214,6 +229,18 @@ function SlackStatusList(props: LaunchProps<{ arguments: Arguments.SetStatus }>)
 
     const statusText = statusTextArgument?.trim() || undefined;
     const emoji = normalizeEmoji(emojiArgument);
+    const expirationValue = normalizeExpiration(expirationArgument);
+
+    if (expirationValue === undefined) {
+      didAutoSetStatus.current = true;
+      showFailureToast(
+        new Error(`"${expirationArgument?.trim()}" isn't a number of minutes, "today", or "week".`),
+        { title: "Failed to set status" },
+      );
+      return;
+    }
+
+    const expiration = getExpirationTimestamp(expirationValue);
 
     // The emoji was provided but couldn't be mapped to a Slack `:name:` (e.g. a composite/ZWJ glyph
     // absent from SLACK_EMOJI_CODE_MAP). Surface it rather than silently dropping the launch.
@@ -240,7 +267,7 @@ function SlackStatusList(props: LaunchProps<{ arguments: Arguments.SetStatus }>)
         await SlackClient.setStatus({
           statusText,
           emoji,
-          expiration: 0,
+          expiration,
           originProfile: profile,
         });
         await mutate();
@@ -252,7 +279,9 @@ function SlackStatusList(props: LaunchProps<{ arguments: Arguments.SetStatus }>)
         error: "An error occurred while changing the state.",
         success: () => ({
           title: "Set status",
-          message: [emoji, statusText].filter(Boolean).join(" "),
+          message: [[emoji, statusText].filter(Boolean).join(" "), getTextForExpiration(expiration)]
+            .filter(Boolean)
+            .join(" · "),
         }),
       },
     );
@@ -265,6 +294,7 @@ function SlackStatusList(props: LaunchProps<{ arguments: Arguments.SetStatus }>)
     mutate,
     statusTextArgument,
     emojiArgument,
+    expirationArgument,
   ]);
 
   return (

--- a/extensions/slack/src/set-status.tsx
+++ b/extensions/slack/src/set-status.tsx
@@ -233,10 +233,9 @@ function SlackStatusList(props: LaunchProps<{ arguments: Arguments.SetStatus }>)
 
     if (expirationValue === undefined) {
       didAutoSetStatus.current = true;
-      showFailureToast(
-        new Error(`"${expirationArgument?.trim()}" isn't a number of minutes, "today", or "week".`),
-        { title: "Failed to set status" },
-      );
+      showFailureToast(new Error(`"${expirationArgument?.trim()}" isn't a number of minutes, "today", or "week".`), {
+        title: "Failed to set status",
+      });
       return;
     }
 


### PR DESCRIPTION
## Description

#28669 made **Set Status** launchable from a deep link with `statusText` and `emoji`, but the status it sets never expires — you still had to open the form to pick a clear time.

This adds a third optional argument, `expiration`, accepting **any number of minutes**, or a keyword:

| Value | Clears |
| --- | --- |
| _omitted_ or `0` | never _(previous behavior)_ |
| `90` | in 90 minutes — any positive integer works |
| `today` | end of today |
| `week` | end of this week |

Example — "Lunch 🍔", clearing in 90 minutes:

```
raycast://extensions/mommertf/slack/set-status?arguments=%7B%22statusText%22%3A%22Lunch%22%2C%22emoji%22%3A%22%3Ahamburger%3A%22%2C%22expiration%22%3A%2290%22%7D
```

No new expiration logic: the value goes to the existing `getExpirationTimestamp`, whose `default` branch already parsed a minute count, and the success toast reports the clear time via the existing `getTextForExpiration`, which already formats arbitrary durations. Deep links and the in-app form resolve expirations through one code path.

### Why a text argument rather than a dropdown

A dropdown would cap this at a handful of presets, but arbitrary expirations are already a first-class concept here — `getDurationOptionFromTimestamp` maps any non-preset timestamp to `custom` for the form's DatePicker. Constraining the deep link to presets would make it strictly less capable than the UI it's meant to automate.

Unparseable input is reported rather than silently accepted. `getExpirationTimestamp` maps `NaN` to `0`, so without a check `expiration=1h` would quietly set a status that never clears. `normalizeExpiration` rejects it up front and shows a failure toast, matching how #28728 handles an unrecognized emoji. This also covers `custom`, which `getExpirationTimestamp` throws on.

### Note

`expiration` on its own (no text, no emoji) doesn't trigger the launch path — it falls through to the normal list rather than expiring an empty status.

## Screencast

No screencast — the change adds one optional argument and is invisible unless it's passed. Launched with no arguments, or with only `statusText`/`emoji`, behavior is unchanged.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration) — build passes; interactive test still to do, hence draft
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
