### PR TITLE
Update file-tidy extension

### DIFF
--- a/extensions/file-tidy/CHANGELOG.md
+++ b/extensions/file-tidy/CHANGELOG.md
@@ -1,6 +1,6 @@
 # File Tidy Changelog
 
-## [Maintenance] - {PR_MERGE_DATE}
+## [Maintenance] - 2026-08-08
 
 - Internal cleanup with no change to how the commands behave. The ` (n)` suffix used for a name collision is now produced in a single place, so the name shown in the plan and the name written to disk cannot drift apart as the code changes.
 

--- a/extensions/file-tidy/CHANGELOG.md
+++ b/extensions/file-tidy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # File Tidy Changelog
 
+## [Maintenance] - {PR_MERGE_DATE}
+
+- Internal cleanup with no change to how the commands behave. The ` (n)` suffix used for a name collision is now produced in a single place, so the name shown in the plan and the name written to disk cannot drift apart as the code changes.
+
 ## [Smart Checks and a Prefixed Archive Structure] - 2026-08-04
 
 - Archive folders are now named `ft_Category/[Subcategory]/[date]`. The `ft_` prefix keeps tidy's output apart from folders you made yourself; an existing un-prefixed archive is reused rather than split in two. Subcategories (Screenshots, Ebooks, Invoices, Installers, …) come from configurable name and extension rules.

--- a/extensions/file-tidy/package.json
+++ b/extensions/file-tidy/package.json
@@ -66,7 +66,7 @@
     "dev": "ray develop",
     "lint": "ray lint",
     "fix-lint": "ray lint --fix",
-    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test tests/core.test.js tests/smart.test.js",
+    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test tests/*.test.js",
     "publish": "npx @raycast/api@latest publish"
   }
 }

--- a/extensions/file-tidy/src/core/analyze.js
+++ b/extensions/file-tidy/src/core/analyze.js
@@ -1,4 +1,4 @@
-import { buildExtIndex, buildFolderNamer, organizedDirNames, quarantineDirNames } from "./config.js";
+import { TIDY_DIR, buildExtIndex, buildFolderNamer, organizedDirNames, quarantineDirNames } from "./config.js";
 import { findDuplicates } from "./dedup.js";
 import { checkHealth } from "./health.js";
 import { clusterByHash, hashImages, isHashableImage, loadHashCache, saveHashCache } from "./phash.js";
@@ -48,7 +48,7 @@ export async function analyze({ sourceDir, destDir, config, recursive = false, i
   // were created under.
   const destFiles = scanDest(destDir, {
     onlyDirs: inPlace ? organizedDirs : undefined,
-    skipDirs: new Set([".tidy", ...quarantineDirNames(config)]),
+    skipDirs: new Set([TIDY_DIR, ...quarantineDirNames(config)]),
   });
 
   onPhase("dedup", { files: sound.length });

--- a/extensions/file-tidy/src/core/config.d.ts
+++ b/extensions/file-tidy/src/core/config.d.ts
@@ -23,11 +23,12 @@ export interface TidyConfig {
 }
 export const DUPLICATES_DIR: string;
 export const REVIEW_DIR: string;
+export const TIDY_DIR: string;
 export function loadConfig(): TidyConfig;
+export function tidyPath(destDir: string, ...sub: string[]): string;
 export function buildExtIndex(config: TidyConfig): Map<string, string>;
 export function buildFolderNamer(destDir: string, config: TidyConfig): (base: string) => string;
 export function organizedDirNames(config: TidyConfig): Set<string>;
 export function quarantineDirNames(config: TidyConfig): Set<string>;
-export function expandTilde(p: string): string;
 export function canonicalPath(p: string): string;
 export function isInsideDir(parent: string, child: string): boolean;

--- a/extensions/file-tidy/src/core/config.js
+++ b/extensions/file-tidy/src/core/config.js
@@ -125,14 +125,6 @@ export const TIDY_DIR = ".tidy";
  */
 const POST_PREFIX_BASES = new Set([REVIEW_DIR, "Fonts"]);
 
