### PR TITLE
feat(zoom): add personal meeting ID preference to start meeting

### DIFF
--- a/extensions/zoom/CHANGELOG.md
+++ b/extensions/zoom/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zoom Changelog
 
+## [Personal Meeting ID Support] - {PR_MERGE_DATE}
+
+- Added a `Personal Meeting ID` preference to the Start Meeting command so you can always start your own personal meeting room with a consistent meeting ID.
+
 ## [Improvements] - 2026-06-29
 
 - Retry meeting list requests when Zoom rate limits the API

--- a/extensions/zoom/CHANGELOG.md
+++ b/extensions/zoom/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Zoom Changelog
 
-## [Personal Meeting ID Support] - {PR_MERGE_DATE}
+## [Personal Meeting ID Support] - 2026-08-10
 
 - Added a `Personal Meeting ID` preference to the Start Meeting command so you can always start your own personal meeting room with a consistent meeting ID.
 

--- a/extensions/zoom/README.md
+++ b/extensions/zoom/README.md
@@ -24,6 +24,16 @@ Start, schedule and join Zoom meetings.
 
 The extension uses Raycast's Zoom OAuth integration. The first command that needs Zoom access will ask you to sign in to Zoom and authorize Raycast. After that, Raycast stores and refreshes the access token for future commands.
 
+## Start Meeting with a Personal Meeting ID
+
+By default, the **Start Meeting** command creates a new instant meeting with a random meeting ID each time. If you prefer to always start your own personal meeting, set your [Personal Meeting ID (PMI)](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0068443) in the command's preferences:
+
+- **Set**: Start Meeting opens your personal meeting room directly and copies `https://zoom.us/j/<your-pmi>` to your clipboard. No Zoom sign-in is required for this. Spaces and dashes in the ID are ignored (e.g. `123 456 7891` works).
+- **Empty** (default): Start Meeting keeps the existing behavior and creates a new instant meeting.
+- **Invalid** (not 9–11 digits): Start Meeting shows an error and does nothing.
+
+Note: the copied personal meeting link does not include a passcode. Participants are only prompted for one if you have configured a separate passcode for your personal meeting room.
+
 ## Limitations
 
 Upcoming meetings are fetched from both Zoom's scheduled meetings endpoint and Zoom's upcoming meetings endpoint:

--- a/extensions/zoom/package.json
+++ b/extensions/zoom/package.json
@@ -32,7 +32,17 @@
       "name": "start-meeting",
       "title": "Start Meeting",
       "description": "Start a new Zoom meeting.",
