### PR TITLE
Fix note prefill in the save form and refresh AI tags

### DIFF
--- a/extensions/mymind/CHANGELOG.md
+++ b/extensions/mymind/CHANGELOG.md
@@ -1,6 +1,6 @@
 # mymind Changelog
 
-## [Fix Save Form Prefill and Refresh AI Tags] - {PR_MERGE_DATE}
+## [Fix Save Form Prefill and Refresh AI Tags] - 2026-08-10
 
 - Fixed `Save to mymind` not prefilling detected content: the form relied on `defaultValue` with a changing `key` to remount, but `defaultValue` is only applied once per component lifecycle, so values resolved after mount (such as clipboard detection) never reached the fields. They are now controlled inputs
 - Refresh the item detail view after saving so mymind's automatic AI tags appear without a manual reload

--- a/extensions/mymind/CHANGELOG.md
+++ b/extensions/mymind/CHANGELOG.md
@@ -1,5 +1,10 @@
 # mymind Changelog
 
+## [Fix Save Form Prefill and Refresh AI Tags] - {PR_MERGE_DATE}
+
+- Fixed `Save to mymind` not prefilling detected content: the form relied on `defaultValue` with a changing `key` to remount, but `defaultValue` is only applied once per component lifecycle, so values resolved after mount (such as clipboard detection) never reached the fields. They are now controlled inputs
+- Refresh the item detail view after saving so mymind's automatic AI tags appear without a manual reload
+
 ## [Faster Saves from Clipboard] - 2026-07-20
 
 - Updated `Save to mymind` to detect links, notes, images, videos, and other supported files from recent clipboard history, then select the matching type and prepopulate the form

