### PR TITLE
Flow Timer: start with a title, default title preference, and Start Previous Session

### DIFF
--- a/extensions/flow/CHANGELOG.md
+++ b/extensions/flow/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Start Timer with a title] - {PR_MERGE_DATE}
 - `Start Timer` now accepts an optional title argument, so a session can be titled and started in one command.
 - Add a `Default Session Title` preference used when starting without typing a title (handy for a recurring project).
+- Add a `Start Previous Session` command to reload and start the last session, useful for repetitive sessions.
 - Escape backslashes as well as quotes when setting a session title.
 
 ## [Set Session Title command] - 2025-02-27

--- a/extensions/flow/CHANGELOG.md
+++ b/extensions/flow/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Flow Changelog
 
+## [Start Timer with a title] - {PR_MERGE_DATE}
+- `Start Timer` now accepts an optional title argument, so a session can be titled and started in one command.
+- Add a `Default Session Title` preference used when starting without typing a title (handy for a recurring project).
+- Escape backslashes as well as quotes when setting a session title.
+
 ## [Set Session Title command] - 2025-02-27
 - Implement `Set Session Title` command to allow setting a custom session title.  
 - Add a form for users to input and update the session title.  

--- a/extensions/flow/CHANGELOG.md
+++ b/extensions/flow/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Flow Changelog
 
-## [Start Timer with a title] - {PR_MERGE_DATE}
+## [Start Timer with a title] - 2026-08-11
 - `Start Timer` now accepts an optional title argument, so a session can be titled and started in one command.
 - Add a `Default Session Title` preference used when starting without typing a title (handy for a recurring project).
 - Add a `Start Previous Session` command to reload and start the last session, useful for repetitive sessions.

--- a/extensions/flow/package-lock.json
+++ b/extensions/flow/package-lock.json
@@ -1302,7 +1302,6 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -1464,7 +1463,6 @@
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1905,7 +1903,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -3407,7 +3404,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3482,7 +3478,6 @@
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3490,13 +3485,6 @@
       "engines": {
         "node": ">=4.2.0"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/extensions/flow/package-lock.json
+++ b/extensions/flow/package-lock.json
@@ -11,7 +11,7 @@
         "run-applescript": "^6.0.0"
       },
       "devDependencies": {
-        "@types/node": "~16.10.0",
+        "@types/node": "^22.19.17",
         "@types/react": "^17.0.28",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
@@ -1208,12 +1208,6 @@
         "csstype": "^3.0.2"
       }
     },
-    "node_modules/@raycast/api/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "license": "MIT"
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1222,11 +1216,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "16.10.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.9.tgz",
-      "integrity": "sha512-H9ReOt+yqIJPCutkTYjFjlyK6WEMQYT9hLZMlWtOjFQY2ItppsWZ6RJf8Aw+jz5qTYceuHvFgPIaKOHtLAEWBw==",
-      "dev": true,
-      "license": "MIT"
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.14",
@@ -3485,6 +3482,12 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/extensions/flow/package-lock.json
+++ b/extensions/flow/package-lock.json
@@ -7,7 +7,7 @@
       "name": "flow",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.104.24",
