### PR TITLE
feat(coffee): Add auto-caffeinate when Raycast launches

### DIFF
--- a/extensions/coffee/CHANGELOG.md
+++ b/extensions/coffee/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Coffee Changelog
 
-## [Enhancement] - {PR_MERGE_DATE}
+## [Enhancement] - 2026-08-14
 
 - Added an "instant on" feature: when the new *Start caffeination when Raycast starts* preference is enabled, Coffee automatically keeps your Mac awake (indefinitely) shortly after Raycast launches. Manual decaffeination persists until the next Raycast restart.
 

--- a/extensions/coffee/CHANGELOG.md
+++ b/extensions/coffee/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Coffee Changelog
 
+## [Enhancement] - {PR_MERGE_DATE}
+
+- Added an "instant on" feature: when the new *Start caffeination when Raycast starts* preference is enabled, Coffee automatically keeps your Mac awake (indefinitely) shortly after Raycast launches. Manual decaffeination persists until the next Raycast restart.
+
 ## [AI Extension] - 2026-07-22
 
 - Added AI tools to caffeinate until a specific date and time.

--- a/extensions/coffee/README.md
+++ b/extensions/coffee/README.md
@@ -79,4 +79,8 @@ Get the status of current caffeination in your menu bar.
 
 ### 8. **Auto-Caffeinate on Launch**
 
-Optionally have Coffee start caffeinating your Mac (indefinitely) automatically whenever Raycast launches. Enable the *Start caffeination when Raycast starts* toggle in the extension's preferences. After you manually decaffeinate, your Mac stays decaffeinated until the next Raycast restart.
+Optionally have Coffee start caffeinating your Mac (indefinitely) automatically whenever Raycast launches. Enable the **Start caffeination when Raycast starts** toggle under the **Launch** section in the extension's preferences.
+
+> **Requirements:** Either the *Caffeinate Status* command (15 s background interval) or the *Caffeinate Status Menu Bar* command (1 m background interval) must be enabled in Raycast — the auto-start feature piggybacks on these background ticks.
+
+**How session detection works:** Coffee tracks the Raycast process PID. A new PID means Raycast actually relaunched, so the Mac is caffeinated automatically. Putting the Mac to sleep and waking it does **not** trigger a re-caffeination, because the PID stays the same — your manual decaffeination is honoured until you truly restart Raycast.

--- a/extensions/coffee/README.md
+++ b/extensions/coffee/README.md
@@ -76,3 +76,7 @@ Get the current state of caffeination.
 ### 7. **Caffeinate Status Menu Bar**
 
 Get the status of current caffeination in your menu bar.
+
+### 8. **Auto-Caffeinate on Launch**
+
+Optionally have Coffee start caffeinating your Mac (indefinitely) automatically whenever Raycast launches. Enable the *Start caffeination when Raycast starts* toggle in the extension's preferences. After you manually decaffeinate, your Mac stays decaffeinated until the next Raycast restart.

--- a/extensions/coffee/package.json
+++ b/extensions/coffee/package.json
@@ -229,11 +229,12 @@
     },
     {
       "name": "startCaffeinateOnLaunch",
-      "description": "Automatically keep your Mac awake (indefinitely) shortly after Raycast starts",
+      "description": "Automatically keep your Mac awake (indefinitely) when Raycast starts. Requires the Caffeinate Status command (15 s interval) or the Caffeinate Status Menu Bar command (1 m interval) to be enabled.",
       "type": "checkbox",
       "required": false,
       "default": false,
-      "label": "Start Caffeination When Raycast Starts"
+      "title": "Launch",
+      "label": "Start caffeination when Raycast starts"
     }
   ],
   "dependencies": {

--- a/extensions/coffee/package.json
+++ b/extensions/coffee/package.json
@@ -13,12 +13,14 @@
     "xilopaint",
     "ridemountainpig",
     "zakj",
-    "Visual-Studio-Coder",
     "Katsuba",
     "alexi.build",
     "mbuvarp",
     "frederik_obe",
     "bsradcliffe"
+  ],
+  "pastContributors", [
+    "Visual-Studio-Coder"
   ],
   "platforms": [
     "macOS"

--- a/extensions/coffee/package.json
+++ b/extensions/coffee/package.json
@@ -226,6 +226,14 @@
           "value": "paper-cup"
         }
       ]
+    },
+    {
+      "name": "startCaffeinateOnLaunch",
+      "description": "Automatically keep your Mac awake (indefinitely) shortly after Raycast starts",
+      "type": "checkbox",
+      "required": false,
+      "default": false,
+      "label": "Start Caffeination When Raycast Starts"
     }
   ],
   "dependencies": {

--- a/extensions/coffee/package.json
+++ b/extensions/coffee/package.json
@@ -19,7 +19,7 @@
     "frederik_obe",
     "bsradcliffe"
   ],
