### PR TITLE
[GitHub] Show organization projects in My Projects

### DIFF
--- a/extensions/github/CHANGELOG.md
+++ b/extensions/github/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GitHub Changelog
 
+## [Show organization projects in My Projects] - {PR_MERGE_DATE}
+
+- The "My Projects" command now lists projects owned by your organizations alongside projects owned by your user account, sorted by last update. Previously only user-owned projects were shown, so the command was empty for people whose projects all live under an organization.
+
 ## [View Pull Request Diffs] - 2026-08-06
 
 - Added a "View Diff" action to pull requests, showing changed files with per-file patches that load progressively as you scroll.

--- a/extensions/github/src/api/project.graphql
+++ b/extensions/github/src/api/project.graphql
@@ -34,3 +34,22 @@ query projectDetails($nodeId: ID!) {
     ...ProjectFields
   }
 }
+
+query getMyProjects {
+  viewer {
+    projectsV2(first: 50, orderBy: { field: UPDATED_AT, direction: DESC }) {
+      nodes {
+        ...ProjectFields
+      }
+    }
+    organizations(first: 50) {
+      nodes {
+        projectsV2(first: 50, orderBy: { field: UPDATED_AT, direction: DESC }) {
+          nodes {
+            ...ProjectFields
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/github/src/api/user.graphql
+++ b/extensions/github/src/api/user.graphql
@@ -75,11 +75,5 @@ query getViewer {
         login
       }
     }
-    projectsV2(first: 50) {
-      totalCount
-      nodes {
-        ...ProjectFields
-      }
-    }
   }
 }

--- a/extensions/github/src/generated/graphql.ts
+++ b/extensions/github/src/generated/graphql.ts
@@ -40300,9 +40300,17 @@ export type GetViewerQuery = {
       totalCount: number;
       nodes?: Array<{ __typename?: "Organization"; avatarUrl: any; login: string } | null> | null;
     };
+  };
+};
+
+export type GetMyProjectsQueryVariables = Exact<{ [key: string]: never }>;
+
+export type GetMyProjectsQuery = {
+  __typename?: "Query";
+  viewer: {
+    __typename?: "User";
     projectsV2: {
       __typename?: "ProjectV2Connection";
-      totalCount: number;
       nodes?: Array<{
         __typename?: "ProjectV2";
         id: string;
@@ -40329,6 +40337,56 @@ export type GetViewerQuery = {
           __typename?: "ProjectV2ViewConnection";
           totalCount: number;
           nodes?: Array<{ __typename?: "ProjectV2View"; id: string; name: string; number: number } | null> | null;
+        };
+      } | null> | null;
+    };
+    organizations: {
+      __typename?: "OrganizationConnection";
+      nodes?: Array<{
+        __typename?: "Organization";
+        projectsV2: {
+          __typename?: "ProjectV2Connection";
+          nodes?: Array<{
+            __typename?: "ProjectV2";
+            id: string;
+            title: string;
+            public: boolean;
+            number: number;
+            readme?: string | null;
+            closed: boolean;
+            shortDescription?: string | null;
+            url: any;
+            createdAt: any;
+            updatedAt: any;
+            viewerCanClose: boolean;
+            viewerCanUpdate: boolean;
+            viewerCanReopen: boolean;
+            creator?:
+              | { __typename?: "Bot"; id: string; login: string; avatarUrl: any }
+              | {
+                  __typename?: "EnterpriseUserAccount";
+                  id: string;
+                  login: string;
+                  name?: string | null;
+                  avatarUrl: any;
+                }
+              | { __typename?: "Mannequin"; id: string; login: string; avatarUrl: any }
+              | { __typename?: "Organization"; id: string; login: string; name?: string | null; avatarUrl: any }
+              | {
+                  __typename?: "User";
+                  id: string;
+                  avatarUrl: any;
+                  name?: string | null;
+                  login: string;
+                  isViewer: boolean;
+                }
+              | null;
+            views: {
+              __typename?: "ProjectV2ViewConnection";
+              totalCount: number;
+              nodes?: Array<{ __typename?: "ProjectV2View"; id: string; name: string; number: number } | null> | null;
+            };
+          } | null> | null;
         };
       } | null> | null;
     };
@@ -41605,15 +41663,29 @@ export const GetViewerDocument = gql`
           login
         }
       }
-      projectsV2(first: 50) {
-        totalCount
+    }
+  }
+  ${UserFieldsFragmentDoc}
+`;
+export const GetMyProjectsDocument = gql`
+  query getMyProjects {
+    viewer {
+      projectsV2(first: 50, orderBy: { field: UPDATED_AT, direction: DESC }) {
         nodes {
           ...ProjectFields
         }
       }
+      organizations(first: 50) {
+        nodes {
+          projectsV2(first: 50, orderBy: { field: UPDATED_AT, direction: DESC }) {
+            nodes {
+              ...ProjectFields
+            }
+          }
+        }
+      }
     }
   }
-  ${UserFieldsFragmentDoc}
   ${ProjectFieldsFragmentDoc}
 `;
 export const GetViewerStatsDocument = gql`
@@ -42626,6 +42698,24 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
             signal,
           }),
         "getViewer",
+        "query",
+        variables,
+      );
+    },
+    getMyProjects(
+      variables?: GetMyProjectsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<GetMyProjectsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetMyProjectsQuery>({
+            document: GetMyProjectsDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "getMyProjects",
         "query",
         variables,
       );

--- a/extensions/github/src/hooks/useMyProjects.ts
+++ b/extensions/github/src/hooks/useMyProjects.ts
@@ -8,12 +8,21 @@ export function useMyProjects(closed: boolean | null) {
 
   return useCachedPromise(
     async (closed: boolean | null) => {
-      const { viewer } = await github.getViewer();
+      const { viewer } = await github.getMyProjects();
+
+      const userProjects = (viewer?.projectsV2?.nodes ?? []) as ProjectFieldsFragment[];
+      const organizationProjects = (viewer?.organizations?.nodes ?? []).flatMap(
+        (organization) => (organization?.projectsV2?.nodes ?? []) as ProjectFieldsFragment[],
+      );
+
+      const projects = [...userProjects, ...organizationProjects]
+        .filter((p) => p)
+        .sort((a, b) => String(b.updatedAt).localeCompare(String(a.updatedAt)));
 
       if (closed === null) {
-        return (viewer?.projectsV2?.nodes ?? []) as ProjectFieldsFragment[];
+        return projects;
       }
-      return (viewer?.projectsV2?.nodes?.filter((p) => p && p.closed === closed) ?? []) as ProjectFieldsFragment[];
+      return projects.filter((p) => p.closed === closed);
     },
     [closed],
   );


### PR DESCRIPTION
## Description

Fixes #20343.

The "My Projects" command only queries `viewer.projectsV2`, which returns projects owned by your personal account. If your projects all live under an organization — which is how most teams use Projects — the command comes up empty. That's how I found this: my company's boards are all org-owned, so "My Projects" showed me nothing at all.

What this PR does:

- Adds a `getMyProjects` query that fetches projects from your account *and* from each of your organizations, ordered by most recently updated
- Merges the two in `useMyProjects` and sorts the combined list by last update; the open/closed dropdown works the same as before
- Drops the now-unused `projectsV2` field from `getViewer`, so every other command that loads the viewer gets a slightly lighter query

One thing worth flagging for review: I didn't commit a full codegen run for `src/generated/graphql.ts`. The codegen fetches the live schema from GitHub's API, and it has drifted since that file was last generated — a fresh regen produced ~4,600 lines of unrelated churn and flipped the custom scalars from `any` to `unknown`, which breaks `my-stats-menu.tsx`. To keep this diff reviewable I added the types for the new query by hand, matching the existing file's style. Happy to do the full regen (plus the fixes it needs) as a follow-up if you'd rather get the schema current.

## Screencast

No visual changes — the list just has data in it now. Before: empty "My Projects" for anyone whose projects are org-owned. After: org projects show up alongside personal ones, newest first. Verified in `ray develop` against a real account where every project is org-owned, and the raw query against the live GraphQL API.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