-export function expandTilde(p) {
-  if (p === "~") return os.homedir();
-  if (p.startsWith("~/") || (process.platform === "win32" && p.startsWith("~\\"))) {
-    return path.join(os.homedir(), p.slice(2));
-  }
-  return p;
-}
-
 /**
  * Canonicalize a path for containment checks: resolve symlinks (macOS's
  * /var → /private/var, case-insensitive spellings, …). For a path that

--- a/extensions/file-tidy/src/core/date.d.ts
+++ b/extensions/file-tidy/src/core/date.d.ts
@@ -1,0 +1,7 @@
+import type { Granularity } from "./config.js";
+import type { SourceFile } from "./scan.js";
+
+export function resolveDateBucket(
+  file: SourceFile,
+  granularity?: Granularity,
+): Promise<{ bucket: string; source: "exif" | "fs" | "none" }>;

--- a/extensions/file-tidy/src/core/execute.js
+++ b/extensions/file-tidy/src/core/execute.js
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { tidyPath } from "./config.js";
 import { moveFile } from "./move.js";
+import { firstFreeName } from "./plan.js";
 
 /**
  * Execute the plan: move every file, resolving name collisions with " (n)"
@@ -92,14 +93,7 @@ function missingDirs(dir, stopDir) {
 }
 
 function resolveCollision(target, reserved = null) {
-  if (target !== reserved && !fs.existsSync(target)) return target;
-  const dir = path.dirname(target);
-  const ext = path.extname(target);
-  const base = path.basename(target, ext);
-  for (let i = 1; ; i++) {
-    const candidate = path.join(dir, `${base} (${i})${ext}`);
-    if (candidate !== reserved && !fs.existsSync(candidate)) return candidate;
-  }
+  return firstFreeName(target, (candidate) => candidate !== reserved && !fs.existsSync(candidate));
 }
 
 function defaultDupBlock(dups) {

--- a/extensions/file-tidy/src/core/plan.d.ts
+++ b/extensions/file-tidy/src/core/plan.d.ts
@@ -35,5 +35,6 @@ export function buildPlan(input: {
   similar?: Map<string, SimilarInfo>;
   perceptual?: Map<string, PerceptualInfo>;
 }): Promise<PlanEntry[]>;
+export function firstFreeName(target: string, isFree: (candidate: string) => boolean): string;
 export function bucketLabel(entry: PlanEntry, destDir: string): string;
 export function formatSize(bytes: number): string;

--- a/extensions/file-tidy/src/core/plan.js
+++ b/extensions/file-tidy/src/core/plan.js
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { DUPLICATES_DIR, REVIEW_DIR } from "./config.js";
+import { DUPLICATES_DIR, REVIEW_DIR, TIDY_DIR } from "./config.js";
 import { classify, subClassify } from "./scan.js";
 import { resolveDateBucket } from "./date.js";
 
@@ -123,14 +123,23 @@ function reserve(target, reserved) {
 /** The target itself if it's free, otherwise the first free "name (n).ext". */
 function reserveTarget(target, reserved) {
   const isFree = (candidate) => !reserved.has(reserveKey(candidate)) && !fs.existsSync(candidate);
-  if (isFree(target)) return reserve(target, reserved);
+  return reserve(firstFreeName(target, isFree), reserved);
+}
 
+/**
+ * The first name satisfying `isFree`: the target itself, or "name (n).ext"
+ * with the lowest free n. Planning and execution both resolve collisions
+ * through here, so the suffix format shown in the preview and the one written
+ * to disk can never drift apart.
+ */
+export function firstFreeName(target, isFree) {
+  if (isFree(target)) return target;
   const dir = path.dirname(target);
   const ext = path.extname(target);
   const base = path.basename(target, ext);
   for (let i = 1; ; i++) {
     const candidate = path.join(dir, `${base} (${i})${ext}`);
-    if (isFree(candidate)) return reserve(candidate, reserved);
+    if (isFree(candidate)) return candidate;
   }
 }
 
