### PR TITLE
Update proxmox extension - add multiple servers support

### DIFF
--- a/extensions/proxmox/CHANGELOG.md
+++ b/extensions/proxmox/CHANGELOG.md
@@ -8,6 +8,7 @@
 - An unreachable server no longer hides the results of the other servers
 - The server configured in the extension preferences keeps working as before
 - VM actions now check the HTTP status of the response, failed actions no longer show a success toast
+- Added mock data for the storage list, used for development and store screenshots
 
 ## [Updates] - 2025-12-12
 

--- a/extensions/proxmox/CHANGELOG.md
+++ b/extensions/proxmox/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Proxmox Changelog
 
+## [Multiple Servers] - {PR_MERGE_DATE}
+
+- Added support for multiple Proxmox servers ([#27260](https://github.com/raycast/extensions/issues/27260))
+- Added a `Manage Servers` command to add, edit or remove servers
+- The VM and storage lists now show the resources of all configured servers, grouped per server
+- An unreachable server no longer hides the results of the other servers
+- The server configured in the extension preferences keeps working as before
+- VM actions now check the HTTP status of the response, failed actions no longer show a success toast
+
 ## [Updates] - 2025-12-12
 
 - Cleanup codebase, refactored almost all code to separate files

--- a/extensions/proxmox/CHANGELOG.md
+++ b/extensions/proxmox/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Proxmox Changelog
 
-## [Multiple Servers] - {PR_MERGE_DATE}
+## [Multiple Servers] - 2026-09-07
 
 - Added support for multiple Proxmox servers ([#27260](https://github.com/raycast/extensions/issues/27260))
 - Added a `Manage Servers` command to add, edit or remove servers

--- a/extensions/proxmox/README.md
+++ b/extensions/proxmox/README.md
@@ -10,6 +10,14 @@
 2. Token ID: `Follow` instructions in next section
 3. Token Secret: `Follow` instructions in next section
 
+### 🖥️ Multiple Servers
+
+You can manage more than one Proxmox server (e.g. multiple non-clustered nodes) with the **Manage Servers** command:
+
+- The server from the extension preferences (if configured) always shows up as the first server
+- Additional servers can be added, edited and removed in **Manage Servers**
+- The **Manage VMs** and **Manage Storage** commands show the resources of all configured servers, grouped per server
+
 ### 🔐 API
 
 The exact steps may vary based on your Proxmox version. In **8.4.6.**:

--- a/extensions/proxmox/README.md
+++ b/extensions/proxmox/README.md
@@ -35,11 +35,13 @@ The exact steps may vary based on your Proxmox version. In **8.4.6.**:
 ### Troubleshooting
 
 #### Empty list of VMs/LXCs
+
 If you have an empty list of VMs/LXCs (while your account can see them in Proxmox), check your API token permissions:
 
 > **Privilege Separation**: Unchecked
 
 ### HTTPS certificate
+
 You need to setup a trusted certificate to work properly. You can do this by following the instructions here:
 https://pve.proxmox.com/wiki/Certificate_Management
 

--- a/extensions/proxmox/package-lock.json
+++ b/extensions/proxmox/package-lock.json
@@ -8,7 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.103.9",
-        "@raycast/utils": "^2.2.2"
+        "@raycast/utils": "^2.3.1"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.1.1",
@@ -1335,9 +1335,9 @@
       }
     },
     "node_modules/@raycast/utils": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.2.tgz",
-      "integrity": "sha512-tZcyWCHZvz4L/i1CGEnSZkBoK6wwX1pzlTKjcWWugbrQyG0QCMOxjKJfRC/iNkD+hHaqhMWUj4Y0LNo/NknvFw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.3.1.tgz",
+      "integrity": "sha512-GaByXcbQP05vBkHw3rPevZRkSmVZikOIXwbKOLFlQqqC9T8MxoDYp9KyeXBngjnaDzS3ELGqGkmoxNueGhjJww==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"

--- a/extensions/proxmox/package.json
+++ b/extensions/proxmox/package.json
@@ -34,14 +34,26 @@
         "pve",
         "storage"
       ]
+    },
+    {
+      "name": "manage-servers",
+      "title": "Manage Servers",
+      "subtitle": "Proxmox",
+      "description": "Add, edit or remove Proxmox servers",
+      "mode": "view",
+      "keywords": [
+        "pve",
+        "server",
+        "host"
+      ]
     }
   ],
   "preferences": [
     {
       "name": "serverUrl",
-      "description": "The URL of your Proxmox server",
+      "description": "The URL of your Proxmox server. Additional servers can be added with the Manage Servers command",
       "type": "textfield",
-      "required": true,
+      "required": false,
       "title": "Server URL",
       "placeholder": "https://pve.local:8006"
     },
@@ -49,7 +61,7 @@
       "name": "tokenId",
       "description": "The token ID of your Proxmox server",
       "type": "textfield",
-      "required": true,
+      "required": false,
       "title": "Token ID",
       "placeholder": "root@pam!raycast"
     },
@@ -57,7 +69,7 @@
       "name": "tokenSecret",
       "description": "The token secret of your Proxmox server",
       "type": "password",
-      "required": true,
+      "required": false,
       "title": "Token Secret",
       "placeholder": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
     }

--- a/extensions/proxmox/package.json
+++ b/extensions/proxmox/package.json
@@ -76,7 +76,7 @@
   ],
   "dependencies": {
     "@raycast/api": "^1.103.9",
-    "@raycast/utils": "^2.2.2"
+    "@raycast/utils": "^2.3.1"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.1.1",

--- a/extensions/proxmox/src/api/index.ts
+++ b/extensions/proxmox/src/api/index.ts
@@ -1,63 +1,65 @@
-import { getPreferenceValues } from "@raycast/api";
-import type { ApiResponse, PveVm } from "@/types";
+import type { ApiResponse, PveServer, PveVm, WithServer } from "@/types";
 import { buildHeaders } from "@/utils/headers";
 
-async function pveFetch<T = unknown>(url: string, options?: RequestInit) {
-  const preferences = getPreferenceValues<Preferences>();
-  const fetchUrl = new URL(url, preferences.serverUrl).toString();
+export async function pveFetch<T = unknown>(server: PveServer, url: string, options?: RequestInit) {
+  const fetchUrl = new URL(url, server.url).toString();
   const fetchOptions = Object.assign({}, options, {
-    headers: buildHeaders(),
+    headers: buildHeaders(server),
   });
 
   const response = await fetch(fetchUrl, fetchOptions);
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`);
+  }
+
   return (await response.json()) as ApiResponse<T>;
 }
 
-export async function startVm(vm: PveVm) {
+export async function startVm(vm: WithServer<PveVm>) {
   const url = `api2/json/nodes/${vm.node}/${vm.id}/status/start`;
-  await pveFetch(url, {
+  await pveFetch(vm.server, url, {
     method: "POST",
   });
 }
 
-export async function stopVm(vm: PveVm) {
+export async function stopVm(vm: WithServer<PveVm>) {
   const url = `api2/json/nodes/${vm.node}/${vm.id}/status/stop`;
-  await pveFetch(url, {
+  await pveFetch(vm.server, url, {
     method: "POST",
   });
 }
 
-export async function shutdownVm(vm: PveVm) {
+export async function shutdownVm(vm: WithServer<PveVm>) {
   const url = `api2/json/nodes/${vm.node}/${vm.id}/status/shutdown`;
-  await pveFetch(url, {
+  await pveFetch(vm.server, url, {
     method: "POST",
   });
 }
 
-export async function suspendVm(vm: PveVm) {
+export async function suspendVm(vm: WithServer<PveVm>) {
   const url = `api2/json/nodes/${vm.node}/${vm.id}/status/suspend`;
-  await pveFetch(url, {
+  await pveFetch(vm.server, url, {
     method: "POST",
   });
 }
 
-export async function resetVm(vm: PveVm) {
+export async function resetVm(vm: WithServer<PveVm>) {
   const url = `api2/json/nodes/${vm.node}/${vm.id}/status/reset`;
-  await pveFetch(url, {
+  await pveFetch(vm.server, url, {
     method: "POST",
   });
 }
 
-export async function resumeVm(vm: PveVm) {
+export async function resumeVm(vm: WithServer<PveVm>) {
   const url = `api2/json/nodes/${vm.node}/${vm.id}/status/resume`;
-  await pveFetch(url, {
+  await pveFetch(vm.server, url, {
     method: "POST",
   });
 }
 
-export async function rebootVm(vm: PveVm) {
+export async function rebootVm(vm: WithServer<PveVm>) {
   const url = `api2/json/nodes/${vm.node}/${vm.id}/status/reboot`;
-  await pveFetch(url, {
+  await pveFetch(vm.server, url, {
     method: "POST",
   });
 }

--- a/extensions/proxmox/src/components/NoServersEmptyView.tsx
+++ b/extensions/proxmox/src/components/NoServersEmptyView.tsx
@@ -1,0 +1,18 @@
+import { Action, ActionPanel, Icon, List, openExtensionPreferences } from "@raycast/api";
+import { ManageServers } from "@/screens/ManageServers";
+
+export const NoServersEmptyView = () => {
+  return (
+    <List.EmptyView
+      icon={Icon.Plug}
+      title="No Proxmox Servers Configured"
+      description="Add servers with the Manage Servers command, or set one in the extension preferences."
+      actions={
+        <ActionPanel>
+          <Action.Push title="Manage Servers" icon={Icon.Gear} target={<ManageServers />} />
+          <Action title="Open Extension Preferences" icon={Icon.Gear} onAction={openExtensionPreferences} />
+        </ActionPanel>
+      }
+    />
+  );
+};

--- a/extensions/proxmox/src/components/ServerErrorItem.tsx
+++ b/extensions/proxmox/src/components/ServerErrorItem.tsx
@@ -1,0 +1,35 @@
+import { Action, ActionPanel, Color, Icon, List } from "@raycast/api";
+import type { PveServer } from "@/types";
+import { ManageServers } from "@/screens/ManageServers";
+
+type ServerErrorItemProps = {
+  server: PveServer;
+  error: string;
+  revalidate: () => void;
+};
+
+export const ServerErrorItem = ({ server, error, revalidate }: ServerErrorItemProps) => {
+  return (
+    <List.Item
+      icon={{ source: Icon.Warning, tintColor: Color.Red }}
+      title="Connection Failed"
+      keywords={[server.name]}
+      detail={
+        <List.Item.Detail
+          markdown={`**${server.name}**\n\nFailed to connect to \`${server.url}\`\n\n\`\`\`\n${error}\n\`\`\``}
+        />
+      }
+      actions={
+        <ActionPanel>
+          <Action
+            title="Refresh"
+            icon={Icon.ArrowClockwise}
+            shortcut={{ modifiers: ["cmd"], key: "r" }}
+            onAction={revalidate}
+          />
+          <Action.Push title="Manage Servers" icon={Icon.Gear} target={<ManageServers />} />
+        </ActionPanel>
+      }
+    />
+  );
+};

--- a/extensions/proxmox/src/components/StorageDetail.tsx
+++ b/extensions/proxmox/src/components/StorageDetail.tsx
@@ -6,10 +6,14 @@ import { ErrorDetailGuard } from "@/components/ErrorDetailGuard";
 
 type StorageDetailProps = {
   storage: WithServer<PveStorageParsed>;
+  /** Set to false to skip fetching the live storage status, e.g. for mock data */
+  live?: boolean;
 };
 