-      "mode": "no-view"
+      "mode": "no-view",
+      "preferences": [
+        {
+          "name": "personalMeetingId",
+          "title": "Personal Meeting ID",
+          "description": "Use your Zoom Personal Meeting ID when starting a meeting. Leave empty to create a new instant meeting.",
+          "type": "textfield",
+          "placeholder": "1234567890",
+          "required": false
+        }
+      ]
     },
     {
       "name": "upcoming-meetings",

--- a/extensions/zoom/src/helpers/meetings.ts
+++ b/extensions/zoom/src/helpers/meetings.ts
@@ -151,3 +151,33 @@ export function getZoomUrlForPlatform(zoomUrl: string): string {
 export function getZoomUrlForMeetingId(meetingId: string): string {
   return isWindows ? `zoommtg://zoom.us/join?confno=${meetingId}` : `https://zoom.us/j/${meetingId}`;
 }
+
+/**
+ * Gets the canonical shareable HTTPS join URL for a meeting ID.
+ * Unlike {@link getZoomUrlForMeetingId}, this always returns an HTTPS URL
+ * so it can be shared with participants on any platform.
+ * @param meetingId - The Zoom meeting ID
+ * @returns The shareable HTTPS join URL
+ */
+export function getZoomJoinUrlForMeetingId(meetingId: string): string {
+  return `https://zoom.us/j/${meetingId}`;
+}
+
+/**
+ * Normalizes a Zoom meeting ID by removing whitespace and dashes.
+ * Users often format their ID like "123 456 7891" or "123-456-7891".
+ * @param id - The raw meeting ID value
+ * @returns The normalized meeting ID
+ */
+export function normalizeZoomMeetingId(id: string): string {
+  return id.replace(/[\s-]/g, "");
+}
+
+/**
+ * Checks whether a value is a valid Zoom meeting ID.
+ * @param id - The value to check
+ * @returns Whether the value is a valid meeting ID
+ */
+export function isValidZoomMeetingId(id: string): boolean {
+  return /^\d{9,11}$/.test(id);
+}

--- a/extensions/zoom/src/start-meeting.tsx
+++ b/extensions/zoom/src/start-meeting.tsx
@@ -1,9 +1,47 @@
-import { open, closeMainWindow, Clipboard, popToRoot, showToast, Toast, showHUD } from "@raycast/api";
+import {
+  open,
+  closeMainWindow,
+  Clipboard,
+  popToRoot,
+  showToast,
+  Toast,
+  showHUD,
+  getPreferenceValues,
+} from "@raycast/api";
 import { createInstantMeeting } from "./api/meetings";
 import { zoom } from "./components/withZoomAuth";
-import { getZoomUrlForPlatform } from "./helpers/meetings";
+import {
+  getZoomJoinUrlForMeetingId,
+  getZoomUrlForMeetingId,
+  getZoomUrlForPlatform,
+  isValidZoomMeetingId,
+  normalizeZoomMeetingId,
+} from "./helpers/meetings";
 
 export default async function Command() {
+  const { personalMeetingId } = getPreferenceValues<Preferences.StartMeeting>();
+  const meetingId = personalMeetingId ? normalizeZoomMeetingId(personalMeetingId) : "";
+
+  if (personalMeetingId) {
+    if (!isValidZoomMeetingId(meetingId)) {
+      await showHUD("Invalid Zoom Personal Meeting ID");
+      return;
+    }
+
+    try {
+      await open(getZoomUrlForMeetingId(meetingId));
+      await Clipboard.copy(getZoomJoinUrlForMeetingId(meetingId));
+      await showHUD("Started Personal Meeting");
+
+      await closeMainWindow();
+      await popToRoot();
+    } catch {
+      await showToast({ style: Toast.Style.Failure, title: "Failed to start meeting" });
+    }
+
+    return;
+  }
+
   const token = await zoom.authorize();
 
   try {


### PR DESCRIPTION
Fixes #29093 

## Description

Adds a **Personal Meeting ID** preference to the **Start Meeting** command so users who always use their own Zoom personal meeting room get a consistent meeting ID instead of a new random one each time.

**Behavior:**
- **Preference set** (e.g. `123 456 7890`): Start Meeting opens the personal meeting room directly (platform-aware URL — `https://zoom.us/j/<pmi>` on macOS, `zoommtg://` on Windows) and copies the shareable join URL (`https://zoom.us/j/<pmi>`) to the clipboard. No Zoom OAuth sign-in or meeting-creation API call is needed for this path.
- **Preference empty** (default): behavior is unchanged — the command creates a new instant meeting via the Zoom API as before (fully backward compatible).
- **Invalid ID** (not 9–11 digits): shows a "Invalid Zoom Personal Meeting ID" HUD and does nothing.
- **Input normalization**: spaces and dashes in the entered ID are ignored, so `123 456 7891` and `123-456-7891` work.

**Implementation:**
- `package.json` — command-level `personalMeetingId` textfield preference for `start-meeting`.
- `src/start-meeting.tsx` — reads the preference, normalizes/validates it, and branches between the PMI path and the existing instant-meeting flow.
- `src/helpers/meetings.ts` — new `normalizeZoomMeetingId`, `isValidZoomMeetingId`, and `getZoomJoinUrlForMeetingId` helpers (all URL construction stays in the helpers module).
- `README.md` / `CHANGELOG.md` — documented the new setting.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)