### PR TITLE
Fix Keyboard Maestro List Macros crash when filter preference is unset

### DIFF
--- a/extensions/keyboard-maestro/CHANGELOG.md
+++ b/extensions/keyboard-maestro/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Keyboard Maestro Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Fix "List Macros" failing with "Unable to list Macros" when the "Filter Macro Groups" preference has never been set
+
 ## [Update] - 2026-05-25
 - Update @raycast/api and @raycast/utils
 

--- a/extensions/keyboard-maestro/src/lib/fetch-macros.tsx
+++ b/extensions/keyboard-maestro/src/lib/fetch-macros.tsx
@@ -13,7 +13,8 @@ export async function fetchMacros() {
     const data = plist.parse(scriptResult) as TypeMacroGroup[];
 
     // Filtering groups with filter pattern and enabled groups
-    const filterPattern = preferences.filterPattern.trim();
+    // Raycast omits optional text preferences that were never set, so this can be undefined
+    const filterPattern = (preferences.filterPattern ?? "").trim();
     const hasFilter = filterPattern !== "";
     let matchFunction: (groupName: string) => boolean;
 

--- a/extensions/keyboard-maestro/src/lib/types.tsx
+++ b/extensions/keyboard-maestro/src/lib/types.tsx
@@ -2,7 +2,7 @@ export interface Preferences {
   displayShortcuts: boolean;
   displayTriggers: boolean;
   displayIcon: boolean;
-  filterPattern: string;
+  filterPattern?: string;
   useRegex: boolean;
   showDisabled: boolean;
 }


### PR DESCRIPTION
## Description

The `List Macros` command fails for any user who has never set the **Filter Macro Groups** preference. It shows a generic `Unable to list Macros` failure toast and renders an empty list.

The `filterPattern` preference is declared optional with `"default": ""`. Raycast omits optional text preferences whose value has never been set, so `getPreferenceValues()` returns an object with no `filterPattern` key at all — not the empty string the `Preferences` type promises.

`preferences.filterPattern.trim()` therefore throws, and because the whole body of `fetchMacros` is wrapped in a bare `catch`, the real error is discarded and replaced with the unhelpful `Unable to list Macros` toast. That misdirects debugging toward Keyboard Maestro or AppleScript permissions, when neither is involved.

Captured on a real install by instrumenting the built bundle:

```
TypeError: Cannot read properties of undefined (reading 'trim')
    at fetchMacros (.../list.js:23:64)
PREFS={"displayShortcuts":false,"displayTriggers":false,"displayIcon":false,"useRegex":false,"showDisabled":false}
```

Note the absence of any `filterPattern` key.

## Changes

- `src/lib/fetch-macros.tsx` — read the preference through `?? ""` so an unset filter behaves the same as an empty one, which is the intended "no filtering" path.
- `src/lib/types.tsx` — mark `filterPattern` as optional so the type reflects runtime reality and this cannot silently regress.

## Testing

- `ray build` passes, including the TypeScript check.
- `ray lint` passes (ESLint + Prettier).
- Verified against a real Keyboard Maestro install with the preference unset: the command previously threw the `TypeError` above, and after the fix returns 39 groups / 132 macros and renders normally. Setting a filter value still filters as before.

## Note for maintainers

The bare `catch` in `fetchMacros` is what made this hard to diagnose — it converts every failure into the same message. Surfacing the underlying error there would be a worthwhile follow-up, but I left it out to keep this PR to the crash fix.