### PR TITLE
Add Elsewhere AI tools

### DIFF
--- a/extensions/elsewhere/CHANGELOG.md
+++ b/extensions/elsewhere/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Elsewhere Changelog
 
+## [AI Tools] - 2026-08-10
+
+- Create spatial soundscape previews from natural-language prompts through Raycast AI.
+- Control playback, ambience and music volume, and background music with native AI tools.
+- Update the extension metadata and documentation for the new AI capabilities.
+
 ## [Initial Version] - 2026-08-06
 
 - Toggle all Elsewhere audio from one contextual command.

--- a/extensions/elsewhere/CHANGELOG.md
+++ b/extensions/elsewhere/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Create spatial soundscape previews from natural-language prompts through Raycast AI.
 - Control playback, ambience and music volume, and background music with native AI tools.
+- Switch spatial soundscapes and background-music tracks by name with native AI tools.
 - Update the extension metadata and documentation for the new AI capabilities.
 
 ## [Initial Version] - 2026-08-06

--- a/extensions/elsewhere/CHANGELOG.md
+++ b/extensions/elsewhere/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Elsewhere Changelog
 
-## [AI Tools] - 2026-08-10
+## [AI Tools] - {PR_MERGE_DATE}
 
 - Create spatial soundscape previews from natural-language prompts through Raycast AI.
 - Control playback, ambience and music volume, and background music with native AI tools.

--- a/extensions/elsewhere/CHANGELOG.md
+++ b/extensions/elsewhere/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Elsewhere Changelog
 
-## [AI Tools] - {PR_MERGE_DATE}
+## [AI Tools] - 2026-08-11
 
 - Create spatial soundscape previews from natural-language prompts through Raycast AI.
 - Control playback, ambience and music volume, and background music with native AI tools.

--- a/extensions/elsewhere/README.md
+++ b/extensions/elsewhere/README.md
@@ -26,6 +26,12 @@ Volume commands leave Raycast open, so press Enter repeatedly for quick adjustme
 Immediate actions are no-view commands. Commands that require choosing a Space or track open a focused
 Raycast list with current-state context.
 
+## Raycast AI controls
+
+Raycast AI can directly play or pause Elsewhere audio, adjust ambience or background-music volume, and turn background
+music on or off through native background controls. Switching Spaces or music tracks remains list-based because the
+extension uses Elsewhere's live snapshot to present unambiguous current choices.
+
 If Elsewhere is not running, selection commands offer to open it and populate automatically when it is ready.
 Immediate commands provide an **Open Elsewhere and Retry** confirmation.
 

--- a/extensions/elsewhere/README.md
+++ b/extensions/elsewhere/README.md
@@ -1,6 +1,6 @@
 # Elsewhere
 
-Control Elsewhere from focused Raycast commands without leaving your current context.
+Create and control immersive spatial soundscapes without leaving your current context.
 
 Elsewhere for macOS is required.
 
@@ -26,18 +26,14 @@ Volume commands leave Raycast open, so press Enter repeatedly for quick adjustme
 Immediate actions are no-view commands. Commands that require choosing a Space or track open a focused
 Raycast list with current-state context.
 
-## Raycast AI controls
+## Raycast AI
 
 Raycast AI can directly play or pause Elsewhere audio, adjust ambience or background-music volume, and turn background
 music on or off through native background controls. Switching Spaces or music tracks remains list-based because the
 extension uses Elsewhere's live snapshot to present unambiguous current choices.
 
+Describe a place, mood, or moment to generate a Space preview in Elsewhere. The preview opens automatically for review
+before you save it. This feature uses Glaze AI credits and requires Elsewhere v13.0.0 or later.
+
 If Elsewhere is not running, selection commands offer to open it and populate automatically when it is ready.
 Immediate commands provide an **Open Elsewhere and Retry** confirmation.
-
-## State snapshot contract
-
-Elsewhere publishes the versioned `elsewhere-control-v1.json` snapshot in its macOS user-data directory. The extension
-discovers that file below `~/Library/Application Support` using the app-family identifier
-`app.glaze.macos.27b0yt1l*`, validates schema version 1 at runtime, and never reads Elsewhere's editable Space
-documents directly.

--- a/extensions/elsewhere/ai.yaml
+++ b/extensions/elsewhere/ai.yaml
@@ -1,0 +1,72 @@
+instructions: |
+  Use control-audio for every request to play, resume, or pause Elsewhere audio; adjust audio, ambience, soundscape, spatial-audio, music, or background-music volume; or turn background music on or off. It is a first-party, reversible control that runs in the background and needs no confirmation. Never use Run Command, shell commands, AppleScript, System Events, or accessibility automation for Elsewhere controls.
+
+  For “increase/decrease Elsewhere volume” without a target, use control-audio with `ambience-louder` or `ambience-quieter`. Use the music controls only when the user explicitly means background music volume.
+
+  Switching Spaces or background-music tracks remains a regular Raycast command because it presents the live snapshot for safe, unambiguous selection. Do not attempt those actions with generic automation.
+
+  Use create-space-from-prompt when the user asks to create an Elsewhere Space from a natural-language description.
+
+  Pass the user's description as the prompt, preserving its language and requested ambience, mood, setting, and spatial sound-source details. Raycast asks for confirmation before calling the tool; accepting starts Glaze AI generation and uses Glaze AI credits. Do not claim that a Space was created: Elsewhere generates a preview, then the user reviews and explicitly confirms the final Space there.
+evals:
+  - input: "@elsewhere increase Elsewhere volume"
+    mocks:
+      control-audio: "Elsewhere ambience volume increased."
+    expected:
+      - callsTool:
+          name: control-audio
+          arguments:
+            control: ambience-louder
+      - meetsCriteria: Confirms the native Elsewhere ambience volume was increased without suggesting Run Command or AppleScript
+
+  - input: "@elsewhere pause the audio"
+    mocks:
+      control-audio: "Elsewhere audio is paused."
+    expected:
+      - callsTool:
+          name: control-audio
+          arguments:
+            control: pause
+      - meetsCriteria: Confirms Elsewhere audio was paused
+
+  - input: "@elsewhere resume my soundscape"
+    mocks:
+      control-audio: "Elsewhere audio is playing."
+    expected:
+      - callsTool:
+          name: control-audio
+          arguments:
+            control: play
+      - meetsCriteria: Uses the native Elsewhere tool and does not suggest generic automation
+
+  - input: "@elsewhere make the background music quieter"
+    mocks:
+      control-audio: "Elsewhere music volume decreased."
+    expected:
+      - callsTool:
+          name: control-audio
+          arguments:
+            control: music-quieter
+      - meetsCriteria: Confirms background music volume was reduced without suggesting Run Command or AppleScript
+
+  - input: "@elsewhere create a quiet rainy cabin for deep work with rain on the windows, distant thunder, and a crackling fire"
+    mocks:
+      create-space-from-prompt: "Elsewhere started generating a Space preview."
+    expected:
+      - callsTool:
+          name: create-space-from-prompt
+          arguments:
+            prompt:
+              includes: "rain on the windows"
+      - meetsCriteria: Explains that Elsewhere started generating a preview and that final Space creation still requires confirmation in Elsewhere
+
+  - input: "@elsewhere make me a calm coastal reading space with gentle waves, gulls far away, and wind through dune grass"
+    mocks:
+      create-space-from-prompt: "Elsewhere started generating a Space preview."
+    expected:
+      - callsTool:
+          name: create-space-from-prompt
+          arguments:
+            prompt:
+              includes: "gentle waves"
+      - meetsCriteria: Explains that Glaze AI generation started without claiming that the Space was already created

