### PR TITLE
fix: recover interrupted speech sessions

### DIFF
--- a/extensions/elevenlabs-tts/CHANGELOG.md
+++ b/extensions/elevenlabs-tts/CHANGELOG.md
@@ -15,10 +15,12 @@
 ## [1.2.0] - 2025-11-27
 
 ### Added
+
 - Dynamic chunk scheduling based on text length for better short text support
 - Voice display name mapping for improved toast readability
 
 ### Fixed
+
 - Audio playback cutoff issue by implementing non-blocking playback
 - Short text (< 100 chars) not generating audio due to chunk size threshold
 - API error handling to prevent duplicate error messages
@@ -26,6 +28,7 @@
 - Race condition between audio streaming and playback
 
 ### Changed
+
 - Migrated to `eleven_turbo_v2_5` model for free tier compatibility
 - Streamlined toast notifications for compact HUD display
 - Adopted `showFailureToast` utility from `@raycast/utils` for better error UX
@@ -33,6 +36,7 @@
 - Improved error handling with specific messages for quota, API key, and model issues
 
 ### Technical
+
 - Added completion tracking for both stream and playback states
 - Implemented non-blocking audio playback to allow chunk writing during playback
 - Enhanced error detection and propagation throughout the audio pipeline
@@ -41,6 +45,7 @@
 ## [1.1.0] - 2025-01-19
 
 ### Added
+
 - Playback speed control with options from 0.5x to 2.0x speed
 - New preferences dropdown for playback speed selection
 - Integration with macOS afplay command for speed-adjusted playback
@@ -48,6 +53,7 @@
 ## [1.0.0] - 2025-01-12
 
 ### Added
+
 - Text-to-speech conversion using ElevenLabs API
 - Support for multiple premium AI voices
 - Voice customization with stability and similarity boost settings
@@ -57,6 +63,7 @@
 - Automatic cleanup of temporary audio files
 
 ### Features
+
 - Speak selected text from any application
 - Configure voice settings through preferences
 - Stop playback by running command again
@@ -64,6 +71,7 @@
 - Real-time audio streaming
 
 ### Technical
+
 - WebSocket-based streaming for efficient audio delivery
 - Temporary file management for audio chunks
 - Event-based architecture for audio processing

--- a/extensions/elevenlabs-tts/CHANGELOG.md
+++ b/extensions/elevenlabs-tts/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Raycast ElevenLabs TTS Changelog
 
+## [Fix Stuck Playback Sessions] - {PR_MERGE_DATE}
+
+### Fixed
+
+- Commands getting stuck reporting that audio was already playing after an interrupted session
+
 ## [Speak Copied Text] - 2026-08-05
 
 ### Added

--- a/extensions/elevenlabs-tts/CHANGELOG.md
+++ b/extensions/elevenlabs-tts/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Raycast ElevenLabs TTS Changelog
 
-## [Fix Stuck Playback Sessions] - {PR_MERGE_DATE}
+## [Fix Stuck Playback Sessions] - 2026-08-10
 
 ### Fixed
 

--- a/extensions/elevenlabs-tts/package-lock.json
+++ b/extensions/elevenlabs-tts/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@raycast/api": "1.84.12",
         "@raycast/utils": "1.18.0",
+        "proper-lockfile": "4.1.2",
         "ws": "8.18.0"
       },
       "devDependencies": {
@@ -18,6 +19,7 @@
         "@types/jest": "29.5.0",
         "@types/node": "22.9.0",
         "@types/play-sound": "1.1.2",
+        "@types/proper-lockfile": "4.1.4",
         "@types/react": "18.3.12",
         "@types/ws": "8.5.13",
         "eslint": "8.57.1",
@@ -1365,6 +1367,16 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
       "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA=="
     },
