### PR TITLE
[Badges] Show `labelColor` when `label` is empty

### DIFF
--- a/extensions/badges/CHANGELOG.md
+++ b/extensions/badges/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Badges Changelog
 
-## [Bugfix] - {PR_MERGE_DATE}
+## [Bugfix] - 2026-08-08
 
 - Show `labelColor` when `label` is empty
 

--- a/extensions/badges/CHANGELOG.md
+++ b/extensions/badges/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Badges Changelog
 
+## [Bugfix] - {PR_MERGE_DATE}
+
+- Show `labelColor` when `label` is empty
+
 ## [Bugfix] - 2026-08-03
 
 - Fix badge preview positioning issue

--- a/extensions/badges/src/components/parameters.tsx
+++ b/extensions/badges/src/components/parameters.tsx
@@ -131,7 +131,7 @@ export const Color = ({ badge, onChange }: ParameterProps) => {
 export const LabelColor = ({ badge, onChange }: ParameterProps) => {
   return (
     <>
-      {badge.label && (
+      {(badge.$icon || badge.label) && (
         <Detail.Metadata.TagList title="labelColor">
           <Detail.Metadata.TagList.Item
             text="default"


### PR DESCRIPTION
## Description

- Show `labelColor` when `label` is empty

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
