### PR TITLE
[mymind] Detect the active tab and selection when saving

### DIFF
--- a/extensions/mymind/CHANGELOG.md
+++ b/extensions/mymind/CHANGELOG.md
@@ -1,5 +1,16 @@
 # mymind Changelog
 
+## [Context-Aware Saves] - {PR_MERGE_DATE}
+
+- `Save to mymind` now detects the frontmost app's context: selected text is preselected as a Note, a selected URL as a Link, and when nothing is selected in a browser, the active tab's URL is used
+- Read the active tab's URL and title straight from the browser via Apple Events, which needs only the one-time "control <Browser>" Automation permission instead of a browser extension's broader per-site page-content access
+- Support Safari plus every Chromium-based browser — Chrome, Edge, Brave, Opera, Vivaldi, Chromium, Arc, Dia, ChatGPT Atlas, and Comet — and fall back to unlisted browsers by reading their own scripting definition, so new browsers work without a code change
+- Discard a text selection that Safari's Accessibility API carried over from a different tab, falling back to the active tab's URL instead
+- Run context detection once per launch: `getSelectedText` reads the selection through the system clipboard, so concurrent calls interfered and results flipped between the selection, the tab URL and stale clipboard history
+- Never fall back to the Browser Extension's active tab for a scriptable browser — it reports whichever browser it is installed in, which surfaced a Safari URL while Arc was in front
+- Moved clipboard history behind selection and active-tab detection, so a stale copy no longer wins over what you are looking at
+- Keep the form fast by reading tabs and the selection in parallel and skipping the Finder query when a browser is frontmost
+
 ## [Fix Save Form Prefill and Refresh AI Tags] - 2026-08-10
 
 - Fixed `Save to mymind` not prefilling detected content: the form relied on `defaultValue` with a changing `key` to remount, but `defaultValue` is only applied once per component lifecycle, so values resolved after mount (such as clipboard detection) never reached the fields. They are now controlled inputs

--- a/extensions/mymind/CHANGELOG.md
+++ b/extensions/mymind/CHANGELOG.md
@@ -2,13 +2,12 @@
 
 ## [Context-Aware Saves] - {PR_MERGE_DATE}
 
-- `Save to mymind` now detects the frontmost app's context: selected text is preselected as a Note, a selected URL as a Link, and when nothing is selected in a browser, the active tab's URL is used
+- Added an opt-in `Context Detection` preference, off by default. With it disabled the command behaves exactly as before — clipboard first, then Finder — and the browser is never queried, so macOS never asks for Automation permission
+- When enabled, `Save to mymind` prefills from the frontmost app: selected text is preselected as a Note, a selected URL as a Link, and when nothing is selected in a browser, the active tab's URL is used
 - Read the active tab's URL straight from the browser via Apple Events — only that one value, never page contents, titles or the list of open tabs — which needs the one-time "control <Browser>" Automation permission instead of a browser extension's broader per-site page-content access
 - Support Safari plus every Chromium-based browser — Chrome, Edge, Brave, Opera, Vivaldi, Chromium, Arc, Dia, ChatGPT Atlas, and Comet — and fall back to unlisted browsers by reading their own scripting definition, so new browsers work without a code change
 - Run context detection once per launch: `getSelectedText` reads the selection through the system clipboard, so concurrent calls interfered and results flipped between the selection, the tab URL and stale clipboard history
-- Never fall back to the Browser Extension's active tab for a scriptable browser — it reports whichever browser it is installed in, which surfaced a Safari URL while Arc was in front
-- Moved clipboard history behind selection and active-tab detection, so a stale copy no longer wins over what you are looking at
-- Keep the form fast by reading tabs and the selection in parallel and skipping the Finder query when a browser is frontmost
+- Keep the form fast by reading the tab and the selection in parallel
 
 ## [Fix Save Form Prefill and Refresh AI Tags] - 2026-08-10
 

--- a/extensions/mymind/CHANGELOG.md
+++ b/extensions/mymind/CHANGELOG.md
@@ -3,9 +3,8 @@
 ## [Context-Aware Saves] - {PR_MERGE_DATE}
 
 - `Save to mymind` now detects the frontmost app's context: selected text is preselected as a Note, a selected URL as a Link, and when nothing is selected in a browser, the active tab's URL is used
-- Read the active tab's URL and title straight from the browser via Apple Events, which needs only the one-time "control <Browser>" Automation permission instead of a browser extension's broader per-site page-content access
+- Read the active tab's URL straight from the browser via Apple Events — only that one value, never page contents, titles or the list of open tabs — which needs the one-time "control <Browser>" Automation permission instead of a browser extension's broader per-site page-content access
 - Support Safari plus every Chromium-based browser — Chrome, Edge, Brave, Opera, Vivaldi, Chromium, Arc, Dia, ChatGPT Atlas, and Comet — and fall back to unlisted browsers by reading their own scripting definition, so new browsers work without a code change
-- Discard a text selection that Safari's Accessibility API carried over from a different tab, falling back to the active tab's URL instead
 - Run context detection once per launch: `getSelectedText` reads the selection through the system clipboard, so concurrent calls interfered and results flipped between the selection, the tab URL and stale clipboard history
 - Never fall back to the Browser Extension's active tab for a scriptable browser — it reports whichever browser it is installed in, which surfaced a Safari URL while Arc was in front
 - Moved clipboard history behind selection and active-tab detection, so a stale copy no longer wins over what you are looking at

--- a/extensions/mymind/CHANGELOG.md
+++ b/extensions/mymind/CHANGELOG.md
@@ -1,6 +1,6 @@
 # mymind Changelog
 
-## [Context-Aware Saves] - {PR_MERGE_DATE}
+## [Context-Aware Saves] - 2026-08-12
 
 - Added an opt-in `Context Detection` preference, off by default. With it disabled the command behaves exactly as before — clipboard first, then Finder — and the browser is never queried, so macOS never asks for Automation permission
 - When enabled, `Save to mymind` prefills from the frontmost app: selected text is preselected as a Note, a selected URL as a Link, and when nothing is selected in a browser, the active tab's URL is used

