### PR TITLE
Home Assistant: add mattiacolombomc to contributors

### DIFF
--- a/extensions/homeassistant/CHANGELOG.md
+++ b/extensions/homeassistant/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Home Assistant Changelog
 
-## [Add contributor] - {PR_MERGE_DATE}
+## [Add contributor] - 2026-08-10
 
 - Add mattiacolombomc to the contributors list
 

--- a/extensions/homeassistant/CHANGELOG.md
+++ b/extensions/homeassistant/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Home Assistant Changelog
 
+## [Add contributor] - {PR_MERGE_DATE}
+
+- Add mattiacolombomc to the contributors list
+
 ## [Fix .local resolution picking unbracketed IPv6] - 2026-08-10
 
 - Prefer mDNS A records (IPv4) when resolving `.local` hostnames, falling back to an AAAA record only if no A record arrives before the timeout

--- a/extensions/homeassistant/package.json
+++ b/extensions/homeassistant/package.json
@@ -11,7 +11,8 @@
     "xilopaint",
     "krsntn",
     "mikikiv",
-    "techmaved"
+    "techmaved",
+    "mattiacolombomc"
   ],
   "license": "MIT",
   "description": "Manage your smart home with Raycast",


### PR DESCRIPTION
## Description

Adds `mattiacolombomc` to the Home Assistant extension `contributors` list.

I contributed the merged fix in #30087 (*Home Assistant: fix invalid URL when mDNS resolves .local to IPv6*) but was not added to the `contributors` array in `package.json` at the time. This PR corrects that.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] Change is limited to adding the contributor entry — no functional changes