--- a/extensions/mymind/package.json
+++ b/extensions/mymind/package.json
@@ -9,7 +9,8 @@
   "owner": "mymind",
   "contributors": [
     "yannglt",
-    "peduarte"
+    "peduarte",
+    "sebastiangonzales"
   ],
   "categories": [
     "Applications",

--- a/extensions/mymind/src/components/ObjectActions.tsx
+++ b/extensions/mymind/src/components/ObjectActions.tsx
@@ -654,14 +654,19 @@ export function ObjectActions(props: {
   );
 }
 
+const TAG_POLL_INTERVAL_MS = 3000;
+const TAG_POLL_MAX_ATTEMPTS = 6;
+
 export function ObjectDetail(props: {
   objectId: string;
   fallbackObject?: MyMindObject;
+  pollForTags?: boolean;
   onDeleted?: () => Promise<void> | void;
 }) {
   const { pop, push } = useNavigation();
   const [assets, setAssets] = useState<DetailAssets>(EMPTY_DETAIL_ASSETS);
   const [isAssetsLoading, setIsAssetsLoading] = useState(false);
+  const [tagPollAttempts, setTagPollAttempts] = useState(0);
   const {
     data: object,
     isLoading: isObjectLoading,
@@ -672,6 +677,7 @@ export function ObjectDetail(props: {
       void showFailureToast(error, { title: "Couldn't load item details" });
     },
   });
+
   const { data: spaces = [] } = useCachedPromise(() => listSpaces(), [], { initialData: [] });
 
   const resolvedSpaces = useMemo(() => {
@@ -717,6 +723,21 @@ export function ObjectDetail(props: {
       cancelled = true;
     };
   }, [object, objectUrl]);
+
+  // mymind assigns AI tags asynchronously after an object is created, so a freshly saved
+  // item arrives untagged. Re-fetch a few times so the tags show up without a manual reload.
+  useEffect(() => {
+    if (!props.pollForTags || !object || object.tags.length > 0 || tagPollAttempts >= TAG_POLL_MAX_ATTEMPTS) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setTagPollAttempts((attempts) => attempts + 1);
+      revalidate();
+    }, TAG_POLL_INTERVAL_MS);
+
+    return () => clearTimeout(timer);
+  }, [props.pollForTags, object, tagPollAttempts, revalidate]);
 
   return (
     <Detail

--- a/extensions/mymind/src/components/ObjectActions.tsx
+++ b/extensions/mymind/src/components/ObjectActions.tsx
@@ -50,7 +50,7 @@ import {
   getMainEntityTypeNames,
   getObjectDetailMarkdown,
 } from "../object-detail";
-import { isUserTag } from "../tag-utils";
+import { isAiTag, isUserTag } from "../tag-utils";
 import { RelatedObjectList } from "./RelatedObjectList";
 import { SimilarObjectList } from "./SimilarObjectList";
 import { SpaceObjectList } from "./SpaceObjectList";
@@ -725,9 +725,13 @@ export function ObjectDetail(props: {
   }, [object, objectUrl]);
 
   // mymind assigns AI tags asynchronously after an object is created, so a freshly saved
-  // item arrives untagged. Re-fetch a few times so the tags show up without a manual reload.
+  // item arrives without them. Re-fetch a few times so they show up without a manual reload.
+  //
+  // The stop condition looks for an AI tag specifically: saving with manually picked tags
+  // means the object already comes back tagged, and checking for any tag at all would end
+  // the polling before the AI ones ever arrive.
   useEffect(() => {
-    if (!props.pollForTags || !object || object.tags.length > 0 || tagPollAttempts >= TAG_POLL_MAX_ATTEMPTS) {
+    if (!props.pollForTags || !object || object.tags.some(isAiTag) || tagPollAttempts >= TAG_POLL_MAX_ATTEMPTS) {
       return;
     }
 

--- a/extensions/mymind/src/save-to-mymind.tsx
+++ b/extensions/mymind/src/save-to-mymind.tsx
@@ -157,7 +157,9 @@ export default function SaveToMymindCommand(props: LaunchProps) {
   const accessKeyScope = getAccessKeyScope(accessKeyId, accessKeySecret);
   const launchContext = useMemo(() => (props.launchContext ?? {}) as SaveLaunchContext, [props.launchContext]);
   const [kind, setKind] = useState<SaveValues["kind"]>("note");
-  const [initialState, setInitialState] = useState<InitialState>(EMPTY_INITIAL_STATE);
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [url, setUrl] = useState("");
   const [selectedFiles, setSelectedFiles] = useState<string[]>([]);
   const [isInitializing, setIsInitializing] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -181,17 +183,6 @@ export default function SaveToMymindCommand(props: LaunchProps) {
         .filter(Boolean),
     [tags],
   );
-  const formKey = useMemo(
-    () =>
-      JSON.stringify({
-        content: initialState.content,
-        files: initialState.files,
-        kind: initialState.kind,
-        title: initialState.title,
-        url: initialState.url,
-      }),
-    [initialState.content, initialState.files, initialState.kind, initialState.title, initialState.url],
-  );
   const unsupportedSelectedFiles = useMemo(() => getUnsupportedUploadFiles(selectedFiles), [selectedFiles]);
 
   useEffect(() => {
@@ -205,9 +196,11 @@ export default function SaveToMymindCommand(props: LaunchProps) {
           return;
         }
 
-        setInitialState(nextState);
         setKind(nextState.kind);
         setSelectedFiles(nextState.files);
+        setTitle(nextState.title);
+        setContent(nextState.content);
+        setUrl(nextState.url);
       } finally {
         if (!cancelled) {
           setIsInitializing(false);
@@ -248,21 +241,19 @@ export default function SaveToMymindCommand(props: LaunchProps) {
 
   async function handleSubmit(values: SaveValues) {
     const existingTags = values.existingTags ?? [];
-    const title = values.title ?? "";
-    const url = values.url ?? "";
-    const content = values.content ?? "";
     const files = values.files ?? selectedFiles;
     const tagNames = Array.from(new Set(existingTags));
     const trimmedTitle = title.trim();
     const trimmedContent = content.trim();
+    const trimmedUrl = url.trim();
     const spaceId = values.spaceId || undefined;
 
-    if (kind === "url" && !url.trim()) {
+    if (kind === "url" && !trimmedUrl) {
       await showToast({ style: Toast.Style.Failure, title: "URL is required" });
       return;
     }
 
-    if (kind === "note" && !content.trim()) {
+    if (kind === "note" && !trimmedContent) {
       await showToast({ style: Toast.Style.Failure, title: "Note content is required" });
       return;
     }
@@ -343,7 +334,7 @@ export default function SaveToMymindCommand(props: LaunchProps) {
             : `${createdCount} file${createdCount === 1 ? "" : "s"} uploaded`;
 
         if (supportedFiles.value.length === 1 && firstCreatedObjectId) {
-          push(<ObjectDetail objectId={firstCreatedObjectId} />, () => {
+          push(<ObjectDetail objectId={firstCreatedObjectId} pollForTags={true} />, () => {
             void popToRoot();
           });
         }
@@ -353,7 +344,7 @@ export default function SaveToMymindCommand(props: LaunchProps) {
 
       const result = await createObject({
         title: kind === "note" ? trimmedTitle || undefined : undefined,
-        url: kind === "url" ? url.trim() : undefined,
+        url: kind === "url" ? trimmedUrl : undefined,
         content: kind === "note" ? trimmedContent || undefined : undefined,
         tags: tagNames.length > 0 ? tagNames : undefined,
         spaceId,
@@ -385,7 +376,7 @@ export default function SaveToMymindCommand(props: LaunchProps) {
       toast.message = result.object.title?.trim() || "Untitled";
 
       if (result.created) {
-        push(<ObjectDetail objectId={result.object.id} fallbackObject={result.object} />, () => {
+        push(<ObjectDetail objectId={result.object.id} fallbackObject={result.object} pollForTags={true} />, () => {
           void popToRoot();
         });
       }
@@ -400,7 +391,6 @@ export default function SaveToMymindCommand(props: LaunchProps) {
 
   return (
     <Form
-      key={formKey}
       isLoading={isInitializing || isSubmitting}
       actions={
         <ActionPanel>
@@ -414,7 +404,7 @@ export default function SaveToMymindCommand(props: LaunchProps) {
         <Form.Dropdown.Item value="file" title="File" />
       </Form.Dropdown>
       {kind === "note" ? (
-        <Form.TextField id="title" title="Title" placeholder="Optional title" defaultValue={initialState.title} />
+        <Form.TextField id="title" title="Title" placeholder="Optional title" value={title} onChange={setTitle} />
       ) : null}
       {kind === "file" ? (
         <>
@@ -438,21 +428,23 @@ export default function SaveToMymindCommand(props: LaunchProps) {
             id="content"
             title="Note"
             placeholder="Optional note to attach to each uploaded file"
-            defaultValue={initialState.content}
+            value={content}
+            onChange={setContent}
           />
         </>
       ) : null}
       {kind === "url" ? (
         <>
-          <Form.TextField id="url" title="URL" placeholder="https://example.com" defaultValue={initialState.url} />
-          <Form.TextArea id="content" title="Body" placeholder="Optional note" defaultValue={initialState.content} />
+          <Form.TextField id="url" title="URL" placeholder="https://example.com" value={url} onChange={setUrl} />
+          <Form.TextArea id="content" title="Body" placeholder="Optional note" value={content} onChange={setContent} />
         </>
       ) : kind === "note" ? (
         <Form.TextArea
           id="content"
           title="Body"
           placeholder="Write your note here…"
-          defaultValue={initialState.content}
+          value={content}
+          onChange={setContent}
         />
       ) : null}
       <Form.Dropdown id="spaceId" title="Space" storeValue={true}>

--- a/extensions/mymind/src/save-to-mymind.tsx
+++ b/extensions/mymind/src/save-to-mymind.tsx
@@ -38,13 +38,11 @@ import {
 } from "./save-input";
 import { isUserTag } from "./tag-utils";
 
+/** Only the fields still read from the submitted form; title, URL and body are controlled state. */
 type SaveValues = {
   kind: "url" | "note" | "file";
   existingTags: string[];
   files: string[];
-  title?: string;
-  url: string;
-  content: string;
   spaceId: string;
 };
 


### PR DESCRIPTION
## Description

Copying plain text and opening `Save to mymind` shows the correct type (`Note`) but an empty Body. The text *is* detected — it just never reaches the field.

The form fields use `defaultValue`, which per the API docs "will be configured once per component lifecycle". Since `kind` already defaults to `"note"`, the Body `TextArea` is mounted before detection finishes, so the value resolved afterwards is never applied. A changing `key` on the `Form` was there to force a remount and work around this, but it doesn't reliably reset an already-mounted field.

This is also why the bug is easy to miss: copying a **URL** works, because that flips `kind` from `"note"` to `"url"` and mounts the URL field for the first time — a fresh lifecycle, so `defaultValue` applies. Only the case where the detected type matches the default type is broken.

Title, URL and body are now controlled inputs (`value` + `onChange`), which makes prefill deterministic regardless of when detection resolves. `handleSubmit` reads that state instead of the submitted form values, and the now-unused `formKey` memo is removed.

**To reproduce:** copy plain text such as `hello world`, then open `Save to mymind`. Before: Type is `Note` and Body is empty. After: Body contains the text. Copying a URL works before and after — that path was never affected.

**Also here:** mymind assigns AI tags asynchronously after an object is created, so a freshly saved item always shows up untagged and you had to leave and re-open it to see them. The detail view now re-fetches after a save (3s apart, up to 6 attempts, stopping as soon as tags arrive), opt-in via a `pollForTags` prop so it only runs right after saving.

Built with AI assistance, reviewed and manually tested.

## Screencast

https://github.com/user-attachments/assets/7b5a06b4-d428-4237-8372-f7e5dc2a8c0c

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

Note: `assets/mymind-logo.svg` doesn't appear to be referenced anywhere. It predates this change, so I left it untouched — flagging it in case it's worth cleaning up separately.