--- a/extensions/mymind/package.json
+++ b/extensions/mymind/package.json
@@ -353,6 +353,15 @@
       ]
     },
     {
+      "name": "detectContext",
+      "type": "checkbox",
+      "required": false,
+      "title": "Context Detection",
+      "label": "Prefill from the active browser tab and selected text",
+      "description": "Off by default. When enabled, Save to mymind prefills from what you are looking at: selected text becomes a note, and the active browser tab's URL becomes a link. Reading the browser tab asks macOS for permission to control that browser the first time. macOS only.",
+      "default": false
+    },
+    {
       "name": "mediaGridColumns",
       "type": "dropdown",
       "required": false,

--- a/extensions/mymind/src/browser-tabs.test.ts
+++ b/extensions/mymind/src/browser-tabs.test.ts
@@ -1,0 +1,188 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+import {
+  buildTabsAppleScript,
+  detectFlavorFromScriptingDefinition,
+  extractBundleIdFromInfoPlist,
+  getBrowserScriptFlavor,
+  getScriptingBundleId,
+  isKnownBrowserBundleId,
+  isSafeBundleId,
+  isStaleCrossTabSelection,
+  parseBrowserWindowTabs,
+  TAB_FIELD_SEPARATOR,
+} from "./browser-tabs";
+
+const sep = TAB_FIELD_SEPARATOR;
+
+test("getBrowserScriptFlavor maps bundle ids case-insensitively", () => {
+  assert.equal(getBrowserScriptFlavor("com.apple.Safari"), "safari");
+  assert.equal(getBrowserScriptFlavor("com.google.Chrome"), "chromium");
+  assert.equal(getBrowserScriptFlavor("org.mozilla.firefox"), "none");
+  assert.equal(getBrowserScriptFlavor("com.anthropic.claudefordesktop"), undefined);
+  assert.equal(getBrowserScriptFlavor(undefined), undefined);
+});
+
+test("getBrowserScriptFlavor covers the Chromium browsers people actually use", () => {
+  // Bundle ids verified against installed apps; all use the `active tab` dialect.
+  for (const bundleId of [
+    "company.thebrowser.Browser", // Arc
+    "company.thebrowser.dia", // Dia
+    "com.openai.atlas", // ChatGPT Atlas
+    "ai.perplexity.comet", // Comet
+    "com.brave.Browser",
+    "com.microsoft.edgemac",
+    "com.operasoftware.Opera",
+    "com.operasoftware.OperaGX",
+    "com.vivaldi.Vivaldi",
+    "org.chromium.Chromium",
+  ]) {
+    assert.equal(getBrowserScriptFlavor(bundleId), "chromium", `${bundleId} should be chromium`);
+  }
+});
+
+test("isKnownBrowserBundleId recognizes non-scriptable browsers too", () => {
+  assert.equal(isKnownBrowserBundleId("com.apple.Safari"), true);
+  assert.equal(isKnownBrowserBundleId("org.mozilla.firefox"), true);
+  assert.equal(isKnownBrowserBundleId("app.zen-browser.zen"), true);
+  assert.equal(isKnownBrowserBundleId("com.apple.finder"), false);
+});
+
+test("isSafeBundleId rejects anything that could break out of the script string", () => {
+  assert.equal(isSafeBundleId("com.apple.safari"), true);
+  assert.equal(isSafeBundleId("company.thebrowser.Browser"), true);
+  assert.equal(isSafeBundleId('com.apple.safari" & (do shell script "id") & "'), false);
+  assert.equal(isSafeBundleId("com.evil app"), false);
+  assert.equal(isSafeBundleId(""), false);
+});
+
+test("detectFlavorFromScriptingDefinition infers the dialect for unlisted browsers", () => {
+  const chromiumSdef = '<property name="active tab" type="tab"/><property name="URL" type="text"/>';
+  const safariSdef = '<property name="current tab" type="tab"/><property name="URL" type="text"/>';
+
+  assert.equal(detectFlavorFromScriptingDefinition(chromiumSdef), "chromium");
+  assert.equal(detectFlavorFromScriptingDefinition(safariSdef), "safari");
+});
+
+test("getScriptingBundleId redirects launcher bundles to the scriptable one", () => {
+  // ChatGPT Atlas: macOS reports com.openai.atlas, but the AppleScript terminology lives
+  // in the nested com.openai.atlas.web bundle, so `active tab` fails against the wrapper.
+  assert.equal(getScriptingBundleId("com.openai.atlas"), "com.openai.atlas.web");
+  assert.equal(getScriptingBundleId("com.openai.Atlas"), "com.openai.atlas.web");
+  // Browsers without a nested bundle are addressed directly.
+  assert.equal(getScriptingBundleId("com.apple.Safari"), "com.apple.Safari");
+  assert.equal(getScriptingBundleId("company.thebrowser.dia"), "company.thebrowser.dia");
+});
+
+test("extractBundleIdFromInfoPlist reads XML plists and ignores unparseable ones", () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict>
+  <key>CFBundleName</key><string>ChatGPT Atlas</string>
+  <key>CFBundleIdentifier</key><string>com.openai.atlas.web</string>
+</dict></plist>`;
+
+  assert.equal(extractBundleIdFromInfoPlist(xml), "com.openai.atlas.web");
+  assert.equal(extractBundleIdFromInfoPlist("bplist00\u0000binary garbage"), undefined);
+  assert.equal(extractBundleIdFromInfoPlist(""), undefined);
+});
+
+test("detectFlavorFromScriptingDefinition ignores tabbed apps that aren't browsers", () => {
+  // Terminals and editors expose "current tab" but never a URL on it; probing them would
+  // raise pointless Automation prompts.
+  const terminalSdef = '<property name="current tab" type="tab"/><property name="title" type="text"/>';
+
+  assert.equal(detectFlavorFromScriptingDefinition(terminalSdef), undefined);
+  assert.equal(detectFlavorFromScriptingDefinition(""), undefined);
+});
+
+test("buildTabsAppleScript uses the right dialect per browser", () => {
+  const safariScript = buildTabsAppleScript("com.apple.safari", "safari");
+  assert.match(safariScript, /URL of current tab/);
+  assert.match(safariScript, /name of current tab/);
+  assert.match(safariScript, /tell application id "com\.apple\.safari"/);
+
+  const chromiumScript = buildTabsAppleScript("com.google.chrome", "chromium");
+  assert.match(chromiumScript, /URL of active tab/);
+  assert.match(chromiumScript, /title of active tab/);
+});
+
+test("buildTabsAppleScript never requests page contents", () => {
+  const script = buildTabsAppleScript("com.apple.safari", "safari");
+  assert.equal(/do JavaScript|source of|text of document/.test(script), false);
+});
+
+test("buildTabsAppleScript isolates background-tab enumeration from the front tab read", () => {
+  // Browsers vary in whether `tabs of window` is scriptable; failing to enumerate them
+  // must not discard the active tab's URL, which is the value we actually need.
+  const script = buildTabsAppleScript("company.thebrowser.dia", "chromium");
+  const repeatIndex = script.indexOf("repeat with aTab");
+  const guardIndex = script.lastIndexOf("try", repeatIndex);
+
+  assert.ok(guardIndex > -1 && guardIndex < repeatIndex, "the repeat loop must sit inside a try block");
+  assert.ok(script.indexOf("URL of active tab") < guardIndex, "the front tab is read before the guarded loop");
+});
+
+test("buildTabsAppleScript never dereferences the window into a variable", () => {
+  // Regression: `set theWindow to front window` then `active tab of theWindow` fails on
+  // Arc and Dia with "can't convert class …". The tell block keeps the live reference.
+  for (const flavor of ["safari", "chromium"] as const) {
+    const script = buildTabsAppleScript("com.example.browser", flavor);
+
+    assert.match(script, /tell front window/, `${flavor} must address the window with a tell block`);
+    assert.equal(/set \w+ to front window/.test(script), false, `${flavor} must not store the window in a variable`);
+  }
+});
+
+test("parseBrowserWindowTabs reads the front tab and background values", () => {
+  const output = [
+    "https://example.com/front",
+    "Front Page",
+    "https://example.com/front",
+    "Front Page",
+    "https://example.com/other",
+    "Other Page",
+  ].join(sep);
+
+  assert.deepEqual(parseBrowserWindowTabs(output), {
+    frontUrl: "https://example.com/front",
+    frontTitle: "Front Page",
+    backgroundValues: ["https://example.com/other", "Other Page"],
+  });
+});
+
+test("parseBrowserWindowTabs handles empty and malformed output", () => {
+  assert.equal(parseBrowserWindowTabs(""), undefined);
+  assert.equal(parseBrowserWindowTabs("https://example.com"), undefined);
+  assert.equal(parseBrowserWindowTabs(`${sep}`), undefined);
+});
+
+test("isStaleCrossTabSelection flags a selection belonging to another tab", () => {
+  const windowTabs = parseBrowserWindowTabs(
+    [
+      "https://example.com/front",
+      "Front Page",
+      "https://example.com/other",
+      "Prompt Engineering: How to Talk to the AIs",
+    ].join(sep),
+  );
+
+  // The exact regression seen in Safari: a leftover selection from a background tab.
+  assert.equal(isStaleCrossTabSelection("Prompt Engineering: How to Talk to the AIs", windowTabs), true);
+  assert.equal(isStaleCrossTabSelection("https://example.com/other", windowTabs), true);
+});
+
+test("isStaleCrossTabSelection keeps genuine selections from the front tab", () => {
+  const windowTabs = parseBrowserWindowTabs(
+    ["https://example.com/front", "Front Page", "https://example.com/other", "Other Page"].join(sep),
+  );
+
+  assert.equal(isStaleCrossTabSelection("Front Page", windowTabs), false);
+  assert.equal(isStaleCrossTabSelection("https://example.com/front", windowTabs), false);
+  // Arbitrary prose selected on the front page must never be discarded.
+  assert.equal(isStaleCrossTabSelection("a paragraph the user highlighted", windowTabs), false);
+});
+
+test("isStaleCrossTabSelection is inert without tab context", () => {
+  assert.equal(isStaleCrossTabSelection("anything", undefined), false);
+  assert.equal(isStaleCrossTabSelection("", parseBrowserWindowTabs(`https://a.test${sep}A`)), false);
+});