+    "node_modules/@types/proper-lockfile": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.4.tgz",
+      "integrity": "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "*"
+      }
+    },
     "node_modules/@types/react": {
       "version": "18.3.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.12.tgz",
@@ -1373,6 +1385,13 @@
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
+      "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/semver": {
       "version": "7.5.8",
@@ -2970,8 +2989,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -4422,6 +4440,23 @@
         "node": ">= 6"
       }
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4547,6 +4582,15 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {

--- a/extensions/elevenlabs-tts/package.json
+++ b/extensions/elevenlabs-tts/package.json
@@ -184,6 +184,7 @@
   "dependencies": {
     "@raycast/api": "1.84.12",
     "@raycast/utils": "1.18.0",
+    "proper-lockfile": "4.1.2",
     "ws": "8.18.0"
   },
   "devDependencies": {
@@ -191,6 +192,7 @@
     "@types/jest": "29.5.0",
     "@types/node": "22.9.0",
     "@types/play-sound": "1.1.2",
+    "@types/proper-lockfile": "4.1.4",
     "@types/react": "18.3.12",
     "@types/ws": "8.5.13",
     "eslint": "8.57.1",

--- a/extensions/elevenlabs-tts/src/audio/playback.test.ts
+++ b/extensions/elevenlabs-tts/src/audio/playback.test.ts
@@ -23,11 +23,17 @@ describe("isOwnedPlaybackCommand", () => {
 describe("speech sessions", () => {
   let directory: string;
   let sessionLock: SpeechSessionLock;
+  let cleanupPreviousSession: jest.Mock<Promise<boolean>, []>;
   const sessions: string[] = [];
 
   beforeEach(async () => {
     directory = await fs.mkdtemp(join(tmpdir(), "elevenlabs-tts-test-"));
-    sessionLock = new SpeechSessionLock(join(directory, "session"), { stale: 2_000, update: 1_000 });
+    cleanupPreviousSession = jest.fn().mockResolvedValue(false);
+    sessionLock = new SpeechSessionLock(
+      join(directory, "session"),
+      { stale: 2_000, update: 1_000 },
+      cleanupPreviousSession,
+    );
   });
 
   afterEach(async () => {
@@ -53,7 +59,7 @@ describe("speech sessions", () => {
     sessions.push(nextSession);
   });
 
-  it("recovers an abandoned session", async () => {
+  it("recovers an abandoned session and cleans up its playback", async () => {
     const lockDirectory = join(directory, "session.lock");
     await fs.mkdir(lockDirectory);
     const staleTime = new Date(Date.now() - 10_000);
@@ -62,6 +68,7 @@ describe("speech sessions", () => {
     const session = await sessionLock.begin();
 
     expect(session).toBeDefined();
+    expect(cleanupPreviousSession).toHaveBeenCalledTimes(1);
     if (!session) throw new Error("Expected to recover the abandoned session");
     sessions.push(session);
   });

--- a/extensions/elevenlabs-tts/src/audio/playback.test.ts
+++ b/extensions/elevenlabs-tts/src/audio/playback.test.ts
@@ -4,9 +4,20 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SpeechSessionLock, isOwnedPlaybackCommand, stopActivePlayback } from "./playback";
 
-jest.mock("child_process", () => ({
-  execFile: jest.fn(),
-}));
+jest.mock("child_process", () => {
+  const { promisify } = jest.requireActual<typeof import("node:util")>("node:util");
+  const execFile = jest.fn();
+  Object.defineProperty(execFile, promisify.custom, {
+    value: (...args: unknown[]) =>
+      new Promise((resolve, reject) => {
+        execFile(...args, (error: Error | null, stdout: string, stderr: string) => {
+          if (error) reject(error);
+          else resolve({ stdout, stderr });
+        });
+      }),
+  });
+  return { execFile };
+});
 
 const mockedExecFile = execFile as jest.MockedFunction<typeof execFile>;
 const PLAYBACK_FILE = join(tmpdir(), "elevenlabs-tts-playback.json");
@@ -138,16 +149,52 @@ describe("stopActivePlayback", () => {
     await expect(fs.access(PLAYBACK_FILE)).rejects.toThrow();
   });
 
-  it("clears playback record when inspection fails but SIGTERM succeeds", async () => {
+  it("preserves playback record without signalling when inspection fails and the process is alive", async () => {
     mockedExecFile.mockImplementation((_file, _args, options, callback) => {
       const cb = typeof options === "function" ? options : callback;
       cb?.(new Error("ps timed out"), "", "");
       return {} as ChildProcess;
     });
 
-    jest.spyOn(process, "kill").mockImplementation(() => true);
+    const kill = jest.spyOn(process, "kill").mockImplementation(() => true);
+
+    await expect(stopActivePlayback()).resolves.toBe(false);
+    expect(kill).toHaveBeenCalledWith(pid, 0);
+    expect(kill).not.toHaveBeenCalledWith(pid, "SIGTERM");
+    await expect(fs.readFile(PLAYBACK_FILE, "utf8")).resolves.toBe(JSON.stringify({ sessionId, pid, audioFile }));
+  });
+
+  it("terminates the verified player and clears the record once it exits", async () => {
+    mockedExecFile.mockImplementation((_file, _args, options, callback) => {
+      const cb = typeof options === "function" ? options : callback;
+      cb?.(null, `/usr/bin/afplay ${audioFile}\n`, "");
+      return {} as ChildProcess;
+    });
+
+    let terminated = false;
+    jest.spyOn(process, "kill").mockImplementation((_pid, signal) => {
+      if (signal === "SIGTERM") {
+        terminated = true;
+        return true;
+      }
+      if (terminated) throw Object.assign(new Error("No such process"), { code: "ESRCH" });
+      return true;
+    });
 
     await expect(stopActivePlayback()).resolves.toBe(true);
     await expect(fs.access(PLAYBACK_FILE)).rejects.toThrow();
+  });
+
+  it("preserves playback record when the verified player survives SIGTERM", async () => {
+    mockedExecFile.mockImplementation((_file, _args, options, callback) => {
+      const cb = typeof options === "function" ? options : callback;
+      cb?.(null, `/usr/bin/afplay ${audioFile}\n`, "");
+      return {} as ChildProcess;
+    });
+
+    jest.spyOn(process, "kill").mockImplementation(() => true);
+
+    await expect(stopActivePlayback()).resolves.toBe(false);
+    await expect(fs.readFile(PLAYBACK_FILE, "utf8")).resolves.toBe(JSON.stringify({ sessionId, pid, audioFile }));
   });
 });

--- a/extensions/elevenlabs-tts/src/audio/playback.test.ts
+++ b/extensions/elevenlabs-tts/src/audio/playback.test.ts
@@ -1,4 +1,7 @@
-import { beginSpeechSession, endSpeechSession, isOwnedPlaybackCommand } from "./playback";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SpeechSessionLock, isOwnedPlaybackCommand } from "./playback";
 
 describe("isOwnedPlaybackCommand", () => {
   const audioFile = "/tmp/raycast-tts-123.mp3";
@@ -18,26 +21,48 @@ describe("isOwnedPlaybackCommand", () => {
 });
 
 describe("speech sessions", () => {
+  let directory: string;
+  let sessionLock: SpeechSessionLock;
   const sessions: string[] = [];
 
+  beforeEach(async () => {
+    directory = await fs.mkdtemp(join(tmpdir(), "elevenlabs-tts-test-"));
+    sessionLock = new SpeechSessionLock(join(directory, "session"), { stale: 2_000, update: 1_000 });
+  });
+
   afterEach(async () => {
-    await Promise.all(sessions.splice(0).map(endSpeechSession));
+    await Promise.all(sessions.splice(0).map((sessionId) => sessionLock.end(sessionId)));
+    await fs.rm(directory, { recursive: true, force: true });
   });
 
   it("allows only one command to synthesize at a time", async () => {
-    const firstSession = await beginSpeechSession();
+    const firstSession = await sessionLock.begin();
     expect(firstSession).toBeDefined();
     if (!firstSession) throw new Error("Expected to acquire the first speech session");
     sessions.push(firstSession);
 
-    await expect(beginSpeechSession()).resolves.toBeUndefined();
+    const competingLock = new SpeechSessionLock(join(directory, "session"), { stale: 2_000, update: 1_000 });
+    await expect(competingLock.begin()).resolves.toBeUndefined();
 
-    await endSpeechSession(firstSession);
+    await sessionLock.end(firstSession);
     sessions.pop();
 
-    const nextSession = await beginSpeechSession();
+    const nextSession = await sessionLock.begin();
     expect(nextSession).toBeDefined();
     if (!nextSession) throw new Error("Expected to acquire the next speech session");
     sessions.push(nextSession);
+  });
+
+  it("recovers an abandoned session", async () => {
+    const lockDirectory = join(directory, "session.lock");
+    await fs.mkdir(lockDirectory);
+    const staleTime = new Date(Date.now() - 10_000);
+    await fs.utimes(lockDirectory, staleTime, staleTime);
+
+    const session = await sessionLock.begin();
+
+    expect(session).toBeDefined();
+    if (!session) throw new Error("Expected to recover the abandoned session");
+    sessions.push(session);
   });
 });

--- a/extensions/elevenlabs-tts/src/audio/playback.test.ts
+++ b/extensions/elevenlabs-tts/src/audio/playback.test.ts
@@ -1,7 +1,15 @@
+import { ChildProcess, execFile } from "child_process";
 import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { SpeechSessionLock, isOwnedPlaybackCommand } from "./playback";
+import { SpeechSessionLock, isOwnedPlaybackCommand, stopActivePlayback } from "./playback";
+
+jest.mock("child_process", () => ({
+  execFile: jest.fn(),
+}));
+
+const mockedExecFile = execFile as jest.MockedFunction<typeof execFile>;
+const PLAYBACK_FILE = join(tmpdir(), "elevenlabs-tts-playback.json");
 
 describe("isOwnedPlaybackCommand", () => {
   const audioFile = "/tmp/raycast-tts-123.mp3";
@@ -71,5 +79,65 @@ describe("speech sessions", () => {
     expect(cleanupPreviousSession).toHaveBeenCalledTimes(1);
     if (!session) throw new Error("Expected to recover the abandoned session");
     sessions.push(session);
+  });
+});
+
+describe("stopActivePlayback", () => {
+  const sessionId = "stale-session";
+  const pid = 4242;
+  const audioFile = "/tmp/raycast-tts-stale.mp3";
+
+  beforeEach(async () => {
+    mockedExecFile.mockReset();
+    await fs.writeFile(PLAYBACK_FILE, JSON.stringify({ sessionId, pid, audioFile }), "utf8");
+  });
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+    await fs.unlink(PLAYBACK_FILE).catch(() => undefined);
+  });
+
+  it("preserves playback record when inspection fails and termination is blocked", async () => {
+    mockedExecFile.mockImplementation((_file, _args, options, callback) => {
+      const cb = typeof options === "function" ? options : callback;
+      cb?.(new Error("ps timed out"), "", "");
+      return {} as ChildProcess;
+    });
+
+    const killError = Object.assign(new Error("Operation not permitted"), { code: "EPERM" });
+    jest.spyOn(process, "kill").mockImplementation(() => {
+      throw killError;
+    });
+
+    await expect(stopActivePlayback()).resolves.toBe(false);
+    await expect(fs.readFile(PLAYBACK_FILE, "utf8")).resolves.toBe(JSON.stringify({ sessionId, pid, audioFile }));
+  });
+
+  it("clears playback record when inspection fails but the process is already gone", async () => {
+    mockedExecFile.mockImplementation((_file, _args, options, callback) => {
+      const cb = typeof options === "function" ? options : callback;
+      cb?.(new Error("ps timed out"), "", "");
+      return {} as ChildProcess;
+    });
+
+    jest.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("No such process"), { code: "ESRCH" });
+    });
+
+    await expect(stopActivePlayback()).resolves.toBe(false);
+    await expect(fs.access(PLAYBACK_FILE)).rejects.toThrow();
+  });
+
+  it("clears playback record when inspection fails but SIGTERM succeeds", async () => {
+    mockedExecFile.mockImplementation((_file, _args, options, callback) => {
+      const cb = typeof options === "function" ? options : callback;
+      cb?.(new Error("ps timed out"), "", "");
+      return {} as ChildProcess;
+    });
+
+    jest.spyOn(process, "kill").mockImplementation(() => true);
+
+    await expect(stopActivePlayback()).resolves.toBe(true);
+    await expect(fs.access(PLAYBACK_FILE)).rejects.toThrow();
   });
 });

--- a/extensions/elevenlabs-tts/src/audio/playback.test.ts
+++ b/extensions/elevenlabs-tts/src/audio/playback.test.ts
@@ -80,6 +80,16 @@ describe("speech sessions", () => {
     if (!session) throw new Error("Expected to recover the abandoned session");
     sessions.push(session);
   });
+
+  it("denies takeover when stale playback cleanup leaves an active record", async () => {
+    const playback = { sessionId: "stale-session", pid: 4242, audioFile: "/tmp/raycast-tts-stale.mp3" };
+    await fs.writeFile(PLAYBACK_FILE, JSON.stringify(playback), "utf8");
+    cleanupPreviousSession.mockResolvedValue(false);
+
+    await expect(sessionLock.begin()).resolves.toBeUndefined();
+    expect(cleanupPreviousSession).toHaveBeenCalledTimes(1);
+    await expect(fs.readFile(PLAYBACK_FILE, "utf8")).resolves.toBe(JSON.stringify(playback));
+  });
 });
 
 describe("stopActivePlayback", () => {

--- a/extensions/elevenlabs-tts/src/audio/playback.ts
+++ b/extensions/elevenlabs-tts/src/audio/playback.ts
@@ -18,6 +18,7 @@ interface PlaybackRecord {
 }
 
 const SESSION_LOCK_PATH = join(tmpdir(), "elevenlabs-tts-session-v2");
+const SESSION_LOCK_OPTIONS: LockOptions = { stale: 10_000, update: 2_000 };
 const PLAYBACK_FILE = join(tmpdir(), "elevenlabs-tts-playback.json");
 const execFileAsync = promisify(execFile);
 
@@ -26,7 +27,8 @@ export class SpeechSessionLock {
 
   constructor(
     private readonly lockPath: string,
-    private readonly options: LockOptions = { stale: 10_000, update: 2_000 },
+    private readonly options: LockOptions = SESSION_LOCK_OPTIONS,
+    private readonly cleanupPreviousSession: () => Promise<unknown> = async () => undefined,
   ) {}
 
   async begin(): Promise<string | undefined> {
@@ -49,6 +51,12 @@ export class SpeechSessionLock {
     }
 
     this.sessions.set(sessionId, { release, isCompromised: () => compromised });
+    try {
+      await this.cleanupPreviousSession();
+    } catch (error) {
+      await this.end(sessionId);
+      throw error;
+    }
     return sessionId;
   }
 
@@ -71,7 +79,7 @@ export class SpeechSessionLock {
   }
 }
 
-const speechSessionLock = new SpeechSessionLock(SESSION_LOCK_PATH);
+const speechSessionLock = new SpeechSessionLock(SESSION_LOCK_PATH, SESSION_LOCK_OPTIONS, stopActivePlayback);
 
 export function isOwnedPlaybackCommand(command: string, audioFile: string): boolean {
   const normalizedCommand = command.trim();

--- a/extensions/elevenlabs-tts/src/audio/playback.ts
+++ b/extensions/elevenlabs-tts/src/audio/playback.ts
@@ -53,6 +53,10 @@ export class SpeechSessionLock {
     this.sessions.set(sessionId, { release, isCompromised: () => compromised });
     try {
       await this.cleanupPreviousSession();
+      if (await readPlayback()) {
+        await this.end(sessionId);
+        return undefined;
+      }
     } catch (error) {
       await this.end(sessionId);
       throw error;

--- a/extensions/elevenlabs-tts/src/audio/playback.ts
+++ b/extensions/elevenlabs-tts/src/audio/playback.ts
@@ -3,11 +3,12 @@ import { randomUUID } from "crypto";
 import { promises as fs } from "node:fs";
 import { tmpdir } from "os";
 import { basename, join } from "path";
+import { lock, LockOptions } from "proper-lockfile";
 import { promisify } from "util";
 
-interface SpeechSession {
-  id: string;
-  ownerPid: number;
+interface HeldSession {
+  release: () => Promise<void>;
+  isCompromised: () => boolean;
 }
 
 interface PlaybackRecord {
@@ -16,9 +17,61 @@ interface PlaybackRecord {
   audioFile: string;
 }
 
-const SESSION_FILE = join(tmpdir(), "elevenlabs-tts-session.json");
+const SESSION_LOCK_PATH = join(tmpdir(), "elevenlabs-tts-session-v2");
 const PLAYBACK_FILE = join(tmpdir(), "elevenlabs-tts-playback.json");
 const execFileAsync = promisify(execFile);
+
+export class SpeechSessionLock {
+  private readonly sessions = new Map<string, HeldSession>();
+
+  constructor(
+    private readonly lockPath: string,
+    private readonly options: LockOptions = { stale: 10_000, update: 2_000 },
+  ) {}
+
+  async begin(): Promise<string | undefined> {
+    const sessionId = randomUUID();
+    let compromised = false;
+    let release: () => Promise<void>;
+
+    try {
+      release = await lock(this.lockPath, {
+        ...this.options,
+        realpath: false,
+        retries: 0,
+        onCompromised: () => {
+          compromised = true;
+        },
+      });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ELOCKED") return undefined;
+      throw error;
+    }
+
+    this.sessions.set(sessionId, { release, isCompromised: () => compromised });
+    return sessionId;
+  }
+
+  async end(sessionId: string): Promise<void> {
+    const heldSession = this.sessions.get(sessionId);
+    if (!heldSession) return;
+
+    this.sessions.delete(sessionId);
+    try {
+      await heldSession.release();
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ERELEASED" && code !== "ENOTACQUIRED") throw error;
+    }
+  }
+
+  owns(sessionId: string): boolean {
+    const heldSession = this.sessions.get(sessionId);
+    return Boolean(heldSession && !heldSession.isCompromised());
+  }
+}
+
+const speechSessionLock = new SpeechSessionLock(SESSION_LOCK_PATH);
 
 export function isOwnedPlaybackCommand(command: string, audioFile: string): boolean {
   const normalizedCommand = command.trim();
@@ -27,34 +80,17 @@ export function isOwnedPlaybackCommand(command: string, audioFile: string): bool
 }
 
 export async function beginSpeechSession(): Promise<string | undefined> {
-  for (let attempt = 0; attempt < 3; attempt++) {
-    const session: SpeechSession = { id: randomUUID(), ownerPid: process.pid };
-    try {
-      await fs.writeFile(SESSION_FILE, JSON.stringify(session), { encoding: "utf8", flag: "wx" });
-      return session.id;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-    }
-
-    const activeSession = await readSession();
-    if (!activeSession || isProcessRunning(activeSession.ownerPid)) return undefined;
-
-    await stopPlaybackForSession(activeSession.id);
-    await removeSessionFile(activeSession.id);
-  }
-
-  return undefined;
+  return speechSessionLock.begin();
 }
 
 export async function endSpeechSession(sessionId: string): Promise<void> {
   const playback = await readPlayback();
   if (playback?.sessionId === sessionId) await removePlaybackFile();
-  await removeSessionFile(sessionId);
+  await speechSessionLock.end(sessionId);
 }
 
 export async function registerPlayback(sessionId: string, pid: number, audioFile: string): Promise<void> {
-  const session = await readSession();
-  if (session?.id !== sessionId) throw new Error("Speech session expired");
+  if (!speechSessionLock.owns(sessionId)) throw new Error("Speech session expired");
 
   await fs.writeFile(PLAYBACK_FILE, JSON.stringify({ sessionId, pid, audioFile }), "utf8");
 }
@@ -67,19 +103,10 @@ export async function clearPlayback(sessionId: string, expectedPid: number): Pro
 }
 
 export async function stopActivePlayback(): Promise<boolean> {
-  const session = await readSession();
-  if (!session) return false;
+  const playback = await readPlayback();
+  if (!playback) return false;
 
-  return stopPlaybackForSession(session.id);
-}
-
-function isProcessRunning(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
+  return stopPlaybackForSession(playback.sessionId);
 }
 
 async function stopPlaybackForSession(sessionId: string): Promise<boolean> {
@@ -104,18 +131,6 @@ async function stopPlaybackForSession(sessionId: string): Promise<boolean> {
   }
 }
 
-async function readSession(): Promise<SpeechSession | undefined> {
-  try {
-    const value = JSON.parse(await fs.readFile(SESSION_FILE, "utf8")) as Partial<SpeechSession>;
-    if (typeof value.id !== "string" || !Number.isInteger(value.ownerPid) || (value.ownerPid as number) <= 0) {
-      return undefined;
-    }
-    return value as SpeechSession;
-  } catch {
-    return undefined;
-  }
-}
-
 async function readPlayback(): Promise<PlaybackRecord | undefined> {
   try {
     const value = JSON.parse(await fs.readFile(PLAYBACK_FILE, "utf8")) as Partial<PlaybackRecord>;
@@ -132,17 +147,6 @@ async function readPlayback(): Promise<PlaybackRecord | undefined> {
   } catch {
     await removePlaybackFile();
     return undefined;
-  }
-}
-
-async function removeSessionFile(expectedId: string): Promise<void> {
-  const session = await readSession();
-  if (session?.id !== expectedId) return;
-
-  try {
-    await fs.unlink(SESSION_FILE);
-  } catch {
-    // Speech session cleanup is best-effort.
   }
 }
 

--- a/extensions/elevenlabs-tts/src/audio/playback.ts
+++ b/extensions/elevenlabs-tts/src/audio/playback.ts
@@ -125,30 +125,50 @@ async function stopPlaybackForSession(sessionId: string): Promise<boolean> {
   const record = await readPlayback();
   if (record?.sessionId !== sessionId) return false;
 
+  let command: string;
   try {
-    const { stdout } = await execFileAsync("ps", ["-p", String(record.pid), "-o", "command="], {
+    ({ stdout: command } = await execFileAsync("ps", ["-p", String(record.pid), "-o", "command="], {
       timeout: 1000,
-    });
-    if (!isOwnedPlaybackCommand(stdout, record.audioFile)) {
-      await removePlaybackFile();
-      return false;
-    }
-
-    process.kill(record.pid, "SIGTERM");
-    await clearPlayback(sessionId, record.pid);
-    return true;
+    }));
   } catch {
-    try {
-      process.kill(record.pid, "SIGTERM");
-      await clearPlayback(sessionId, record.pid);
-      return true;
-    } catch (killError) {
-      if ((killError as NodeJS.ErrnoException).code === "ESRCH") {
-        await clearPlayback(sessionId, record.pid);
-      }
-      return false;
-    }
+    // ps exits non-zero when the PID is gone; on any other failure the owner is unverified,
+    // so keep the record and let begin() deny takeover rather than signal a possibly reused PID.
+    if (isProcessGone(record.pid)) await clearPlayback(sessionId, record.pid);
+    return false;
   }
+
+  if (!isOwnedPlaybackCommand(command, record.audioFile)) {
+    await removePlaybackFile();
+    return false;
+  }
+
+  try {
+    process.kill(record.pid, "SIGTERM");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ESRCH") return false;
+  }
+  if (!(await waitForProcessExit(record.pid, 1_000))) return false;
+
+  await clearPlayback(sessionId, record.pid);
+  return true;
+}
+
+function isProcessGone(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return false;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "ESRCH";
+  }
+}
+
+async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    if (isProcessGone(pid)) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  } while (Date.now() < deadline);
+  return isProcessGone(pid);
 }
 
 async function readPlayback(): Promise<PlaybackRecord | undefined> {

--- a/extensions/elevenlabs-tts/src/audio/playback.ts
+++ b/extensions/elevenlabs-tts/src/audio/playback.ts
@@ -134,8 +134,16 @@ async function stopPlaybackForSession(sessionId: string): Promise<boolean> {
     await clearPlayback(sessionId, record.pid);
     return true;
   } catch {
-    await clearPlayback(sessionId, record.pid);
-    return false;
+    try {
+      process.kill(record.pid, "SIGTERM");
+      await clearPlayback(sessionId, record.pid);
+      return true;
+    } catch (killError) {
+      if ((killError as NodeJS.ErrnoException).code === "ESRCH") {
+        await clearPlayback(sessionId, record.pid);
+      }
+      return false;
+    }
   }
 }
 


### PR DESCRIPTION
## Description

Replaces PID-based speech session tracking with an atomic, heartbeat-backed lock. Interrupted commands can now recover after the lock expires instead of remaining blocked by the long-running Raycast extension host, while concurrent synthesis and owned-playback stopping remain coordinated.

## Screencast

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)