-  "pastContributors", [
+  "pastContributors": [
     "Visual-Studio-Coder"
   ],
   "platforms": [

--- a/extensions/coffee/src/hooks/useLoadStoredSchedules.tsx
+++ b/extensions/coffee/src/hooks/useLoadStoredSchedules.tsx
@@ -1,6 +1,7 @@
 import { LocalStorage } from "@raycast/api";
 import { Schedule } from "../interfaces";
 import { useEffect, useRef } from "react";
+import { parseSchedule } from "../utils";
 
 const dayOrder: { [key: string]: number } = {
   sunday: 0,
@@ -35,7 +36,9 @@ export function useLoadStoredSchedules(
 
       if (!isMounted) return;
 
-      const schedules: Schedule[] = Object.values(allStoredItems).map((item) => JSON.parse(item) as Schedule);
+      const schedules: Schedule[] = Object.values(allStoredItems)
+        .map(parseSchedule)
+        .filter((schedule): schedule is Schedule => schedule !== undefined);
 
       if (schedules.length > 0) {
         schedules.sort((a, b) => (dayOrder[a.day] ?? -1) - (dayOrder[b.day] ?? -1));

--- a/extensions/coffee/src/index.tsx
+++ b/extensions/coffee/src/index.tsx
@@ -11,6 +11,7 @@ import {
 import { useExec } from "@raycast/utils";
 import { useEffect, useState } from "react";
 import { formatDuration, startCaffeinate, stopCaffeinate } from "./utils";
+import { maybeAutoCaffeinate } from "./status";
 
 function parseEtime(etime: string): number {
   const parts = etime.split(":").reverse();
@@ -91,6 +92,11 @@ export default function Command(props: LaunchProps) {
   useEffect(() => {
     setLocalCaffeinateStatus(null);
   }, [caffeinateStatus]);
+
+  useEffect(() => {
+    if (isLoading) return;
+    void maybeAutoCaffeinate();
+  }, [isLoading]);
 
   useEffect(() => {
     if (!displayCaffeinateStatus || data.totalSeconds === null || data.startTime === null) return;

--- a/extensions/coffee/src/status.ts
+++ b/extensions/coffee/src/status.ts
@@ -1,8 +1,37 @@
 import { getPreferenceValues, LocalStorage, updateCommandMetadata } from "@raycast/api";
+import { execFileSync } from "node:child_process";
 import { Schedule, startCaffeinate, getSchedule, stopCaffeinate, isCaffeinateRunning } from "./utils";
 
-const AUTO_CAFFEINATE_LAST_RUN_KEY = "autoCaffeinateLastRun";
-const AUTO_CAFFEINATE_SESSION_GAP_MS = 2 * 60_000;
+const AUTO_CAFFEINATE_PID_KEY = "autoCaffeinateRaycastPid";
+
+/**
+ * Returns a session identifier for the currently-running Raycast instance.
+ *
+ * Primary: `lsappinfo` queries Raycast's start time via LaunchServices using
+ * the bundle ID — immune to process-table visibility restrictions that cause
+ * `pgrep` to return nothing from within the extension context.
+ *
+ * Fallback: `process.ppid` (the Raycast Helper PID) which is stable within a
+ * session in production builds, though it may vary across commands in dev mode.
+ */
+function getRaycastSessionId(): string {
+  try {
+    const out = execFileSync("/usr/bin/lsappinfo", ["info", "-app", "com.raycast.macos"], { encoding: "utf8" }).trim();
+
+    const pidMatch = out.match(/pid\s*=\s*(\d+)/);
+    if (pidMatch?.[1]) {
+      return `pid:${pidMatch[1]}`;
+    }
+
+    const dateMatch = out.match(/\d{4}\/\d{2}\/\d{2}\s+\d{2}:\d{2}:\d{2}/);
+    if (dateMatch?.[0]) {
+      return `launch:${dateMatch[0]}`;
+    }
+  } catch {
+    // lsappinfo unavailable or Raycast not registered yet — fall through.
+  }
+  return `ppid:${process.ppid}`;
+}
 
 async function handleScheduledCaffeinate(schedule: Schedule): Promise<boolean> {
   if (!schedule || Object.keys(schedule).length === 0) {
@@ -58,16 +87,20 @@ export async function checkSchedule() {
  * "Start caffeination when Raycast starts" preference is enabled and the Mac
  * is not already caffeinated or covered by a schedule. Returns true when
  * caffeination was started.
+ *
+ * Session detection is keyed off the Raycast launch time stored in
+ * LocalStorage. The session ID changes only when Raycast actually relaunches, so
+ * sleep/wake cycles (where background intervals simply don't fire but the ID
+ * stays the same) cannot trigger a spurious auto-caffeinate.
  */
 export async function maybeAutoCaffeinate(isScheduled?: boolean): Promise<boolean> {
-  // The last-run marker is refreshed on every background tick so the gap below
-  // only grows when Raycast is quit (or the Mac is asleep) - i.e. a fresh
-  // Raycast session. It must be updated before the early returns, otherwise it
-  // goes stale while the Mac is caffeinated and the next decaffeination would
-  // look like a fresh session.
-  const now = Date.now();
-  const lastRun = (await LocalStorage.getItem<number>(AUTO_CAFFEINATE_LAST_RUN_KEY)) ?? 0;
-  await LocalStorage.setItem(AUTO_CAFFEINATE_LAST_RUN_KEY, now);
+  const currentSessionId = getRaycastSessionId();
+  const storedSessionId = await LocalStorage.getItem<string>(AUTO_CAFFEINATE_PID_KEY);
+
+  // Always refresh the stored session ID so it reflects the running Raycast process.
+  // This must happen before the early returns so that after a manual decaf the
+  // marker stays current and won't look like a new session on the next tick.
+  await LocalStorage.setItem(AUTO_CAFFEINATE_PID_KEY, currentSessionId);
 
   if (!getPreferenceValues<Preferences>().startCaffeinateOnLaunch) return false;
   if (isCaffeinateRunning()) return false;
@@ -75,11 +108,11 @@ export async function maybeAutoCaffeinate(isScheduled?: boolean): Promise<boolea
   const scheduled = isScheduled ?? (await checkSchedule());
   if (scheduled) return false;
 
-  // A gap larger than the session threshold means Raycast was quit (or the Mac
-  // was asleep) since the last background run, i.e. a fresh Raycast session.
-  if (now - lastRun < AUTO_CAFFEINATE_SESSION_GAP_MS) return false;
+  // A different (or absent) session ID means Raycast relaunched — treat as new session.
+  // Sleep/wake does not change the session ID, so it cannot trigger a false positive.
+  if (currentSessionId === storedSessionId) return false;
 
-  await startCaffeinate({ menubar: true, status: true });
+  await startCaffeinate({ menubar: true, status: true }, "Auto-caffeinating your Mac");
   return true;
 }
 

--- a/extensions/coffee/src/status.ts
+++ b/extensions/coffee/src/status.ts
@@ -1,5 +1,8 @@
-import { LocalStorage, updateCommandMetadata } from "@raycast/api";
+import { getPreferenceValues, LocalStorage, updateCommandMetadata } from "@raycast/api";
 import { Schedule, startCaffeinate, getSchedule, stopCaffeinate, isCaffeinateRunning } from "./utils";
+
+const AUTO_CAFFEINATE_LAST_RUN_KEY = "autoCaffeinateLastRun";
+const AUTO_CAFFEINATE_SESSION_GAP_MS = 2 * 60_000;
 
 async function handleScheduledCaffeinate(schedule: Schedule): Promise<boolean> {
   if (!schedule || Object.keys(schedule).length === 0) {
@@ -50,13 +53,44 @@ export async function checkSchedule() {
   return false;
 }
 
+/**
+ * Starts caffeination (indefinitely) once per Raycast session when the
+ * "Start caffeination when Raycast starts" preference is enabled and the Mac
+ * is not already caffeinated or covered by a schedule. Returns true when
+ * caffeination was started.
+ */
+export async function maybeAutoCaffeinate(isScheduled?: boolean): Promise<boolean> {
+  // The last-run marker is refreshed on every background tick so the gap below
+  // only grows when Raycast is quit (or the Mac is asleep) - i.e. a fresh
+  // Raycast session. It must be updated before the early returns, otherwise it
+  // goes stale while the Mac is caffeinated and the next decaffeination would
+  // look like a fresh session.
+  const now = Date.now();
+  const lastRun = (await LocalStorage.getItem<number>(AUTO_CAFFEINATE_LAST_RUN_KEY)) ?? 0;
+  await LocalStorage.setItem(AUTO_CAFFEINATE_LAST_RUN_KEY, now);
+
+  if (!getPreferenceValues<Preferences>().startCaffeinateOnLaunch) return false;
+  if (isCaffeinateRunning()) return false;
+
+  const scheduled = isScheduled ?? (await checkSchedule());
+  if (scheduled) return false;
+
+  // A gap larger than the session threshold means Raycast was quit (or the Mac
+  // was asleep) since the last background run, i.e. a fresh Raycast session.
+  if (now - lastRun < AUTO_CAFFEINATE_SESSION_GAP_MS) return false;
+
+  await startCaffeinate({ menubar: true, status: true });
+  return true;
+}
+
 export default async function Command() {
   const isCaffeinated = isCaffeinateRunning();
   const isScheduled = await checkSchedule();
+  const autoStarted = await maybeAutoCaffeinate(isScheduled);
 
   let subtitle = "✖ Decaffeinated";
 
-  if (isCaffeinated || isScheduled) {
+  if (isCaffeinated || isScheduled || autoStarted) {
     subtitle = "✔ Caffeinated";
   }
 

--- a/extensions/coffee/src/tools/list-caffeination-schedules.ts
+++ b/extensions/coffee/src/tools/list-caffeination-schedules.ts
@@ -1,6 +1,6 @@
 import { LocalStorage } from "@raycast/api";
 import { Schedule } from "../interfaces";
-import { numberToDayString } from "../utils";
+import { numberToDayString, parseSchedule } from "../utils";
 
 /**
  * Lists all recurring caffeination schedules in weekday order.
@@ -22,27 +22,6 @@ export default async function tool() {
     })),
     count: schedules.length,
   };
-}
-
-function parseSchedule(value: string | number | boolean): Schedule | undefined {
-  if (typeof value !== "string") return undefined;
-
-  try {
-    const schedule = JSON.parse(value) as Partial<Schedule>;
-    if (
-      typeof schedule.day === "string" &&
-      typeof schedule.from === "string" &&
-      typeof schedule.to === "string" &&
-      typeof schedule.IsManuallyDecafed === "boolean" &&
-      typeof schedule.IsRunning === "boolean"
-    ) {
-      return schedule as Schedule;
-    }
-  } catch {
-    // Ignore unrelated local storage values.
-  }
-
-  return undefined;
 }
 
 function dayIndex(day: string): number {

--- a/extensions/coffee/src/utils.ts
+++ b/extensions/coffee/src/utils.ts
@@ -87,6 +87,27 @@ export async function getSchedule() {
   return schedule;
 }
 
+export function parseSchedule(value: string | number | boolean): Schedule | undefined {
+  if (typeof value !== "string") return undefined;
+
+  try {
+    const schedule = JSON.parse(value) as Partial<Schedule>;
+    if (
+      typeof schedule.day === "string" &&
+      typeof schedule.from === "string" &&
+      typeof schedule.to === "string" &&
+      typeof schedule.IsManuallyDecafed === "boolean" &&
+      typeof schedule.IsRunning === "boolean"
+    ) {
+      return schedule as Schedule;
+    }
+  } catch {
+    // Ignore unrelated local storage values.
+  }
+
+  return undefined;
+}
+
 export async function changeScheduleState(operation: string, schedule: Schedule) {
   switch (operation) {
     case "caffeinate": {


### PR DESCRIPTION
Fixes #29965 

## Description

Adds an "instant on" feature to the Coffee extension, addressing the request to automatically keep the Mac awake whenever Raycast launches (like Amphetamine's "start when app opens").
A new "Start caffeination when Raycast starts" preference (checkbox, default off) makes Coffee caffeinate the Mac indefinitely shortly after Raycast starts — no manual action needed.


How it works
- Raycast has no true "on launch" hook, so the feature piggybacks on the extension's existing background refresh: the Caffeinate Status command (15s) and the menu bar command (1m).
- A new maybeAutoCaffeinate() helper (in src/status.ts) records the last background run in LocalStorage. When the gap since the last run exceeds 2 minutes, it means Raycast was quit (or the Mac was asleep) — i.e., a fresh session — so it starts caffeinate indefinitely via startCaffeinate().
- Because the marker is refreshed on every background tick (before the early returns), manually decaffeinating stays in effect for the rest of the session; the Mac re-caffeinates only on the next Raycast restart.
- The helper is wired into both the status command and the menu bar command so it works regardless of which background refresh is active.

Supporting fix

- The new LocalStorage key exposed a latent bug: useLoadStoredSchedules did a blind JSON.parse on every stored value and would have crashed the Schedule Caffeination view on the numeric marker. Extracted a shared parseSchedule validator (already used by the AI schedule-listing tool) and applied it in the schedule loader.

Changes

- package.json — new startCaffeinateOnLaunch preference
- src/status.ts — maybeAutoCaffeinate() + wiring into the status command
- src/index.tsx — call the helper once the menu bar status loads
- src/utils.ts — extracted parseSchedule
- src/hooks/useLoadStoredSchedules.tsx, src/tools/list-caffeination-schedules.ts — use the shared validator
- README.md, CHANGELOG.md — documented the feature

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