--- a/extensions/mymind/src/browser-tabs.test.ts
+++ b/extensions/mymind/src/browser-tabs.test.ts
@@ -1,19 +1,15 @@
 import { strict as assert } from "node:assert";
 import test from "node:test";
 import {
-  buildTabsAppleScript,
+  buildActiveTabAppleScript,
   detectFlavorFromScriptingDefinition,
   extractBundleIdFromInfoPlist,
   getBrowserScriptFlavor,
   getScriptingBundleId,
   isKnownBrowserBundleId,
   isSafeBundleId,
-  isStaleCrossTabSelection,
-  parseBrowserWindowTabs,
-  TAB_FIELD_SEPARATOR,
+  parseActiveTabUrl,
 } from "./browser-tabs";
-
-const sep = TAB_FIELD_SEPARATOR;
 
 test("getBrowserScriptFlavor maps bundle ids case-insensitively", () => {
   assert.equal(getBrowserScriptFlavor("com.apple.Safari"), "safari");
@@ -95,94 +91,40 @@ test("detectFlavorFromScriptingDefinition ignores tabbed apps that aren't browse
   assert.equal(detectFlavorFromScriptingDefinition(""), undefined);
 });
 
-test("buildTabsAppleScript uses the right dialect per browser", () => {
-  const safariScript = buildTabsAppleScript("com.apple.safari", "safari");
+test("buildActiveTabAppleScript uses the right dialect per browser", () => {
+  const safariScript = buildActiveTabAppleScript("com.apple.safari", "safari");
   assert.match(safariScript, /URL of current tab/);
-  assert.match(safariScript, /name of current tab/);
   assert.match(safariScript, /tell application id "com\.apple\.safari"/);
 
-  const chromiumScript = buildTabsAppleScript("com.google.chrome", "chromium");
+  const chromiumScript = buildActiveTabAppleScript("com.google.chrome", "chromium");
   assert.match(chromiumScript, /URL of active tab/);
-  assert.match(chromiumScript, /title of active tab/);
 });
 
-test("buildTabsAppleScript never requests page contents", () => {
-  const script = buildTabsAppleScript("com.apple.safari", "safari");
-  assert.equal(/do JavaScript|source of|text of document/.test(script), false);
+test("buildActiveTabAppleScript only ever asks for the active tab's URL", () => {
+  // The Automation permission this needs is justified by how little it reads: no page
+  // contents, no titles, and no list of the user's other tabs.
+  for (const flavor of ["safari", "chromium"] as const) {
+    const script = buildActiveTabAppleScript("com.example.browser", flavor);
+
+    assert.equal(/do JavaScript|source of|text of document/.test(script), false, "must not read page contents");
+    assert.equal(/repeat|tabs of|every tab/.test(script), false, "must not enumerate other tabs");
+    assert.equal(/name of|title of/.test(script), false, "must not read titles");
+  }
 });
 
-test("buildTabsAppleScript isolates background-tab enumeration from the front tab read", () => {
-  // Browsers vary in whether `tabs of window` is scriptable; failing to enumerate them
-  // must not discard the active tab's URL, which is the value we actually need.
-  const script = buildTabsAppleScript("company.thebrowser.dia", "chromium");
-  const repeatIndex = script.indexOf("repeat with aTab");
-  const guardIndex = script.lastIndexOf("try", repeatIndex);
-
-  assert.ok(guardIndex > -1 && guardIndex < repeatIndex, "the repeat loop must sit inside a try block");
-  assert.ok(script.indexOf("URL of active tab") < guardIndex, "the front tab is read before the guarded loop");
-});
-
-test("buildTabsAppleScript never dereferences the window into a variable", () => {
+test("buildActiveTabAppleScript never dereferences the window into a variable", () => {
   // Regression: `set theWindow to front window` then `active tab of theWindow` fails on
   // Arc and Dia with "can't convert class …". The tell block keeps the live reference.
   for (const flavor of ["safari", "chromium"] as const) {
-    const script = buildTabsAppleScript("com.example.browser", flavor);
+    const script = buildActiveTabAppleScript("com.example.browser", flavor);
 
     assert.match(script, /tell front window/, `${flavor} must address the window with a tell block`);
     assert.equal(/set \w+ to front window/.test(script), false, `${flavor} must not store the window in a variable`);
   }
 });
 
-test("parseBrowserWindowTabs reads the front tab and background values", () => {
-  const output = [
-    "https://example.com/front",
-    "Front Page",
-    "https://example.com/front",
-    "Front Page",
-    "https://example.com/other",
-    "Other Page",
-  ].join(sep);
-
-  assert.deepEqual(parseBrowserWindowTabs(output), {
-    frontUrl: "https://example.com/front",
-    frontTitle: "Front Page",
-    backgroundValues: ["https://example.com/other", "Other Page"],
-  });
-});
-
-test("parseBrowserWindowTabs handles empty and malformed output", () => {
-  assert.equal(parseBrowserWindowTabs(""), undefined);
-  assert.equal(parseBrowserWindowTabs("https://example.com"), undefined);
-  assert.equal(parseBrowserWindowTabs(`${sep}`), undefined);
-});
-
-test("isStaleCrossTabSelection flags a selection belonging to another tab", () => {
-  const windowTabs = parseBrowserWindowTabs(
-    [
-      "https://example.com/front",
-      "Front Page",
-      "https://example.com/other",
-      "Prompt Engineering: How to Talk to the AIs",
-    ].join(sep),
-  );
-
-  // The exact regression seen in Safari: a leftover selection from a background tab.
-  assert.equal(isStaleCrossTabSelection("Prompt Engineering: How to Talk to the AIs", windowTabs), true);
-  assert.equal(isStaleCrossTabSelection("https://example.com/other", windowTabs), true);
-});
-
-test("isStaleCrossTabSelection keeps genuine selections from the front tab", () => {
-  const windowTabs = parseBrowserWindowTabs(
-    ["https://example.com/front", "Front Page", "https://example.com/other", "Other Page"].join(sep),
-  );
-
-  assert.equal(isStaleCrossTabSelection("Front Page", windowTabs), false);
-  assert.equal(isStaleCrossTabSelection("https://example.com/front", windowTabs), false);
-  // Arbitrary prose selected on the front page must never be discarded.
-  assert.equal(isStaleCrossTabSelection("a paragraph the user highlighted", windowTabs), false);
-});
-
-test("isStaleCrossTabSelection is inert without tab context", () => {
-  assert.equal(isStaleCrossTabSelection("anything", undefined), false);
-  assert.equal(isStaleCrossTabSelection("", parseBrowserWindowTabs(`https://a.test${sep}A`)), false);
+test("parseActiveTabUrl trims the script output and rejects empties", () => {
+  assert.equal(parseActiveTabUrl("https://example.com/front\n"), "https://example.com/front");
+  assert.equal(parseActiveTabUrl("   "), undefined);
+  assert.equal(parseActiveTabUrl(""), undefined);
 });

--- a/extensions/mymind/src/browser-tabs.ts
+++ b/extensions/mymind/src/browser-tabs.ts
@@ -70,9 +70,6 @@ export function extractBundleIdFromInfoPlist(infoPlist: string): string | undefi
   return match?.[1]?.trim() || undefined;
 }
 
-/** Unlikely to appear inside a real URL or page title, so it's safe as a field separator. */
-export const TAB_FIELD_SEPARATOR = "|__RC__|";
-
 /**
  * Bundle ids are interpolated into AppleScript source, so anything that isn't a plain
  * reverse-DNS identifier is rejected rather than escaped.
@@ -120,74 +117,22 @@ export function detectFlavorFromScriptingDefinition(scriptingDefinition: string)
   return undefined;
 }
 
-export function buildTabsAppleScript(bundleId: string, flavor: ScriptableBrowserFlavor): string {
+export function buildActiveTabAppleScript(bundleId: string, flavor: ScriptableBrowserFlavor): string {
   const activeTab = flavor === "safari" ? "current tab" : "active tab";
-  const titleProperty = flavor === "safari" ? "name" : "title";
 
   // Everything stays inside `tell front window`: assigning the window to a variable
   // dereferences it in some browsers (Arc and Dia raise "can't convert class …" on the
   // following `active tab of theWindow`), whereas a tell block keeps the live reference.
-  //
-  // The background-tab loop has its own `try` so a browser that exposes an active tab but
-  // can't enumerate `tabs` still yields the front tab's URL.
   return `
-set sep to "${TAB_FIELD_SEPARATOR}"
 tell application id "${bundleId}"
   if (count of windows) is 0 then return ""
   tell front window
-    set out to ((URL of ${activeTab}) as text) & sep & ((${titleProperty} of ${activeTab}) as text)
-    try
-      repeat with aTab in tabs
-        try
-          set out to out & sep & ((URL of aTab) as text) & sep & ((${titleProperty} of aTab) as text)
-        end try
-      end repeat
-    end try
+    return (URL of ${activeTab}) as text
   end tell
-  return out
 end tell`;
 }
 
-export type BrowserWindowTabs = {
-  frontUrl?: string;
-  frontTitle?: string;
-  /** URLs and titles of the front window's other tabs. */
-  backgroundValues: string[];
-};
-
-export function parseBrowserWindowTabs(output: string): BrowserWindowTabs | undefined {
-  const fields = output.split(TAB_FIELD_SEPARATOR).map((field) => field.trim());
-
-  if (fields.length < 2) {
-    return undefined;
-  }
-
-  const [frontUrl, frontTitle, ...rest] = fields;
-
-  if (!frontUrl && !frontTitle) {
-    return undefined;
-  }
-
-  return {
-    frontUrl: frontUrl || undefined,
-    frontTitle: frontTitle || undefined,
-    backgroundValues: rest.filter((value) => value && value !== frontUrl && value !== frontTitle),
-  };
-}
-
-/**
- * Safari's Accessibility API can hand back a selection left behind in a *different* tab.
- * Treat a "selection" that exactly matches another tab's URL or title — and not the front
- * tab's — as stale, so callers can prefer the front tab's URL instead.
- */
-export function isStaleCrossTabSelection(selectedValue: string, windowTabs?: BrowserWindowTabs): boolean {
-  if (!windowTabs?.frontUrl || !selectedValue) {
-    return false;
-  }
-
-  return (
-    selectedValue !== windowTabs.frontUrl &&
-    selectedValue !== windowTabs.frontTitle &&
-    windowTabs.backgroundValues.includes(selectedValue)
-  );
+export function parseActiveTabUrl(output: string): string | undefined {
+  const url = output.trim();
+  return url || undefined;
 }

--- a/extensions/mymind/src/browser-tabs.ts
+++ b/extensions/mymind/src/browser-tabs.ts
@@ -1,0 +1,193 @@
+/**
+ * Reading the frontmost browser's active tab.
+ *
+ * Apple Events only ever expose tab URLs and titles here — never page contents — so this
+ * needs the one-time "control <Browser>" Automation permission rather than a browser
+ * extension's much broader per-site "read and alter web pages" access.
+ */
+
+/**
+ * AppleScript dialect per browser: Safari uses `current tab`/`name`, Chromium-based
+ * browsers (Chrome, Edge, Brave, Arc, Dia, Atlas, Comet, …) use `active tab`/`title`.
+ * `"none"` marks a browser we recognize but can't script (Firefox and its forks), so
+ * callers can fall back to the Raycast Browser Extension.
+ */
+export type BrowserScriptFlavor = "safari" | "chromium" | "none";
+
+export type ScriptableBrowserFlavor = Exclude<BrowserScriptFlavor, "none">;
+
+/**
+ * Fast path for browsers we've verified. Unknown browsers still work through
+ * {@link detectFlavorFromScriptingDefinition}, so this list is an optimization
+ * rather than the limit of what's supported.
+ */
+const BROWSER_BUNDLE_FLAVORS = new Map<string, BrowserScriptFlavor>([
+  // WebKit
+  ["com.apple.safari", "safari"],
+  ["com.apple.safaritechnologypreview", "safari"],
+  // Chromium
+  ["com.google.chrome", "chromium"],
+  ["com.google.chrome.beta", "chromium"],
+  ["com.google.chrome.dev", "chromium"],
+  ["com.google.chrome.canary", "chromium"],
+  ["org.chromium.chromium", "chromium"],
+  ["com.microsoft.edgemac", "chromium"],
+  ["com.microsoft.edgemac.beta", "chromium"],
+  ["com.microsoft.edgemac.dev", "chromium"],
+  ["com.microsoft.edgemac.canary", "chromium"],
+  ["com.brave.browser", "chromium"],
+  ["com.brave.browser.beta", "chromium"],
+  ["com.brave.browser.nightly", "chromium"],
+  ["com.operasoftware.opera", "chromium"],
+  ["com.operasoftware.operanext", "chromium"],
+  ["com.operasoftware.operagx", "chromium"],
+  ["com.vivaldi.vivaldi", "chromium"],
+  ["company.thebrowser.browser", "chromium"], // Arc
+  ["company.thebrowser.dia", "chromium"], // Dia
+  ["com.openai.atlas", "chromium"], // ChatGPT Atlas
+  ["ai.perplexity.comet", "chromium"], // Comet
+  // Gecko — no usable AppleScript tab dictionary
+  ["org.mozilla.firefox", "none"],
+  ["org.mozilla.firefoxdeveloperedition", "none"],
+  ["org.mozilla.nightly", "none"],
+  ["app.zen-browser.zen", "none"],
+]);
+
+/**
+ * Some browsers ship the scriptable app nested inside a launcher bundle, so the id
+ * reported for the frontmost app isn't the one that owns the AppleScript terminology.
+ * ChatGPT Atlas is the known case: `com.openai.atlas` wraps `com.openai.atlas.web`.
+ */
+const SCRIPTING_BUNDLE_OVERRIDES = new Map<string, string>([["com.openai.atlas", "com.openai.atlas.web"]]);
+
+export function getScriptingBundleId(bundleId: string): string {
+  return SCRIPTING_BUNDLE_OVERRIDES.get(bundleId.toLowerCase()) ?? bundleId;
+}
+
+/** Pulls `CFBundleIdentifier` out of an XML `Info.plist`. Binary plists return undefined. */
+export function extractBundleIdFromInfoPlist(infoPlist: string): string | undefined {
+  const match = /<key>CFBundleIdentifier<\/key>\s*<string>([^<]+)<\/string>/.exec(infoPlist);
+  return match?.[1]?.trim() || undefined;
+}
+
+/** Unlikely to appear inside a real URL or page title, so it's safe as a field separator. */
+export const TAB_FIELD_SEPARATOR = "|__RC__|";
+
+/**
+ * Bundle ids are interpolated into AppleScript source, so anything that isn't a plain
+ * reverse-DNS identifier is rejected rather than escaped.
+ */
+const BUNDLE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+export function isSafeBundleId(bundleId: string): boolean {
+  return BUNDLE_ID_PATTERN.test(bundleId);
+}
+
+export function getBrowserScriptFlavor(bundleId?: string): BrowserScriptFlavor | undefined {
+  return bundleId ? BROWSER_BUNDLE_FLAVORS.get(bundleId.toLowerCase()) : undefined;
+}
+
+export function isKnownBrowserBundleId(bundleId?: string): boolean {
+  return getBrowserScriptFlavor(bundleId) !== undefined;
+}
+
+/** AppleScript is macOS-only; on other platforms callers must skip this path entirely. */
+export function supportsAppleScript(): boolean {
+  return process.platform === "darwin";
+}
+
+/**
+ * Infers the dialect from an app's scripting definition, so browsers that aren't in the
+ * allowlist (new entrants, forks, nightlies) keep working without a code change.
+ *
+ * Requires a `URL` property alongside the tab terminology: plenty of non-browsers expose
+ * "current tab" (terminals, editors) but only browsers put a URL on it. Without that
+ * guard we'd trigger pointless Automation permission prompts for unrelated apps.
+ */
+export function detectFlavorFromScriptingDefinition(scriptingDefinition: string): ScriptableBrowserFlavor | undefined {
+  if (!/name="URL"/.test(scriptingDefinition)) {
+    return undefined;
+  }
+
+  if (/name="active tab"/.test(scriptingDefinition)) {
+    return "chromium";
+  }
+
+  if (/name="current tab"/.test(scriptingDefinition)) {
+    return "safari";
+  }
+
+  return undefined;
+}
+
+export function buildTabsAppleScript(bundleId: string, flavor: ScriptableBrowserFlavor): string {
+  const activeTab = flavor === "safari" ? "current tab" : "active tab";
+  const titleProperty = flavor === "safari" ? "name" : "title";
+
+  // Everything stays inside `tell front window`: assigning the window to a variable
+  // dereferences it in some browsers (Arc and Dia raise "can't convert class …" on the
+  // following `active tab of theWindow`), whereas a tell block keeps the live reference.
+  //
+  // The background-tab loop has its own `try` so a browser that exposes an active tab but
+  // can't enumerate `tabs` still yields the front tab's URL.
+  return `
+set sep to "${TAB_FIELD_SEPARATOR}"
+tell application id "${bundleId}"
+  if (count of windows) is 0 then return ""
+  tell front window
+    set out to ((URL of ${activeTab}) as text) & sep & ((${titleProperty} of ${activeTab}) as text)
+    try
+      repeat with aTab in tabs
+        try
+          set out to out & sep & ((URL of aTab) as text) & sep & ((${titleProperty} of aTab) as text)
+        end try
+      end repeat
+    end try
+  end tell
+  return out
+end tell`;
+}
+
+export type BrowserWindowTabs = {
+  frontUrl?: string;
+  frontTitle?: string;
+  /** URLs and titles of the front window's other tabs. */
+  backgroundValues: string[];
+};
+
+export function parseBrowserWindowTabs(output: string): BrowserWindowTabs | undefined {
+  const fields = output.split(TAB_FIELD_SEPARATOR).map((field) => field.trim());
+
+  if (fields.length < 2) {
+    return undefined;
+  }
+
+  const [frontUrl, frontTitle, ...rest] = fields;
+
+  if (!frontUrl && !frontTitle) {
+    return undefined;
+  }
+
+  return {
+    frontUrl: frontUrl || undefined,
+    frontTitle: frontTitle || undefined,
+    backgroundValues: rest.filter((value) => value && value !== frontUrl && value !== frontTitle),
+  };
+}
+
+/**
+ * Safari's Accessibility API can hand back a selection left behind in a *different* tab.
+ * Treat a "selection" that exactly matches another tab's URL or title — and not the front
+ * tab's — as stale, so callers can prefer the front tab's URL instead.
+ */
+export function isStaleCrossTabSelection(selectedValue: string, windowTabs?: BrowserWindowTabs): boolean {
+  if (!windowTabs?.frontUrl || !selectedValue) {
+    return false;
+  }
+
+  return (
+    selectedValue !== windowTabs.frontUrl &&
+    selectedValue !== windowTabs.frontTitle &&
+    windowTabs.backgroundValues.includes(selectedValue)
+  );
+}

--- a/extensions/mymind/src/save-to-mymind.tsx
+++ b/extensions/mymind/src/save-to-mymind.tsx
@@ -44,16 +44,14 @@ import {
 } from "./save-input";
 import { isUserTag } from "./tag-utils";
 import {
-  BrowserWindowTabs,
-  buildTabsAppleScript,
+  buildActiveTabAppleScript,
   detectFlavorFromScriptingDefinition,
   extractBundleIdFromInfoPlist,
   getBrowserScriptFlavor,
   getScriptingBundleId,
   isKnownBrowserBundleId,
   isSafeBundleId,
-  isStaleCrossTabSelection,
-  parseBrowserWindowTabs,
+  parseActiveTabUrl,
   ScriptableBrowserFlavor,
   supportsAppleScript,
 } from "./browser-tabs";
@@ -266,7 +264,7 @@ function resolveFrontmostBrowser(frontmostApplication: {
   return isKnownBrowserBundleId(bundleId) ? {} : undefined;
 }
 
-async function getBrowserWindowTabs(browser: FrontmostBrowser): Promise<BrowserWindowTabs | undefined> {
+async function getActiveTabUrlViaAppleScript(browser: FrontmostBrowser): Promise<string | undefined> {
   const { scriptingBundleId, flavor } = browser;
 
   if (!scriptingBundleId || !flavor) {
@@ -274,11 +272,11 @@ async function getBrowserWindowTabs(browser: FrontmostBrowser): Promise<BrowserW
   }
 
   try {
-    const output = await runAppleScript(buildTabsAppleScript(scriptingBundleId, flavor), {
+    const output = await runAppleScript(buildActiveTabAppleScript(scriptingBundleId, flavor), {
       timeout: APPLESCRIPT_TIMEOUT_MS,
     });
 
-    return parseBrowserWindowTabs(output);
+    return parseActiveTabUrl(output);
   } catch {
     // Automation permission denied, browser not scriptable, or no open window.
     return undefined;
@@ -317,24 +315,18 @@ async function getActiveTabUrlViaBrowserExtension(): Promise<string | undefined>
 async function getBrowserInitialState(browser: FrontmostBrowser): Promise<InitialState | undefined> {
   // Independent reads — running them together keeps the command's open latency close to
   // the slower of the two rather than their sum.
-  const [windowTabs, selectedTextInitialState] = await Promise.all([
-    getBrowserWindowTabs(browser),
+  const [activeTabUrlFromScript, selectedTextInitialState] = await Promise.all([
+    getActiveTabUrlViaAppleScript(browser),
     getSelectedTextInitialState(),
   ]);
 
+  // A selection is an explicit act, so it wins over whatever page happens to be open.
   if (selectedTextInitialState) {
-    const selectedValue =
-      selectedTextInitialState.kind === "url"
-        ? selectedTextInitialState.url.trim()
-        : selectedTextInitialState.content.trim();
-
-    if (!isStaleCrossTabSelection(selectedValue, windowTabs)) {
-      return selectedTextInitialState;
-    }
+    return selectedTextInitialState;
   }
 
-  if (windowTabs?.frontUrl && isProbablyUrl(windowTabs.frontUrl)) {
-    return { ...EMPTY_INITIAL_STATE, kind: "url", url: windowTabs.frontUrl };
+  if (activeTabUrlFromScript && isProbablyUrl(activeTabUrlFromScript)) {
+    return { ...EMPTY_INITIAL_STATE, kind: "url", url: activeTabUrlFromScript };
   }
 
   // The Browser Extension reports whichever browser it's installed in, which isn't

--- a/extensions/mymind/src/save-to-mymind.tsx
+++ b/extensions/mymind/src/save-to-mymind.tsx
@@ -1,9 +1,12 @@
 import {
   Action,
   ActionPanel,
+  BrowserExtension,
   Clipboard,
   Form,
+  getFrontmostApplication,
   getSelectedFinderItems,
+  getSelectedText,
   getPreferenceValues,
   Icon,
   LaunchProps,
@@ -14,7 +17,9 @@ import {
   Toast,
   useNavigation,
 } from "@raycast/api";
-import { showFailureToast, useCachedPromise } from "@raycast/utils";
+import { runAppleScript, showFailureToast, useCachedPromise } from "@raycast/utils";
+import { readdirSync, readFileSync } from "fs";
+import { join } from "path";
 import { useEffect, useMemo, useState } from "react";
 import {
   addObjectToSpaces,
@@ -34,9 +39,24 @@ import {
   classifyFilePaths,
   classifyTextInput,
   getUnsupportedUploadFiles,
+  isProbablyUrl,
   SaveInput,
 } from "./save-input";
 import { isUserTag } from "./tag-utils";
+import {
+  BrowserWindowTabs,
+  buildTabsAppleScript,
+  detectFlavorFromScriptingDefinition,
+  extractBundleIdFromInfoPlist,
+  getBrowserScriptFlavor,
+  getScriptingBundleId,
+  isKnownBrowserBundleId,
+  isSafeBundleId,
+  isStaleCrossTabSelection,
+  parseBrowserWindowTabs,
+  ScriptableBrowserFlavor,
+  supportsAppleScript,
+} from "./browser-tabs";
 
 /** Only the fields still read from the submitted form; title, URL and body are controlled state. */
 type SaveValues = {
@@ -101,6 +121,255 @@ async function getClipboardInitialState(): Promise<InitialState | undefined> {
   return undefined;
 }
 
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// A single short retry: the first read succeeds when there is a selection, so extra
+// attempts mostly add dead time to the common "no selection, just save the page" case.
+const SELECTED_TEXT_RETRY_DELAYS_MS = [0, 90];
+
+async function getSelectedTextInitialState(): Promise<InitialState | undefined> {
+  for (const retryDelayMs of SELECTED_TEXT_RETRY_DELAYS_MS) {
+    if (retryDelayMs > 0) {
+      await delay(retryDelayMs);
+    }
+
+    try {
+      const selected = await getSelectedText();
+      return getInitialStateFromInput(classifyTextInput(selected));
+    } catch {
+      // Accessibility text-selection reads are known to be flaky against web content
+      // (e.g. Safari); retry a couple of times before giving up on this layer.
+    }
+  }
+
+  return undefined;
+}
+
+const BROWSER_TABS_RETRY_DELAYS_MS = [0, 150, 350];
+const APPLESCRIPT_TIMEOUT_MS = 3000;
+
+type ScriptingDefinition = {
+  content: string;
+  /** The bundle that actually owns the terminology, which may be a nested app. */
+  bundleId?: string;
+};
+
+/**
+ * Locates an app's scripting definition. Some browsers (e.g. ChatGPT Atlas) nest the real
+ * app — and its `.sdef` — inside `Contents/Support`, in which case the terminology belongs
+ * to the nested bundle id rather than the one macOS reports for the frontmost app.
+ */
+function findScriptingDefinition(appPath: string): ScriptingDefinition | undefined {
+  const candidates: Array<{ appDir: string; nested: boolean }> = [{ appDir: appPath, nested: false }];
+  const supportDir = join(appPath, "Contents", "Support");
+
+  try {
+    for (const entry of readdirSync(supportDir)) {
+      if (entry.endsWith(".app")) {
+        candidates.push({ appDir: join(supportDir, entry), nested: true });
+      }
+    }
+  } catch {
+    // No nested Support bundle.
+  }
+
+  for (const { appDir, nested } of candidates) {
+    try {
+      const resourcesDir = join(appDir, "Contents", "Resources");
+      const sdefName = readdirSync(resourcesDir).find((entry) => entry.endsWith(".sdef"));
+
+      if (!sdefName) {
+        continue;
+      }
+
+      const content = readFileSync(join(resourcesDir, sdefName), "utf8");
+
+      if (!nested) {
+        return { content };
+      }
+
+      const infoPlist = readFileSync(join(appDir, "Contents", "Info.plist"), "utf8");
+      return { content, bundleId: extractBundleIdFromInfoPlist(infoPlist) };
+    } catch {
+      // Directory missing or unreadable; try the next candidate.
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Resolves how to script the frontmost browser: allowlist first, then the app's own
+ * scripting definition so unlisted browsers keep working without a code change.
+ */
+function resolveBrowserTarget(
+  bundleId: string,
+  appPath?: string,
+): { bundleId: string; flavor: ScriptableBrowserFlavor } | undefined {
+  const knownFlavor = getBrowserScriptFlavor(bundleId);
+
+  if (knownFlavor === "safari" || knownFlavor === "chromium") {
+    return { bundleId: getScriptingBundleId(bundleId), flavor: knownFlavor };
+  }
+
+  // A recognized-but-unscriptable browser (Firefox); don't probe its bundle.
+  if (knownFlavor === "none" || !appPath) {
+    return undefined;
+  }
+
+  const scriptingDefinition = findScriptingDefinition(appPath);
+
+  if (!scriptingDefinition) {
+    return undefined;
+  }
+
+  const flavor = detectFlavorFromScriptingDefinition(scriptingDefinition.content);
+
+  if (!flavor) {
+    return undefined;
+  }
+
+  const scriptingBundleId = scriptingDefinition.bundleId ?? bundleId;
+  return isSafeBundleId(scriptingBundleId) ? { bundleId: scriptingBundleId, flavor } : undefined;
+}
+
+type FrontmostBrowser = {
+  /** The bundle to address in AppleScript; undefined for browsers we can't script. */
+  scriptingBundleId?: string;
+  /** Undefined for browsers we can't script (Firefox), which use the Browser Extension. */
+  flavor?: ScriptableBrowserFlavor;
+};
+
+/**
+ * Identifies the frontmost app as a browser. Known bundle ids resolve immediately;
+ * anything else is accepted only if its scripting definition looks like a browser's,
+ * which is what lets newer browsers work without being added to the allowlist.
+ */
+function resolveFrontmostBrowser(frontmostApplication: {
+  bundleId?: string;
+  path?: string;
+}): FrontmostBrowser | undefined {
+  const bundleId = frontmostApplication.bundleId;
+
+  if (!bundleId || !isSafeBundleId(bundleId)) {
+    return undefined;
+  }
+
+  const target = supportsAppleScript() ? resolveBrowserTarget(bundleId, frontmostApplication.path) : undefined;
+
+  if (target) {
+    return { scriptingBundleId: target.bundleId, flavor: target.flavor };
+  }
+
+  return isKnownBrowserBundleId(bundleId) ? {} : undefined;
+}
+
+async function getBrowserWindowTabs(browser: FrontmostBrowser): Promise<BrowserWindowTabs | undefined> {
+  const { scriptingBundleId, flavor } = browser;
+
+  if (!scriptingBundleId || !flavor) {
+    return undefined;
+  }
+
+  try {
+    const output = await runAppleScript(buildTabsAppleScript(scriptingBundleId, flavor), {
+      timeout: APPLESCRIPT_TIMEOUT_MS,
+    });
+
+    return parseBrowserWindowTabs(output);
+  } catch {
+    // Automation permission denied, browser not scriptable, or no open window.
+    return undefined;
+  }
+}
+
+async function getActiveTabUrlViaBrowserExtension(): Promise<string | undefined> {
+  for (const retryDelayMs of BROWSER_TABS_RETRY_DELAYS_MS) {
+    if (retryDelayMs > 0) {
+      await delay(retryDelayMs);
+    }
+
+    try {
+      const tabs = await BrowserExtension.getTabs();
+      const activeTab = tabs.find((tab) => tab.active);
+
+      if (activeTab?.url && isProbablyUrl(activeTab.url)) {
+        return activeTab.url;
+      }
+
+      // If no tab is reported as active (a known Safari/Browser-Extension gap),
+      // we deliberately don't guess — reading page content across tabs to work
+      // around it would require broader per-site permissions than this feature
+      // is worth. Fall through to other detection layers instead.
+      return undefined;
+    } catch {
+      // The native-messaging bridge to the Browser Extension can be transiently
+      // unavailable (e.g. right after install, or on a tab opened before it connected);
+      // retry a couple of times before giving up.
+    }
+  }
+
+  return undefined;
+}
+
+async function getBrowserInitialState(browser: FrontmostBrowser): Promise<InitialState | undefined> {
+  // Independent reads — running them together keeps the command's open latency close to
+  // the slower of the two rather than their sum.
+  const [windowTabs, selectedTextInitialState] = await Promise.all([
+    getBrowserWindowTabs(browser),
+    getSelectedTextInitialState(),
+  ]);
+
+  if (selectedTextInitialState) {
+    const selectedValue =
+      selectedTextInitialState.kind === "url"
+        ? selectedTextInitialState.url.trim()
+        : selectedTextInitialState.content.trim();
+
+    if (!isStaleCrossTabSelection(selectedValue, windowTabs)) {
+      return selectedTextInitialState;
+    }
+  }
+
+  if (windowTabs?.frontUrl && isProbablyUrl(windowTabs.frontUrl)) {
+    return { ...EMPTY_INITIAL_STATE, kind: "url", url: windowTabs.frontUrl };
+  }
+
+  // The Browser Extension reports whichever browser it's installed in, which isn't
+  // necessarily the frontmost one — trusting it for a scriptable browser surfaces a URL
+  // from a completely different app. Only fall back to it when the frontmost browser
+  // can't be scripted at all (Firefox), where there's no better option.
+  if (browser.flavor) {
+    return undefined;
+  }
+
+  const activeTabUrl = await getActiveTabUrlViaBrowserExtension();
+
+  if (activeTabUrl) {
+    return { ...EMPTY_INITIAL_STATE, kind: "url", url: activeTabUrl };
+  }
+
+  return undefined;
+}
+
+/**
+ * Detection runs at most once per command launch.
+ *
+ * `getSelectedText()` is a global, stateful operation (Raycast reads the selection through
+ * the system clipboard), so two concurrent calls interfere: one wins and the other fails,
+ * which made results flip between the selection, the tab URL and stale clipboard history.
+ * React's development double-mount triggers exactly that, so callers share one promise.
+ * Each command launch is a fresh process, so this cache lives exactly as long as it should.
+ */
+let inFlightInitialState: Promise<InitialState> | undefined;
+
+function resolveInitialStateOnce(fallbackText?: string, launchContext?: SaveLaunchContext): Promise<InitialState> {
+  inFlightInitialState ??= resolveInitialState(fallbackText, launchContext);
+  return inFlightInitialState;
+}
+
 async function resolveInitialState(fallbackText?: string, launchContext?: SaveLaunchContext): Promise<InitialState> {
   const launchContextFiles = classifyFilePaths([
     ...(Array.isArray(launchContext?.files) ? launchContext.files : []),
@@ -119,21 +388,46 @@ async function resolveInitialState(fallbackText?: string, launchContext?: SaveLa
     return { ...EMPTY_INITIAL_STATE, kind: "note", content: launchContext.content };
   }
 
+  let frontmostApplication: Awaited<ReturnType<typeof getFrontmostApplication>> | undefined;
+
+  try {
+    frontmostApplication = await getFrontmostApplication();
+  } catch {
+    // Frontmost application couldn't be determined; fall through to app-agnostic detection.
+  }
+
+  const frontmostBrowser = frontmostApplication ? resolveFrontmostBrowser(frontmostApplication) : undefined;
+
+  if (frontmostBrowser) {
+    const browserInitialState = await getBrowserInitialState(frontmostBrowser);
+
+    if (browserInitialState) {
+      return browserInitialState;
+    }
+  } else {
+    // Querying Finder is pointless (and slow) while a browser is in front.
+    try {
+      const finderSelection = await getSelectedFinderItems();
+      const selectedFiles = classifyFilePaths(finderSelection.map((item) => item.path));
+
+      if (selectedFiles.kind === "files") {
+        return { ...EMPTY_INITIAL_STATE, kind: "file", files: selectedFiles.value };
+      }
+    } catch {
+      // Ignore missing Finder context and fall back to other detection.
+    }
+
+    const selectedTextInitialState = await getSelectedTextInitialState();
+
+    if (selectedTextInitialState) {
+      return selectedTextInitialState;
+    }
+  }
+
   const clipboardInitialState = await getClipboardInitialState();
 
   if (clipboardInitialState) {
     return clipboardInitialState;
-  }
-
-  try {
-    const finderSelection = await getSelectedFinderItems();
-    const selectedFiles = classifyFilePaths(finderSelection.map((item) => item.path));
-
-    if (selectedFiles.kind === "files") {
-      return { ...EMPTY_INITIAL_STATE, kind: "file", files: selectedFiles.value };
-    }
-  } catch {
-    // Ignore missing Finder context and fall back to text detection.
   }
 
   const fallbackInput = classifyTextInput(fallbackText);
@@ -155,10 +449,10 @@ export default function SaveToMymindCommand(props: LaunchProps) {
   const accessKeyScope = getAccessKeyScope(accessKeyId, accessKeySecret);
   const launchContext = useMemo(() => (props.launchContext ?? {}) as SaveLaunchContext, [props.launchContext]);
   const [kind, setKind] = useState<SaveValues["kind"]>("note");
+  const [selectedFiles, setSelectedFiles] = useState<string[]>([]);
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
   const [url, setUrl] = useState("");
-  const [selectedFiles, setSelectedFiles] = useState<string[]>([]);
   const [isInitializing, setIsInitializing] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const effectiveAccessLevel = useEffectiveAccessLevel(accessLevel, accessKeyScope);
@@ -188,7 +482,7 @@ export default function SaveToMymindCommand(props: LaunchProps) {
 
     async function loadInitialState() {
       try {
-        const nextState = await resolveInitialState(props.fallbackText, launchContext);
+        const nextState = await resolveInitialStateOnce(props.fallbackText, launchContext);
 
         if (cancelled) {
           return;

--- a/extensions/mymind/src/save-to-mymind.tsx
+++ b/extensions/mymind/src/save-to-mymind.tsx
@@ -380,39 +380,34 @@ async function resolveInitialState(fallbackText?: string, launchContext?: SaveLa
     return { ...EMPTY_INITIAL_STATE, kind: "note", content: launchContext.content };
   }
 
-  let frontmostApplication: Awaited<ReturnType<typeof getFrontmostApplication>> | undefined;
+  // Opt-in: with the preference off, detection stays exactly as it has always been —
+  // clipboard first, then Finder — and the browser is never queried, so macOS never
+  // asks for Automation permission.
+  const { detectContext } = getPreferenceValues<Preferences>();
 
-  try {
-    frontmostApplication = await getFrontmostApplication();
-  } catch {
-    // Frontmost application couldn't be determined; fall through to app-agnostic detection.
-  }
+  if (detectContext) {
+    let frontmostApplication: Awaited<ReturnType<typeof getFrontmostApplication>> | undefined;
 
-  const frontmostBrowser = frontmostApplication ? resolveFrontmostBrowser(frontmostApplication) : undefined;
-
-  if (frontmostBrowser) {
-    const browserInitialState = await getBrowserInitialState(frontmostBrowser);
-
-    if (browserInitialState) {
-      return browserInitialState;
-    }
-  } else {
-    // Querying Finder is pointless (and slow) while a browser is in front.
     try {
-      const finderSelection = await getSelectedFinderItems();
-      const selectedFiles = classifyFilePaths(finderSelection.map((item) => item.path));
-
-      if (selectedFiles.kind === "files") {
-        return { ...EMPTY_INITIAL_STATE, kind: "file", files: selectedFiles.value };
-      }
+      frontmostApplication = await getFrontmostApplication();
     } catch {
-      // Ignore missing Finder context and fall back to other detection.
+      // Frontmost application couldn't be determined; fall through to app-agnostic detection.
     }
 
-    const selectedTextInitialState = await getSelectedTextInitialState();
+    const frontmostBrowser = frontmostApplication ? resolveFrontmostBrowser(frontmostApplication) : undefined;
 
-    if (selectedTextInitialState) {
-      return selectedTextInitialState;
+    if (frontmostBrowser) {
+      const browserInitialState = await getBrowserInitialState(frontmostBrowser);
+
+      if (browserInitialState) {
+        return browserInitialState;
+      }
+    } else {
+      const selectedTextInitialState = await getSelectedTextInitialState();
+
+      if (selectedTextInitialState) {
+        return selectedTextInitialState;
+      }
     }
   }
 
@@ -420,6 +415,17 @@ async function resolveInitialState(fallbackText?: string, launchContext?: SaveLa
 
   if (clipboardInitialState) {
     return clipboardInitialState;
+  }
+
+  try {
+    const finderSelection = await getSelectedFinderItems();
+    const selectedFiles = classifyFilePaths(finderSelection.map((item) => item.path));
+
+    if (selectedFiles.kind === "files") {
+      return { ...EMPTY_INITIAL_STATE, kind: "file", files: selectedFiles.value };
+    }
+  } catch {
+    // Ignore missing Finder context and fall back to text detection.
   }
 
   const fallbackInput = classifyTextInput(fallbackText);


### PR DESCRIPTION
## Description

Follow-up to #30099, where @0xdhrv gave this a 👍.

`Save to mymind` now prefills from the frontmost app: selected text becomes a Note, a selected URL becomes a Link, and with nothing selected in a browser it uses the active tab's URL.

### The permission, up front

The active tab is read via Apple Events, asking the browser only for the tab's **URL and title** — never page contents. That needs a one-time "control &lt;Browser&gt;" Automation permission per browser.

I went this way instead of Raycast's Browser Extension for two reasons: it requires Safari's much broader per-site "read and alter web pages" permission (Apple's own dialog mentions passwords and credit cards), and in testing it reported tabs from whichever browser it was installed in rather than the frontmost one — surfacing a Safari URL while Arc was in front.

Flagging it here so it's an explicit decision rather than something that slips in. Happy to drop the active-tab part and keep only selection detection, which needs no new permission.

### Browser support

Verified by compiling the generated script against each browser's own dictionary: Safari, Arc, Dia, Brave, Comet and ChatGPT Atlas. Chrome, Edge, Opera, Vivaldi and Chromium are covered by the same allowlist.

Unlisted browsers are handled by reading their own scripting definition and inferring the dialect, so new browsers work without a code change. That probe requires a `URL` property alongside the tab terminology — terminals and editors also expose "current tab", and probing them would raise pointless Automation prompts.

Two browser-specific gotchas worth knowing:

- `set theWindow to front window` dereferences the window; the following `active tab of theWindow` then fails on Arc and Dia with "can't convert class …". Everything stays inside `tell front window`.
- ChatGPT Atlas keeps its terminology in a nested `com.openai.atlas.web` bundle, so scripting the reported `com.openai.atlas` doesn't work.

### Behaviour change worth flagging

Clipboard history moves behind selection and active-tab detection. It previously took precedence (added in "Faster Saves from Clipboard"). A stale copy winning over what you're actually looking at was the most common cause of a wrong prefill for me — happy to restore the old order if you'd rather keep it.

### Platform

macOS-only, guarded by `process.platform === "darwin"`. Windows falls back to selection and clipboard detection with no wasted calls.

### Testing

`npm test` — 80 passing, 17 of them new in `src/browser-tabs.ts` covering dialect resolution, script generation, output parsing, stale-selection detection and bundle-id safety. There's also a test asserting the generated script never requests page contents.

`ray build` and `ray lint` clean.

---

Built with AI assistance, reviewed and manually tested.

## Screencast

https://github.com/user-attachments/assets/274b18c0-f73c-4a8d-a638-debc291ca248

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
