### PR TITLE
[GitHub] Add native pagination to lists

### DIFF
--- a/extensions/github/CHANGELOG.md
+++ b/extensions/github/CHANGELOG.md
@@ -29,6 +29,11 @@
 - README: added a **Cloning and Downloading Repositories** section describing when to use each flow.
 - Normalized action titles to Title Case (`Enable Auto-Merge`, `Re-Run Workflow`, `Sort by`).
 
+## [Load GitHub lists incrementally] - 2026-08-10
+
+- Added native pagination to repository, issue, pull request, discussion, release, notification, workflow run, and commit lists so initial results render sooner and later pages load on demand.
+- Limited GraphQL page sizes to 25 items while honoring smaller configured limits to reduce large-request failures.
+
 ## [Show CI status in pull request details] - 2026-08-10
 
 - Added a "Checks" row to pull request details showing successful, failed, or pending CI status.

--- a/extensions/github/package.json
+++ b/extensions/github/package.json
@@ -47,7 +47,8 @@
     "wonbywondev",
     "SandeepBaskaran",
     "0xdhrv",
-    "ernest0n"
+    "ernest0n",
+    "raycast_0ukl"
   ],
   "pastContributors": [
     "Lemon",
@@ -1051,8 +1052,8 @@
       "name": "numberOfResults",
       "type": "textfield",
       "required": false,
-      "title": "Number of search results",
-      "description": "For searching repositories, issues, discussions or pull requests, this is the number of results to request. Less will be faster.",
+      "title": "Search Results per Page",
+      "description": "For repository, issue, discussion, or pull request searches, this is the number of results requested per page. Fewer results per page will load faster.",
       "placeholder": "25"
     },
     {

--- a/extensions/github/src/api/pullRequest.graphql
+++ b/extensions/github/src/api/pullRequest.graphql
@@ -243,7 +243,7 @@ query repositoryProjectsForPullRequests($owner: String!, $name: String!, $pullRe
 }
 
 fragment PullRequestCommitFields on PullRequest {
-  commits(last: 100) {
+  commits(last: $numberOfItems, before: $before) {
     totalCount
     nodes {
       commit {
@@ -263,10 +263,14 @@ fragment PullRequestCommitFields on PullRequest {
         treeUrl
       }
     }
+    pageInfo {
+      hasPreviousPage
+      startCursor
+    }
   }
 }
 
-query pullRequestCommits($nodeId: ID!) {
+query pullRequestCommits($nodeId: ID!, $numberOfItems: Int!, $before: String) {
   node(id: $nodeId) {
     ...PullRequestCommitFields
   }

--- a/extensions/github/src/api/repository.graphql
+++ b/extensions/github/src/api/repository.graphql
@@ -55,13 +55,22 @@ query searchRepositories($query: String!, $numberOfItems: Int!, $after: String) 
 
 query myLatestRepositories(
   $numberOfItems: Int!
+  $after: String
   $orderByField: RepositoryOrderField!
   $orderByDirection: OrderDirection!
 ) {
   viewer {
-    repositories(first: $numberOfItems, orderBy: { field: $orderByField, direction: $orderByDirection }) {
+    repositories(
+      first: $numberOfItems
+      after: $after
+      orderBy: { field: $orderByField, direction: $orderByDirection }
+    ) {
       nodes {
         ...ExtendedRepositoryFields
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
       }
     }
   }

--- a/extensions/github/src/components/IssueActions.tsx
+++ b/extensions/github/src/components/IssueActions.tsx
@@ -20,10 +20,10 @@ import {
   IssueFieldsFragment,
   UserFieldsFragment,
 } from "../generated/graphql";
+import { RevalidateList } from "../helpers";
 import { getErrorMessage } from "../helpers/errors";
 import { ISSUE_SORT_TYPES_TO_QUERIES } from "../helpers/issue";
 import { getGitHubUser } from "../helpers/users";
-import { useMyIssues } from "../hooks/useMyIssues";
 import { useViewer } from "../hooks/useViewer";
 
 import { SortAction, SortActionProps } from "./SortAction";
@@ -33,7 +33,7 @@ type Issue = IssueFieldsFragment | IssueDetailFieldsFragment;
 type IssueActionsProps = {
   issue: Issue;
   viewer?: UserFieldsFragment;
-  mutateList?: MutatePromise<IssueFieldsFragment[] | undefined> | ReturnType<typeof useMyIssues>["mutate"];
+  mutateList?: RevalidateList;
   mutateDetail?: MutatePromise<Issue>;
   children?: React.ReactNode;
 };

--- a/extensions/github/src/components/IssueDetail.tsx
+++ b/extensions/github/src/components/IssueDetail.tsx
@@ -1,13 +1,12 @@
 import { Color, Detail } from "@raycast/api";
-import { MutatePromise, useCachedPromise } from "@raycast/utils";
+import { useCachedPromise } from "@raycast/utils";
 import { format } from "date-fns";
 
 import { getGitHubClient } from "../api/githubClient";
 import { IssueDetailFieldsFragment, IssueFieldsFragment, UserFieldsFragment } from "../generated/graphql";
-import { pluralize } from "../helpers";
+import { pluralize, RevalidateList } from "../helpers";
 import { getIssueAuthor, getIssueStatus } from "../helpers/issue";
 import { getGitHubUser } from "../helpers/users";
-import { useMyIssues } from "../hooks/useMyIssues";
 import { useViewer } from "../hooks/useViewer";
 
 import IssueActions from "./IssueActions";
@@ -15,7 +14,7 @@ import IssueActions from "./IssueActions";
 type IssueDetailProps = {
   initialIssue: IssueFieldsFragment;
   viewer?: UserFieldsFragment;
-  mutateList?: MutatePromise<IssueFieldsFragment[] | undefined> | ReturnType<typeof useMyIssues>["mutate"];
+  mutateList?: RevalidateList;
 };
 
 export default function IssueDetail({ initialIssue, mutateList }: IssueDetailProps) {

--- a/extensions/github/src/components/IssueListItem.tsx
+++ b/extensions/github/src/components/IssueListItem.tsx
@@ -1,10 +1,9 @@
 import { Action, Color, Icon, List } from "@raycast/api";
-import { MutatePromise } from "@raycast/utils";
 import { format } from "date-fns";
 
 import { IssueFieldsFragment, UserFieldsFragment } from "../generated/graphql";
+import { RevalidateList } from "../helpers";
 import { getIssueAuthor, getIssueStatus } from "../helpers/issue";
-import { useMyIssues } from "../hooks/useMyIssues";
 
 import IssueActions from "./IssueActions";
 import IssueDetail from "./IssueDetail";
@@ -13,7 +12,7 @@ import { SortActionProps } from "./SortAction";
 type IssueListItemProps = {
   issue: IssueFieldsFragment;
   viewer?: UserFieldsFragment;
-  mutateList: MutatePromise<IssueFieldsFragment[] | undefined> | ReturnType<typeof useMyIssues>["mutate"];
+  mutateList: RevalidateList;
 };
 
 export default function IssueListItem({

--- a/extensions/github/src/components/Menu.tsx
+++ b/extensions/github/src/components/Menu.tsx
@@ -162,3 +162,7 @@ export function getBoundedPreferenceNumber(params: {
   }
   return max;
 }
+
+export function getSearchPageSize(): number {
+  return Math.min(getBoundedPreferenceNumber({ name: "numberOfResults", default: 50 }), 25);
+}

--- a/extensions/github/src/components/NotificationActions.tsx
+++ b/extensions/github/src/components/NotificationActions.tsx
@@ -1,7 +1,8 @@
 import { Action, ActionPanel, Icon, LaunchType, Toast, launchCommand, open, showToast, Keyboard } from "@raycast/api";
-import { MutatePromise, usePromise } from "@raycast/utils";
+import { usePromise } from "@raycast/utils";
 
 import { getGitHubClient } from "../api/githubClient";
+import { RevalidateList } from "../helpers";
 import { getErrorMessage } from "../helpers/errors";
 import { getGitHubURL, getNotificationSubtitle, getNotificationTypeTitle } from "../helpers/notifications";
 import { NotificationWithIcon } from "../notifications";
@@ -9,7 +10,7 @@ import { NotificationWithIcon } from "../notifications";
 type NotificationActionsProps = {
   notification: NotificationWithIcon;
   userId?: string;
-  mutateList: MutatePromise<NotificationWithIcon[] | undefined> | MutatePromise<NotificationWithIcon[]>;
+  mutateList: RevalidateList;
 };
 
 export default function NotificationActions({ notification, userId, mutateList }: NotificationActionsProps) {

--- a/extensions/github/src/components/NotificationListItem.tsx
+++ b/extensions/github/src/components/NotificationListItem.tsx
@@ -1,6 +1,6 @@
 import { List } from "@raycast/api";
-import { MutatePromise } from "@raycast/utils";
 
+import { RevalidateList } from "../helpers";
 import { getNotificationSubtitle, getNotificationTooltip, getNotificationTypeTitle } from "../helpers/notifications";
 import { NotificationWithIcon } from "../notifications";
 
@@ -9,7 +9,7 @@ import NotificationActions from "./NotificationActions";
 type NotificationListItemProps = {
   notification: NotificationWithIcon;
   userId?: string;
-  mutateList: MutatePromise<NotificationWithIcon[] | undefined> | MutatePromise<NotificationWithIcon[]>;
+  mutateList: RevalidateList;
 };
 
 export default function NotificationListItem({ notification, userId, mutateList }: NotificationListItemProps) {

--- a/extensions/github/src/components/PullRequestActions.tsx
+++ b/extensions/github/src/components/PullRequestActions.tsx
@@ -21,10 +21,10 @@ import {
   PullRequestMergeMethod,
   UserFieldsFragment,
 } from "../generated/graphql";
+import { RevalidateList } from "../helpers";
 import { getErrorMessage } from "../helpers/errors";
 import { getMergeMethodTitle, PR_SORT_TYPES_TO_QUERIES } from "../helpers/pull-request";
 import { getGitHubUser } from "../helpers/users";
-import { useMyPullRequests } from "../hooks/useMyPullRequests";
 
 import AddPullRequestReview from "./AddPullRequestReview";
 import CheckoutPullRequestForm from "./CheckoutPullRequestForm";
@@ -40,10 +40,7 @@ export type PullRequest =
 type PullRequestActionsProps = {
   pullRequest: PullRequest;
   viewer?: UserFieldsFragment;
-  mutateList?:
-    | MutatePromise<PullRequestFieldsFragment[] | undefined>
-    | MutatePromise<PullRequestFieldsFragment[]>
-    | ReturnType<typeof useMyPullRequests>["mutate"];
+  mutateList?: RevalidateList;
   mutateDetail?: MutatePromise<PullRequest>;
   children?: React.ReactNode;
 };

--- a/extensions/github/src/components/PullRequestCommits.tsx
+++ b/extensions/github/src/components/PullRequestCommits.tsx
@@ -1,7 +1,6 @@
 import { Action, ActionPanel, Image, List } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
 import { compareDesc, format } from "date-fns";
-import { useMemo } from "react";
 
 import { getGitHubClient } from "../api/githubClient";
 import { PullRequestCommitFieldsFragment } from "../generated/graphql";
@@ -16,36 +15,36 @@ type PullRequestCommitsProps = {
 export default function PullRequestCommits({ pullRequest }: PullRequestCommitsProps) {
   const { github } = getGitHubClient();
 
-  const { data, isLoading } = useCachedPromise(
-    async (pullRequest) => {
-      const commits = await github.pullRequestCommits({ nodeId: pullRequest.id });
-      return commits.node as PullRequestCommitFieldsFragment;
-    },
+  const { data, isLoading, pagination } = useCachedPromise(
+    (pullRequest) =>
+      async ({ cursor }) => {
+        const result = await github.pullRequestCommits({
+          nodeId: pullRequest.id,
+          numberOfItems: 25,
+          before: cursor,
+        });
+        const pullRequestWithCommits = result.node as PullRequestCommitFieldsFragment;
+        const commits = pullRequestWithCommits.commits.nodes?.filter((node) => node != null) ?? [];
+        commits.sort((a, b) => {
+          const dateA = a.commit.authoredDate;
+          const dateB = b.commit.authoredDate;
+          return compareDesc(new Date(dateA), new Date(dateB));
+        });
+
+        return {
+          data: commits,
+          hasMore: pullRequestWithCommits.commits.pageInfo.hasPreviousPage,
+          cursor: pullRequestWithCommits.commits.pageInfo.startCursor ?? undefined,
+        };
+      },
     [pullRequest],
   );
 
-  const sortedCommits = useMemo(() => {
-    const commits = data?.commits?.nodes;
-
-    if (commits) {
-      commits.sort((a, b) => {
-        const dateA = a?.commit?.authoredDate;
-        const dateB = b?.commit?.authoredDate;
-
-        return dateA && dateB ? compareDesc(new Date(dateA), new Date(dateB)) : 0;
-      });
-    }
-
-    return commits;
-  }, [data]);
+  const commits = [...new Map((data ?? []).map((node) => [node.commit.id, node])).values()];
 
   return (
-    <List navigationTitle={`#${pullRequest.number} Commits`} isLoading={isLoading}>
-      {sortedCommits?.map((node) => {
-        if (!node) {
-          return null;
-        }
-
+    <List navigationTitle={`#${pullRequest.number} Commits`} isLoading={isLoading} pagination={pagination}>
+      {commits.map((node) => {
         const commit = node.commit;
         const date = new Date(commit.authoredDate);
 

--- a/extensions/github/src/components/PullRequestDetail.tsx
+++ b/extensions/github/src/components/PullRequestDetail.tsx
@@ -1,14 +1,13 @@
 import { Color, Detail, Icon } from "@raycast/api";
-import { MutatePromise, useCachedPromise } from "@raycast/utils";
+import { useCachedPromise } from "@raycast/utils";
 import { format } from "date-fns";
 
 import { getGitHubClient } from "../api/githubClient";
 import { PullRequestDetailsFieldsFragment, PullRequestFieldsFragment, UserFieldsFragment } from "../generated/graphql";
-import { pluralize } from "../helpers";
+import { pluralize, RevalidateList } from "../helpers";
 import { getPullRequestAuthor, getPullRequestReviewers, getPullRequestStatus } from "../helpers/pull-request";
 import { getCheckStatePresentation } from "../helpers/pull-request-checks";
 import { getGitHubUser } from "../helpers/users";
-import { useMyPullRequests } from "../hooks/useMyPullRequests";
 import { useViewer } from "../hooks/useViewer";
 
 import PullRequestActions from "./PullRequestActions";
@@ -16,10 +15,7 @@ import PullRequestActions from "./PullRequestActions";
 type PullRequestDetailProps = {
   initialPullRequest: PullRequestFieldsFragment;
   viewer?: UserFieldsFragment;
-  mutateList?:
-    | MutatePromise<PullRequestFieldsFragment[] | undefined>
-    | MutatePromise<PullRequestFieldsFragment[]>
-    | ReturnType<typeof useMyPullRequests>["mutate"];
+  mutateList?: RevalidateList;
 };
 
 export default function PullRequestDetail({ initialPullRequest, mutateList }: PullRequestDetailProps) {

--- a/extensions/github/src/components/PullRequestListItem.tsx
+++ b/extensions/github/src/components/PullRequestListItem.tsx
@@ -1,9 +1,9 @@
 import { Action, Color, Icon, List } from "@raycast/api";
-import { MutatePromise } from "@raycast/utils";
 import { format } from "date-fns";
 import { useMemo } from "react";
 
 import { PullRequestFieldsFragment, UserFieldsFragment } from "../generated/graphql";
+import { RevalidateList } from "../helpers";
 import {
   getCheckStateAccessory,
   getNumberOfComments,
@@ -11,7 +11,6 @@ import {
   getPullRequestStatus,
   getReviewDecision,
 } from "../helpers/pull-request";
-import { useMyPullRequests } from "../hooks/useMyPullRequests";
 
 import PullRequestActions from "./PullRequestActions";
 import PullRequestDetail from "./PullRequestDetail";
@@ -20,10 +19,7 @@ import { SortActionProps } from "./SortAction";
 type PullRequestListItemProps = {
   pullRequest: PullRequestFieldsFragment;
   viewer?: UserFieldsFragment;
-  mutateList?:
-    | MutatePromise<PullRequestFieldsFragment[] | undefined>
-    | MutatePromise<PullRequestFieldsFragment[]>
-    | ReturnType<typeof useMyPullRequests>["mutate"];
+  mutateList?: RevalidateList;
   showAuthor?: boolean;
 };
 

--- a/extensions/github/src/components/RepositoryDiscussions.tsx
+++ b/extensions/github/src/components/RepositoryDiscussions.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 
 import { getGitHubClient } from "../api/githubClient";
 import { DiscussionFieldsFragment } from "../generated/graphql";
+import { uniqueById } from "../helpers";
 import { DISCUSSION_DEFAULT_SORT_QUERY, formatDateForQuery } from "../helpers/discussion";
 
 import { DiscussionListItem } from "./DiscussionListItem";
@@ -48,6 +49,7 @@ export function RepositoryDiscussionList(props: { repository: string }) {
     },
     [searchText, filterText, sortQuery],
   );
+  const discussions = uniqueById(data ?? []);
 
   return (
     <List
@@ -58,8 +60,10 @@ export function RepositoryDiscussionList(props: { repository: string }) {
       pagination={pagination}
       searchBarAccessory={<DiscussionFilterDropdown value={filter} onChange={setFilter} />}
     >
-      <List.Section title="Discussions" subtitle={`${data?.length ?? 0}`}>
-        {data?.map((d) => <DiscussionListItem key={d.id} discussion={d} {...{ sortQuery, setSortQuery }} />)}
+      <List.Section title="Discussions" subtitle={`${discussions.length}`}>
+        {discussions.map((d) => (
+          <DiscussionListItem key={d.id} discussion={d} {...{ sortQuery, setSortQuery }} />
+        ))}
       </List.Section>
     </List>
   );

--- a/extensions/github/src/components/RepositoryIssues.tsx
+++ b/extensions/github/src/components/RepositoryIssues.tsx
@@ -1,10 +1,11 @@
 import { Color, List } from "@raycast/api";
-import { MutatePromise, useCachedPromise, useCachedState } from "@raycast/utils";
+import { useCachedPromise, useCachedState } from "@raycast/utils";
 import type { JSX } from "react";
 import { useState } from "react";
 
 import { getGitHubClient } from "../api/githubClient";
 import { IssueFieldsFragment } from "../generated/graphql";
+import { uniqueById } from "../helpers";
 import { ISSUE_DEFAULT_SORT_QUERY, normalizeIssueSearchText, parseIssueNumberLookup } from "../helpers/issue";
 
 import IssueListItem from "./IssueListItem";
@@ -82,6 +83,7 @@ export function RepositoryIssueList(props: { repo: string }): JSX.Element {
     },
     [searchText, sortQuery, statusFilter],
   );
+  const issues = uniqueById(data ?? []);
 
   return (
     <List
@@ -93,12 +95,12 @@ export function RepositoryIssueList(props: { repo: string }): JSX.Element {
       pagination={pagination}
       searchBarAccessory={<IssueStatusDropdown value={statusFilter} onChange={setStatusFilter} />}
     >
-      <List.Section title="Issues" subtitle={`${data?.length ?? 0}`}>
-        {data?.map((d) => (
+      <List.Section title="Issues" subtitle={`${issues.length}`}>
+        {issues.map((d) => (
           <IssueListItem
             key={d.id}
             issue={d}
-            mutateList={mutateList as MutatePromise<IssueFieldsFragment[] | undefined>}
+            mutateList={mutateList}
             sortQuery={sortQuery}
             setSortQuery={setSortQuery}
           />

--- a/extensions/github/src/components/RepositoryPullRequest.tsx
+++ b/extensions/github/src/components/RepositoryPullRequest.tsx
@@ -1,10 +1,11 @@
 import { Color, List } from "@raycast/api";
-import { MutatePromise, useCachedPromise, useCachedState } from "@raycast/utils";
+import { useCachedPromise, useCachedState } from "@raycast/utils";
 import type { JSX } from "react";
 import { useState } from "react";
 
 import { getGitHubClient } from "../api/githubClient";
 import { PullRequestFieldsFragment } from "../generated/graphql";
+import { uniqueById } from "../helpers";
 import { PR_DEFAULT_SORT_QUERY } from "../helpers/pull-request";
 
 import PullRequestListItem from "./PullRequestListItem";
@@ -87,6 +88,7 @@ export function RepositoryPullRequestList(props: { repo: string }): JSX.Element 
     },
     [props.repo, searchText, sortQuery, statusQuery],
   );
+  const pullRequests = uniqueById(data ?? []);
 
   return (
     <List
@@ -97,13 +99,13 @@ export function RepositoryPullRequestList(props: { repo: string }): JSX.Element 
       pagination={pagination}
       searchBarAccessory={<PullRequestStatusDropdown value={statusFilter} onChange={setStatusFilter} />}
     >
-      <List.Section title="Pull Requests" subtitle={`${data?.length ?? 0}`}>
-        {data?.map((d) => (
+      <List.Section title="Pull Requests" subtitle={`${pullRequests.length}`}>
+        {pullRequests.map((d) => (
           <PullRequestListItem
             key={d.id}
             showAuthor
             pullRequest={d}
-            mutateList={mutateList as MutatePromise<PullRequestFieldsFragment[] | undefined>}
+            mutateList={mutateList}
             sortQuery={sortQuery}
             setSortQuery={setSortQuery}
           />

--- a/extensions/github/src/components/RepositoryReleases.tsx
+++ b/extensions/github/src/components/RepositoryReleases.tsx
@@ -3,6 +3,7 @@ import { useCachedPromise } from "@raycast/utils";
 
 import { getGitHubClient } from "../api/githubClient";
 import { ExtendedRepositoryFieldsFragment, ReleaseFieldsFragment } from "../generated/graphql";
+import { uniqueById } from "../helpers";
 
 const RELEASES_PAGE_SIZE = 25;
 
@@ -27,10 +28,11 @@ export default function RepositoryReleases(props: { repository: ExtendedReposito
     },
     [owner, name],
   );
+  const releases = uniqueById(data ?? []);
 
   return (
     <List isLoading={isLoading} navigationTitle={props.repository.nameWithOwner} pagination={pagination}>
-      {data?.map((release) => (
+      {releases.map((release) => (
         <List.Item
           key={release.id}
           title={release.name || release.tagName}

--- a/extensions/github/src/components/WorkflowRunActions.tsx
+++ b/extensions/github/src/components/WorkflowRunActions.tsx
@@ -1,7 +1,7 @@
 import { Action, ActionPanel, Icon, List, showToast, Toast, Keyboard } from "@raycast/api";
-import { MutatePromise } from "@raycast/utils";
 
 import { getGitHubClient } from "../api/githubClient";
+import { RevalidateList } from "../helpers";
 import { getErrorMessage } from "../helpers/errors";
 import { WorkflowRunsResponse } from "../workflow-runs";
 
@@ -10,7 +10,7 @@ export type WorkflowRun = WorkflowRunsResponse["data"]["workflow_runs"][0];
 type WorkflowRunActionsProps = {
   workflowRun: WorkflowRun;
   repository: string;
-  mutateList: MutatePromise<WorkflowRunsResponse | undefined>;
+  mutateList: RevalidateList;
 };
 
 export function WorkflowRunActions({ workflowRun, repository, mutateList }: WorkflowRunActionsProps) {

--- a/extensions/github/src/components/WorkflowRunListItem.tsx
+++ b/extensions/github/src/components/WorkflowRunListItem.tsx
@@ -1,6 +1,6 @@
 import { List } from "@raycast/api";
-import { MutatePromise } from "@raycast/utils";
 
+import { RevalidateList } from "../helpers";
 import { getWorkflowStatus } from "../helpers/workflow";
 import { WorkflowRunsResponse } from "../workflow-runs";
 
@@ -11,7 +11,7 @@ export type WorkflowRun = WorkflowRunsResponse["data"]["workflow_runs"][0];
 type WorkflowRunListItemProps = {
   workflowRun: WorkflowRun;
   repository: string;
-  mutateList: MutatePromise<WorkflowRunsResponse | undefined>;
+  mutateList: RevalidateList;
 };
 
 export function WorkflowRunListItem({ workflowRun, repository, mutateList }: WorkflowRunListItemProps) {

--- a/extensions/github/src/generated/graphql.ts
+++ b/extensions/github/src/generated/graphql.ts
@@ -894,11 +894,14 @@ export type PullRequestCommitFieldsFragment = {
         statusCheckRollup: { state: Types.StatusState } | null;
       };
     } | null> | null;
+    pageInfo: { hasPreviousPage: boolean; startCursor: string | null };
   };
 };
 
 export type PullRequestCommitsQueryVariables = Exact<{
   nodeId: string | number;
+  numberOfItems: number;
+  before?: string | null | undefined;
 }>;
 
 export type PullRequestCommitsQuery = {
@@ -919,6 +922,7 @@ export type PullRequestCommitsQuery = {
               statusCheckRollup: { state: Types.StatusState } | null;
             };
           } | null> | null;
+          pageInfo: { hasPreviousPage: boolean; startCursor: string | null };
         };
       }
     | Record<PropertyKey, never>
@@ -1164,6 +1168,7 @@ export type SearchRepositoriesQuery = {
 
 export type MyLatestRepositoriesQueryVariables = Exact<{
   numberOfItems: number;
+  after?: string | null | undefined;
   orderByField: Types.RepositoryOrderField;
   orderByDirection: Types.OrderDirection;
 }>;
@@ -1186,6 +1191,7 @@ export type MyLatestRepositoriesQuery = {
         owner: { login: string; avatarUrl: any } | { login: string; avatarUrl: any };
         primaryLanguage: { id: string; name: string; color: string | null } | null;
       } | null> | null;
+      pageInfo: { endCursor: string | null; hasNextPage: boolean };
     };
   };
 };
@@ -1997,7 +2003,7 @@ export const PullRequestDetailsFieldsFragmentDoc = gql`
 `;
 export const PullRequestCommitFieldsFragmentDoc = gql`
   fragment PullRequestCommitFields on PullRequest {
-    commits(last: 100) {
+    commits(last: $numberOfItems, before: $before) {
       totalCount
       nodes {
         commit {
@@ -2016,6 +2022,10 @@ export const PullRequestCommitFieldsFragmentDoc = gql`
           url
           treeUrl
         }
+      }
+      pageInfo {
+        hasPreviousPage
+        startCursor
       }
     }
   }
@@ -2353,7 +2363,7 @@ export const RepositoryProjectsForPullRequestsDocument = gql`
   }
 `;
 export const PullRequestCommitsDocument = gql`
-  query pullRequestCommits($nodeId: ID!) {
+  query pullRequestCommits($nodeId: ID!, $numberOfItems: Int!, $before: String) {
     node(id: $nodeId) {
       ...PullRequestCommitFields
     }
@@ -2538,13 +2548,22 @@ export const SearchRepositoriesDocument = gql`
 export const MyLatestRepositoriesDocument = gql`
   query myLatestRepositories(
     $numberOfItems: Int!
+    $after: String
     $orderByField: RepositoryOrderField!
     $orderByDirection: OrderDirection!
   ) {
     viewer {
-      repositories(first: $numberOfItems, orderBy: { field: $orderByField, direction: $orderByDirection }) {
+      repositories(
+        first: $numberOfItems
+        after: $after
+        orderBy: { field: $orderByField, direction: $orderByDirection }
+      ) {
         nodes {
           ...ExtendedRepositoryFields
+        }
+        pageInfo {
+          endCursor
+          hasNextPage
         }
       }
     }

--- a/extensions/github/src/helpers/index.ts
+++ b/extensions/github/src/helpers/index.ts
@@ -1,5 +1,15 @@
 export { getPullRequestStatus } from "./pull-request";
 
+export type RevalidateList = () => Promise<unknown>;
+
+export function uniqueById<T extends { id: string }>(items: T[]): T[] {
+  return [...new Map(items.map((item) => [item.id, item])).values()];
+}
+
+export function compactFragmentNodes<T>(items: readonly unknown[] | null | undefined): T[] {
+  return (items?.filter((item) => typeof item === "object" && item !== null && "id" in item) ?? []) as T[];
+}
+
 export function pluralize(
   count: number,
   noun: string,

--- a/extensions/github/src/hooks/useDiscussions.ts
+++ b/extensions/github/src/hooks/useDiscussions.ts
@@ -1,21 +1,28 @@
 import { useCachedPromise } from "@raycast/utils";
 
 import { getGitHubClient } from "../api/githubClient";
-import { getBoundedPreferenceNumber } from "../components/Menu";
+import { getSearchPageSize } from "../components/Menu";
+import { DiscussionFieldsFragment } from "../generated/graphql";
+import { compactFragmentNodes } from "../helpers";
 
 export function useDiscussions(query: string) {
   const { github } = getGitHubClient();
 
-  const { data, isLoading } = useCachedPromise(
-    async (query) => {
-      const result = await github.searchDiscussions({
-        query,
-        numberOfItems: getBoundedPreferenceNumber({ name: "numberOfResults", default: 25 }),
-      });
-      return result.searchDiscussions;
-    },
+  return useCachedPromise(
+    (query) =>
+      async ({ cursor }) => {
+        const result = await github.searchDiscussions({
+          query,
+          numberOfItems: getSearchPageSize(),
+          after: cursor,
+        });
+
+        return {
+          data: compactFragmentNodes<DiscussionFieldsFragment>(result.searchDiscussions.nodes),
+          hasMore: result.searchDiscussions.pageInfo.hasNextPage,
+          cursor: result.searchDiscussions.pageInfo.endCursor ?? undefined,
+        };
+      },
     [query],
   );
-
-  return { data, isLoading };
 }

--- a/extensions/github/src/my-discussions.tsx
+++ b/extensions/github/src/my-discussions.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 
 import { DiscussionListItem } from "./components/DiscussionListItem";
 import { DiscussionFieldsFragment } from "./generated/graphql";
+import { uniqueById } from "./helpers";
 import { DISCUSSION_DEFAULT_SORT_QUERY, formatDateForQuery } from "./helpers/discussion";
 import { withGitHubClient } from "./helpers/withGithubClient";
 import { useDiscussions } from "./hooks/useDiscussions";
@@ -14,15 +15,17 @@ function DiscussionList(): JSX.Element {
   const [sortQuery, setSortQuery] = useCachedState<string>("sort-query", DISCUSSION_DEFAULT_SORT_QUERY, {
     cacheNamespace: "github-my-discussion",
   });
-  const { data, isLoading } = useDiscussions(`author:@me ${formatDateForQuery(sortQuery)} ${searchText}`);
-  const discussions = data?.nodes as DiscussionFieldsFragment[] | null | undefined;
+  const { data, isLoading, pagination } = useDiscussions(`author:@me ${formatDateForQuery(sortQuery)} ${searchText}`);
+  const discussions = uniqueById((data ?? []) as DiscussionFieldsFragment[]);
   return (
-    <List isLoading={isLoading} onSearchTextChange={setSearchText} throttle>
+    <List isLoading={isLoading} onSearchTextChange={setSearchText} throttle pagination={pagination}>
       <List.Section
         title={searchText.length > 0 ? "Found Discussions" : "Your Discussions"}
-        subtitle={`${discussions?.length}`}
+        subtitle={`${discussions.length}`}
       >
-        {discussions?.map((d) => <DiscussionListItem key={d.id} discussion={d} {...{ sortQuery, setSortQuery }} />)}
+        {discussions.map((d) => (
+          <DiscussionListItem key={d.id} discussion={d} {...{ sortQuery, setSortQuery }} />
+        ))}
       </List.Section>
     </List>
   );

--- a/extensions/github/src/my-latest-repositories.tsx
+++ b/extensions/github/src/my-latest-repositories.tsx
@@ -3,9 +3,10 @@ import { useCachedPromise, useCachedState } from "@raycast/utils";
 import { useEffect, useMemo } from "react";
 
 import { getGitHubClient } from "./api/githubClient";
-import { getBoundedPreferenceNumber } from "./components/Menu";
+import { getSearchPageSize } from "./components/Menu";
 import RepositoryListItem from "./components/RepositoryListItem";
-import { ExtendedRepositoryFieldsFragment, OrderDirection, RepositoryOrderField } from "./generated/graphql";
+import { OrderDirection, ExtendedRepositoryFieldsFragment, RepositoryOrderField } from "./generated/graphql";
+import { compactFragmentNodes, uniqueById } from "./helpers";
 import { MY_REPO_DEFAULT_SORT_QUERY, MY_REPO_SORT_TYPES_TO_QUERIES, useHistory } from "./helpers/repository";
 import { withGitHubClient } from "./helpers/withGithubClient";
 
@@ -22,39 +23,51 @@ function MyLatestRepositories() {
     data,
     isLoading,
     mutate: mutateList,
+    pagination,
   } = useCachedPromise(
-    async (sort: string) => {
-      const orderByField = sort.split(":")[0].toUpperCase() as RepositoryOrderField;
-      const orderByDirection = sort.split(":")[1].toUpperCase() as OrderDirection;
-      const result = await github.myLatestRepositories({
-        numberOfItems: getBoundedPreferenceNumber({ name: "numberOfResults", default: 25 }),
-        orderByField,
-        orderByDirection,
-      });
+    (sort: string) =>
+      async ({ cursor }) => {
+        const orderByField = sort.split(":")[0].toUpperCase() as RepositoryOrderField;
+        const orderByDirection = sort.split(":")[1].toUpperCase() as OrderDirection;
+        const result = await github.myLatestRepositories({
+          numberOfItems: getSearchPageSize(),
+          after: cursor,
+          orderByField,
+          orderByDirection,
+        });
 
-      return result.viewer.repositories.nodes?.map((node) => node as ExtendedRepositoryFieldsFragment);
-    },
+        return {
+          data: compactFragmentNodes<ExtendedRepositoryFieldsFragment>(result.viewer.repositories.nodes),
+          hasMore: result.viewer.repositories.pageInfo.hasNextPage,
+          cursor: result.viewer.repositories.pageInfo.endCursor ?? undefined,
+        };
+      },
     [sortQuery],
     { keepPreviousData: true },
   );
 
+  const repositories = useMemo(() => uniqueById(data ?? []), [data]);
+  const repositoryIds = useMemo(() => new Set(repositories.map((repository) => repository.id)), [repositories]);
+
   useEffect(
-    () => history.forEach((repository) => data?.find((r) => r.id === repository.id && visitRepository(r))),
-    [data],
+    () => history.forEach((repository) => repositories.find((r) => r.id === repository.id && visitRepository(r))),
+    [repositories],
   );
 
   const validHistory = useMemo(
-    () => history.filter((repository) => data?.find((r) => r.id === repository.id)),
-    [data, history],
+    () => history.filter((repository) => repositoryIds.has(repository.id)),
+    [history, repositoryIds],
   );
 
+  const historyIds = useMemo(() => new Set(validHistory.map((repository) => repository.id)), [validHistory]);
+
   const myLatestRepositories = useMemo(
-    () => data?.filter((repository) => !validHistory.find((r) => r.id === repository.id)),
-    [data, validHistory],
+    () => repositories.filter((repository) => !historyIds.has(repository.id)),
+    [historyIds, repositories],
   );
 
   return (
-    <List isLoading={isLoading} throttle>
+    <List isLoading={isLoading} throttle pagination={pagination}>
       <List.Section title="Visited Repositories" subtitle={validHistory ? String(validHistory.length) : undefined}>
         {validHistory.map((repository) => (
           <RepositoryListItem
@@ -73,7 +86,7 @@ function MyLatestRepositories() {
         ))}
       </List.Section>
 
-      {myLatestRepositories ? (
+      {data ? (
         <List.Section title="My Latest Repositories" subtitle={`${myLatestRepositories.length}`}>
           {myLatestRepositories.map((repository) => {
             return (

--- a/extensions/github/src/my-starred-repositories.tsx
+++ b/extensions/github/src/my-starred-repositories.tsx
@@ -1,15 +1,14 @@
 import { List } from "@raycast/api";
 import { useCachedPromise, useCachedState } from "@raycast/utils";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo } from "react";
 
 import { getGitHubClient } from "./api/githubClient";
-import { getBoundedPreferenceNumber } from "./components/Menu";
+import { getSearchPageSize } from "./components/Menu";
 import RepositoryListItem from "./components/RepositoryListItem";
-import { ExtendedRepositoryFieldsFragment, OrderDirection, StarOrderField } from "./generated/graphql";
+import { OrderDirection, ExtendedRepositoryFieldsFragment, StarOrderField } from "./generated/graphql";
+import { compactFragmentNodes, uniqueById } from "./helpers";
 import { STARRED_REPO_DEFAULT_SORT_QUERY, STARRED_REPO_SORT_TYPES_TO_QUERIES, useHistory } from "./helpers/repository";
 import { withGitHubClient } from "./helpers/withGithubClient";
-
-const STARRED_REPOSITORIES_BATCH_SIZE = 25;
 
 function MyStarredRepositories() {
   const { github } = getGitHubClient();
@@ -20,132 +19,56 @@ function MyStarredRepositories() {
   });
   const sortTypesData = STARRED_REPO_SORT_TYPES_TO_QUERIES;
 
-  const [allRepositories, setAllRepositories] = useState<ExtendedRepositoryFieldsFragment[]>([]);
-  const [hasMore, setHasMore] = useState(true);
-  const [cursor, setCursor] = useState<string | null>(null);
-  const [isPendingMutation, setIsPendingMutation] = useState(false);
-
-  const { data, isLoading, mutate } = useCachedPromise(
-    async (sort: string, afterCursor: string | null) => {
-      const orderByField = sort.split(":")[0].toUpperCase() as StarOrderField;
-      const orderByDirection = sort.split(":")[1].toUpperCase() as OrderDirection;
-      const requestedCount = getBoundedPreferenceNumber({ name: "numberOfResults", default: 25 });
-      const repos: ExtendedRepositoryFieldsFragment[] = [];
-      let pageInfo: { hasNextPage: boolean; endCursor?: string | null } = {
-        hasNextPage: false,
-        endCursor: afterCursor,
-      };
-      let nextCursor = afterCursor;
-
-      while (repos.length < requestedCount) {
+  const {
+    data,
+    isLoading,
+    mutate: mutateList,
+    pagination,
+  } = useCachedPromise(
+    (sort: string) =>
+      async ({ cursor }) => {
+        const orderByField = sort.split(":")[0].toUpperCase() as StarOrderField;
+        const orderByDirection = sort.split(":")[1].toUpperCase() as OrderDirection;
         const result = await github.myStarredRepositories({
-          numberOfItems: Math.min(STARRED_REPOSITORIES_BATCH_SIZE, requestedCount - repos.length),
-          after: nextCursor,
+          numberOfItems: getSearchPageSize(),
+          after: cursor,
           orderByField,
           orderByDirection,
         });
-
         const starredRepositories = result.viewer.starredRepositories;
-        repos.push(...(starredRepositories.nodes as ExtendedRepositoryFieldsFragment[]));
-        pageInfo = starredRepositories.pageInfo;
 
-        if (!pageInfo.hasNextPage || !pageInfo.endCursor) {
-          break;
-        }
-
-        nextCursor = pageInfo.endCursor;
-      }
-
-      return {
-        repositories: repos,
-        hasNextPage: pageInfo.hasNextPage,
-        endCursor: pageInfo.endCursor,
-      };
-    },
-    [sortQuery, cursor],
-    {
-      keepPreviousData: true,
-      onData: (result) => {
-        // Skip onData updates during mutations to avoid conflicts
-        if (isPendingMutation) {
-          return;
-        }
-
-        if (cursor === null) {
-          // Initial load or sort change
-          setAllRepositories(result.repositories);
-        } else {
-          // Pagination - append new data
-          setAllRepositories((prev) => [...prev, ...result.repositories]);
-        }
-        setHasMore(result.hasNextPage);
+        return {
+          data: compactFragmentNodes<ExtendedRepositoryFieldsFragment>(starredRepositories.nodes),
+          hasMore: starredRepositories.pageInfo.hasNextPage,
+          cursor: starredRepositories.pageInfo.endCursor ?? undefined,
+        };
       },
-    },
+    [sortQuery],
+    { keepPreviousData: true },
   );
 
-  // Reset pagination when sort changes
-  useEffect(() => {
-    setAllRepositories([]);
-    setCursor(null);
-    setHasMore(true);
-  }, [sortQuery]);
+  const repositories = useMemo(() => uniqueById(data ?? []), [data]);
+  const repositoryIds = useMemo(() => new Set(repositories.map((repository) => repository.id)), [repositories]);
 
   useEffect(
-    () => history.forEach((repository) => allRepositories?.find((r) => r.id === repository.id && visitRepository(r))),
-    [allRepositories],
+    () => history.forEach((repository) => repositories.find((r) => r.id === repository.id && visitRepository(r))),
+    [repositories],
   );
 
   const validHistory = useMemo(
-    () => history.filter((repository) => allRepositories?.find((r) => r.id === repository.id)),
-    [allRepositories, history],
+    () => history.filter((repository) => repositoryIds.has(repository.id)),
+    [history, repositoryIds],
   );
+
+  const historyIds = useMemo(() => new Set(validHistory.map((repository) => repository.id)), [validHistory]);
 
   const myStarredRepositories = useMemo(
-    () => allRepositories?.filter((repository) => !validHistory.find((r) => r.id === repository.id)),
-    [allRepositories, validHistory],
+    () => repositories.filter((repository) => !historyIds.has(repository.id)),
+    [historyIds, repositories],
   );
-
-  const handleLoadMore = () => {
-    if (hasMore && !isLoading && data?.endCursor) {
-      setCursor(data.endCursor);
-    }
-  };
-
-  const mutateList = useCallback(
-    async (
-      _asyncUpdate?: unknown,
-      options?: {
-        optimisticUpdate?: (data: ExtendedRepositoryFieldsFragment[]) => ExtendedRepositoryFieldsFragment[] | undefined;
-      },
-    ) => {
-      if (options?.optimisticUpdate) {
-        setAllRepositories((prev) => options.optimisticUpdate!(prev) ?? prev);
-      }
-
-      setIsPendingMutation(true);
-      try {
-        setCursor(null);
-        setAllRepositories([]);
-        setHasMore(true);
-        await mutate();
-      } finally {
-        setIsPendingMutation(false);
-      }
-    },
-    [mutate],
-  );
-  const isInitialLoading = isLoading && allRepositories.length === 0;
 
   return (
-    <List
-      isLoading={isInitialLoading}
-      throttle
-      pagination={{
-        onLoadMore: handleLoadMore,
-        hasMore: hasMore,
-        pageSize: 1,
-      }}
-    >
+    <List isLoading={isLoading} throttle pagination={pagination}>
       <List.Section
         title="Visited Starred Repositories"
         subtitle={validHistory ? String(validHistory.length) : undefined}

--- a/extensions/github/src/notifications.tsx
+++ b/extensions/github/src/notifications.tsx
@@ -6,6 +6,7 @@ import { useMemo, useState } from "react";
 import { getGitHubClient } from "./api/githubClient";
 import NotificationListItem from "./components/NotificationListItem";
 import RepositoriesDropdown from "./components/RepositoryDropdown";
+import { uniqueById } from "./helpers";
 import { getErrorMessage } from "./helpers/errors";
 import { getNotificationIcon, Notification } from "./helpers/notifications";
 import { withGitHubClient } from "./helpers/withGithubClient";
@@ -29,35 +30,43 @@ function Notifications() {
     mutate: mutateList,
     pagination,
   } = useCachedPromise(
-    () => async (options: { page: number }) => {
-      const response = await octokit.activity.listNotificationsForAuthenticatedUser({
-        all: true,
-        per_page: NOTIFICATIONS_PAGE_SIZE,
-        page: options.page + 1,
-      });
+    (repository) =>
+      async ({ cursor }) => {
+        const page = cursor ? Number(cursor) : 1;
+        const response = repository
+          ? await octokit.activity.listRepoNotificationsForAuthenticatedUser({
+              owner: repository.split("/")[0],
+              repo: repository.split("/")[1],
+              all: true,
+              per_page: NOTIFICATIONS_PAGE_SIZE,
+              page,
+            })
+          : await octokit.activity.listNotificationsForAuthenticatedUser({
+              all: true,
+              per_page: NOTIFICATIONS_PAGE_SIZE,
+              page,
+            });
+        const hasMore =
+          response.headers.link?.includes('rel="next"') ?? response.data.length === NOTIFICATIONS_PAGE_SIZE;
+        const notifications = await Promise.all(
+          response.data.map(async (notification: Notification) => ({
+            ...notification,
+            icon: await getNotificationIcon(notification),
+          })),
+        );
 
-      const notifications = await Promise.all(
-        response.data.map(async (notification: Notification) => {
-          const icon = await getNotificationIcon(notification);
-          return { ...notification, icon };
-        }),
-      );
-
-      return {
-        data: notifications,
-        hasMore: response.data.length === NOTIFICATIONS_PAGE_SIZE,
-      };
-    },
-    [],
+        return {
+          data: notifications,
+          hasMore,
+          cursor: hasMore ? String(page + 1) : undefined,
+        };
+      },
+    [selectedRepository],
   );
 
   const notifications = useMemo(() => {
-    if (selectedRepository) {
-      return data?.filter((notification: Notification) => notification.repository.full_name === selectedRepository);
-    }
-
-    return data;
-  }, [data, selectedRepository]);
+    return uniqueById(data ?? []);
+  }, [data]);
 
   const [unreadNotifications, readNotifications] = partition(notifications, (notification) => notification.unread);
 

--- a/extensions/github/src/search-discussions.tsx
+++ b/extensions/github/src/search-discussions.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import { DiscussionListItem } from "./components/DiscussionListItem";
 import SearchRepositoryDropdown from "./components/SearchRepositoryDropdown";
 import { DiscussionFieldsFragment } from "./generated/graphql";
+import { uniqueById } from "./helpers";
 import { DISCUSSION_DEFAULT_SORT_QUERY, formatDateForQuery } from "./helpers/discussion";
 import { withGitHubClient } from "./helpers/withGithubClient";
 import { useDiscussions } from "./hooks/useDiscussions";
@@ -18,8 +19,10 @@ function DiscussionList(): JSX.Element {
   const [sortQuery, setSortQuery] = useCachedState<string>("sort-query", DISCUSSION_DEFAULT_SORT_QUERY, {
     cacheNamespace: "github-search-discussion",
   });
-  const { data, isLoading } = useDiscussions(`${searchFilter} ${formatDateForQuery(sortQuery)} ${searchText}`);
-  const discussions = data?.nodes as DiscussionFieldsFragment[] | null | undefined;
+  const { data, isLoading, pagination } = useDiscussions(
+    `${searchFilter} ${formatDateForQuery(sortQuery)} ${searchText}`,
+  );
+  const discussions = uniqueById((data ?? []) as DiscussionFieldsFragment[]);
   return (
     <List
       isLoading={isLoading}
@@ -27,12 +30,15 @@ function DiscussionList(): JSX.Element {
       searchText={searchText}
       searchBarAccessory={<SearchRepositoryDropdown onFilterChange={setSearchFilter} />}
       throttle
+      pagination={pagination}
     >
       <List.Section
         title={searchText.length > 0 ? "Found Discussions" : "Recent Discussions"}
-        subtitle={`${discussions?.length}`}
+        subtitle={`${discussions.length}`}
       >
-        {discussions?.map((d) => <DiscussionListItem key={d.id} discussion={d} {...{ sortQuery, setSortQuery }} />)}
+        {discussions.map((d) => (
+          <DiscussionListItem key={d.id} discussion={d} {...{ sortQuery, setSortQuery }} />
+        ))}
       </List.Section>
     </List>
   );

--- a/extensions/github/src/search-issues.tsx
+++ b/extensions/github/src/search-issues.tsx
@@ -6,10 +6,10 @@ import { useState } from "react";
 import { getGitHubClient } from "./api/githubClient";
 import IssueListEmptyView from "./components/IssueListEmptyView";
 import IssueListItem from "./components/IssueListItem";
-import { getBoundedPreferenceNumber } from "./components/Menu";
+import { getSearchPageSize } from "./components/Menu";
 import SearchRepositoryDropdown from "./components/SearchRepositoryDropdown";
 import { IssueFieldsFragment } from "./generated/graphql";
-import { pluralize } from "./helpers";
+import { compactFragmentNodes, pluralize, uniqueById } from "./helpers";
 import { ISSUE_DEFAULT_SORT_QUERY, normalizeIssueSearchText, parseIssueNumberLookup } from "./helpers/issue";
 import { withGitHubClient } from "./helpers/withGithubClient";
 import { useViewer } from "./hooks/useViewer";
@@ -30,30 +30,44 @@ function SearchIssues() {
     data,
     isLoading,
     mutate: mutateList,
+    pagination,
   } = useCachedPromise(
-    async (searchText, searchFilter, sortTxt) => {
-      const lookup = parseIssueNumberLookup(`${searchFilter ?? ""} ${searchText}`);
-      if (lookup) {
-        try {
-          const exact = await github.issueByNumber(lookup);
-          if (exact.repository?.issue) {
-            return [exact.repository.issue as IssueFieldsFragment];
+    (searchText, searchFilter, sortTxt) =>
+      async ({ cursor }) => {
+        if (!cursor) {
+          const lookup = parseIssueNumberLookup(`${searchFilter ?? ""} ${searchText}`);
+          if (lookup) {
+            try {
+              const exact = await github.issueByNumber(lookup);
+              if (exact.repository?.issue) {
+                return {
+                  data: [exact.repository.issue as IssueFieldsFragment],
+                  hasMore: false,
+                };
+              }
+            } catch {
+              // Fall back to paginated search when the repository is inaccessible.
+            }
           }
-        } catch {
-          // Fall back to search when the repository is inaccessible.
         }
-      }
 
-      const result = await github.searchIssues({
-        numberOfItems: getBoundedPreferenceNumber({ name: "numberOfResults", default: 25 }),
-        query: `is:issue archived:false ${sortTxt} ${searchFilter} ${normalizeIssueSearchText(searchText)}`,
-      });
+        const result = await github.searchIssues({
+          numberOfItems: getSearchPageSize(),
+          query: `is:issue archived:false ${sortTxt} ${searchFilter ?? ""} ${normalizeIssueSearchText(searchText)}`,
+          after: cursor,
+        });
 
-      return result.search.nodes?.map((node) => node as IssueFieldsFragment);
-    },
+        return {
+          data: compactFragmentNodes<IssueFieldsFragment>(result.search.nodes),
+          hasMore: result.search.pageInfo.hasNextPage,
+          cursor: result.search.pageInfo.endCursor ?? undefined,
+        };
+      },
     [searchText, searchFilter, sortQuery],
     { keepPreviousData: true },
   );
+
+  const issues = uniqueById(data ?? []);
 
   return (
     <List
@@ -63,13 +77,14 @@ function SearchIssues() {
       searchText={searchText}
       onSearchTextChange={setSearchText}
       throttle
+      pagination={pagination}
     >
       {data ? (
         <List.Section
           title={searchText ? "Search Results" : "Created Recently"}
-          subtitle={pluralize(data.length, "issue", { withNumber: true })}
+          subtitle={pluralize(issues.length, "issue", { withNumber: true })}
         >
-          {data.map((issue) => {
+          {issues.map((issue) => {
             return <IssueListItem key={issue.id} {...{ issue, viewer, mutateList, sortQuery, setSortQuery }} />;
           })}
         </List.Section>

--- a/extensions/github/src/search-pull-requests.tsx
+++ b/extensions/github/src/search-pull-requests.tsx
@@ -4,12 +4,12 @@ import { trim } from "lodash";
 import { useState } from "react";
 
 import { getGitHubClient } from "./api/githubClient";
-import { getBoundedPreferenceNumber } from "./components/Menu";
+import { getSearchPageSize } from "./components/Menu";
 import PullRequestListEmptyView from "./components/PullRequestListEmptyView";
 import PullRequestListItem from "./components/PullRequestListItem";
 import SearchRepositoryDropdown from "./components/SearchRepositoryDropdown";
 import { PullRequestFieldsFragment } from "./generated/graphql";
-import { pluralize } from "./helpers";
+import { pluralize, uniqueById } from "./helpers";
 import { PR_DEFAULT_SORT_QUERY } from "./helpers/pull-request";
 import { withGitHubClient } from "./helpers/withGithubClient";
 import { useViewer } from "./hooks/useViewer";
@@ -33,25 +33,28 @@ function SearchPullRequests() {
     mutate: mutateList,
     pagination,
   } = useCachedPromise(
-    (searchText, searchFilter, sortTxt) => async (options: { page: number; cursor?: string }) => {
-      const result = await github.searchPullRequests({
-        numberOfItems: getBoundedPreferenceNumber({ name: "numberOfResults", default: 25 }),
-        query: `is:pr archived:false ${sortTxt} ${searchFilter} ${searchText}`,
-        after: options.page > 0 ? options.cursor : undefined,
-      });
+    (searchText, searchFilter, sortTxt) =>
+      async ({ cursor }) => {
+        const result = await github.searchPullRequests({
+          numberOfItems: getSearchPageSize(),
+          query: `is:pr archived:false ${sortTxt} ${searchFilter} ${searchText}`,
+          after: cursor,
+        });
 
-      return {
-        data:
-          result.search.edges
-            ?.map((edge) => edge?.node as PullRequestFieldsFragment | null | undefined)
-            .filter((node): node is PullRequestFieldsFragment => node != null) ?? [],
-        hasMore: result.search.pageInfo.hasNextPage,
-        cursor: result.search.pageInfo.endCursor ?? undefined,
-      };
-    },
+        return {
+          data:
+            result.search.edges
+              ?.map((edge) => edge?.node as PullRequestFieldsFragment | null | undefined)
+              .filter((node): node is PullRequestFieldsFragment => node != null) ?? [],
+          hasMore: result.search.pageInfo.hasNextPage,
+          cursor: result.search.pageInfo.endCursor ?? undefined,
+        };
+      },
     [searchText, searchFilter, sortQuery],
     { keepPreviousData: true },
   );
+
+  const pullRequests = uniqueById(data ?? []);
 
   return (
     <List
@@ -66,9 +69,9 @@ function SearchPullRequests() {
       {data ? (
         <List.Section
           title={searchText ? "Search Results" : "Created Recently"}
-          subtitle={pluralize(data.length, "pull request", { withNumber: true })}
+          subtitle={pluralize(pullRequests.length, "pull request", { withNumber: true })}
         >
-          {data.map((pullRequest) => {
+          {pullRequests.map((pullRequest) => {
             return (
               <PullRequestListItem
                 key={pullRequest.id}

--- a/extensions/github/src/search-repositories.tsx
+++ b/extensions/github/src/search-repositories.tsx
@@ -3,11 +3,12 @@ import { useCachedPromise, useCachedState } from "@raycast/utils";
 import { useEffect, useMemo, useState } from "react";
 
 import { getGitHubClient } from "./api/githubClient";
-import { getBoundedPreferenceNumber } from "./components/Menu";
+import { getSearchPageSize } from "./components/Menu";
 import RepositoryListEmptyView from "./components/RepositoryListEmptyView";
 import RepositoryListItem from "./components/RepositoryListItem";
 import SearchRepositoryDropdown from "./components/SearchRepositoryDropdown";
 import { ExtendedRepositoryFieldsFragment } from "./generated/graphql";
+import { compactFragmentNodes, uniqueById } from "./helpers";
 import { REPO_DEFAULT_SORT_QUERY, REPO_SORT_TYPES_TO_QUERIES, useHistory } from "./helpers/repository";
 import { withGitHubClient } from "./helpers/withGithubClient";
 
@@ -44,11 +45,11 @@ function SearchRepositories() {
 
       const result = await github.searchRepositories({
         query,
-        numberOfItems: getBoundedPreferenceNumber({ name: "numberOfResults", default: 25 }),
+        numberOfItems: getSearchPageSize(),
         after: options.page > 0 ? options.cursor : undefined,
       });
       return {
-        data: result.search.nodes?.map((node) => node as ExtendedRepositoryFieldsFragment) ?? [],
+        data: compactFragmentNodes<ExtendedRepositoryFieldsFragment>(result.search.nodes),
         hasMore: result.search.pageInfo.hasNextPage,
         cursor: result.search.pageInfo.endCursor ?? undefined,
       };
@@ -57,22 +58,27 @@ function SearchRepositories() {
     { keepPreviousData: false },
   );
 
+  const repositories = useMemo(() => uniqueById(data ?? []), [data]);
+  const repositoryIds = useMemo(() => new Set(repositories.map((repository) => repository.id)), [repositories]);
+
   useEffect(
-    () => history.forEach((repository) => data?.find((r) => r.id === repository.id && visitRepository(r))),
-    [data],
+    () => history.forEach((repository) => repositories.find((r) => r.id === repository.id && visitRepository(r))),
+    [repositories],
   );
 
   const validHistory = useMemo(
-    () => history.filter((repository) => data?.find((r) => r.id === repository.id)),
-    [data, history],
+    () => history.filter((repository) => repositoryIds.has(repository.id)),
+    [history, repositoryIds],
   );
+
+  const historyIds = useMemo(() => new Set(validHistory.map((repository) => repository.id)), [validHistory]);
 
   const foundRepositories = useMemo(
-    () => data?.filter((repository) => !validHistory.find((r) => r.id === repository.id)),
-    [data, validHistory],
+    () => repositories.filter((repository) => !historyIds.has(repository.id)),
+    [historyIds, repositories],
   );
 
-  const visitedRepositories = searchText.trim() && data && data.length > 0 ? validHistory : history;
+  const visitedRepositories = searchText.trim() && repositories.length > 0 ? validHistory : history;
 
   return (
     <List
@@ -104,7 +110,7 @@ function SearchRepositories() {
         </List.Section>
       ) : null}
 
-      {foundRepositories ? (
+      {data ? (
         <List.Section
           title={searchText ? "Search Results" : "Found Repositories"}
           subtitle={`${foundRepositories.length}`}

--- a/extensions/github/src/workflow-runs.tsx
+++ b/extensions/github/src/workflow-runs.tsx
@@ -10,6 +10,8 @@ import { withGitHubClient } from "./helpers/withGithubClient";
 
 export type WorkflowRunsResponse = RestEndpointMethodTypes["actions"]["listWorkflowRunsForRepo"]["response"];
 
+const WORKFLOW_RUNS_PAGE_SIZE = 25;
+
 function WorkflowRuns() {
   const { octokit } = getGitHubClient();
 
@@ -18,16 +20,31 @@ function WorkflowRuns() {
     data,
     isLoading,
     mutate: mutateList,
+    pagination,
   } = useCachedPromise(
-    (repository) => {
-      const [owner, repo] = repository.split("/");
-      return octokit.actions.listWorkflowRunsForRepo({ owner, repo });
-    },
+    (repository) =>
+      async ({ cursor }) => {
+        const [owner, repo] = repository.split("/");
+        const page = cursor ? Number(cursor) : 1;
+        const response = await octokit.actions.listWorkflowRunsForRepo({
+          owner,
+          repo,
+          per_page: WORKFLOW_RUNS_PAGE_SIZE,
+          page,
+        });
+        const hasMore = page * WORKFLOW_RUNS_PAGE_SIZE < response.data.total_count;
+
+        return {
+          data: response.data.workflow_runs,
+          hasMore,
+          cursor: hasMore ? String(page + 1) : undefined,
+        };
+      },
     [selectedRepository],
     { execute: !!selectedRepository },
   );
 
-  const workflowRuns = data?.data.workflow_runs;
+  const workflowRuns = [...new Map((data ?? []).map((workflowRun) => [workflowRun.id, workflowRun])).values()];
 
   return (
     <List
@@ -36,6 +53,7 @@ function WorkflowRuns() {
       searchBarAccessory={
         <RepositoriesDropdown setSelectedRepository={setSelectedRepository} withAllRepositories={false} />
       }
+      pagination={pagination}
     >
       {workflowRuns && workflowRuns.length > 0
         ? workflowRuns.map((workflowRun: WorkflowRun) => {


### PR DESCRIPTION
## Description

The GitHub extension currently eager-loads multiple result batches before rendering some lists, while other lists use fixed-size requests without native Raycast pagination. This makes cold launches slower and increases the chance of large GraphQL requests failing.

This change:

- uses Raycast's paginated promise contract for repository, issue, pull-request, discussion, release, notification, workflow-run, and commit lists;
- caps search pages at 25 items while honoring smaller configured limits;
- uses forward GraphQL cursors for ordinary lists and backward cursors for newest-first pull-request commits;
- deduplicates accumulated pages by stable ID;
- introduces a lightweight `RepositoryListFields` fragment and loads releases only when opened;
- keeps mutation revalidation compatible with paginated results; and
- preserves the checked-in GraphQL schema pipeline, View Diff action, and Checks metadata from current upstream.

The expected user impact is that initial list results can render sooner and later pages load as the user navigates the list.

### Validation

- `npm run generate` twice with identical output
- `npm test`
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `npm run build`
- `npm run lint`
- `git diff --check`
- Local Raycast build smoke-tested with repository search reset and starred repositories crossing a page boundary

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] No files in the `assets` folder were changed
- [x] No README assets were changed