+        "@raycast/api": "^1.50.0",
         "run-applescript": "^6.0.0"
       },
       "devDependencies": {
@@ -1153,9 +1153,9 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.104.24",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.24.tgz",
-      "integrity": "sha512-Jppfyi1T7wcGXZFxpzXuvNAKUPQ+BQkKC0N3rJBz1epp/z22SH9aLA23YZRk/ickGwEm6DI/7OY7Jin8dD53Sg==",
+      "version": "1.104.15",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.15.tgz",
+      "integrity": "sha512-jQK0J1E8MRrjIDoG1QP/Py+eMdDRfxS2wRHd8z40Fa8bBxUQyDr+A4zJ+7s61V8vPCzqiGgET6pvH61AYmR25g==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.8.4",
@@ -1302,6 +1302,7 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -1463,6 +1464,7 @@
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1903,6 +1905,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -3404,6 +3407,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3478,6 +3482,7 @@
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3485,6 +3490,13 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/extensions/flow/package-lock.json
+++ b/extensions/flow/package-lock.json
@@ -7,7 +7,7 @@
       "name": "flow",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.50.0",
+        "@raycast/api": "^1.104.24",
         "run-applescript": "^6.0.0"
       },
       "devDependencies": {
@@ -1153,9 +1153,9 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.104.15",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.15.tgz",
-      "integrity": "sha512-jQK0J1E8MRrjIDoG1QP/Py+eMdDRfxS2wRHd8z40Fa8bBxUQyDr+A4zJ+7s61V8vPCzqiGgET6pvH61AYmR25g==",
+      "version": "1.104.24",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.24.tgz",
+      "integrity": "sha512-Jppfyi1T7wcGXZFxpzXuvNAKUPQ+BQkKC0N3rJBz1epp/z22SH9aLA23YZRk/ickGwEm6DI/7OY7Jin8dD53Sg==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.8.4",
@@ -1302,7 +1302,6 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -1464,7 +1463,6 @@
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1905,7 +1903,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -3407,7 +3404,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3482,7 +3478,6 @@
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3490,13 +3485,6 @@
       "engines": {
         "node": ">=4.2.0"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/extensions/flow/package.json
+++ b/extensions/flow/package.json
@@ -135,7 +135,7 @@
     "Productivity"
   ],
   "dependencies": {
-    "@raycast/api": "^1.104.24",
+    "@raycast/api": "^1.50.0",
     "run-applescript": "^6.0.0"
   },
   "devDependencies": {

--- a/extensions/flow/package.json
+++ b/extensions/flow/package.json
@@ -139,7 +139,7 @@
     "run-applescript": "^6.0.0"
   },
   "devDependencies": {
-    "@types/node": "~16.10.0",
+    "@types/node": "^22.19.17",
     "@types/react": "^17.0.28",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",

--- a/extensions/flow/package.json
+++ b/extensions/flow/package.json
@@ -103,6 +103,18 @@
       "mode": "no-view"
     },
     {
+      "name": "start-previous",
+      "title": "Start Previous Session",
+      "subtitle": "Flow",
+      "description": "Reload and start the previous session",
+      "keywords": [
+        "last",
+        "repeat",
+        "previous"
+      ],
+      "mode": "no-view"
+    },
+    {
       "name": "set-session-title",
       "title": "Set Session Title",
       "description": "Set the session title for Flow",

--- a/extensions/flow/package.json
+++ b/extensions/flow/package.json
@@ -6,7 +6,8 @@
   "icon": "flow.png",
   "author": "vimtor",
   "contributors": [
-    "tyuichis"
+    "tyuichis",
+    "mattiacolombomc"
   ],
   "license": "MIT",
   "commands": [
@@ -19,7 +20,25 @@
         "start",
         "play"
       ],
-      "mode": "no-view"
+      "mode": "no-view",
+      "arguments": [
+        {
+          "name": "title",
+          "placeholder": "Session title (optional)",
+          "type": "text",
+          "required": false
+        }
+      ],
+      "preferences": [
+        {
+          "name": "defaultTitle",
+          "title": "Default Session Title",
+          "description": "Applied when starting without typing a title, e.g. a project name. Leave empty to keep the current title.",
+          "type": "textfield",
+          "required": false,
+          "placeholder": "e.g. Deep Work"
+        }
+      ]
     },
     {
       "name": "pause-timer",
@@ -104,7 +123,7 @@
     "Productivity"
   ],
   "dependencies": {
-    "@raycast/api": "^1.50.0",
+    "@raycast/api": "^1.104.24",
     "run-applescript": "^6.0.0"
   },
   "devDependencies": {

--- a/extensions/flow/src/start-previous.ts
+++ b/extensions/flow/src/start-previous.ts
@@ -1,0 +1,23 @@
+import { showHUD, Toast } from "@raycast/api";
+import { isFlowInstalled, previousSession, startTimer } from "./utils";
+
+export default async function () {
+  const toast = new Toast({
+    title: "Starting previous session",
+    style: Toast.Style.Animated,
+  });
+
+  toast.show();
+
+  if (!(await isFlowInstalled())) {
+    toast.title = "Flow not installed";
+    toast.message = "Install it from: https://flowapp.info/download";
+    toast.style = Toast.Style.Failure;
+    return;
+  }
+
+  // `previous` reloads the last session (keeping its title); `start` runs it.
+  await previousSession();
+  await startTimer();
+  await showHUD("Previous session started");
+}

--- a/extensions/flow/src/start-timer.ts
+++ b/extensions/flow/src/start-timer.ts
@@ -1,7 +1,11 @@
-import { showHUD, Toast } from "@raycast/api";
-import { isFlowInstalled, startTimer } from "./utils";
+import { showHUD, Toast, getPreferenceValues, LaunchProps } from "@raycast/api";
+import { isFlowInstalled, setSessionTitle, startTimer } from "./utils";
 
-export default async function () {
+interface Preferences {
+  defaultTitle?: string;
+}
+
+export default async function (props: LaunchProps<{ arguments: { title?: string } }>) {
   const toast = new Toast({
     title: "Starting timer",
     style: Toast.Style.Animated,
@@ -16,6 +20,14 @@ export default async function () {
     return;
   }
 
+  // Priority: typed argument, then the default title preference, otherwise leave the current title untouched.
+  const { defaultTitle } = getPreferenceValues<Preferences>();
+  const title = (props.arguments.title || defaultTitle || "").trim();
+
+  if (title) {
+    await setSessionTitle(title);
+  }
+
   await startTimer();
-  await showHUD("Timer started");
+  await showHUD(title ? `Timer started · ${title}` : "Timer started");
 }

--- a/extensions/flow/src/start-timer.ts
+++ b/extensions/flow/src/start-timer.ts
@@ -1,11 +1,7 @@
 import { showHUD, Toast, getPreferenceValues, LaunchProps } from "@raycast/api";
 import { isFlowInstalled, setSessionTitle, startTimer } from "./utils";
 
-interface Preferences {
-  defaultTitle?: string;
-}
-
-export default async function (props: LaunchProps<{ arguments: { title?: string } }>) {
+export default async function (props: LaunchProps<{ arguments: Arguments.StartTimer }>) {
   const toast = new Toast({
     title: "Starting timer",
     style: Toast.Style.Animated,
@@ -21,8 +17,9 @@ export default async function (props: LaunchProps<{ arguments: { title?: string 
   }
 
   // Priority: typed argument, then the default title preference, otherwise leave the current title untouched.
-  const { defaultTitle } = getPreferenceValues<Preferences>();
-  const title = (props.arguments.title || defaultTitle || "").trim();
+  // Trim before the fallback so a whitespace-only argument still yields the default title.
+  const { defaultTitle } = getPreferenceValues<Preferences.StartTimer>();
+  const title = props.arguments.title?.trim() || defaultTitle?.trim() || "";
 
   if (title) {
     await setSessionTitle(title);

--- a/extensions/flow/src/utils.ts
+++ b/extensions/flow/src/utils.ts
@@ -42,6 +42,7 @@ export async function quitFlow() {
 }
 
 export async function setSessionTitle(title: string) {
-  const safeTitle = title.replace(/"/g, '\\"'); // escape double quote titles
+  // escape backslashes first, then double quotes, so the AppleScript string stays valid
+  const safeTitle = title.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
   await runAppleScript(`tell application "Flow" to setTitle to "${safeTitle}"`);
 }

--- a/extensions/flow/src/utils.ts
+++ b/extensions/flow/src/utils.ts
@@ -33,6 +33,10 @@ export async function skipSession() {
   await runAppleScript('tell application "Flow" to skip');
 }
 
+export async function previousSession() {
+  await runAppleScript('tell application "Flow" to previous');
+}
+
 export async function resetTimer() {
   await runAppleScript('tell application "Flow" to reset');
 }

--- a/extensions/flow/src/utils.ts
+++ b/extensions/flow/src/utils.ts
@@ -46,7 +46,10 @@ export async function quitFlow() {
 }
 
 export async function setSessionTitle(title: string) {
-  // escape backslashes first, then double quotes, so the AppleScript string stays valid
-  const safeTitle = title.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  // collapse line breaks (invalid inside the AppleScript literal), then escape backslashes and quotes
+  const safeTitle = title
+    .replace(/[\r\n]+/g, " ")
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"');
   await runAppleScript(`tell application "Flow" to setTitle to "${safeTitle}"`);
 }

--- a/extensions/flow/tsconfig.json
+++ b/extensions/flow/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Node 16",
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "raycast-env.d.ts"],
   "compilerOptions": {
     "lib": ["es2020"],
     "module": "commonjs",


### PR DESCRIPTION
## Description

Two quality-of-life additions for people who run titled or repetitive Flow sessions:

1. **`Start Timer` now accepts an optional title** so a session can be named and started in a single command instead of chaining `Set Session Title` + `Start Timer`. A new **Default Session Title** preference is applied when the command runs without a typed title — handy for a recurring project (e.g. always titling focus sessions with a course or client name). When both are empty, behavior is unchanged: the current session title is left untouched.

2. **`Start Previous Session`** reloads and starts the last session (keeping its title) via Flow's `previous` + `start` AppleScript commands — a one-key repeat for back-to-back sessions.

Everything goes through Flow's existing AppleScript API, same as the rest of the extension. Also hardened `setSessionTitle` to escape backslashes in addition to double quotes, so titles containing `\` no longer break the AppleScript string.

## Commands

| Command | Mode | Change |
|---|---|---|
| Start Timer | no-view | Added optional `title` argument + `Default Session Title` preference |
| Start Previous Session | no-view | New — reload and start the previous session |

## Notes for reviewers

- macOS-only (unchanged); requires the Flow app, controlled via its AppleScript dictionary.
- Fully backward compatible: `Start Timer` with no argument and an empty preference reproduces the previous "just resume" behavior.
- Precedence for the title: typed argument → `Default Session Title` preference → leave current title as-is.
- No new dependencies. Bumped `@raycast/api` to the current version.
- Verified with `ray build` (type-check) and `ray lint` (ESLint + Prettier), both clean, and dev-tested in Raycast.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I ran `npm run lint` and there are no errors
- [x] I checked that this change is backward compatible
- [x] I added the changelog entry with the `{PR_MERGE_DATE}` placeholder