-export const StorageDetail = ({ storage }: StorageDetailProps) => {
-  const { data, showErrorScreen } = useStorageStatus(storage.server, storage.node, storage.storage);
+export const StorageDetail = ({ storage, live = true }: StorageDetailProps) => {
+  const { data, showErrorScreen } = useStorageStatus(storage.server, storage.node, storage.storage, {
+    execute: live,
+  });
 
   return (
     <ErrorDetailGuard showErrorScreen={showErrorScreen}>

--- a/extensions/proxmox/src/components/StorageDetail.tsx
+++ b/extensions/proxmox/src/components/StorageDetail.tsx
@@ -1,15 +1,15 @@
 import { List } from "@raycast/api";
-import type { PveStorageParsed } from "@/types";
+import type { PveStorageParsed, WithServer } from "@/types";
 import { useStorageStatus } from "@/hooks/use-storage-status";
 import { formatNumberAsBoolean, formatStorageSize } from "@/utils/format";
 import { ErrorDetailGuard } from "@/components/ErrorDetailGuard";
 
 type StorageDetailProps = {
-  storage: PveStorageParsed;
+  storage: WithServer<PveStorageParsed>;
 };
 
 export const StorageDetail = ({ storage }: StorageDetailProps) => {
-  const { data, showErrorScreen } = useStorageStatus(storage.node, storage.storage);
+  const { data, showErrorScreen } = useStorageStatus(storage.server, storage.node, storage.storage);
 
   return (
     <ErrorDetailGuard showErrorScreen={showErrorScreen}>
@@ -17,6 +17,7 @@ export const StorageDetail = ({ storage }: StorageDetailProps) => {
         metadata={
           <List.Item.Detail.Metadata>
             <List.Item.Detail.Metadata.Label title="Name" text={storage.storage} />
+            <List.Item.Detail.Metadata.Label title="Server" text={storage.server.name} />
             <List.Item.Detail.Metadata.Label title="Node" text={storage.node} />
             <List.Item.Detail.Metadata.Label title="Status" text={storage.status} />
             <List.Item.Detail.Metadata.Separator />

--- a/extensions/proxmox/src/components/VmActionPanel.tsx
+++ b/extensions/proxmox/src/components/VmActionPanel.tsx
@@ -1,19 +1,19 @@
 import { Action, ActionPanel, Color, Icon, Toast, confirmAlert, showToast } from "@raycast/api";
-import type { MutatePromise } from "@raycast/utils";
 import { showFailureToast } from "@raycast/utils";
-import type { PveVm, VmAction } from "@/types";
+import type { PveVm, VmAction, WithServer } from "@/types";
 import { PveVmStatus, PveVmTypes } from "@/types";
+import type { useVmList } from "@/hooks/use-vm-list";
 import { ALL_ACTIONS } from "@/utils/const";
 import { formatBrowserUrl } from "@/utils/format";
 
 type VmActionPanelProps = {
-  vm: PveVm;
+  vm: WithServer<PveVm>;
   revalidate: () => void;
-  mutate: MutatePromise<PveVm[] | undefined>;
+  mutate: ReturnType<typeof useVmList>["mutate"];
 };
 
 export const VmActionPanel = ({ vm, revalidate, mutate }: VmActionPanelProps) => {
-  const handleAction = async (vm: PveVm, { title, labels, func, needConfirm = true }: VmAction) => {
+  const handleAction = async (vm: WithServer<PveVm>, { title, labels, func, needConfirm = true }: VmAction) => {
     const confirm =
       !needConfirm ||
       (await confirmAlert({
@@ -90,7 +90,7 @@ export const VmActionPanel = ({ vm, revalidate, mutate }: VmActionPanelProps) =>
       </ActionPanel.Section>
       <ActionPanel.Section title="Browser">
         <Action.OpenInBrowser
-          url={formatBrowserUrl(`#v1:0:=${vm.type}/${vm.vmid}`)}
+          url={formatBrowserUrl(vm.server, `#v1:0:=${vm.type}/${vm.vmid}`)}
           title="Open Dashboard"
           icon={Icon.Globe}
         />

--- a/extensions/proxmox/src/components/VmDetail.tsx
+++ b/extensions/proxmox/src/components/VmDetail.tsx
@@ -1,9 +1,9 @@
 import { List } from "@raycast/api";
-import { type PveVm, PveVmStatus, PveVmTypes } from "@/types";
+import { type PveVm, PveVmStatus, PveVmTypes, type WithServer } from "@/types";
 import { formatCPU, formatPercentage, formatShortTime, formatStorageSize } from "@/utils/format";
 
 type VmDetailProps = {
-  vm: PveVm;
+  vm: WithServer<PveVm>;
 };
 
 export const VmDetail = ({ vm }: VmDetailProps) => {
@@ -36,6 +36,7 @@ export const VmDetail = ({ vm }: VmDetailProps) => {
       metadata={
         <List.Item.Detail.Metadata>
           <List.Item.Detail.Metadata.Label title="ID" text={vm.vmid.toString()} />
+          <List.Item.Detail.Metadata.Label title="Server" text={vm.server.name} />
           <List.Item.Detail.Metadata.Label title="Node" text={vm.node} />
           <List.Item.Detail.Metadata.Label title="Status" text={vm.status} />
           <List.Item.Detail.Metadata.Separator />

--- a/extensions/proxmox/src/hooks/use-multi-pve-fetch.ts
+++ b/extensions/proxmox/src/hooks/use-multi-pve-fetch.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { usePromise } from "@raycast/utils";
 import type { PveServer, PveServerResult } from "@/types";
 import { pveFetch } from "@/api";
@@ -19,26 +19,29 @@ type MultiPveFetchOptions = {
 export const useMultiPveFetch = <T>(url: string, options?: MultiPveFetchOptions) => {
   const { timerInterval = 1000, execute = true } = options ?? {};
   const { servers, isLoading: isLoadingServers } = useServers();
-
-  // Serialized so the promise re-executes exactly when the server list changes
-  const serversKey = JSON.stringify(servers);
+  const abortable = useRef<AbortController>(null);
 
   const result = usePromise(
-    async (key: string): Promise<PveServerResult<T>[]> => {
-      const keyServers = JSON.parse(key) as PveServer[];
-      return Promise.all(
-        keyServers.map(async (server) => {
+    async (servers: PveServer[]): Promise<PveServerResult<T>[]> =>
+      Promise.all(
+        servers.map(async (server) => {
           try {
-            const response = await pveFetch<T>(server, url);
+            const response = await pveFetch<T>(server, url, { signal: abortable.current?.signal });
             return { server, data: response.data };
           } catch (error) {
+            // Let an aborted request reject the whole call, usePromise ignores it.
+            // Keeping it would show a stale request as a connection error.
+            if (error instanceof Error && error.name === "AbortError") {
+              throw error;
+            }
+
             return { server, error: describeFetchError(error) };
           }
         }),
-      );
-    },
-    [serversKey],
+      ),
+    [servers],
     {
+      abortable,
       execute: execute && !isLoadingServers,
     },
   );

--- a/extensions/proxmox/src/hooks/use-multi-pve-fetch.ts
+++ b/extensions/proxmox/src/hooks/use-multi-pve-fetch.ts
@@ -1,0 +1,65 @@
+import { useEffect } from "react";
+import { usePromise } from "@raycast/utils";
+import type { PveServer, PveServerResult } from "@/types";
+import { pveFetch } from "@/api";
+import { describeFetchError } from "@/utils/errors";
+import { useServers } from "@/utils/servers";
+
+type MultiPveFetchOptions = {
+  timerInterval?: number | null;
+  execute?: boolean;
+};
+
+/**
+ * Fetch the same resource from every configured server.
+ *
+ * Failures are captured per server, so one unreachable server
+ * doesn't prevent showing the results of the others.
+ */
+export const useMultiPveFetch = <T>(url: string, options?: MultiPveFetchOptions) => {
+  const { timerInterval = 1000, execute = true } = options ?? {};
+  const { servers, isLoading: isLoadingServers } = useServers();
+
+  // Serialized so the promise re-executes exactly when the server list changes
+  const serversKey = JSON.stringify(servers);
+
+  const result = usePromise(
+    async (key: string): Promise<PveServerResult<T>[]> => {
+      const keyServers = JSON.parse(key) as PveServer[];
+      return Promise.all(
+        keyServers.map(async (server) => {
+          try {
+            const response = await pveFetch<T>(server, url);
+            return { server, data: response.data };
+          } catch (error) {
+            return { server, error: describeFetchError(error) };
+          }
+        }),
+      );
+    },
+    [serversKey],
+    {
+      execute: execute && !isLoadingServers,
+    },
+  );
+
+  useEffect(() => {
+    if (timerInterval === null || !execute) {
+      return;
+    }
+
+    const handle = setInterval(() => {
+      result.revalidate();
+    }, timerInterval);
+
+    return () => clearInterval(handle);
+  }, [result.revalidate, timerInterval, execute]);
+
+  return {
+    ...result,
+    servers,
+    isLoading: isLoadingServers || result.isLoading,
+  };
+};
+
+export type MultiPveFetchResult<T> = ReturnType<typeof useMultiPveFetch<T>>;

--- a/extensions/proxmox/src/hooks/use-multi-pve-fetch.ts
+++ b/extensions/proxmox/src/hooks/use-multi-pve-fetch.ts
@@ -22,7 +22,7 @@ export const useMultiPveFetch = <T>(url: string, options?: MultiPveFetchOptions)
   const abortable = useRef<AbortController>(null);
 
   const result = usePromise(
-    async (servers: PveServer[]): Promise<PveServerResult<T>[]> =>
+    async (url: string, servers: PveServer[]): Promise<PveServerResult<T>[]> =>
       Promise.all(
         servers.map(async (server) => {
           try {
@@ -39,7 +39,7 @@ export const useMultiPveFetch = <T>(url: string, options?: MultiPveFetchOptions)
           }
         }),
       ),
-    [servers],
+    [url, servers],
     {
       abortable,
       execute: execute && !isLoadingServers,

--- a/extensions/proxmox/src/hooks/use-pve-fetch.ts
+++ b/extensions/proxmox/src/hooks/use-pve-fetch.ts
@@ -1,7 +1,6 @@
 import { useEffect } from "react";
-import { getPreferenceValues } from "@raycast/api";
 import { useFetch } from "@raycast/utils";
-import type { ApiResponse, FetchOptions } from "@/types";
+import type { ApiResponse, FetchOptions, PveServer } from "@/types";
 import type { OmitData, WithData } from "@/types";
 import { buildHeaders } from "@/utils/headers";
 
@@ -9,13 +8,12 @@ type PveFetchOptions<T> = FetchOptions<T> & {
   timerInterval?: number | null;
 };
 
-export const usePveFetch = <T>(url: string, options?: PveFetchOptions<T>) => {
+export const usePveFetch = <T>(server: PveServer, url: string, options?: PveFetchOptions<T>) => {
   const { timerInterval = 1000, ...rest } = options ?? {};
-  const preferences = getPreferenceValues<Preferences>();
-  const fetchUrl = new URL(url, preferences.serverUrl).toString();
+  const fetchUrl = new URL(url, server.url).toString();
   const fetchOptions: FetchOptions<T> = {
     ...rest,
-    headers: buildHeaders(),
+    headers: buildHeaders(server),
     mapResult(result) {
       return { data: (result as ApiResponse<T>).data };
     },

--- a/extensions/proxmox/src/hooks/use-pve-fetch.ts
+++ b/extensions/proxmox/src/hooks/use-pve-fetch.ts
@@ -21,8 +21,9 @@ export const usePveFetch = <T>(server: PveServer, url: string, options?: PveFetc
 
   const result = useFetch<T>(fetchUrl, fetchOptions);
 
+  const execute = rest.execute !== false;
   useEffect(() => {
-    if (timerInterval === null) {
+    if (timerInterval === null || !execute) {
       return;
     }
 
@@ -31,7 +32,7 @@ export const usePveFetch = <T>(server: PveServer, url: string, options?: PveFetc
     }, timerInterval);
 
     return () => clearInterval(handle);
-  }, [result.revalidate, timerInterval]);
+  }, [result.revalidate, timerInterval, execute]);
 
   return result;
 };

--- a/extensions/proxmox/src/hooks/use-storage-content.ts
+++ b/extensions/proxmox/src/hooks/use-storage-content.ts
@@ -1,15 +1,16 @@
 import { useState } from "react";
 import { showFailureToast } from "@raycast/utils";
-import type { PveStorageContent, WithShowErrorScreen } from "@/types";
+import type { PveServer, PveStorageContent, WithShowErrorScreen } from "@/types";
 import { type PveFetchWithDataResult, usePveFetch } from "@/hooks/use-pve-fetch";
 
 export const useStorageContent = (
+  server: PveServer,
   node: string,
   id: string,
 ): WithShowErrorScreen<PveFetchWithDataResult<PveStorageContent[]>> => {
   const [showErrorScreen, setShowErrorScreen] = useState<boolean>(false);
 
-  const { data, ...rest } = usePveFetch<PveStorageContent[]>(`api2/json/nodes/${node}/storage/${id}/content`, {
+  const { data, ...rest } = usePveFetch<PveStorageContent[]>(server, `api2/json/nodes/${node}/storage/${id}/content`, {
     onError: (error) => {
       showFailureToast(error);
       setShowErrorScreen(true);

--- a/extensions/proxmox/src/hooks/use-storage-list.ts
+++ b/extensions/proxmox/src/hooks/use-storage-list.ts
@@ -1,39 +1,49 @@
-import { useState } from "react";
-import { showFailureToast } from "@raycast/utils";
-import type { PveStorageParsed, WithShowErrorScreen } from "@/types";
-import { type PveFetchWithDataResult, usePveFetch } from "@/hooks/use-pve-fetch";
+import type { PveServer, PveStorage, PveStorageParsed, WithServer } from "@/types";
+import { useMultiPveFetch } from "@/hooks/use-multi-pve-fetch";
 import { formatStorageSize } from "@/utils/format";
 
-export const useStorageList = (mock = false): WithShowErrorScreen<PveFetchWithDataResult<PveStorageParsed[]>> => {
-  const [showErrorScreen, setShowErrorScreen] = useState<boolean>(false);
+export type StorageListGroup = {
+  server: PveServer;
+  storages: WithServer<PveStorageParsed>[];
+  error?: string;
+};
+
+export const useStorageList = (mock = false) => {
   const url = "api2/json/cluster/resources";
   const search = new URLSearchParams({
     type: "storage",
   });
 
-  const { data, ...rest } = usePveFetch<PveStorageParsed[]>(`${url}?${search.toString()}`, {
+  const { data, servers, isLoading, revalidate } = useMultiPveFetch<PveStorage[]>(`${url}?${search.toString()}`, {
     execute: !mock,
-    onError: (error) => {
-      showFailureToast(error);
-      setShowErrorScreen(true);
-    },
     timerInterval: 5000,
   });
 
-  const parsedData: PveStorageParsed[] =
-    data?.map((storage) => ({
-      ...storage,
-      contentTypes: storage.content
-        .split(",")
-        .map((type) => type.trim())
-        .filter((type) => type !== "")
-        .sort((a, b) => a.localeCompare(b)),
-      maxdiskParsed: formatStorageSize(storage.maxdisk),
-    })) ?? [];
+  const groups: StorageListGroup[] = (data ?? []).map((result) => ({
+    server: result.server,
+    error: result.error,
+    storages: (result.data ?? [])
+      .map((storage) => ({
+        ...storage,
+        server: result.server,
+        contentTypes: storage.content
+          .split(",")
+          .map((type) => type.trim())
+          .filter((type) => type !== "")
+          .sort((a, b) => a.localeCompare(b)),
+        maxdiskParsed: formatStorageSize(storage.maxdisk),
+      }))
+      .sort((a, b) => a.storage.localeCompare(b.storage)),
+  }));
+
+  const hasServers = mock || servers.length > 0;
+  const showErrorScreen = !mock && servers.length === 1 && groups.length > 0 && groups[0].error !== undefined;
 
   return {
-    ...rest,
-    data: parsedData.sort((a, b) => a.storage.localeCompare(b.storage)) ?? [],
+    isLoading: !mock && isLoading,
+    groups,
+    hasServers,
+    revalidate,
     showErrorScreen,
   };
 };

--- a/extensions/proxmox/src/hooks/use-storage-list.ts
+++ b/extensions/proxmox/src/hooks/use-storage-list.ts
@@ -1,6 +1,7 @@
 import type { PveServer, PveStorage, PveStorageParsed, WithServer } from "@/types";
 import { useMultiPveFetch } from "@/hooks/use-multi-pve-fetch";
 import { formatStorageSize } from "@/utils/format";
+import { getMockPveStorageResults } from "@/utils/mock";
 
 export type StorageListGroup = {
   server: PveServer;
@@ -19,7 +20,8 @@ export const useStorageList = (mock = false) => {
     timerInterval: 5000,
   });
 
-  const groups: StorageListGroup[] = (data ?? []).map((result) => ({
+  const results = mock ? getMockPveStorageResults() : (data ?? []);
+  const groups: StorageListGroup[] = results.map((result) => ({
     server: result.server,
     error: result.error,
     storages: (result.data ?? [])

--- a/extensions/proxmox/src/hooks/use-storage-list.ts
+++ b/extensions/proxmox/src/hooks/use-storage-list.ts
@@ -39,13 +39,11 @@ export const useStorageList = (mock = false) => {
   }));
 
   const hasServers = mock || servers.length > 0;
-  const showErrorScreen = !mock && servers.length === 1 && groups.length > 0 && groups[0].error !== undefined;
 
   return {
     isLoading: !mock && isLoading,
     groups,
     hasServers,
     revalidate,
-    showErrorScreen,
   };
 };

--- a/extensions/proxmox/src/hooks/use-storage-status.ts
+++ b/extensions/proxmox/src/hooks/use-storage-status.ts
@@ -7,10 +7,12 @@ export const useStorageStatus = (
   server: PveServer,
   node: string,
   id: string,
+  options?: { execute?: boolean },
 ): WithShowErrorScreen<PveFetchResult<PveStorageStatus>> => {
   const [showErrorScreen, setShowErrorScreen] = useState<boolean>(false);
 
   const result = usePveFetch<PveStorageStatus>(server, `api2/json/nodes/${node}/storage/${id}/status`, {
+    execute: options?.execute,
     onError: (error) => {
       showFailureToast(error);
       setShowErrorScreen(true);

--- a/extensions/proxmox/src/hooks/use-storage-status.ts
+++ b/extensions/proxmox/src/hooks/use-storage-status.ts
@@ -1,12 +1,16 @@
 import { useState } from "react";
 import { showFailureToast } from "@raycast/utils";
-import type { PveStorageStatus, WithShowErrorScreen } from "@/types";
+import type { PveServer, PveStorageStatus, WithShowErrorScreen } from "@/types";
 import { type PveFetchResult, usePveFetch } from "@/hooks/use-pve-fetch";
 
-export const useStorageStatus = (node: string, id: string): WithShowErrorScreen<PveFetchResult<PveStorageStatus>> => {
+export const useStorageStatus = (
+  server: PveServer,
+  node: string,
+  id: string,
+): WithShowErrorScreen<PveFetchResult<PveStorageStatus>> => {
   const [showErrorScreen, setShowErrorScreen] = useState<boolean>(false);
 
-  const result = usePveFetch<PveStorageStatus>(`api2/json/nodes/${node}/storage/${id}/status`, {
+  const result = usePveFetch<PveStorageStatus>(server, `api2/json/nodes/${node}/storage/${id}/status`, {
     onError: (error) => {
       showFailureToast(error);
       setShowErrorScreen(true);

--- a/extensions/proxmox/src/hooks/use-vm-list.ts
+++ b/extensions/proxmox/src/hooks/use-vm-list.ts
@@ -1,47 +1,50 @@
 import { useState } from "react";
-import { showFailureToast } from "@raycast/utils";
-import type { OmitData, PveVm, WithShowErrorScreen } from "@/types";
-import { type PveFetchResult, usePveFetch } from "@/hooks/use-pve-fetch";
-import { getMockPveVmData } from "@/utils/mock";
+import type { PveServer, PveVm, WithServer } from "@/types";
+import { useMultiPveFetch } from "@/hooks/use-multi-pve-fetch";
+import { getMockPveVmResults } from "@/utils/mock";
 
-const useVmListInternal = (enabled = true): WithShowErrorScreen<PveFetchResult<PveVm[]>> => {
-  const [showErrorScreen, setShowErrorScreen] = useState<boolean>(false);
+export type VmListGroup = {
+  server: PveServer;
+  vms: WithServer<PveVm>[];
+  error?: string;
+};
+
+/**
+ * Hook to get the list of VMs of every configured server
+ *
+ * @param mock - If true, use mock data instead of fetching from the API
+ */
+export const useVmList = (mock = false) => {
+  const [type, setType] = useState<string>("all");
+
   const url = "api2/json/cluster/resources";
   const search = new URLSearchParams({
     type: "vm",
   });
 
-  const result = usePveFetch<PveVm[]>(`${url}?${search.toString()}`, {
-    execute: enabled,
-    onError: (error) => {
-      showFailureToast(error);
-      setShowErrorScreen(true);
-    },
+  const { data, servers, isLoading, revalidate, mutate } = useMultiPveFetch<PveVm[]>(`${url}?${search.toString()}`, {
+    execute: !mock,
   });
 
-  return {
-    ...result,
-    showErrorScreen,
-  };
-};
+  const results = mock ? getMockPveVmResults() : (data ?? []);
+  const groups: VmListGroup[] = results.map((result) => ({
+    server: result.server,
+    error: result.error,
+    vms: (result.data ?? [])
+      .filter((vm) => (type === "all" ? true : vm.type === type))
+      .map((vm) => ({ ...vm, server: result.server })),
+  }));
 
-/**
- * Hook to get the list of VMs
- *
- * @param mock - If true, use mock data instead of fetching from the API
- */
-export const useVmList = (
-  mock = false,
-): OmitData<ReturnType<typeof useVmListInternal>> & { setType: (type: string) => void; data: PveVm[] } => {
-  const [type, setType] = useState<string>("all");
-
-  const { data, ...rest } = useVmListInternal(!mock);
-  const filteredData =
-    (mock ? getMockPveVmData() : data)?.filter((vm) => (type === "all" ? true : vm.type === type)) ?? [];
+  const hasServers = mock || servers.length > 0;
+  const showErrorScreen = !mock && servers.length === 1 && groups.length > 0 && groups[0].error !== undefined;
 
   return {
-    ...rest,
-    data: filteredData,
+    isLoading: !mock && isLoading,
+    groups,
+    hasServers,
+    revalidate,
+    mutate,
     setType,
+    showErrorScreen,
   };
 };

--- a/extensions/proxmox/src/hooks/use-vm-list.ts
+++ b/extensions/proxmox/src/hooks/use-vm-list.ts
@@ -36,7 +36,6 @@ export const useVmList = (mock = false) => {
   }));
 
   const hasServers = mock || servers.length > 0;
-  const showErrorScreen = !mock && servers.length === 1 && groups.length > 0 && groups[0].error !== undefined;
 
   return {
     isLoading: !mock && isLoading,
@@ -45,6 +44,5 @@ export const useVmList = (mock = false) => {
     revalidate,
     mutate,
     setType,
-    showErrorScreen,
   };
 };

--- a/extensions/proxmox/src/index.tsx
+++ b/extensions/proxmox/src/index.tsx
@@ -1,7 +1,6 @@
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { type VmListGroup, useVmList } from "@/hooks/use-vm-list";
 import { getVmStatusIcon } from "@/utils/ui";
-import { ErrorGuard } from "@/components/ErrorGuard";
 import { NoServersEmptyView } from "@/components/NoServersEmptyView";
 import { ServerErrorItem } from "@/components/ServerErrorItem";
 import { VmActionPanel } from "@/components/VmActionPanel";
@@ -10,7 +9,7 @@ import { VmTypeDropdown } from "@/components/VmTypeDropdown";
 import { ManageServers } from "@/screens/ManageServers";
 
 const Command = () => {
-  const { isLoading, groups, hasServers, revalidate, mutate, setType, showErrorScreen } = useVmList();
+  const { isLoading, groups, hasServers, revalidate, mutate, setType } = useVmList();
   const showSections = groups.length > 1;
   const showNoServers = !isLoading && !hasServers;
 
@@ -49,26 +48,24 @@ const Command = () => {
   };
 
   return (
-    <ErrorGuard showErrorScreen={showErrorScreen}>
-      <List
-        isLoading={isLoading}
-        isShowingDetail={!showNoServers}
-        actions={
-          <ActionPanel>
-            <Action
-              title="Refresh"
-              icon={Icon.ArrowClockwise}
-              shortcut={{ modifiers: ["cmd"], key: "r" }}
-              onAction={revalidate}
-            />
-            <Action.Push title="Manage Servers" icon={Icon.Gear} target={<ManageServers />} />
-          </ActionPanel>
-        }
-        searchBarAccessory={<VmTypeDropdown onChange={setType} />}
-      >
-        {showNoServers ? <NoServersEmptyView /> : groups.map(renderGroup)}
-      </List>
-    </ErrorGuard>
+    <List
+      isLoading={isLoading}
+      isShowingDetail={!showNoServers}
+      actions={
+        <ActionPanel>
+          <Action
+            title="Refresh"
+            icon={Icon.ArrowClockwise}
+            shortcut={{ modifiers: ["cmd"], key: "r" }}
+            onAction={revalidate}
+          />
+          <Action.Push title="Manage Servers" icon={Icon.Gear} target={<ManageServers />} />
+        </ActionPanel>
+      }
+      searchBarAccessory={<VmTypeDropdown onChange={setType} />}
+    >
+      {showNoServers ? <NoServersEmptyView /> : groups.map(renderGroup)}
+    </List>
   );
 };
 

--- a/extensions/proxmox/src/index.tsx
+++ b/extensions/proxmox/src/index.tsx
@@ -1,19 +1,58 @@
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
-import { useVmList } from "@/hooks/use-vm-list";
+import { type VmListGroup, useVmList } from "@/hooks/use-vm-list";
 import { getVmStatusIcon } from "@/utils/ui";
 import { ErrorGuard } from "@/components/ErrorGuard";
+import { NoServersEmptyView } from "@/components/NoServersEmptyView";
+import { ServerErrorItem } from "@/components/ServerErrorItem";
 import { VmActionPanel } from "@/components/VmActionPanel";
 import { VmDetail } from "@/components/VmDetail";
 import { VmTypeDropdown } from "@/components/VmTypeDropdown";
+import { ManageServers } from "@/screens/ManageServers";
 
 const Command = () => {
-  const { isLoading, data, revalidate, mutate, setType, showErrorScreen } = useVmList();
+  const { isLoading, groups, hasServers, revalidate, mutate, setType, showErrorScreen } = useVmList();
+  const showSections = groups.length > 1;
+  const showNoServers = !isLoading && !hasServers;
+
+  const renderGroup = (group: VmListGroup) => {
+    const items =
+      group.error !== undefined ? (
+        <ServerErrorItem
+          key={`${group.server.id}/error`}
+          server={group.server}
+          error={group.error}
+          revalidate={revalidate}
+        />
+      ) : (
+        group.vms.map((vm) => (
+          <List.Item
+            key={`${group.server.id}/${vm.id}`}
+            icon={{ ...getVmStatusIcon(vm.status), tooltip: vm.status }}
+            title={vm.name}
+            actions={<VmActionPanel vm={vm} mutate={mutate} revalidate={revalidate} />}
+            keywords={[vm.vmid.toString(), group.server.name]}
+            detail={<VmDetail vm={vm} />}
+            accessories={[{ text: vm.id }]}
+          />
+        ))
+      );
+
+    return (
+      <List.Section
+        key={group.server.id}
+        title={showSections ? group.server.name : undefined}
+        subtitle={showSections && group.error === undefined ? `${group.vms.length}` : undefined}
+      >
+        {items}
+      </List.Section>
+    );
+  };
 
   return (
     <ErrorGuard showErrorScreen={showErrorScreen}>
       <List
         isLoading={isLoading}
-        isShowingDetail
+        isShowingDetail={!showNoServers}
         actions={
           <ActionPanel>
             <Action
@@ -22,21 +61,12 @@ const Command = () => {
               shortcut={{ modifiers: ["cmd"], key: "r" }}
               onAction={revalidate}
             />
+            <Action.Push title="Manage Servers" icon={Icon.Gear} target={<ManageServers />} />
           </ActionPanel>
         }
         searchBarAccessory={<VmTypeDropdown onChange={setType} />}
       >
-        {data.map((vm) => (
-          <List.Item
-            key={vm.id}
-            icon={{ ...getVmStatusIcon(vm.status), tooltip: vm.status }}
-            title={vm.name}
-            actions={<VmActionPanel vm={vm} mutate={mutate!} revalidate={revalidate} />}
-            keywords={[vm.vmid.toString()]}
-            detail={<VmDetail vm={vm} />}
-            accessories={[{ text: vm.id }]}
-          />
-        ))}
+        {showNoServers ? <NoServersEmptyView /> : groups.map(renderGroup)}
       </List>
     </ErrorGuard>
   );

--- a/extensions/proxmox/src/manage-servers.tsx
+++ b/extensions/proxmox/src/manage-servers.tsx
@@ -1,0 +1,7 @@
+import { ManageServers } from "@/screens/ManageServers";
+
+const Command = () => {
+  return <ManageServers />;
+};
+
+export default Command;

--- a/extensions/proxmox/src/screens/ManageServers.tsx
+++ b/extensions/proxmox/src/screens/ManageServers.tsx
@@ -1,10 +1,13 @@
+import { useRef } from "react";
 import { Action, ActionPanel, Alert, Icon, List, confirmAlert, openExtensionPreferences } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
 import type { PveServer } from "@/types";
 import { isPreferencesServer, useServers } from "@/utils/servers";
 import { ServerForm } from "@/screens/ServerForm";
 
 export const ManageServers = () => {
   const { servers, isLoading, addServer, updateServer, removeServer } = useServers();
+  const pendingRemovalIds = useRef(new Set<string>());
 
   const addServerAction = (
     <Action.Push
@@ -14,6 +17,21 @@ export const ManageServers = () => {
       target={<ServerForm onSave={addServer} />}
     />
   );
+
+  const handleUpdate = async (server: PveServer, values: Omit<PveServer, "id">) => {
+    if (pendingRemovalIds.current.has(server.id)) {
+      const error = new Error("This server was removed");
+      await showFailureToast(error, { title: "Failed to Update Server" });
+      throw error;
+    }
+
+    try {
+      await updateServer({ id: server.id, ...values });
+    } catch (error) {
+      await showFailureToast(error, { title: "Failed to Update Server" });
+      throw error;
+    }
+  };
 
   const handleRemove = async (server: PveServer) => {
     const confirmed = await confirmAlert({
@@ -25,8 +43,16 @@ export const ManageServers = () => {
       },
     });
 
-    if (confirmed) {
+    if (!confirmed) {
+      return;
+    }
+
+    pendingRemovalIds.current.add(server.id);
+    try {
       await removeServer(server);
+    } catch (error) {
+      pendingRemovalIds.current.delete(server.id);
+      await showFailureToast(error, { title: "Failed to Remove Server" });
     }
   };
 
@@ -62,7 +88,7 @@ export const ManageServers = () => {
                 <Action.Push
                   title="Edit Server"
                   icon={Icon.Pencil}
-                  target={<ServerForm server={server} onSave={(values) => updateServer({ ...server, ...values })} />}
+                  target={<ServerForm server={server} onSave={(values) => handleUpdate(server, values)} />}
                 />
               )}
               {addServerAction}

--- a/extensions/proxmox/src/screens/ManageServers.tsx
+++ b/extensions/proxmox/src/screens/ManageServers.tsx
@@ -1,0 +1,84 @@
+import { Action, ActionPanel, Alert, Icon, List, confirmAlert, openExtensionPreferences } from "@raycast/api";
+import type { PveServer } from "@/types";
+import { isPreferencesServer, useServers } from "@/utils/servers";
+import { ServerForm } from "@/screens/ServerForm";
+
+export const ManageServers = () => {
+  const { servers, isLoading, addServer, updateServer, removeServer } = useServers();
+
+  const addServerAction = (
+    <Action.Push
+      title="Add Server"
+      icon={Icon.Plus}
+      shortcut={{ modifiers: ["cmd"], key: "n" }}
+      target={<ServerForm onSave={addServer} />}
+    />
+  );
+
+  const handleRemove = async (server: PveServer) => {
+    const confirmed = await confirmAlert({
+      title: "Remove Server",
+      message: `Are you sure you want to remove ${server.name}?`,
+      primaryAction: {
+        title: "Remove",
+        style: Alert.ActionStyle.Destructive,
+      },
+    });
+
+    if (confirmed) {
+      await removeServer(server);
+    }
+  };
+
+  return (
+    <List isLoading={isLoading} navigationTitle="Manage Servers">
+      <List.EmptyView
+        icon={Icon.HardDrive}
+        title="No Proxmox Servers Configured"
+        description="Add your first server here, or set one in the extension preferences."
+        actions={
+          <ActionPanel>
+            {addServerAction}
+            <Action title="Open Extension Preferences" icon={Icon.Gear} onAction={openExtensionPreferences} />
+          </ActionPanel>
+        }
+      />
+      {servers.map((server) => (
+        <List.Item
+          key={server.id}
+          icon={Icon.HardDrive}
+          title={server.name}
+          subtitle={server.url}
+          accessories={
+            isPreferencesServer(server)
+              ? [{ tag: "Preferences", tooltip: "This server is configured in the extension preferences" }]
+              : []
+          }
+          actions={
+            <ActionPanel>
+              {isPreferencesServer(server) ? (
+                <Action title="Edit in Preferences" icon={Icon.Gear} onAction={openExtensionPreferences} />
+              ) : (
+                <Action.Push
+                  title="Edit Server"
+                  icon={Icon.Pencil}
+                  target={<ServerForm server={server} onSave={(values) => updateServer({ ...server, ...values })} />}
+                />
+              )}
+              {addServerAction}
+              {!isPreferencesServer(server) && (
+                <Action
+                  title="Remove Server"
+                  icon={Icon.Trash}
+                  style={Action.Style.Destructive}
+                  shortcut={{ modifiers: ["ctrl"], key: "x" }}
+                  onAction={() => handleRemove(server)}
+                />
+              )}
+            </ActionPanel>
+          }
+        />
+      ))}
+    </List>
+  );
+};

--- a/extensions/proxmox/src/screens/ServerForm.tsx
+++ b/extensions/proxmox/src/screens/ServerForm.tsx
@@ -1,0 +1,122 @@
+import { Action, ActionPanel, Form, Icon, Toast, confirmAlert, showToast, useNavigation } from "@raycast/api";
+import { FormValidation, useForm } from "@raycast/utils";
+import type { PveServer } from "@/types";
+import { pveFetch } from "@/api";
+import { describeFetchError } from "@/utils/errors";
+import { serverNameFromUrl } from "@/utils/servers";
+
+type ServerFormValues = {
+  name: string;
+  url: string;
+  tokenId: string;
+  tokenSecret: string;
+};
+
+type ServerFormProps = {
+  server?: PveServer;
+  onSave: (server: Omit<PveServer, "id">) => Promise<void>;
+};
+
+async function verifyConnection(server: PveServer): Promise<string | undefined> {
+  try {
+    await pveFetch(server, "api2/json/version", { signal: AbortSignal.timeout(5000) });
+    return undefined;
+  } catch (error) {
+    return describeFetchError(error);
+  }
+}
+
+export const ServerForm = ({ server, onSave }: ServerFormProps) => {
+  const { pop } = useNavigation();
+
+  const { handleSubmit, itemProps } = useForm<ServerFormValues>({
+    initialValues: {
+      name: server?.name ?? "",
+      url: server?.url ?? "",
+      tokenId: server?.tokenId ?? "",
+      tokenSecret: server?.tokenSecret ?? "",
+    },
+    validation: {
+      url: (value) => {
+        if (!value) {
+          return "The item is required";
+        }
+
+        try {
+          new URL(value);
+        } catch {
+          return "Enter a valid URL, e.g. https://pve.local:8006";
+        }
+      },
+      tokenId: FormValidation.Required,
+      tokenSecret: FormValidation.Required,
+    },
+    async onSubmit(values) {
+      const candidate = {
+        name: values.name.trim() || serverNameFromUrl(values.url),
+        url: values.url,
+        tokenId: values.tokenId,
+        tokenSecret: values.tokenSecret,
+      };
+
+      const toast = await showToast({ style: Toast.Style.Animated, title: "Checking Connection..." });
+      const connectionError = await verifyConnection({ ...candidate, id: server?.id ?? "unsaved" });
+      await toast.hide();
+
+      if (connectionError !== undefined) {
+        const saveAnyway = await confirmAlert({
+          title: "Connection Failed",
+          message: `${candidate.url}\n${connectionError}\n\nSave the server anyway?`,
+          primaryAction: { title: "Save Anyway" },
+        });
+
+        if (!saveAnyway) {
+          return;
+        }
+      }
+
+      await onSave(candidate);
+      await showToast({ style: Toast.Style.Success, title: server ? "Server Updated" : "Server Added" });
+      pop();
+    },
+  });
+
+  return (
+    <Form
+      navigationTitle={server ? "Edit Server" : "Add Server"}
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm
+            title={server ? "Save Server" : "Add Server"}
+            icon={server ? Icon.Check : Icon.Plus}
+            onSubmit={handleSubmit}
+          />
+        </ActionPanel>
+      }
+    >
+      <Form.TextField
+        {...itemProps.url}
+        title="Server URL"
+        placeholder="https://pve.local:8006"
+        info="The URL of your Proxmox server, including the port"
+      />
+      <Form.TextField
+        {...itemProps.tokenId}
+        title="Token ID"
+        placeholder="root@pam!raycast"
+        info="The API token ID, see the extension README for how to create one"
+      />
+      <Form.PasswordField
+        {...itemProps.tokenSecret}
+        title="Token Secret"
+        placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      />
+      <Form.TextField
+        {...itemProps.name}
+        title="Name"
+        placeholder="Optional display name"
+        info="Shown in lists to tell servers apart, defaults to the hostname of the URL"
+      />
+    </Form>
+  );
+};

--- a/extensions/proxmox/src/screens/StorageContentList.tsx
+++ b/extensions/proxmox/src/screens/StorageContentList.tsx
@@ -1,15 +1,17 @@
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
+import type { PveServer } from "@/types";
 import { useStorageContent } from "@/hooks/use-storage-content";
 import { formatStorageSize } from "@/utils/format";
 import { ErrorGuard } from "@/components/ErrorGuard";
 
 type StorageContentListProps = {
+  server: PveServer;
   node: string;
   id: string;
 };
 
-export const StorageContentList = ({ node, id }: StorageContentListProps) => {
-  const { data, isLoading, showErrorScreen, revalidate } = useStorageContent(node, id);
+export const StorageContentList = ({ server, node, id }: StorageContentListProps) => {
+  const { data, isLoading, showErrorScreen, revalidate } = useStorageContent(server, node, id);
 
   return (
     <ErrorGuard showErrorScreen={showErrorScreen}>

--- a/extensions/proxmox/src/storage.tsx
+++ b/extensions/proxmox/src/storage.tsx
@@ -1,7 +1,6 @@
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { type StorageListGroup, useStorageList } from "@/hooks/use-storage-list";
 import { getStorageStatusIcon } from "@/utils/ui";
-import { ErrorGuard } from "@/components/ErrorGuard";
 import { NoServersEmptyView } from "@/components/NoServersEmptyView";
 import { ServerErrorItem } from "@/components/ServerErrorItem";
 import { StorageDetail } from "@/components/StorageDetail";
@@ -9,7 +8,7 @@ import { ManageServers } from "@/screens/ManageServers";
 import { StorageContentList } from "@/screens/StorageContentList";
 
 const Command = () => {
-  const { isLoading, groups, hasServers, revalidate, showErrorScreen } = useStorageList();
+  const { isLoading, groups, hasServers, revalidate } = useStorageList();
   const showSections = groups.length > 1;
   const showNoServers = !isLoading && !hasServers;
 
@@ -56,25 +55,23 @@ const Command = () => {
   };
 
   return (
-    <ErrorGuard showErrorScreen={showErrorScreen}>
-      <List
-        isLoading={isLoading}
-        isShowingDetail={!showNoServers}
-        actions={
-          <ActionPanel>
-            <Action
-              title="Refresh"
-              icon={Icon.ArrowClockwise}
-              shortcut={{ modifiers: ["cmd"], key: "r" }}
-              onAction={revalidate}
-            />
-            <Action.Push title="Manage Servers" icon={Icon.Gear} target={<ManageServers />} />
-          </ActionPanel>
-        }
-      >
-        {showNoServers ? <NoServersEmptyView /> : groups.map(renderGroup)}
-      </List>
-    </ErrorGuard>
+    <List
+      isLoading={isLoading}
+      isShowingDetail={!showNoServers}
+      actions={
+        <ActionPanel>
+          <Action
+            title="Refresh"
+            icon={Icon.ArrowClockwise}
+            shortcut={{ modifiers: ["cmd"], key: "r" }}
+            onAction={revalidate}
+          />
+          <Action.Push title="Manage Servers" icon={Icon.Gear} target={<ManageServers />} />
+        </ActionPanel>
+      }
+    >
+      {showNoServers ? <NoServersEmptyView /> : groups.map(renderGroup)}
+    </List>
   );
 };
 

--- a/extensions/proxmox/src/storage.tsx
+++ b/extensions/proxmox/src/storage.tsx
@@ -1,18 +1,65 @@
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
-import { useStorageList } from "@/hooks/use-storage-list";
+import { type StorageListGroup, useStorageList } from "@/hooks/use-storage-list";
 import { getStorageStatusIcon } from "@/utils/ui";
 import { ErrorGuard } from "@/components/ErrorGuard";
+import { NoServersEmptyView } from "@/components/NoServersEmptyView";
+import { ServerErrorItem } from "@/components/ServerErrorItem";
 import { StorageDetail } from "@/components/StorageDetail";
+import { ManageServers } from "@/screens/ManageServers";
 import { StorageContentList } from "@/screens/StorageContentList";
 
 const Command = () => {
-  const { isLoading, data, revalidate, showErrorScreen } = useStorageList();
+  const { isLoading, groups, hasServers, revalidate, showErrorScreen } = useStorageList();
+  const showSections = groups.length > 1;
+  const showNoServers = !isLoading && !hasServers;
+
+  const renderGroup = (group: StorageListGroup) => {
+    const items =
+      group.error !== undefined ? (
+        <ServerErrorItem
+          key={`${group.server.id}/error`}
+          server={group.server}
+          error={group.error}
+          revalidate={revalidate}
+        />
+      ) : (
+        group.storages.map((storage) => (
+          <List.Item
+            key={`${group.server.id}/${storage.id}`}
+            title={storage.storage}
+            icon={{ ...getStorageStatusIcon(storage.status), tooltip: storage.status }}
+            accessories={[{ text: storage.maxdiskParsed, tooltip: `Max disk: ${storage.maxdiskParsed}` }]}
+            keywords={[...storage.contentTypes, group.server.name]}
+            detail={<StorageDetail storage={storage} />}
+            actions={
+              <ActionPanel>
+                <Action.Push
+                  title="View Content"
+                  icon={Icon.List}
+                  target={<StorageContentList server={storage.server} node={storage.node} id={storage.storage} />}
+                />
+              </ActionPanel>
+            }
+          />
+        ))
+      );
+
+    return (
+      <List.Section
+        key={group.server.id}
+        title={showSections ? group.server.name : undefined}
+        subtitle={showSections && group.error === undefined ? `${group.storages.length}` : undefined}
+      >
+        {items}
+      </List.Section>
+    );
+  };
 
   return (
     <ErrorGuard showErrorScreen={showErrorScreen}>
       <List
         isLoading={isLoading}
-        isShowingDetail
+        isShowingDetail={!showNoServers}
         actions={
           <ActionPanel>
             <Action
@@ -21,28 +68,11 @@ const Command = () => {
               shortcut={{ modifiers: ["cmd"], key: "r" }}
               onAction={revalidate}
             />
+            <Action.Push title="Manage Servers" icon={Icon.Gear} target={<ManageServers />} />
           </ActionPanel>
         }
       >
-        {data.map((storage) => (
-          <List.Item
-            key={storage.id}
-            title={storage.storage}
-            icon={{ ...getStorageStatusIcon(storage.status), tooltip: storage.status }}
-            accessories={[{ text: storage.maxdiskParsed, tooltip: `Max disk: ${storage.maxdiskParsed}` }]}
-            keywords={storage.contentTypes}
-            detail={<StorageDetail storage={storage} />}
-            actions={
-              <ActionPanel>
-                <Action.Push
-                  title="View Content"
-                  icon={Icon.List}
-                  target={<StorageContentList node={storage.node} id={storage.storage} />}
-                />
-              </ActionPanel>
-            }
-          />
-        ))}
+        {showNoServers ? <NoServersEmptyView /> : groups.map(renderGroup)}
       </List>
     </ErrorGuard>
   );

--- a/extensions/proxmox/src/types/index.ts
+++ b/extensions/proxmox/src/types/index.ts
@@ -2,6 +2,24 @@ import type { useFetch } from "@raycast/utils";
 
 export type FetchOptions<T> = Parameters<typeof useFetch<T>>[1];
 
+export type PveServer = {
+  id: string;
+  name: string;
+  url: string;
+  tokenId: string;
+  tokenSecret: string;
+};
+
+/** An entity tagged with the server it was fetched from */
+export type WithServer<T> = T & { server: PveServer };
+
+/** The outcome of fetching one resource from one server */
+export type PveServerResult<T> = {
+  server: PveServer;
+  data?: T;
+  error?: string;
+};
+
 export const enum PveVmStatus {
   running = "running",
   stopped = "stopped",
@@ -108,7 +126,7 @@ export type VmAction = {
     doing: string;
     ended: string;
   };
-  func: (vm: PveVm) => Promise<unknown>;
+  func: (vm: WithServer<PveVm>) => Promise<unknown>;
   needConfirm?: boolean;
 };
 

--- a/extensions/proxmox/src/utils/errors.ts
+++ b/extensions/proxmox/src/utils/errors.ts
@@ -1,0 +1,30 @@
+type ErrorWithCode = Error & { code?: string };
+
+function describeCause(cause: Error): string {
+  if (cause instanceof AggregateError && cause.errors.length > 0 && cause.errors[0] instanceof Error) {
+    return describeCause(cause.errors[0]);
+  }
+
+  const code = (cause as ErrorWithCode).code;
+  if (cause.message !== "") {
+    return code !== undefined && !cause.message.includes(code) ? `${cause.message} (${code})` : cause.message;
+  }
+
+  return code ?? cause.name;
+}
+
+/**
+ * Node's fetch wraps the interesting part (DNS, TLS, connection errors)
+ * in `error.cause` and only reports "fetch failed" itself.
+ */
+export function describeFetchError(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return String(error);
+  }
+
+  if (error.cause instanceof Error) {
+    return describeCause(error.cause);
+  }
+
+  return error.message;
+}

--- a/extensions/proxmox/src/utils/format.ts
+++ b/extensions/proxmox/src/utils/format.ts
@@ -1,4 +1,4 @@
-import { getPreferenceValues } from "@raycast/api";
+import type { PveServer } from "@/types";
 
 export function formatShortTime(time: number): string {
   const units = "smhdy";
@@ -55,8 +55,7 @@ export function formatCPU(maxcpu: number): string {
 export const formatNumberAsBoolean = (value: number | undefined): string =>
   typeof value === "number" ? (value === 1 ? "Yes" : "No") : "Unknown";
 
-export const formatBrowserUrl = (suffix: string) => {
-  const preferences = getPreferenceValues<Preferences>();
-  const url = new URL(suffix, preferences.serverUrl).toString();
+export const formatBrowserUrl = (server: PveServer, suffix: string) => {
+  const url = new URL(suffix, server.url).toString();
   return url;
 };

--- a/extensions/proxmox/src/utils/headers.ts
+++ b/extensions/proxmox/src/utils/headers.ts
@@ -1,8 +1,7 @@
-import { getPreferenceValues } from "@raycast/api";
+import type { PveServer } from "@/types";
 
-export function buildHeaders() {
-  const preferences = getPreferenceValues<Preferences>();
+export function buildHeaders(server: PveServer) {
   return {
-    Authorization: `PVEAPIToken=${preferences.tokenId}=${preferences.tokenSecret}`,
+    Authorization: `PVEAPIToken=${server.tokenId}=${server.tokenSecret}`,
   };
 }

--- a/extensions/proxmox/src/utils/mock.ts
+++ b/extensions/proxmox/src/utils/mock.ts
@@ -1,4 +1,4 @@
-import { type PveServer, type PveServerResult, type PveVm, PveVmStatus, PveVmTypes } from "@/types";
+import { type PveServer, type PveServerResult, type PveStorage, type PveVm, PveVmStatus, PveVmTypes } from "@/types";
 
 export const getMockServer = (name: string): PveServer => ({
   id: name,
@@ -14,6 +14,47 @@ export const getMockPveVmResults = (): PveServerResult<PveVm[]>[] => {
   return [
     { server: getMockServer("pve-01"), data: vms.slice(0, 3) },
     { server: getMockServer("pve-02"), data: vms.slice(3) },
+  ];
+};
+
+export const getMockPveStorageResults = (): PveServerResult<PveStorage[]>[] => {
+  const GiB = 1024 * 1024 * 1024;
+  const makeStorage = (
+    node: string,
+    storage: string,
+    plugintype: string,
+    content: string,
+    disk: number,
+    maxdisk: number,
+    shared = 0,
+  ): PveStorage => ({
+    id: `storage/${node}/${storage}`,
+    disk,
+    maxdisk,
+    shared,
+    content,
+    status: "available",
+    plugintype,
+    storage,
+    node,
+  });
+
+  return [
+    {
+      server: getMockServer("pve-01"),
+      data: [
+        makeStorage("pve", "local", "dir", "iso,vztmpl,backup", 19 * GiB, 68 * GiB),
+        makeStorage("pve", "local-lvm", "lvmthin", "images,rootdir", 121 * GiB, 349 * GiB),
+        makeStorage("pve", "backups", "nfs", "backup", 590 * GiB, 2048 * GiB, 1),
+      ],
+    },
+    {
+      server: getMockServer("pve-02"),
+      data: [
+        makeStorage("pve2", "local", "dir", "iso,vztmpl,backup", 9 * GiB, 94 * GiB),
+        makeStorage("pve2", "local-lvm", "lvmthin", "images,rootdir", 87 * GiB, 250 * GiB),
+      ],
+    },
   ];
 };
 

--- a/extensions/proxmox/src/utils/mock.ts
+++ b/extensions/proxmox/src/utils/mock.ts
@@ -1,4 +1,21 @@
-import { type PveVm, PveVmStatus, PveVmTypes } from "@/types";
+import { type PveServer, type PveServerResult, type PveVm, PveVmStatus, PveVmTypes } from "@/types";
+
+export const getMockServer = (name: string): PveServer => ({
+  id: name,
+  name,
+  url: `https://${name}.local:8006`,
+  tokenId: "root@pam!raycast",
+  tokenSecret: "mock-secret",
+});
+
+export const getMockPveVmResults = (): PveServerResult<PveVm[]>[] => {
+  const vms = getMockPveVmData();
+
+  return [
+    { server: getMockServer("pve-01"), data: vms.slice(0, 3) },
+    { server: getMockServer("pve-02"), data: vms.slice(3) },
+  ];
+};
 
 export const getMockPveVmData = (): PveVm[] => {
   const baseVmList = [

--- a/extensions/proxmox/src/utils/servers.ts
+++ b/extensions/proxmox/src/utils/servers.ts
@@ -1,0 +1,106 @@
+import { randomUUID } from "node:crypto";
+import { useCallback, useEffect, useMemo } from "react";
+import { LocalStorage, getPreferenceValues } from "@raycast/api";
+import { usePromise } from "@raycast/utils";
+import type { PveServer } from "@/types";
+
+/** The server configured through the extension preferences, kept for backwards compatibility */
+export const PREFERENCES_SERVER_ID = "preferences";
+
+const SERVERS_STORAGE_KEY = "pve-servers";
+
+// Keeps every mounted useServers() instance in sync when one of them writes
+const changeListeners = new Set<() => void>();
+
+function notifyServersChanged() {
+  for (const listener of changeListeners) {
+    listener();
+  }
+}
+
+async function readStoredServers(): Promise<PveServer[]> {
+  const raw = await LocalStorage.getItem<string>(SERVERS_STORAGE_KEY);
+  if (typeof raw !== "string" || raw === "") {
+    return [];
+  }
+
+  try {
+    const servers = JSON.parse(raw);
+    return Array.isArray(servers) ? servers : [];
+  } catch {
+    return [];
+  }
+}
+
+async function writeStoredServers(servers: PveServer[]) {
+  await LocalStorage.setItem(SERVERS_STORAGE_KEY, JSON.stringify(servers));
+  notifyServersChanged();
+}
+
+export function isPreferencesServer(server: PveServer): boolean {
+  return server.id === PREFERENCES_SERVER_ID;
+}
+
+export function serverNameFromUrl(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
+export function getPreferencesServer(): PveServer | undefined {
+  const { serverUrl, tokenId, tokenSecret } = getPreferenceValues<Preferences>();
+  if (!serverUrl || !tokenId || !tokenSecret) {
+    return undefined;
+  }
+
+  return {
+    id: PREFERENCES_SERVER_ID,
+    name: serverNameFromUrl(serverUrl),
+    url: serverUrl,
+    tokenId,
+    tokenSecret,
+  };
+}
+
+export const useServers = () => {
+  const { data: storedServers, isLoading, revalidate } = usePromise(readStoredServers, []);
+
+  useEffect(() => {
+    changeListeners.add(revalidate);
+    return () => {
+      changeListeners.delete(revalidate);
+    };
+  }, [revalidate]);
+
+  const preferencesServer = useMemo(() => getPreferencesServer(), []);
+
+  const servers = useMemo(() => {
+    const extraServers = storedServers ?? [];
+    return preferencesServer ? [preferencesServer, ...extraServers] : extraServers;
+  }, [preferencesServer, storedServers]);
+
+  const addServer = useCallback(async (server: Omit<PveServer, "id">) => {
+    const current = await readStoredServers();
+    await writeStoredServers([...current, { ...server, id: randomUUID() }]);
+  }, []);
+
+  const updateServer = useCallback(async (server: PveServer) => {
+    const current = await readStoredServers();
+    await writeStoredServers(current.map((item) => (item.id === server.id ? server : item)));
+  }, []);
+
+  const removeServer = useCallback(async (server: PveServer) => {
+    const current = await readStoredServers();
+    await writeStoredServers(current.filter((item) => item.id !== server.id));
+  }, []);
+
+  return {
+    servers,
+    isLoading,
+    addServer,
+    updateServer,
+    removeServer,
+  };
+};

--- a/extensions/proxmox/src/utils/servers.ts
+++ b/extensions/proxmox/src/utils/servers.ts
@@ -36,6 +36,29 @@ async function writeStoredServer(server: StoredServer) {
   await LocalStorage.setItem(storageKey(server.id), JSON.stringify(server));
 }
 
+/**
+ * LocalStorage has no compare-and-swap, so overlapping update/remove of the
+ * same key must run one at a time. Per-server keys already isolate different
+ * servers; this queue only serializes mutations that share an id.
+ */
+const mutationQueues = new Map<string, Promise<unknown>>();
+
+function enqueueServerMutation<T>(id: string, mutation: () => Promise<T>): Promise<T> {
+  const previous = mutationQueues.get(id) ?? Promise.resolve();
+  const result = previous.then(mutation, mutation);
+  const settled = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  mutationQueues.set(id, settled);
+  void settled.then(() => {
+    if (mutationQueues.get(id) === settled) {
+      mutationQueues.delete(id);
+    }
+  });
+  return result;
+}
+
 async function migrateLegacyServers() {
   const raw = await LocalStorage.getItem<string>(LEGACY_SERVERS_KEY);
   if (typeof raw !== "string" || raw === "") {
@@ -148,14 +171,22 @@ export const useServers = () => {
   }, []);
 
   const updateServer = useCallback(async (server: PveServer) => {
-    const stored = await readStoredServer(server.id);
-    await writeStoredServer({ ...server, addedAt: stored?.addedAt ?? Date.now() });
-    notifyServersChanged();
+    await enqueueServerMutation(server.id, async () => {
+      const stored = await readStoredServer(server.id);
+      if (!stored) {
+        throw new Error("This server was removed");
+      }
+
+      await writeStoredServer({ ...server, addedAt: stored.addedAt });
+      notifyServersChanged();
+    });
   }, []);
 
   const removeServer = useCallback(async (server: PveServer) => {
-    await LocalStorage.removeItem(storageKey(server.id));
-    notifyServersChanged();
+    await enqueueServerMutation(server.id, async () => {
+      await LocalStorage.removeItem(storageKey(server.id));
+      notifyServersChanged();
+    });
   }, []);
 
   return {

--- a/extensions/proxmox/src/utils/servers.ts
+++ b/extensions/proxmox/src/utils/servers.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, open, stat, unlink } from "node:fs/promises";
+import { mkdir, open, readFile, stat, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { useCallback, useEffect, useMemo } from "react";
 import { LocalStorage, environment, getPreferenceValues } from "@raycast/api";
@@ -66,11 +66,26 @@ async function withSharedServerLock<T>(id: string, mutation: () => Promise<T>): 
   while (Date.now() < deadline) {
     try {
       const handle = await open(path, "wx");
+      const ownerToken = randomUUID();
+      let heartbeat: ReturnType<typeof setInterval> | undefined;
       try {
+        await handle.writeFile(ownerToken);
+        heartbeat = setInterval(() => {
+          void handle.utimes(new Date(), new Date()).catch(() => undefined);
+        }, LOCK_STALE_MS / 2);
         return await mutation();
       } finally {
+        if (heartbeat) {
+          clearInterval(heartbeat);
+        }
         await handle.close().catch(() => undefined);
-        await unlink(path).catch(() => undefined);
+        try {
+          if ((await readFile(path, "utf8")) === ownerToken) {
+            await unlink(path);
+          }
+        } catch {
+          // The lock may have been replaced after this owner went stale.
+        }
       }
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
@@ -147,7 +162,8 @@ async function migrateLegacyServers() {
         const seenIds = new Set<string>();
         const writes: Promise<void>[] = [];
         // The index keeps the order the servers were originally added in
-        for (const [index, server] of legacyServers.entries()) {
+        for (let index = 0; index < legacyServers.length; index += 1) {
+          const server = legacyServers[index];
           if (typeof server?.id !== "string" || seenIds.has(server.id)) {
             continue;
           }

--- a/extensions/proxmox/src/utils/servers.ts
+++ b/extensions/proxmox/src/utils/servers.ts
@@ -41,7 +41,8 @@ async function writeStoredServer(server: StoredServer) {
 /**
  * Command instances do not share module state, and LocalStorage has no CAS, so
  * overlapping update/remove of one server is coordinated with an exclusive
- * lock file under the extension support path.
+ * lock file under the extension support path. Legacy migration writes those
+ * same keys and must take the same per-server lock.
  */
 const LOCK_DIR = "server-locks";
 const LOCK_STALE_MS = 8_000;
@@ -95,6 +96,37 @@ async function withSharedServerLock<T>(id: string, mutation: () => Promise<T>): 
   throw new Error("Timed out waiting to update this server");
 }
 
+async function readStoredServer(id: string): Promise<StoredServer | undefined> {
+  const raw = await LocalStorage.getItem<string>(storageKey(id));
+  if (typeof raw !== "string" || raw === "") {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(raw) as StoredServer;
+  } catch {
+    return undefined;
+  }
+}
+
+async function writeLegacyServerUnlessMutated(server: StoredServer) {
+  await withSharedServerLock(server.id, async () => {
+    if (await readStoredServer(server.id)) {
+      // Keep a concurrent edit, or a value written by a previous partial migration
+      return;
+    }
+
+    // Another instance already finished migrating; a missing key is then a
+    // concurrent removal, not an unmigrated server.
+    const legacy = await LocalStorage.getItem<string>(LEGACY_SERVERS_KEY);
+    if (typeof legacy !== "string" || legacy === "") {
+      return;
+    }
+
+    await writeStoredServer(server);
+  });
+}
+
 async function migrateLegacyServers() {
   const raw = await LocalStorage.getItem<string>(LEGACY_SERVERS_KEY);
   if (typeof raw !== "string" || raw === "") {
@@ -112,12 +144,17 @@ async function migrateLegacyServers() {
     try {
       const legacyServers = JSON.parse(lockedRaw);
       if (Array.isArray(legacyServers)) {
+        const seenIds = new Set<string>();
+        const writes: Promise<void>[] = [];
         // The index keeps the order the servers were originally added in
-        await Promise.all(
-          legacyServers
-            .filter((server) => typeof server?.id === "string")
-            .map((server, index) => writeStoredServer({ ...server, addedAt: index })),
-        );
+        for (const [index, server] of legacyServers.entries()) {
+          if (typeof server?.id !== "string" || seenIds.has(server.id)) {
+            continue;
+          }
+          seenIds.add(server.id);
+          writes.push(writeLegacyServerUnlessMutated({ ...server, addedAt: index }));
+        }
+        await Promise.all(writes);
       }
     } catch {
       // Drop an unreadable legacy value instead of failing every read
@@ -151,19 +188,6 @@ async function readStoredServers(): Promise<PveServer[]> {
   return storedServers
     .sort((a, b) => (a.addedAt ?? 0) - (b.addedAt ?? 0))
     .map(({ id, name, url, tokenId, tokenSecret }) => ({ id, name, url, tokenId, tokenSecret }));
-}
-
-async function readStoredServer(id: string): Promise<StoredServer | undefined> {
-  const raw = await LocalStorage.getItem<string>(storageKey(id));
-  if (typeof raw !== "string" || raw === "") {
-    return undefined;
-  }
-
-  try {
-    return JSON.parse(raw) as StoredServer;
-  } catch {
-    return undefined;
-  }
 }
 
 export function isPreferencesServer(server: PveServer): boolean {
@@ -216,6 +240,9 @@ export const useServers = () => {
   }, []);
 
   const updateServer = useCallback(async (server: PveServer) => {
+    // Finish migrating first so this lock and the migration writes use the
+    // same order (legacy lock, then per-server lock) and cannot deadlock.
+    await migrateLegacyServers();
     await withSharedServerLock(server.id, async () => {
       const stored = await readStoredServer(server.id);
       if (!stored) {
@@ -228,6 +255,7 @@ export const useServers = () => {
   }, []);
 
   const removeServer = useCallback(async (server: PveServer) => {
+    await migrateLegacyServers();
     await withSharedServerLock(server.id, async () => {
       await LocalStorage.removeItem(storageKey(server.id));
       notifyServersChanged();

--- a/extensions/proxmox/src/utils/servers.ts
+++ b/extensions/proxmox/src/utils/servers.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, open, readdir, rm, rmdir, stat, unlink } from "node:fs/promises";
+import { mkdir, open, readdir, rmdir, stat, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { useCallback, useEffect, useMemo } from "react";
 import { LocalStorage, environment, getPreferenceValues } from "@raycast/api";
@@ -44,9 +44,10 @@ async function writeStoredServer(server: StoredServer) {
  * lock directory under the extension support path. Legacy migration writes those
  * same keys and must take the same per-server lock.
  *
- * The lock is a directory plus a uniquely named token file. Release only unlinks
- * that token and rmdirs if empty, so a stale owner cannot delete a replacement
- * command's lock between a content check and unlink.
+ * The lock is a directory plus a uniquely named token file. Release and stale
+ * reclaim only unlink tokens they own or that are still stale, then rmdir if
+ * empty, so neither a finishing owner nor a delayed reclaim can delete a
+ * replacement command's lock.
  */
 const LOCK_DIR = "server-locks";
 const LOCK_STALE_MS = 8_000;
@@ -104,6 +105,51 @@ async function newestLockActivity(lockPath: string): Promise<number | undefined>
   return newest;
 }
 
+async function reclaimStaleLock(lockPath: string): Promise<void> {
+  let info;
+  try {
+    info = await stat(lockPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+
+  if (!info.isDirectory()) {
+    await unlink(lockPath).catch(() => undefined);
+    return;
+  }
+
+  let entries: string[];
+  try {
+    entries = await readdir(lockPath);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") {
+      return;
+    }
+    throw error;
+  }
+
+  for (const entry of entries) {
+    const tokenPath = join(lockPath, entry);
+    try {
+      const { mtimeMs } = await stat(tokenPath);
+      if (Date.now() - mtimeMs > LOCK_STALE_MS) {
+        await unlink(tokenPath);
+      }
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT" && code !== "EPERM" && code !== "EISDIR") {
+        throw error;
+      }
+    }
+  }
+
+  await rmdir(lockPath).catch(() => undefined);
+}
+
 async function withSharedServerLock<T>(id: string, mutation: () => Promise<T>): Promise<T> {
   await mkdir(join(environment.supportPath, LOCK_DIR), { recursive: true });
   const lockPath = serverLockPath(id);
@@ -125,7 +171,7 @@ async function withSharedServerLock<T>(id: string, mutation: () => Promise<T>): 
           continue;
         }
         if (Date.now() - mtimeMs > LOCK_STALE_MS) {
-          await rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
+          await reclaimStaleLock(lockPath);
           continue;
         }
       } catch (statError) {

--- a/extensions/proxmox/src/utils/servers.ts
+++ b/extensions/proxmox/src/utils/servers.ts
@@ -88,11 +88,9 @@ async function newestLockActivity(lockPath: string): Promise<number | undefined>
     throw error;
   }
 
-  if (entries.length === 0) {
-    return 0;
-  }
-
-  let newest = 0;
+  // Seed with the directory mtime so the window between mkdir and the token
+  // file is not treated as immediately stale (mtime 0 is the Unix epoch).
+  let newest = info.mtimeMs;
   for (const entry of entries) {
     try {
       const { mtimeMs } = await stat(join(lockPath, entry));

--- a/extensions/proxmox/src/utils/servers.ts
+++ b/extensions/proxmox/src/utils/servers.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, open, readFile, stat, unlink } from "node:fs/promises";
+import { mkdir, open, readdir, rm, rmdir, stat, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { useCallback, useEffect, useMemo } from "react";
 import { LocalStorage, environment, getPreferenceValues } from "@raycast/api";
@@ -41,8 +41,12 @@ async function writeStoredServer(server: StoredServer) {
 /**
  * Command instances do not share module state, and LocalStorage has no CAS, so
  * overlapping update/remove of one server is coordinated with an exclusive
- * lock file under the extension support path. Legacy migration writes those
+ * lock directory under the extension support path. Legacy migration writes those
  * same keys and must take the same per-server lock.
+ *
+ * The lock is a directory plus a uniquely named token file. Release only unlinks
+ * that token and rmdirs if empty, so a stale owner cannot delete a replacement
+ * command's lock between a content check and unlink.
  */
 const LOCK_DIR = "server-locks";
 const LOCK_STALE_MS = 8_000;
@@ -58,16 +62,87 @@ function serverLockPath(id: string): string {
   return join(environment.supportPath, LOCK_DIR, `${safeId}.lock`);
 }
 
+async function newestLockActivity(lockPath: string): Promise<number | undefined> {
+  let info;
+  try {
+    info = await stat(lockPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+
+  if (!info.isDirectory()) {
+    return info.mtimeMs;
+  }
+
+  let entries: string[];
+  try {
+    entries = await readdir(lockPath);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") {
+      return undefined;
+    }
+    throw error;
+  }
+
+  if (entries.length === 0) {
+    return 0;
+  }
+
+  let newest = 0;
+  for (const entry of entries) {
+    try {
+      const { mtimeMs } = await stat(join(lockPath, entry));
+      newest = Math.max(newest, mtimeMs);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+  return newest;
+}
+
 async function withSharedServerLock<T>(id: string, mutation: () => Promise<T>): Promise<T> {
   await mkdir(join(environment.supportPath, LOCK_DIR), { recursive: true });
-  const path = serverLockPath(id);
+  const lockPath = serverLockPath(id);
   const deadline = Date.now() + LOCK_WAIT_MS;
+  const ownerToken = randomUUID();
+  const tokenPath = join(lockPath, ownerToken);
 
   while (Date.now() < deadline) {
     try {
-      const handle = await open(path, "wx");
-      const ownerToken = randomUUID();
-      let heartbeat: ReturnType<typeof setInterval> | undefined;
+      await mkdir(lockPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw error;
+      }
+
+      try {
+        const mtimeMs = await newestLockActivity(lockPath);
+        if (mtimeMs === undefined) {
+          continue;
+        }
+        if (Date.now() - mtimeMs > LOCK_STALE_MS) {
+          await rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
+          continue;
+        }
+      } catch (statError) {
+        if ((statError as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw statError;
+        }
+      }
+
+      await sleep(20 + Math.random() * 40);
+      continue;
+    }
+
+    let heartbeat: ReturnType<typeof setInterval> | undefined;
+    try {
+      const handle = await open(tokenPath, "wx");
       try {
         await handle.writeFile(ownerToken);
         heartbeat = setInterval(() => {
@@ -79,32 +154,15 @@ async function withSharedServerLock<T>(id: string, mutation: () => Promise<T>): 
           clearInterval(heartbeat);
         }
         await handle.close().catch(() => undefined);
-        try {
-          if ((await readFile(path, "utf8")) === ownerToken) {
-            await unlink(path);
-          }
-        } catch {
-          // The lock may have been replaced after this owner went stale.
-        }
+        await unlink(tokenPath).catch(() => undefined);
       }
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
-        throw error;
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        continue;
       }
-
-      try {
-        const { mtimeMs } = await stat(path);
-        if (Date.now() - mtimeMs > LOCK_STALE_MS) {
-          await unlink(path).catch(() => undefined);
-          continue;
-        }
-      } catch (statError) {
-        if ((statError as NodeJS.ErrnoException).code !== "ENOENT") {
-          throw statError;
-        }
-      }
-
-      await sleep(20 + Math.random() * 40);
+      throw error;
+    } finally {
+      await rmdir(lockPath).catch(() => undefined);
     }
   }
 

--- a/extensions/proxmox/src/utils/servers.ts
+++ b/extensions/proxmox/src/utils/servers.ts
@@ -7,7 +7,17 @@ import type { PveServer } from "@/types";
 /** The server configured through the extension preferences, kept for backwards compatibility */
 export const PREFERENCES_SERVER_ID = "preferences";
 
-const SERVERS_STORAGE_KEY = "pve-servers";
+/**
+ * Every server is stored under its own key, so adding, editing or removing one
+ * never rewrites the entries of the others.
+ */
+const SERVER_KEY_PREFIX = "pve-server:";
+
+/** Servers used to be stored as a single array, migrated on the first read */
+const LEGACY_SERVERS_KEY = "pve-servers";
+
+/** `addedAt` only exists to keep the list in a stable order */
+type StoredServer = PveServer & { addedAt: number };
 
 // Keeps every mounted useServers() instance in sync when one of them writes
 const changeListeners = new Set<() => void>();
@@ -18,32 +28,74 @@ function notifyServersChanged() {
   }
 }
 
-async function readStoredServers(): Promise<PveServer[]> {
-  const raw = await LocalStorage.getItem<string>(SERVERS_STORAGE_KEY);
+function storageKey(id: string): string {
+  return `${SERVER_KEY_PREFIX}${id}`;
+}
+
+async function writeStoredServer(server: StoredServer) {
+  await LocalStorage.setItem(storageKey(server.id), JSON.stringify(server));
+}
+
+async function migrateLegacyServers() {
+  const raw = await LocalStorage.getItem<string>(LEGACY_SERVERS_KEY);
   if (typeof raw !== "string" || raw === "") {
-    return [];
+    return;
   }
 
   try {
-    const servers = JSON.parse(raw);
-    return Array.isArray(servers) ? servers : [];
+    const legacyServers = JSON.parse(raw);
+    if (Array.isArray(legacyServers)) {
+      // The index keeps the order the servers were originally added in
+      await Promise.all(
+        legacyServers
+          .filter((server) => typeof server?.id === "string")
+          .map((server, index) => writeStoredServer({ ...server, addedAt: index })),
+      );
+    }
   } catch {
-    return [];
+    // Drop an unreadable legacy value instead of failing every read
   }
+
+  await LocalStorage.removeItem(LEGACY_SERVERS_KEY);
 }
 
-async function writeStoredServers(servers: PveServer[]) {
-  await LocalStorage.setItem(SERVERS_STORAGE_KEY, JSON.stringify(servers));
-  notifyServersChanged();
+async function readStoredServers(): Promise<PveServer[]> {
+  await migrateLegacyServers();
+
+  const items = await LocalStorage.allItems();
+  const storedServers: StoredServer[] = [];
+
+  for (const [key, value] of Object.entries(items)) {
+    if (!key.startsWith(SERVER_KEY_PREFIX) || typeof value !== "string") {
+      continue;
+    }
+
+    try {
+      const server = JSON.parse(value) as StoredServer;
+      if (typeof server?.id === "string") {
+        storedServers.push(server);
+      }
+    } catch {
+      // Skip a corrupted entry, the other servers still work
+    }
+  }
+
+  return storedServers
+    .sort((a, b) => (a.addedAt ?? 0) - (b.addedAt ?? 0))
+    .map(({ id, name, url, tokenId, tokenSecret }) => ({ id, name, url, tokenId, tokenSecret }));
 }
 
-// Serializes read-modify-write mutations so overlapping ones cannot lose changes
-let mutationQueue: Promise<unknown> = Promise.resolve();
+async function readStoredServer(id: string): Promise<StoredServer | undefined> {
+  const raw = await LocalStorage.getItem<string>(storageKey(id));
+  if (typeof raw !== "string" || raw === "") {
+    return undefined;
+  }
 
-function enqueueMutation<T>(mutation: () => Promise<T>): Promise<T> {
-  const result = mutationQueue.then(mutation, mutation);
-  mutationQueue = result.catch(() => undefined);
-  return result;
+  try {
+    return JSON.parse(raw) as StoredServer;
+  } catch {
+    return undefined;
+  }
 }
 
 export function isPreferencesServer(server: PveServer): boolean {
@@ -91,24 +143,19 @@ export const useServers = () => {
   }, [preferencesServer, storedServers]);
 
   const addServer = useCallback(async (server: Omit<PveServer, "id">) => {
-    await enqueueMutation(async () => {
-      const current = await readStoredServers();
-      await writeStoredServers([...current, { ...server, id: randomUUID() }]);
-    });
+    await writeStoredServer({ ...server, id: randomUUID(), addedAt: Date.now() });
+    notifyServersChanged();
   }, []);
 
   const updateServer = useCallback(async (server: PveServer) => {
-    await enqueueMutation(async () => {
-      const current = await readStoredServers();
-      await writeStoredServers(current.map((item) => (item.id === server.id ? server : item)));
-    });
+    const stored = await readStoredServer(server.id);
+    await writeStoredServer({ ...server, addedAt: stored?.addedAt ?? Date.now() });
+    notifyServersChanged();
   }, []);
 
   const removeServer = useCallback(async (server: PveServer) => {
-    await enqueueMutation(async () => {
-      const current = await readStoredServers();
-      await writeStoredServers(current.filter((item) => item.id !== server.id));
-    });
+    await LocalStorage.removeItem(storageKey(server.id));
+    notifyServersChanged();
   }, []);
 
   return {

--- a/extensions/proxmox/src/utils/servers.ts
+++ b/extensions/proxmox/src/utils/servers.ts
@@ -46,6 +46,7 @@ async function writeStoredServer(server: StoredServer) {
 const LOCK_DIR = "server-locks";
 const LOCK_STALE_MS = 8_000;
 const LOCK_WAIT_MS = 5_000;
+const LEGACY_MIGRATION_LOCK_ID = "legacy-migration";
 
 function sleep(ms: number) {
   return new Promise<void>((resolve) => setTimeout(resolve, ms));
@@ -100,21 +101,30 @@ async function migrateLegacyServers() {
     return;
   }
 
-  try {
-    const legacyServers = JSON.parse(raw);
-    if (Array.isArray(legacyServers)) {
-      // The index keeps the order the servers were originally added in
-      await Promise.all(
-        legacyServers
-          .filter((server) => typeof server?.id === "string")
-          .map((server, index) => writeStoredServer({ ...server, addedAt: index })),
-      );
+  // Re-read under the lock: another instance may have already migrated, and
+  // the user may have edited or removed a server, since the check above.
+  await withSharedServerLock(LEGACY_MIGRATION_LOCK_ID, async () => {
+    const lockedRaw = await LocalStorage.getItem<string>(LEGACY_SERVERS_KEY);
+    if (typeof lockedRaw !== "string" || lockedRaw === "") {
+      return;
     }
-  } catch {
-    // Drop an unreadable legacy value instead of failing every read
-  }
 
-  await LocalStorage.removeItem(LEGACY_SERVERS_KEY);
+    try {
+      const legacyServers = JSON.parse(lockedRaw);
+      if (Array.isArray(legacyServers)) {
+        // The index keeps the order the servers were originally added in
+        await Promise.all(
+          legacyServers
+            .filter((server) => typeof server?.id === "string")
+            .map((server, index) => writeStoredServer({ ...server, addedAt: index })),
+        );
+      }
+    } catch {
+      // Drop an unreadable legacy value instead of failing every read
+    }
+
+    await LocalStorage.removeItem(LEGACY_SERVERS_KEY);
+  });
 }
 
 async function readStoredServers(): Promise<PveServer[]> {

--- a/extensions/proxmox/src/utils/servers.ts
+++ b/extensions/proxmox/src/utils/servers.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto";
+import { mkdir, open, stat, unlink } from "node:fs/promises";
+import { join } from "node:path";
 import { useCallback, useEffect, useMemo } from "react";
-import { LocalStorage, getPreferenceValues } from "@raycast/api";
+import { LocalStorage, environment, getPreferenceValues } from "@raycast/api";
 import { usePromise } from "@raycast/utils";
 import type { PveServer } from "@/types";
 
@@ -37,26 +39,59 @@ async function writeStoredServer(server: StoredServer) {
 }
 
 /**
- * LocalStorage has no compare-and-swap, so overlapping update/remove of the
- * same key must run one at a time. Per-server keys already isolate different
- * servers; this queue only serializes mutations that share an id.
+ * Command instances do not share module state, and LocalStorage has no CAS, so
+ * overlapping update/remove of one server is coordinated with an exclusive
+ * lock file under the extension support path.
  */
-const mutationQueues = new Map<string, Promise<unknown>>();
+const LOCK_DIR = "server-locks";
+const LOCK_STALE_MS = 8_000;
+const LOCK_WAIT_MS = 5_000;
 
-function enqueueServerMutation<T>(id: string, mutation: () => Promise<T>): Promise<T> {
-  const previous = mutationQueues.get(id) ?? Promise.resolve();
-  const result = previous.then(mutation, mutation);
-  const settled = result.then(
-    () => undefined,
-    () => undefined,
-  );
-  mutationQueues.set(id, settled);
-  void settled.then(() => {
-    if (mutationQueues.get(id) === settled) {
-      mutationQueues.delete(id);
+function sleep(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+function serverLockPath(id: string): string {
+  const safeId = id.replace(/[^a-zA-Z0-9._-]/g, "_");
+  return join(environment.supportPath, LOCK_DIR, `${safeId}.lock`);
+}
+
+async function withSharedServerLock<T>(id: string, mutation: () => Promise<T>): Promise<T> {
+  await mkdir(join(environment.supportPath, LOCK_DIR), { recursive: true });
+  const path = serverLockPath(id);
+  const deadline = Date.now() + LOCK_WAIT_MS;
+
+  while (Date.now() < deadline) {
+    try {
+      const handle = await open(path, "wx");
+      try {
+        return await mutation();
+      } finally {
+        await handle.close().catch(() => undefined);
+        await unlink(path).catch(() => undefined);
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw error;
+      }
+
+      try {
+        const { mtimeMs } = await stat(path);
+        if (Date.now() - mtimeMs > LOCK_STALE_MS) {
+          await unlink(path).catch(() => undefined);
+          continue;
+        }
+      } catch (statError) {
+        if ((statError as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw statError;
+        }
+      }
+
+      await sleep(20 + Math.random() * 40);
     }
-  });
-  return result;
+  }
+
+  throw new Error("Timed out waiting to update this server");
 }
 
 async function migrateLegacyServers() {
@@ -171,7 +206,7 @@ export const useServers = () => {
   }, []);
 
   const updateServer = useCallback(async (server: PveServer) => {
-    await enqueueServerMutation(server.id, async () => {
+    await withSharedServerLock(server.id, async () => {
       const stored = await readStoredServer(server.id);
       if (!stored) {
         throw new Error("This server was removed");
@@ -183,7 +218,7 @@ export const useServers = () => {
   }, []);
 
   const removeServer = useCallback(async (server: PveServer) => {
-    await enqueueServerMutation(server.id, async () => {
+    await withSharedServerLock(server.id, async () => {
       await LocalStorage.removeItem(storageKey(server.id));
       notifyServersChanged();
     });

--- a/extensions/proxmox/src/utils/servers.ts
+++ b/extensions/proxmox/src/utils/servers.ts
@@ -37,6 +37,15 @@ async function writeStoredServers(servers: PveServer[]) {
   notifyServersChanged();
 }
 
+// Serializes read-modify-write mutations so overlapping ones cannot lose changes
+let mutationQueue: Promise<unknown> = Promise.resolve();
+
+function enqueueMutation<T>(mutation: () => Promise<T>): Promise<T> {
+  const result = mutationQueue.then(mutation, mutation);
+  mutationQueue = result.catch(() => undefined);
+  return result;
+}
+
 export function isPreferencesServer(server: PveServer): boolean {
   return server.id === PREFERENCES_SERVER_ID;
 }
@@ -82,18 +91,24 @@ export const useServers = () => {
   }, [preferencesServer, storedServers]);
 
   const addServer = useCallback(async (server: Omit<PveServer, "id">) => {
-    const current = await readStoredServers();
-    await writeStoredServers([...current, { ...server, id: randomUUID() }]);
+    await enqueueMutation(async () => {
+      const current = await readStoredServers();
+      await writeStoredServers([...current, { ...server, id: randomUUID() }]);
+    });
   }, []);
 
   const updateServer = useCallback(async (server: PveServer) => {
-    const current = await readStoredServers();
-    await writeStoredServers(current.map((item) => (item.id === server.id ? server : item)));
+    await enqueueMutation(async () => {
+      const current = await readStoredServers();
+      await writeStoredServers(current.map((item) => (item.id === server.id ? server : item)));
+    });
   }, []);
 
   const removeServer = useCallback(async (server: PveServer) => {
-    const current = await readStoredServers();
-    await writeStoredServers(current.filter((item) => item.id !== server.id));
+    await enqueueMutation(async () => {
+      const current = await readStoredServers();
+      await writeStoredServers(current.filter((item) => item.id !== server.id));
+    });
   }, []);
 
   return {

--- a/extensions/proxmox/src/utils/servers.ts
+++ b/extensions/proxmox/src/utils/servers.ts
@@ -258,24 +258,34 @@ async function migrateLegacyServers() {
       return;
     }
 
+    let legacyServers: StoredServer[];
     try {
-      const legacyServers = JSON.parse(lockedRaw);
-      if (Array.isArray(legacyServers)) {
-        const seenIds = new Set<string>();
-        const writes: Promise<void>[] = [];
-        // The index keeps the order the servers were originally added in
-        for (let index = 0; index < legacyServers.length; index += 1) {
-          const server = legacyServers[index];
-          if (typeof server?.id !== "string" || seenIds.has(server.id)) {
-            continue;
-          }
-          seenIds.add(server.id);
-          writes.push(writeLegacyServerUnlessMutated({ ...server, addedAt: index }));
-        }
-        await Promise.all(writes);
-      }
+      const parsed = JSON.parse(lockedRaw);
+      legacyServers = Array.isArray(parsed) ? (parsed as StoredServer[]) : [];
     } catch {
       // Drop an unreadable legacy value instead of failing every read
+      await LocalStorage.removeItem(LEGACY_SERVERS_KEY);
+      return;
+    }
+
+    const seenIds = new Set<string>();
+    const writes: Promise<void>[] = [];
+    // The index keeps the order the servers were originally added in
+    for (let index = 0; index < legacyServers.length; index += 1) {
+      const server = legacyServers[index];
+      if (typeof server?.id !== "string" || seenIds.has(server.id)) {
+        continue;
+      }
+      seenIds.add(server.id);
+      writes.push(writeLegacyServerUnlessMutated({ ...server, addedAt: index }));
+    }
+
+    try {
+      await Promise.all(writes);
+    } catch {
+      // A write failed, so keep the legacy value and migrate again on the next
+      // read instead of dropping the servers it could not write
+      return;
     }
 
     await LocalStorage.removeItem(LEGACY_SERVERS_KEY);

--- a/extensions/proxmox/tsconfig.json
+++ b/extensions/proxmox/tsconfig.json
@@ -1,13 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "include": [
-    "src/**/*",
-    "raycast-env.d.ts",
-  ],
+  "include": ["src/**/*", "raycast-env.d.ts"],
   "compilerOptions": {
-    "lib": [
-      "ES2023"
-    ],
+    "lib": ["ES2023"],
     "module": "commonjs",
     "target": "ES2023",
     "strict": true,
@@ -19,9 +14,7 @@
     "resolveJsonModule": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": [
-        "src/*"
-      ]
+      "@/*": ["src/*"]
     }
   }
 }


### PR DESCRIPTION
## Description

Fixes #27260

Adds support for multiple Proxmox servers:

- New `Manage Servers` command to add, edit or remove servers. Additional servers are stored in `LocalStorage`; the connection is verified on save (with the option to save anyway).
- The existing preferences keep working unchanged as the first server. They are now optional instead of required, so nothing changes for current users and no migration is needed.
- `Manage VMs` and `Manage Storage` fetch all configured servers and group the results into one section per server (single-server setups look exactly as before). An unreachable server shows a per-server error row instead of hiding the other servers' results.
- VM actions and `Open Dashboard` use the server of the row they are triggered on.

Two small fixes that came out of this:

- Fetch errors now surface `error.cause` (e.g. TLS or DNS problems) instead of Node's generic "fetch failed".
- `pveFetch` now checks `response.ok` — before, a failed VM action (e.g. missing token permission) showed a success toast.

Note for review: token secrets of additional servers live in `LocalStorage` (the preference-based server keeps using the encrypted `password` preference). Happy to change this if there is a preferred pattern for multi-instance credentials.

Tested against three Proxmox VE 9 servers (one cluster + two standalone nodes) on macOS.

## Screencast

Mock data, two servers configured:

| Manage VMs | Manage Storage |
|---|---|
| ![Manage VMs with two servers](https://raw.githubusercontent.com/kzaoaai/extensions/proxmox-pr-screenshots/manage-vms.png) | ![Manage Storage with two servers](https://raw.githubusercontent.com/kzaoaai/extensions/proxmox-pr-screenshots/manage-storage.png) |

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