@@ -149,7 +158,7 @@ function validSegment(segment, label) {
     segment.includes("/") ||
     segment.includes("\\") ||
     path.basename(segment) !== segment ||
-    normalized === ".tidy" ||
+    normalized === TIDY_DIR ||
     // Control and format characters: a NUL makes every fs call throw a raw
     // TypeError halfway through executing the plan, and a bidi override makes
     // the folder name render as something other than what it is. Letters,

--- a/extensions/file-tidy/tests/core.test.js
+++ b/extensions/file-tidy/tests/core.test.js
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { test } from "node:test";
+import { after, test } from "node:test";
 import { buildExtIndex, canonicalPath, isInsideDir } from "../src/core/config.js";
 import { findDuplicates } from "../src/core/dedup.js";
 import { executePlan } from "../src/core/execute.js";
@@ -15,8 +15,15 @@ const extIndex = buildExtIndex({ categories: { Images: ["jpg"], Documents: ["txt
 const now = new Date();
 const ym = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
 
+const tmpDirs = [];
+after(() => {
+  for (const dir of tmpDirs) fs.rmSync(dir, { recursive: true, force: true });
+});
+
 function tmp() {
-  return fs.mkdtempSync(path.join(os.tmpdir(), "tidy-test-"));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tidy-test-"));
+  tmpDirs.push(dir);
+  return dir;
 }
 
 function write(dir, rel, content) {

--- a/extensions/file-tidy/tests/smart.test.js
+++ b/extensions/file-tidy/tests/smart.test.js
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { test } from "node:test";
+import { after, test } from "node:test";
 import jpeg from "jpeg-js";
 import { analyze } from "../src/core/analyze.js";
 import { buildExtIndex, buildFolderNamer, organizedDirNames } from "../src/core/config.js";
@@ -38,8 +38,15 @@ const now = new Date();
 const ym = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
 const yr = String(now.getFullYear());
 
+const tmpDirs = [];
+after(() => {
+  for (const dir of tmpDirs) fs.rmSync(dir, { recursive: true, force: true });
+});
+
 function tmp() {
-  return fs.mkdtempSync(path.join(os.tmpdir(), "tidy-smart-"));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tidy-smart-"));
+  tmpDirs.push(dir);
+  return dir;
 }
 function write(dir, rel, content) {
   const p = path.join(dir, rel);


### PR DESCRIPTION
## Description

Maintenance update for **File Tidy** — internal cleanup, **no user-facing behaviour change**. No command, preference, form or list rendering was touched.

- **Collision naming now has a single definition.** Planning and execution each carried their own copy of the `" (n)"` suffix loop. They agreed, but nothing *kept* them agreeing — and the plan preview promises the exact name a file will land under, so an edit to one side would have silently broken that promise. Both now resolve through one `firstFreeName` helper in `plan.js`.
- **The `.tidy` bookkeeping directory is referenced through a `TIDY_DIR` constant** where it used to be spelled out in logic (the scan's skip list, the plan's segment validation). User-facing copy keeps the literal spelling.
- **Every core module now carries its type declaration.** `date.d.ts` was missing entirely, and `TIDY_DIR` / `tidyPath` were undeclared in `config.d.ts`.
- **`expandTilde` moved out of core** into the CLI that was its only caller — the extension's form and file pickers always hand core absolute paths, so core no longer exports a helper for one adapter.

The remainder of the diff is the test suite: every `mkdtemp` directory is now registered and removed in an `after()` hook (leftovers had been piling up in the OS tmpdir), and the test script globs `*.test.js` so a newly added test file cannot be silently skipped.

## Screencast

No new screenshots — nothing visible changed. The three images under `metadata/` were reshot for the previous release and still match exactly what the extension renders.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

### Verification

`ray build -e dist` compiles clean, `ray lint` passes, and the 54-case suite covering archiving, dedup, undo and the detection passes is green — including the existing tests that assert the ` (n)` collision suffix, which is what pins the refactor above to identical behaviour.