--- a/extensions/elsewhere/ai.yaml
+++ b/extensions/elsewhere/ai.yaml
@@ -3,7 +3,9 @@ instructions: |
 
   For “increase/decrease Elsewhere volume” without a target, use control-audio with `ambience-louder` or `ambience-quieter`. Use the music controls only when the user explicitly means background music volume.
 
-  Switching Spaces or background-music tracks remains a regular Raycast command because it presents the live snapshot for safe, unambiguous selection. Do not attempt those actions with generic automation.
+  Use switch-space when the user asks to switch, open, or use an existing Elsewhere Space or spatial soundscape by name. Pass the complete title as one `name`, including conjunctions such as “and”; for example, “switch to Coffee and Thunder” means switch-space with `name: Coffee and Thunder`. Do not split a Space title into multiple tool calls.
+
+  Use switch-background-music only when the user explicitly asks for music, background music, or a track by name. A soundscape title containing words that could describe audio is not a music request. These selection tools resolve names against Elsewhere's live catalog and reject unavailable or ambiguous choices. Never invent a name, guess between choices, or use generic automation.
 
   Use create-space-from-prompt when the user asks to create an Elsewhere Space from a natural-language description.
 
@@ -70,3 +72,34 @@ evals:
             prompt:
               includes: "gentle waves"
       - meetsCriteria: Explains that the generated preview is ready without claiming that the Space was already saved
+
+  - input: "@elsewhere switch to my Coastal Airport soundscape"
+    mocks:
+      switch-space: "Switched to Coastal Airport."
+    expected:
+      - callsTool:
+          name: switch-space
+          arguments:
+            name: Coastal Airport
+      - meetsCriteria: Confirms that the existing Coastal Airport spatial soundscape is active without creating a new one
+
+  - input: "@elsewhere change the background music to Lo-fi Hip-Hop"
+    mocks:
+      switch-background-music: "Switched background music to Lo-fi Hip-Hop."
+    expected:
+      - callsTool:
+          name: switch-background-music
+          arguments:
+            name: Lo-fi Hip-Hop
+      - meetsCriteria: Confirms that the existing Lo-fi Hip-Hop background music was selected
+
+  - input: "@elsewhere switch to Coffee and Thunder"
+    mocks:
+      switch-space: "Switched to Coffee and Thunder."
+      switch-background-music: "Switched background music to Thunder."
+    expected:
+      - callsTool:
+          name: switch-space
+          arguments:
+            name: Coffee and Thunder
+      - meetsCriteria: Calls only switch-space with the complete Coffee and Thunder title and does not call switch-background-music

--- a/extensions/elsewhere/ai.yaml
+++ b/extensions/elsewhere/ai.yaml
@@ -7,7 +7,7 @@ instructions: |
 
   Use create-space-from-prompt when the user asks to create an Elsewhere Space from a natural-language description.
 
-  Pass the user's description as the prompt, preserving its language and requested ambience, mood, setting, and spatial sound-source details. Raycast asks for confirmation before calling the tool; accepting starts Glaze AI generation and uses Glaze AI credits. Do not claim that a Space was created: Elsewhere generates a preview, then the user reviews and explicitly confirms the final Space there.
+  Pass the user's description as the prompt, preserving its language and requested ambience, mood, setting, and spatial sound-source details. Raycast asks for confirmation before calling the tool; accepting uses Glaze AI credits. Wait for the tool result before reporting success. A successful result means the generated preview is ready and playing, not that the Space has been saved: the user still reviews and explicitly confirms it in Elsewhere.
 evals:
   - input: "@elsewhere increase Elsewhere volume"
     mocks:
@@ -51,22 +51,22 @@ evals:
 
   - input: "@elsewhere create a quiet rainy cabin for deep work with rain on the windows, distant thunder, and a crackling fire"
     mocks:
-      create-space-from-prompt: "Elsewhere started generating a Space preview."
+      create-space-from-prompt: "A generated Space preview is ready and playing in Elsewhere."
     expected:
       - callsTool:
           name: create-space-from-prompt
           arguments:
             prompt:
               includes: "rain on the windows"
-      - meetsCriteria: Explains that Elsewhere started generating a preview and that final Space creation still requires confirmation in Elsewhere
+      - meetsCriteria: Explains that the generated preview is ready and playing and that saving still requires confirmation in Elsewhere
 
   - input: "@elsewhere make me a calm coastal reading space with gentle waves, gulls far away, and wind through dune grass"
     mocks:
-      create-space-from-prompt: "Elsewhere started generating a Space preview."
+      create-space-from-prompt: "A generated Space preview is ready and playing in Elsewhere."
     expected:
       - callsTool:
           name: create-space-from-prompt
           arguments:
             prompt:
               includes: "gentle waves"
-      - meetsCriteria: Explains that Glaze AI generation started without claiming that the Space was already created
+      - meetsCriteria: Explains that the generated preview is ready without claiming that the Space was already saved

--- a/extensions/elsewhere/package.json
+++ b/extensions/elsewhere/package.json
@@ -77,6 +77,16 @@
       "name": "create-space-from-prompt",
       "title": "Create Space from Prompt",
       "description": "Create a spatial soundscape preview from a natural-language description to review before saving."
+    },
+    {
+      "name": "switch-space",
+      "title": "Switch Spatial Soundscape",
+      "description": "Switch to an existing spatial soundscape by name."
+    },
+    {
+      "name": "switch-background-music",
+      "title": "Switch Background Music",
+      "description": "Switch to an existing background music track by name."
     }
   ],
   "dependencies": {

--- a/extensions/elsewhere/package.json
+++ b/extensions/elsewhere/package.json
@@ -2,12 +2,12 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "elsewhere",
   "title": "Elsewhere",
-  "description": "Control Elsewhere's spatial soundscapes, Spaces, background music, and volume.",
+  "description": "Control spatial soundscapes, background music, playback, and volume.",
   "icon": "extension-icon.png",
   "author": "yannglt",
   "platforms": ["macOS"],
   "categories": ["Applications", "Media", "Productivity"],
-  "keywords": ["ambient", "focus", "soundscape", "spatial audio"],
+  "keywords": ["ambient", "ambience", "focus", "soundscape", "spatial audio", "background music", "ai"],
   "license": "MIT",
   "commands": [
     {
@@ -71,12 +71,12 @@
     {
       "name": "control-audio",
       "title": "Control Audio",
-      "description": "Control Elsewhere audio directly in the background: play or pause audio, adjust ambience or music volume, or turn background music on or off. Use this native tool instead of Run Command, shell commands, AppleScript, or accessibility automation."
+      "description": "Control spatial soundscapes, background music, playback, and volume."
     },
     {
       "name": "create-space-from-prompt",
       "title": "Create Space from Prompt",
-      "description": "Immediately start Glaze AI preview generation from the user's natural-language soundscape description. The user reviews and confirms in Elsewhere before a Space is created."
+      "description": "Create a spatial soundscape preview from a natural-language description to review before saving."
     }
   ],
   "dependencies": {

--- a/extensions/elsewhere/package.json
+++ b/extensions/elsewhere/package.json
@@ -67,6 +67,18 @@
       "mode": "no-view"
     }
   ],
+  "tools": [
+    {
+      "name": "control-audio",
+      "title": "Control Audio",
+      "description": "Control Elsewhere audio directly in the background: play or pause audio, adjust ambience or music volume, or turn background music on or off. Use this native tool instead of Run Command, shell commands, AppleScript, or accessibility automation."
+    },
+    {
+      "name": "create-space-from-prompt",
+      "title": "Create Space from Prompt",
+      "description": "Immediately start Glaze AI preview generation from the user's natural-language soundscape description. The user reviews and confirms in Elsewhere before a Space is created."
+    }
+  ],
   "dependencies": {
     "@raycast/api": "^1.104.23",
     "open": "^11.0.0"

--- a/extensions/elsewhere/src/ai-selection.test.ts
+++ b/extensions/elsewhere/src/ai-selection.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveNamedItem } from "./name-resolution";
+
+const spaces = [
+  { id: "coastal", name: "Coastal Airport" },
+  { id: "cafe", name: "Café at Night" },
+  { id: "cabin", name: "Calm Cabin" },
+  { id: "camp", name: "Calm Campsite" },
+];
+
+test("resolves names case-insensitively and ignores punctuation only when unique", () => {
+  assert.equal(resolveNamedItem("coastal airport", spaces, "space").id, "coastal");
+  assert.equal(resolveNamedItem("cafe-at-night", spaces, "space").id, "cafe");
+  assert.equal(
+    resolveNamedItem("lofi", [{ id: "lo-fi", name: "Lo-fi Hip-Hop" }], "background music track").id,
+    "lo-fi",
+  );
+});
+
+test("accepts only a unique normalized prefix and never an arbitrary substring", () => {
+  assert.equal(resolveNamedItem("coastal", spaces, "space").id, "coastal");
+  assert.throws(() => resolveNamedItem("calm", spaces, "space"), /ambiguous.*Calm Cabin, Calm Campsite/s);
+  assert.throws(() => resolveNamedItem("airport", spaces, "space"), /No space named/);
+  assert.throws(() => resolveNamedItem("ca", spaces, "space"), /No space named/);
+});
+
+test("rejects blank, unavailable, and unknown choices with useful available names", () => {
+  assert.throws(() => resolveNamedItem("", spaces, "space"), /Available choices: Coastal Airport/);
+  assert.throws(() => resolveNamedItem("Ocean", [], "space"), /No spaces are currently available/);
+  assert.throws(() => resolveNamedItem("Ocean", spaces, "space"), /Available choices: Coastal Airport/);
+});
+
+test("rejects duplicate exact and normalized names instead of guessing", () => {
+  assert.throws(
+    () =>
+      resolveNamedItem(
+        "Rain Room",
+        [
+          { id: "one", name: "Rain Room" },
+          { id: "two", name: "rain room" },
+        ],
+        "space",
+      ),
+    /matches multiple spaces/,
+  );
+  assert.throws(
+    () =>
+      resolveNamedItem(
+        "lofi",
+        [
+          { id: "one", name: "Lo-fi" },
+          { id: "two", name: "Lo Fi" },
+        ],
+        "background music track",
+      ),
+    /matches multiple background music tracks/,
+  );
+});

--- a/extensions/elsewhere/src/ai-selection.ts
+++ b/extensions/elsewhere/src/ai-selection.ts
@@ -1,0 +1,41 @@
+import { ElsewhereCommand } from "./control-url";
+import { executeElsewhereCommandForAi } from "./command-runner";
+import { AiSelectionKind, resolveNamedItem } from "./name-resolution";
+import { ElsewhereSnapshotV1, readElsewhereState } from "./state-reader";
+
+function unavailableStateMessage(kind: AiSelectionKind): string {
+  return `Could not read the available ${kind}s. Open Elsewhere v13.0.0 or later and try again.`;
+}
+
+async function readySnapshot(kind: AiSelectionKind): Promise<ElsewhereSnapshotV1> {
+  const state = await readElsewhereState();
+  if (state.kind === "unsupported") {
+    throw new Error(
+      "The Elsewhere state format is newer than this extension. Update the Raycast extension and try again.",
+    );
+  }
+  if (state.kind !== "ready" || !state.snapshot.ready) throw new Error(unavailableStateMessage(kind));
+  return state.snapshot;
+}
+
+export async function selectSpaceByName(name: string): Promise<string> {
+  const snapshot = await readySnapshot("space");
+  const space = resolveNamedItem(name, snapshot.spaces, "space");
+  if (space.id === snapshot.activeSpaceId) return `${space.name} is already the active spatial soundscape.`;
+
+  const command: ElsewhereCommand = { kind: "space", action: "select", id: space.id };
+  await executeElsewhereCommandForAi(command);
+  return `Switched to ${space.name}.`;
+}
+
+export async function selectBackgroundMusicByName(name: string): Promise<string> {
+  const snapshot = await readySnapshot("background music track");
+  const track = resolveNamedItem(name, snapshot.musicTracks, "background music track");
+  if (track.id === snapshot.activeMusicTrackId && snapshot.backgroundMusicEnabled) {
+    return `${track.name} is already the active background music.`;
+  }
+
+  const command: ElsewhereCommand = { kind: "music", action: "select", id: track.id };
+  await executeElsewhereCommandForAi(command);
+  return `Switched background music to ${track.name}.`;
+}

--- a/extensions/elsewhere/src/audio-control.ts
+++ b/extensions/elsewhere/src/audio-control.ts
@@ -1,0 +1,50 @@
+import type { ElsewhereCommand } from "./control-url";
+
+export type AudioControl =
+  | "play"
+  | "pause"
+  | "ambience-louder"
+  | "ambience-quieter"
+  | "music-louder"
+  | "music-quieter"
+  | "background-music-on"
+  | "background-music-off";
+
+const controls: Record<AudioControl, { command: ElsewhereCommand; result: string }> = {
+  play: {
+    command: { kind: "experience", action: "play" },
+    result: "Elsewhere audio is playing.",
+  },
+  pause: {
+    command: { kind: "experience", action: "pause" },
+    result: "Elsewhere audio is paused.",
+  },
+  "ambience-louder": {
+    command: { kind: "volume", target: "ambience", delta: 10 },
+    result: "Elsewhere ambience volume increased.",
+  },
+  "ambience-quieter": {
+    command: { kind: "volume", target: "ambience", delta: -10 },
+    result: "Elsewhere ambience volume decreased.",
+  },
+  "music-louder": {
+    command: { kind: "volume", target: "music", delta: 10 },
+    result: "Elsewhere music volume increased.",
+  },
+  "music-quieter": {
+    command: { kind: "volume", target: "music", delta: -10 },
+    result: "Elsewhere music volume decreased.",
+  },
+  "background-music-on": {
+    command: { kind: "music", action: "on" },
+    result: "Elsewhere background music is on.",
+  },
+  "background-music-off": {
+    command: { kind: "music", action: "off" },
+    result: "Elsewhere background music is off.",
+  },
+};
+
+export function audioControl(control: AudioControl): { command: ElsewhereCommand; result: string } {
+  return controls[control];
+}

--- a/extensions/elsewhere/src/command-runner.ts
+++ b/extensions/elsewhere/src/command-runner.ts
@@ -122,3 +122,39 @@ export function executeElsewhereCommand(command: ElsewhereCommand, options: Exec
   commandQueue = queued.catch(() => undefined);
   return queued;
 }
+
+async function sendCommandForAi(command: ElsewhereCommand): Promise<ElsewhereCommandResult> {
+  const correlationId = requestId();
+
+  try {
+    await openUrl(buildElsewhereUrl(command, correlationId), { background: true });
+  } catch (error) {
+    throw new Error(
+      `Could not reach Elsewhere: ${error instanceof Error ? error.message : "Make sure Elsewhere is installed and has been opened once."}`,
+    );
+  }
+
+  const correlated = await waitForCorrelatedResult(correlationId);
+  if (!correlated) {
+    throw new Error("Elsewhere did not confirm the request in time. Open Elsewhere and try again.");
+  }
+  if (correlated.result.status === "error") {
+    throw new Error(correlated.result.message ?? correlated.result.code ?? "Elsewhere could not complete the request.");
+  }
+  return correlated.result;
+}
+
+/**
+ * Runs an AI-initiated command and requires Elsewhere to publish its correlated result.
+ *
+ * Unlike a regular Raycast command, an AI tool must return a deterministic success or
+ * failure so the conversation can accurately report what Elsewhere did.
+ */
+export function executeElsewhereCommandForAi(command: ElsewhereCommand): Promise<ElsewhereCommandResult> {
+  const queued = commandQueue.then(() => sendCommandForAi(command));
+  commandQueue = queued.then(
+    () => undefined,
+    () => undefined,
+  );
+  return queued;
+}

--- a/extensions/elsewhere/src/command-runner.ts
+++ b/extensions/elsewhere/src/command-runner.ts
@@ -4,10 +4,16 @@ import { Toast, showToast } from "@raycast/api";
 import openUrl from "open";
 
 import { buildElsewhereUrl, ElsewhereCommand } from "./control-url";
+import {
+  PreparedSpaceCreateRequest,
+  prepareSpaceCreateRequest,
+  removeSpaceCreateRequest,
+} from "./space-create-request";
 import { ElsewhereCommandResult, ElsewhereSnapshotV1, readElsewhereState } from "./state-reader";
 import { successToastTitle } from "./success-toast";
 
 const CORRELATION_TIMEOUT_MS = 3_000;
+const CREATE_SPACE_CORRELATION_TIMEOUT_MS = 40_000;
 const POLL_INTERVAL_MS = 80;
 
 let commandQueue: Promise<void> = Promise.resolve();
@@ -25,8 +31,11 @@ interface CorrelatedResult {
   snapshot: ElsewhereSnapshotV1;
 }
 
-async function waitForCorrelatedResult(id: string): Promise<CorrelatedResult | null> {
-  const deadline = Date.now() + CORRELATION_TIMEOUT_MS;
+async function waitForCorrelatedResult(
+  id: string,
+  timeoutMilliseconds = CORRELATION_TIMEOUT_MS,
+): Promise<CorrelatedResult | null> {
+  const deadline = Date.now() + timeoutMilliseconds;
   while (Date.now() < deadline) {
     const state = await readElsewhereState();
     if (state.kind === "ready" || state.kind === "stale") {
@@ -125,16 +134,32 @@ export function executeElsewhereCommand(command: ElsewhereCommand, options: Exec
 
 async function sendCommandForAi(command: ElsewhereCommand): Promise<ElsewhereCommandResult> {
   const correlationId = requestId();
+  const isSpaceCreation = command.kind === "space" && command.action === "create";
+  let nonce: string | undefined;
+  let request: PreparedSpaceCreateRequest | undefined;
+  if (command.kind === "space" && command.action === "create") {
+    nonce = randomUUID().replaceAll("-", "");
+    request = await prepareSpaceCreateRequest(correlationId, nonce, command.prompt);
+  }
 
   try {
-    await openUrl(buildElsewhereUrl(command, correlationId), { background: true });
+    await openUrl(buildElsewhereUrl(command, correlationId, nonce), { background: true });
   } catch (error) {
+    if (request) await removeSpaceCreateRequest(request.requestPath);
     throw new Error(
       `Could not reach Elsewhere: ${error instanceof Error ? error.message : "Make sure Elsewhere is installed and has been opened once."}`,
     );
   }
 
-  const correlated = await waitForCorrelatedResult(correlationId);
+  let correlated: CorrelatedResult | null;
+  try {
+    correlated = await waitForCorrelatedResult(
+      correlationId,
+      isSpaceCreation ? CREATE_SPACE_CORRELATION_TIMEOUT_MS : CORRELATION_TIMEOUT_MS,
+    );
+  } finally {
+    if (request) await removeSpaceCreateRequest(request.requestPath);
+  }
   if (!correlated) {
     throw new Error("Elsewhere did not confirm the request in time. Open Elsewhere and try again.");
   }

--- a/extensions/elsewhere/src/control-audio.test.ts
+++ b/extensions/elsewhere/src/control-audio.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { AudioControl, audioControl } from "./audio-control";
+
+test("maps every native AI audio control to an Elsewhere deep-link command", () => {
+  const expected: Record<AudioControl, unknown> = {
+    play: { kind: "experience", action: "play" },
+    pause: { kind: "experience", action: "pause" },
+    "ambience-louder": { kind: "volume", target: "ambience", delta: 10 },
+    "ambience-quieter": { kind: "volume", target: "ambience", delta: -10 },
+    "music-louder": { kind: "volume", target: "music", delta: 10 },
+    "music-quieter": { kind: "volume", target: "music", delta: -10 },
+    "background-music-on": { kind: "music", action: "on" },
+    "background-music-off": { kind: "music", action: "off" },
+  };
+
+  for (const [control, command] of Object.entries(expected) as [AudioControl, unknown][]) {
+    assert.deepEqual(audioControl(control).command, command);
+  }
+});

--- a/extensions/elsewhere/src/control-url.test.ts
+++ b/extensions/elsewhere/src/control-url.test.ts
@@ -19,8 +19,12 @@ test("builds every supported command with correlation", () => {
     `elsewhere://space/select?id=space-123&requestId=${requestId}`,
   );
   assert.equal(
-    buildElsewhereUrl({ kind: "space", action: "create", prompt: "A rainy cabin for deep work" }, requestId),
-    `elsewhere://space/create?prompt=A+rainy+cabin+for+deep+work&requestId=${requestId}`,
+    buildElsewhereUrl(
+      { kind: "space", action: "create", prompt: "A rainy cabin for deep work" },
+      requestId,
+      "abcdefghijklmnopqrstuv",
+    ),
+    `elsewhere://space/create?nonce=abcdefghijklmnopqrstuv&requestId=${requestId}`,
   );
   assert.equal(
     buildElsewhereUrl({ kind: "music", action: "on" }, requestId),
@@ -65,9 +69,9 @@ test("encodes identifiers and clamps volume inputs", () => {
     buildElsewhereUrl({ kind: "space", action: "select", id: "space & focus" }),
     "elsewhere://space/select?id=space+%26+focus",
   );
-  assert.equal(
-    buildElsewhereUrl({ kind: "space", action: "create", prompt: "Rain & thunder / warm lights" }),
-    "elsewhere://space/create?prompt=Rain+%26+thunder+%2F+warm+lights",
+  assert.throws(
+    () => buildElsewhereUrl({ kind: "space", action: "create", prompt: "Rain & thunder / warm lights" }),
+    /private request envelope/,
   );
   assert.equal(
     buildElsewhereUrl({ kind: "volume", target: "ambience", value: 140 }),
@@ -99,7 +103,11 @@ test("keeps absolute and relative volume mutually exclusive", () => {
     /Prompt must be at most 1200 characters/,
   );
   assert.equal(
-    buildElsewhereUrl({ kind: "space", action: "create", prompt: "  Rain and thunder  " }),
-    "elsewhere://space/create?prompt=Rain+and+thunder",
+    buildElsewhereUrl(
+      { kind: "space", action: "create", prompt: "  Rain and thunder  " },
+      "raycast_123",
+      "abcdefghijklmnopqrstuv",
+    ),
+    "elsewhere://space/create?nonce=abcdefghijklmnopqrstuv&requestId=raycast_123",
   );
 });

--- a/extensions/elsewhere/src/control-url.test.ts
+++ b/extensions/elsewhere/src/control-url.test.ts
@@ -19,6 +19,10 @@ test("builds every supported command with correlation", () => {
     `elsewhere://space/select?id=space-123&requestId=${requestId}`,
   );
   assert.equal(
+    buildElsewhereUrl({ kind: "space", action: "create", prompt: "A rainy cabin for deep work" }, requestId),
+    `elsewhere://space/create?prompt=A+rainy+cabin+for+deep+work&requestId=${requestId}`,
+  );
+  assert.equal(
     buildElsewhereUrl({ kind: "music", action: "on" }, requestId),
     `elsewhere://music/on?requestId=${requestId}`,
   );
@@ -62,6 +66,10 @@ test("encodes identifiers and clamps volume inputs", () => {
     "elsewhere://space/select?id=space+%26+focus",
   );
   assert.equal(
+    buildElsewhereUrl({ kind: "space", action: "create", prompt: "Rain & thunder / warm lights" }),
+    "elsewhere://space/create?prompt=Rain+%26+thunder+%2F+warm+lights",
+  );
+  assert.equal(
     buildElsewhereUrl({ kind: "volume", target: "ambience", value: 140 }),
     "elsewhere://volume/ambience?value=100",
   );
@@ -82,4 +90,16 @@ test("keeps absolute and relative volume mutually exclusive", () => {
     "elsewhere://volume/ambience?delta=10",
   );
   assert.throws(() => buildElsewhereUrl({ kind: "volume", target: "music", value: Number.NaN }), /finite number/);
+  assert.throws(
+    () => buildElsewhereUrl({ kind: "space", action: "create", prompt: "   " }),
+    /Prompt must not be empty/,
+  );
+  assert.throws(
+    () => buildElsewhereUrl({ kind: "space", action: "create", prompt: "a".repeat(1201) }),
+    /Prompt must be at most 1200 characters/,
+  );
+  assert.equal(
+    buildElsewhereUrl({ kind: "space", action: "create", prompt: "  Rain and thunder  " }),
+    "elsewhere://space/create?prompt=Rain+and+thunder",
+  );
 });

--- a/extensions/elsewhere/src/control-url.ts
+++ b/extensions/elsewhere/src/control-url.ts
@@ -43,8 +43,20 @@ export type NavigationCommand = {
   destination: "main" | "sources" | "settings";
 };
 
+export type CreateSpaceFromPromptCommand = {
+  kind: "space";
+  action: "create";
+  prompt: string;
+};
+
 export type ElsewhereCommand =
-  ExperienceCommand | SpaceCommand | MusicCommand | VolumeCommand | SourceCommand | NavigationCommand;
+  | ExperienceCommand
+  | SpaceCommand
+  | MusicCommand
+  | VolumeCommand
+  | SourceCommand
+  | NavigationCommand
+  | CreateSpaceFromPromptCommand;
 
 function finiteNumber(value: number, name: string): number {
   if (!Number.isFinite(value)) {
@@ -57,9 +69,22 @@ function clamped(value: number, minimum: number, maximum: number): number {
   return Math.min(maximum, Math.max(minimum, value));
 }
 
+export const CREATE_SPACE_PROMPT_MAX_LENGTH = 1200;
+
+export function normalizeCreateSpacePrompt(prompt: string): string {
+  const normalized = prompt.trim();
+  if (normalized.length === 0) throw new TypeError("Prompt must not be empty.");
+  if (normalized.length > CREATE_SPACE_PROMPT_MAX_LENGTH) {
+    throw new TypeError(`Prompt must be at most ${CREATE_SPACE_PROMPT_MAX_LENGTH} characters.`);
+  }
+  return normalized;
+}
+
 function baseUrl(command: ElsewhereCommand): URL {
   if (command.kind === "experience") return new URL(`elsewhere://${command.action}`);
-  if (command.kind === "space") return new URL("elsewhere://space/select");
+  if (command.kind === "space") {
+    return new URL(command.action === "select" ? "elsewhere://space/select" : "elsewhere://space/create");
+  }
   if (command.kind === "music") {
     return new URL(command.action === "select" ? "elsewhere://music/select" : `elsewhere://music/${command.action}`);
   }
@@ -73,7 +98,11 @@ function baseUrl(command: ElsewhereCommand): URL {
 export function buildElsewhereUrl(command: ElsewhereCommand, requestId?: string): string {
   const url = baseUrl(command);
 
-  if (command.kind === "space" || command.kind === "source") {
+  if (command.kind === "space" && command.action === "select") {
+    url.searchParams.set("id", command.id);
+  } else if (command.kind === "space" && command.action === "create") {
+    url.searchParams.set("prompt", normalizeCreateSpacePrompt(command.prompt));
+  } else if (command.kind === "source") {
     url.searchParams.set("id", command.id);
   } else if (command.kind === "music" && command.action === "select") {
     url.searchParams.set("id", command.id);

--- a/extensions/elsewhere/src/control-url.ts
+++ b/extensions/elsewhere/src/control-url.ts
@@ -95,13 +95,15 @@ function baseUrl(command: ElsewhereCommand): URL {
   return new URL(`elsewhere://open${path}`);
 }
 
-export function buildElsewhereUrl(command: ElsewhereCommand, requestId?: string): string {
+export function buildElsewhereUrl(command: ElsewhereCommand, requestId?: string, requestNonce?: string): string {
   const url = baseUrl(command);
 
   if (command.kind === "space" && command.action === "select") {
     url.searchParams.set("id", command.id);
   } else if (command.kind === "space" && command.action === "create") {
-    url.searchParams.set("prompt", normalizeCreateSpacePrompt(command.prompt));
+    normalizeCreateSpacePrompt(command.prompt);
+    if (!requestId || !requestNonce) throw new TypeError("Space creation requires a private request envelope.");
+    url.searchParams.set("nonce", requestNonce);
   } else if (command.kind === "source") {
     url.searchParams.set("id", command.id);
   } else if (command.kind === "music" && command.action === "select") {

--- a/extensions/elsewhere/src/manifest.test.ts
+++ b/extensions/elsewhere/src/manifest.test.ts
@@ -32,5 +32,15 @@ test("exposes focused Raycast commands instead of a monolithic control command",
       title: "Create Space from Prompt",
       description: "Create a spatial soundscape preview from a natural-language description to review before saving.",
     },
+    {
+      name: "switch-space",
+      title: "Switch Spatial Soundscape",
+      description: "Switch to an existing spatial soundscape by name.",
+    },
+    {
+      name: "switch-background-music",
+      title: "Switch Background Music",
+      description: "Switch to an existing background music track by name.",
+    },
   ]);
 });

--- a/extensions/elsewhere/src/manifest.test.ts
+++ b/extensions/elsewhere/src/manifest.test.ts
@@ -25,14 +25,12 @@ test("exposes focused Raycast commands instead of a monolithic control command",
     {
       name: "control-audio",
       title: "Control Audio",
-      description:
-        "Control Elsewhere audio directly in the background: play or pause audio, adjust ambience or music volume, or turn background music on or off. Use this native tool instead of Run Command, shell commands, AppleScript, or accessibility automation.",
+      description: "Control spatial soundscapes, background music, playback, and volume.",
     },
     {
       name: "create-space-from-prompt",
       title: "Create Space from Prompt",
-      description:
-        "Immediately start Glaze AI preview generation from the user's natural-language soundscape description. The user reviews and confirms in Elsewhere before a Space is created.",
+      description: "Create a spatial soundscape preview from a natural-language description to review before saving.",
     },
   ]);
 });

--- a/extensions/elsewhere/src/manifest.test.ts
+++ b/extensions/elsewhere/src/manifest.test.ts
@@ -21,4 +21,18 @@ test("exposes focused Raycast commands instead of a monolithic control command",
     manifest.commands.some((command) => command.name === "control-elsewhere"),
     false,
   );
+  assert.deepEqual(manifest.tools, [
+    {
+      name: "control-audio",
+      title: "Control Audio",
+      description:
+        "Control Elsewhere audio directly in the background: play or pause audio, adjust ambience or music volume, or turn background music on or off. Use this native tool instead of Run Command, shell commands, AppleScript, or accessibility automation.",
+    },
+    {
+      name: "create-space-from-prompt",
+      title: "Create Space from Prompt",
+      description:
+        "Immediately start Glaze AI preview generation from the user's natural-language soundscape description. The user reviews and confirms in Elsewhere before a Space is created.",
+    },
+  ]);
 });

--- a/extensions/elsewhere/src/name-resolution.ts
+++ b/extensions/elsewhere/src/name-resolution.ts
@@ -1,0 +1,58 @@
+import { ElsewhereNamedItem } from "./state-reader";
+
+export type AiSelectionKind = "space" | "background music track";
+
+function normalizedName(value: string): string {
+  return value
+    .normalize("NFKD")
+    .replaceAll(/\p{Mark}/gu, "")
+    .toLocaleLowerCase("en-US")
+    .replaceAll(/[^a-z0-9]+/g, "")
+    .trim();
+}
+
+function availableNames(items: ElsewhereNamedItem[]): string {
+  return items.length > 0 ? items.map((item) => item.name).join(", ") : "none";
+}
+
+export function resolveNamedItem(
+  query: string,
+  items: ElsewhereNamedItem[],
+  kind: AiSelectionKind,
+): ElsewhereNamedItem {
+  const trimmedQuery = query.trim();
+  if (!trimmedQuery) throw new Error(`Provide the ${kind} name. Available choices: ${availableNames(items)}.`);
+  if (items.length === 0) throw new Error(`No ${kind}s are currently available in Elsewhere.`);
+
+  const caseInsensitiveMatches = items.filter(
+    (item) => item.name.trim().localeCompare(trimmedQuery, undefined, { sensitivity: "accent" }) === 0,
+  );
+  if (caseInsensitiveMatches.length === 1) return caseInsensitiveMatches[0];
+  if (caseInsensitiveMatches.length > 1) {
+    throw new Error(`“${trimmedQuery}” matches multiple ${kind}s. Available choices: ${availableNames(items)}.`);
+  }
+
+  const normalizedQuery = normalizedName(trimmedQuery);
+  if (!normalizedQuery) throw new Error(`Provide the ${kind} name. Available choices: ${availableNames(items)}.`);
+
+  const normalizedMatches = items.filter((item) => normalizedName(item.name) === normalizedQuery);
+  if (normalizedMatches.length === 1) return normalizedMatches[0];
+  if (normalizedMatches.length > 1) {
+    throw new Error(`“${trimmedQuery}” matches multiple ${kind}s. Available choices: ${availableNames(items)}.`);
+  }
+
+  // A unique prefix tolerates concise requests such as “lo-fi” for “Lo-fi Hip-Hop”
+  // without allowing arbitrary substring or edit-distance guesses.
+  if (normalizedQuery.length >= 3) {
+    const prefixMatches = items.filter((item) => normalizedName(item.name).startsWith(normalizedQuery));
+    if (prefixMatches.length === 1) return prefixMatches[0];
+    if (prefixMatches.length > 1) {
+      throw new Error(
+        `“${trimmedQuery}” is ambiguous. Matching ${kind}s: ${availableNames(prefixMatches)}. ` +
+          `Available choices: ${availableNames(items)}.`,
+      );
+    }
+  }
+
+  throw new Error(`No ${kind} named “${trimmedQuery}” is available. Available choices: ${availableNames(items)}.`);
+}

--- a/extensions/elsewhere/src/space-create-request.test.ts
+++ b/extensions/elsewhere/src/space-create-request.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, stat, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  SPACE_CREATE_REQUEST_DIRECTORY,
+  SPACE_CREATE_REQUEST_MAX_PENDING,
+  SPACE_CREATE_REQUEST_TTL_MS,
+  writeSpaceCreateRequest,
+} from "./space-create-request";
+
+const REQUEST_ID = "raycast_123_abcdefghijkl";
+const NONCE = "abcdefghijklmnopqrstuvwxyz012345";
+
+test("writes a private, expiring creation envelope without putting the prompt in the URL contract", async () => {
+  const appDataDirectory = await mkdtemp(path.join(tmpdir(), "elsewhere-request-test-"));
+  const now = new Date("2026-08-10T10:00:00.000Z");
+  const prepared = await writeSpaceCreateRequest(appDataDirectory, REQUEST_ID, NONCE, "  A rainy cabin  ", { now });
+
+  assert.equal(prepared.requestId, REQUEST_ID);
+  assert.equal(prepared.nonce, NONCE);
+  assert.equal(path.basename(prepared.requestPath), `${REQUEST_ID}.json`);
+  const envelope = JSON.parse(await readFile(prepared.requestPath, "utf8"));
+  assert.deepEqual(envelope, {
+    schemaVersion: 1,
+    kind: "space.create",
+    requestId: REQUEST_ID,
+    nonce: NONCE,
+    prompt: "A rainy cabin",
+    createdAt: now.toISOString(),
+    expiresAt: new Date(now.getTime() + SPACE_CREATE_REQUEST_TTL_MS).toISOString(),
+  });
+  assert.equal((await stat(path.dirname(prepared.requestPath))).mode & 0o777, 0o700);
+  assert.equal((await stat(prepared.requestPath)).mode & 0o777, 0o600);
+});
+
+test("prunes expired requests and enforces the pending-request bound", async () => {
+  const appDataDirectory = await mkdtemp(path.join(tmpdir(), "elsewhere-request-test-"));
+  const requestDirectory = path.join(appDataDirectory, SPACE_CREATE_REQUEST_DIRECTORY);
+  await mkdir(requestDirectory, { mode: 0o700 });
+  const now = new Date("2026-08-10T10:00:00.000Z");
+  const base = {
+    schemaVersion: 1,
+    kind: "space.create",
+    nonce: NONCE,
+    prompt: "Rain",
+    createdAt: new Date(now.getTime() - 1_000).toISOString(),
+  };
+  await writeFile(
+    path.join(requestDirectory, "expired.json"),
+    JSON.stringify({ ...base, requestId: "expired", expiresAt: new Date(now.getTime() - 1).toISOString() }),
+    { mode: 0o600 },
+  );
+  for (let index = 0; index < SPACE_CREATE_REQUEST_MAX_PENDING; index += 1) {
+    await writeFile(
+      path.join(requestDirectory, `pending_${index}.json`),
+      JSON.stringify({
+        ...base,
+        requestId: `pending_${index}`,
+        expiresAt: new Date(now.getTime() + 30_000).toISOString(),
+      }),
+      { mode: 0o600 },
+    );
+  }
+
+  await assert.rejects(
+    writeSpaceCreateRequest(appDataDirectory, REQUEST_ID, NONCE, "Rain", { now }),
+    /too many pending creation requests/,
+  );
+  await assert.rejects(readFile(path.join(requestDirectory, "expired.json"), "utf8"), /ENOENT/);
+});
+
+test("removes abandoned temporary envelopes after the request TTL", async () => {
+  const appDataDirectory = await mkdtemp(path.join(tmpdir(), "elsewhere-request-test-"));
+  const requestDirectory = path.join(appDataDirectory, SPACE_CREATE_REQUEST_DIRECTORY);
+  await mkdir(requestDirectory, { mode: 0o700 });
+  const temporaryPath = path.join(requestDirectory, ".abandoned.tmp");
+  await writeFile(temporaryPath, "private prompt", { mode: 0o600 });
+  const now = new Date(Date.now() + SPACE_CREATE_REQUEST_TTL_MS + 1);
+
+  await writeSpaceCreateRequest(appDataDirectory, REQUEST_ID, NONCE, "Rain", { now });
+  await assert.rejects(readFile(temporaryPath, "utf8"), /ENOENT/);
+});
+
+test("rejects symlinked request directories", async () => {
+  const appDataDirectory = await mkdtemp(path.join(tmpdir(), "elsewhere-request-test-"));
+  const target = await mkdtemp(path.join(tmpdir(), "elsewhere-request-target-"));
+  await symlink(target, path.join(appDataDirectory, SPACE_CREATE_REQUEST_DIRECTORY));
+  await assert.rejects(writeSpaceCreateRequest(appDataDirectory, REQUEST_ID, NONCE, "Rain"), /not a regular directory/);
+});
+
+test("rejects invalid identifiers and prompts before writing", async () => {
+  const appDataDirectory = await mkdtemp(path.join(tmpdir(), "elsewhere-request-test-"));
+  await assert.rejects(writeSpaceCreateRequest(appDataDirectory, "../escape", NONCE, "Rain"), /identifier/);
+  await assert.rejects(writeSpaceCreateRequest(appDataDirectory, REQUEST_ID, "short", "Rain"), /nonce/);
+  await assert.rejects(writeSpaceCreateRequest(appDataDirectory, REQUEST_ID, NONCE, " "), /must not be empty/);
+});

--- a/extensions/elsewhere/src/space-create-request.ts
+++ b/extensions/elsewhere/src/space-create-request.ts
@@ -1,0 +1,174 @@
+import { chmod, lstat, mkdir, readFile, readdir, rename, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { normalizeCreateSpacePrompt } from "./control-url";
+import { readElsewhereState } from "./state-reader";
+
+export const SPACE_CREATE_REQUEST_DIRECTORY = "elsewhere-control-requests-v1";
+export const SPACE_CREATE_REQUEST_SCHEMA_VERSION = 1;
+export const SPACE_CREATE_REQUEST_MAX_BYTES = 8_192;
+export const SPACE_CREATE_REQUEST_MAX_PENDING = 16;
+export const SPACE_CREATE_REQUEST_TTL_MS = 60_000;
+
+const REQUEST_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
+const NONCE_PATTERN = /^[A-Za-z0-9_-]{22,128}$/;
+
+export interface SpaceCreateRequestEnvelope {
+  schemaVersion: 1;
+  kind: "space.create";
+  requestId: string;
+  nonce: string;
+  prompt: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
+export interface PreparedSpaceCreateRequest {
+  requestId: string;
+  nonce: string;
+  requestPath: string;
+}
+
+interface WriteRequestOptions {
+  now?: Date;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function currentUid(): number | undefined {
+  return typeof process.getuid === "function" ? process.getuid() : undefined;
+}
+
+async function assertPrivateRegularFile(filePath: string): Promise<void> {
+  const metadata = await lstat(filePath);
+  if (!metadata.isFile() || metadata.isSymbolicLink()) throw new Error("The request envelope is not a regular file.");
+  if ((metadata.mode & 0o777) !== 0o600) throw new Error("The request envelope has unsafe permissions.");
+  const uid = currentUid();
+  if (uid !== undefined && metadata.uid !== uid) throw new Error("The request envelope has an unexpected owner.");
+  if (metadata.size > SPACE_CREATE_REQUEST_MAX_BYTES) throw new Error("The request envelope is too large.");
+}
+
+async function prepareRequestDirectory(appDataDirectory: string): Promise<string> {
+  const parent = await lstat(appDataDirectory);
+  if (!parent.isDirectory() || parent.isSymbolicLink()) {
+    throw new Error("Elsewhere’s application data location is not a regular directory.");
+  }
+
+  const requestDirectory = path.join(appDataDirectory, SPACE_CREATE_REQUEST_DIRECTORY);
+  await mkdir(requestDirectory, { mode: 0o700, recursive: true });
+  const metadata = await lstat(requestDirectory);
+  if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+    throw new Error("Elsewhere’s request location is not a regular directory.");
+  }
+  const uid = currentUid();
+  if (uid !== undefined && metadata.uid !== uid)
+    throw new Error("Elsewhere’s request location has an unexpected owner.");
+  await chmod(requestDirectory, 0o700);
+  return requestDirectory;
+}
+
+function envelopeExpiresAt(value: unknown): number | null {
+  if (!isObject(value) || typeof value.expiresAt !== "string") return null;
+  const expiresAt = Date.parse(value.expiresAt);
+  return Number.isFinite(expiresAt) ? expiresAt : null;
+}
+
+async function pruneExpiredRequests(requestDirectory: string, now: number): Promise<number> {
+  const entries = await readdir(requestDirectory, { withFileTypes: true });
+  let pending = 0;
+  for (const entry of entries) {
+    if ((!entry.name.endsWith(".json") && !entry.name.endsWith(".tmp")) || !entry.isFile() || entry.isSymbolicLink()) {
+      continue;
+    }
+    const requestPath = path.join(requestDirectory, entry.name);
+    try {
+      await assertPrivateRegularFile(requestPath);
+      const metadata = await lstat(requestPath);
+      if (now - metadata.mtimeMs >= SPACE_CREATE_REQUEST_TTL_MS) {
+        await unlink(requestPath);
+        continue;
+      }
+      if (entry.name.endsWith(".tmp")) {
+        pending += 1;
+        continue;
+      }
+      const raw = await readFile(requestPath, "utf8");
+      const expiresAt = envelopeExpiresAt(JSON.parse(raw));
+      if (expiresAt !== null && expiresAt <= now) {
+        await unlink(requestPath);
+      } else {
+        pending += 1;
+      }
+    } catch {
+      // Leave malformed or unexpectedly owned entries for Elsewhere to reject.
+      pending += 1;
+    }
+  }
+  return pending;
+}
+
+export async function writeSpaceCreateRequest(
+  appDataDirectory: string,
+  requestId: string,
+  nonce: string,
+  prompt: string,
+  options: WriteRequestOptions = {},
+): Promise<PreparedSpaceCreateRequest> {
+  if (!REQUEST_ID_PATTERN.test(requestId)) throw new TypeError("The request identifier is invalid.");
+  if (!NONCE_PATTERN.test(nonce)) throw new TypeError("The request nonce is invalid.");
+
+  const normalizedPrompt = normalizeCreateSpacePrompt(prompt);
+  const now = options.now ?? new Date();
+  const requestDirectory = await prepareRequestDirectory(appDataDirectory);
+  const pending = await pruneExpiredRequests(requestDirectory, now.getTime());
+  if (pending >= SPACE_CREATE_REQUEST_MAX_PENDING) {
+    throw new Error("Elsewhere has too many pending creation requests. Try again shortly.");
+  }
+
+  const envelope: SpaceCreateRequestEnvelope = {
+    schemaVersion: SPACE_CREATE_REQUEST_SCHEMA_VERSION,
+    kind: "space.create",
+    requestId,
+    nonce,
+    prompt: normalizedPrompt,
+    createdAt: now.toISOString(),
+    expiresAt: new Date(now.getTime() + SPACE_CREATE_REQUEST_TTL_MS).toISOString(),
+  };
+  const serialized = JSON.stringify(envelope);
+  if (Buffer.byteLength(serialized, "utf8") > SPACE_CREATE_REQUEST_MAX_BYTES) {
+    throw new Error("The creation request is too large.");
+  }
+
+  const requestPath = path.join(requestDirectory, `${requestId}.json`);
+  const temporaryPath = path.join(requestDirectory, `.${requestId}.${nonce}.tmp`);
+  try {
+    await writeFile(temporaryPath, serialized, { encoding: "utf8", flag: "wx", mode: 0o600 });
+    await assertPrivateRegularFile(temporaryPath);
+    await rename(temporaryPath, requestPath);
+    await assertPrivateRegularFile(requestPath);
+  } catch (error) {
+    await unlink(temporaryPath).catch(() => undefined);
+    throw error;
+  }
+  return { requestId, nonce, requestPath };
+}
+
+export async function prepareSpaceCreateRequest(
+  requestId: string,
+  nonce: string,
+  prompt: string,
+): Promise<PreparedSpaceCreateRequest> {
+  const state = await readElsewhereState();
+  if (state.kind !== "ready" && state.kind !== "stale") {
+    throw new Error("Open Elsewhere v13.0.0 or later once, then try again.");
+  }
+  return writeSpaceCreateRequest(path.dirname(state.snapshotPath), requestId, nonce, prompt);
+}
+
+export async function removeSpaceCreateRequest(requestPath: string): Promise<void> {
+  await unlink(requestPath).catch((error: unknown) => {
+    if (!isObject(error) || error.code !== "ENOENT") throw error;
+  });
+}

--- a/extensions/elsewhere/src/tools/control-audio.ts
+++ b/extensions/elsewhere/src/tools/control-audio.ts
@@ -1,0 +1,27 @@
+import { executeElsewhereCommandForAi } from "../command-runner";
+import { AudioControl, audioControl } from "../audio-control";
+
+type Input = {
+  /**
+   * The reversible Elsewhere audio control to perform.
+   *
+   * - Use `play` to play or resume, and `pause` to pause, all Elsewhere audio.
+   * - Use `ambience-louder` or `ambience-quieter` for ambience, soundscape, or
+   *   spatial-audio volume. When the user says only “increase/decrease Elsewhere
+   *   volume”, use ambience.
+   * - Use `music-louder` or `music-quieter` only when the user explicitly means
+   *   music volume or background-music volume.
+   * - Use `background-music-on` or `background-music-off` to enable or disable
+   *   background music.
+   *
+   * Always use this tool for these controls. Never use Run Command, shell commands,
+   * AppleScript, System Events, or accessibility automation.
+   */
+  control: AudioControl;
+};
+
+export default async function controlAudio({ control }: Input) {
+  const action = audioControl(control);
+  await executeElsewhereCommandForAi(action.command);
+  return action.result;
+}

--- a/extensions/elsewhere/src/tools/create-space-from-prompt.ts
+++ b/extensions/elsewhere/src/tools/create-space-from-prompt.ts
@@ -23,7 +23,7 @@ export default async function createSpaceFromPrompt({ prompt }: Input) {
   }
 
   await executeElsewhereCommandForAi({ kind: "space", action: "create", prompt: normalizedPrompt });
-  return "Elsewhere started generating a Space preview. The Space is created only after the user reviews and confirms it in Elsewhere.";
+  return "A generated Space preview is ready and playing in Elsewhere. It is saved only after the user reviews and confirms it there.";
 }
 
 export const confirmation: Tool.Confirmation<Input> = async ({ prompt }) => ({

--- a/extensions/elsewhere/src/tools/create-space-from-prompt.ts
+++ b/extensions/elsewhere/src/tools/create-space-from-prompt.ts
@@ -1,0 +1,33 @@
+import { Tool } from "@raycast/api";
+
+import { executeElsewhereCommandForAi } from "../command-runner";
+import { normalizeCreateSpacePrompt } from "../control-url";
+
+type Input = {
+  /**
+   * The user's complete natural-language description of the Space to create.
+   *
+   * Preserve the user's language and requested details. Include ambience, mood,
+   * setting, and desired spatial sound sources when the user provides them. Do
+   * not invent requirements or rewrite the request as implementation steps.
+   */
+  prompt: string;
+};
+
+export default async function createSpaceFromPrompt({ prompt }: Input) {
+  let normalizedPrompt: string;
+  try {
+    normalizedPrompt = normalizeCreateSpacePrompt(prompt);
+  } catch (error) {
+    throw new Error(error instanceof Error ? error.message : "Describe the Space you want Elsewhere to create.");
+  }
+
+  await executeElsewhereCommandForAi({ kind: "space", action: "create", prompt: normalizedPrompt });
+  return "Elsewhere started generating a Space preview. The Space is created only after the user reviews and confirms it in Elsewhere.";
+}
+
+export const confirmation: Tool.Confirmation<Input> = async ({ prompt }) => ({
+  message:
+    "Start Glaze AI generation for this Space preview? This uses Glaze AI credits. The Space is created only after the user reviews and confirms it in Elsewhere.",
+  info: [{ name: "Prompt", value: prompt }],
+});

--- a/extensions/elsewhere/src/tools/switch-background-music.ts
+++ b/extensions/elsewhere/src/tools/switch-background-music.ts
@@ -1,0 +1,13 @@
+import { selectBackgroundMusicByName } from "../ai-selection";
+
+type Input = {
+  /**
+   * The name of an existing Elsewhere background-music track to select.
+   * Use the name the user provides. Never invent a name or guess between choices.
+   */
+  name: string;
+};
+
+export default async function switchBackgroundMusic({ name }: Input) {
+  return selectBackgroundMusicByName(name);
+}

--- a/extensions/elsewhere/src/tools/switch-space.ts
+++ b/extensions/elsewhere/src/tools/switch-space.ts
@@ -1,0 +1,13 @@
+import { selectSpaceByName } from "../ai-selection";
+
+type Input = {
+  /**
+   * The name of an existing Elsewhere spatial soundscape to switch to.
+   * Use the name the user provides. Never invent a name or guess between choices.
+   */
+  name: string;
+};
+
+export default async function switchSpace({ name }: Input) {
+  return selectSpaceByName(name);
+}


### PR DESCRIPTION
## Description

Adds four Raycast AI tools for Elsewhere:

- **Create Space from Prompt** turns a natural-language description into a generated spatial-soundscape preview that opens ready to review and save
- **Control Audio** plays or pauses the soundscape, adjusts ambience or background-music volume, and turns background music on or off without opening a command view
**Switch Spatial Soundscape** switches to an existing Space by name using Elsewhere's live catalog
- **Switch Background Music** selects an existing music track by name using Elsewhere's live catalog

Updates the extension description, tool descriptions, keywords, README, and changelog for the new AI capabilities

## Demo

https://github.com/user-attachments/assets/41873a8b-431e-4985-b8ce-fed780f2e976



## Testing

[Elsewhere v13.0.0](https://www.glaze.app/app/elsewhere-khfW1h) or later is required to test the AI tools.


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested the distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that README assets follow Raycast metadata guidelines