### PR TITLE
Fix nested GitLab repository URLs in Quick Open Project

### DIFF
--- a/extensions/quick-open-project/.gitignore
+++ b/extensions/quick-open-project/.gitignore
@@ -9,6 +9,7 @@ raycast-env.d.ts
 .swiftpm
 compiled_raycast_swift
 compiled_raycast_rust
+.test-dist
 
 # misc
 .DS_Store

--- a/extensions/quick-open-project/CHANGELOG.md
+++ b/extensions/quick-open-project/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Fix GitLab Nested Group URLs] - {PR_MERGE_DATE}
+## [Fix GitLab Nested Group URLs] - 2026-08-12
 
 - Preserve the complete repository path when opening GitLab projects in nested groups.
 

--- a/extensions/quick-open-project/CHANGELOG.md
+++ b/extensions/quick-open-project/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Fix GitLab Nested Group URLs] - {PR_MERGE_DATE}
+
+- Preserve the complete repository path when opening GitLab projects in nested groups.
+
 ## [1.1.4] - 2026-03-17
 
 - Add Windows support for opening projects in editor and terminal

--- a/extensions/quick-open-project/package-lock.json
+++ b/extensions/quick-open-project/package-lock.json
@@ -14,8 +14,7 @@
         "frecency": "^1.3.2",
         "fuzzysort": "^1.1.4",
         "glob": "^7.2.0",
-        "parse-git-config": "^3.0.0",
-        "parse-github-url": "^1.0.2"
+        "parse-git-config": "^3.0.0"
       },
       "devDependencies": {
         "@raycast/eslint-config": "1.0.11",
@@ -23,7 +22,6 @@
         "@types/glob": "^7.2.0",
         "@types/node": "20.8.10",
         "@types/parse-git-config": "^3.0.1",
-        "@types/parse-github-url": "^1.0.0",
         "@types/react": "^19.2.14",
         "eslint": "^8.57.0",
         "prettier": "^3.3.3",
@@ -1200,15 +1198,6 @@
       "resolved": "https://registry.npmjs.org/@types/parse-git-config/-/parse-git-config-3.0.4.tgz",
       "integrity": "sha512-jz5eGdk9lBgAd4rMbXTP7MRG7AsGQ8DrXsRumDcXDLClHcpKluislylPVMP/qp90J/LlIrrPZRZIQUflHfrDnQ==",
       "dev": true
-    },
-    "node_modules/@types/parse-github-url": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/parse-github-url/-/parse-github-url-1.0.3.tgz",
-      "integrity": "sha512-7sTbCVmSVzK/iAsHGIxoqiyAnqix9opZm68lOvaU6DBx9EQ9kHMSp0y7Criu2OCsZ9wDllEyCRU+LU4hPRxXUA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
@@ -2880,17 +2869,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/parse-github-url": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.3.tgz",
-      "integrity": "sha512-tfalY5/4SqGaV/GIGzWyHnFjlpTPTNpENR9Ea2lLldSJ8EWXMsvacWucqY3m3I4YPtas15IxTLQVQ5NSYXPrww==",
-      "bin": {
-        "parse-github-url": "cli.js"
-      },
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/path-exists": {

--- a/extensions/quick-open-project/package-lock.json
+++ b/extensions/quick-open-project/package-lock.json
@@ -14,7 +14,8 @@
         "frecency": "^1.3.2",
         "fuzzysort": "^1.1.4",
         "glob": "^7.2.0",
-        "parse-git-config": "^3.0.0"
+        "parse-git-config": "^3.0.0",
+        "parse-url": "^11.1.0"
       },
       "devDependencies": {
         "@raycast/eslint-config": "1.0.11",
@@ -2871,6 +2872,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/parse-path": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.1.0.tgz",
+      "integrity": "sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==",
+      "license": "MIT",
+      "dependencies": {
+        "protocols": "^2.0.0"
+      }
+    },
+    "node_modules/parse-url": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-11.1.0.tgz",
+      "integrity": "sha512-UYn/lNb1bmkYiM6UaqEbHl9T/VIYreM2Vm79MGZ2soUOXOoOq7qxoTwx8C8p9V4Ko2DLcsVnEhRJzhxsF2kssg==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-path": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=14.13.0"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2948,6 +2970,12 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/protocols": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.2.tgz",
+      "integrity": "sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/extensions/quick-open-project/package-lock.json
+++ b/extensions/quick-open-project/package-lock.json
@@ -3192,13 +3192,13 @@
       "dev": true
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"

--- a/extensions/quick-open-project/package.json
+++ b/extensions/quick-open-project/package.json
@@ -75,8 +75,7 @@
     "frecency": "^1.3.2",
     "fuzzysort": "^1.1.4",
     "glob": "^7.2.0",
-    "parse-git-config": "^3.0.0",
-    "parse-github-url": "^1.0.2"
+    "parse-git-config": "^3.0.0"
   },
   "devDependencies": {
     "@raycast/eslint-config": "1.0.11",
@@ -84,7 +83,6 @@
     "@types/glob": "^7.2.0",
     "@types/node": "20.8.10",
     "@types/parse-git-config": "^3.0.1",
-    "@types/parse-github-url": "^1.0.0",
     "@types/react": "^19.2.14",
     "eslint": "^8.57.0",
     "prettier": "^3.3.3",

--- a/extensions/quick-open-project/package.json
+++ b/extensions/quick-open-project/package.json
@@ -75,7 +75,8 @@
     "frecency": "^1.3.2",
     "fuzzysort": "^1.1.4",
     "glob": "^7.2.0",
-    "parse-git-config": "^3.0.0"
+    "parse-git-config": "^3.0.0",
+    "parse-url": "^11.1.0"
   },
   "devDependencies": {
     "@raycast/eslint-config": "1.0.11",

--- a/extensions/quick-open-project/package.json
+++ b/extensions/quick-open-project/package.json
@@ -92,6 +92,7 @@
   "scripts": {
     "dev": "ray develop",
     "build": "ray build -e dist",
-    "lint": "ray lint"
+    "lint": "ray lint",
+    "test": "tsc src/git-remote.ts src/git-remote.test.ts --module commonjs --target es2021 --esModuleInterop --skipLibCheck --outDir .test-dist && node --test .test-dist/git-remote.test.js"
   }
 }

--- a/extensions/quick-open-project/src/git-remote.test.ts
+++ b/extensions/quick-open-project/src/git-remote.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { parseGitRemote } from "./git-remote";
+
+describe("parseGitRemote", () => {
+  const browserUrlCases = [
+    ["https://github.com/owner/project.git", "https://github.com/owner/project"],
+    ["git@github.com:owner/project.git", "https://github.com/owner/project"],
+    ["https://gitlab.example.com/group/subgroup/project.git", "https://gitlab.example.com/group/subgroup/project"],
+    ["git@gitlab.example.com:group/subgroup/project.git", "https://gitlab.example.com/group/subgroup/project"],
+    ["ssh://git@gitlab.example.com/group/subgroup/project.git", "https://gitlab.example.com/group/subgroup/project"],
+    ["git+ssh://git@host.example.com/group/project.git", "https://host.example.com/group/project"],
+    ["git@ssh.dev.azure.com:v3/org/project/repository", "https://ssh.dev.azure.com/v3/org/project/repository"],
+  ] as const;
+  for (const [remoteUrl, expectedUrl] of browserUrlCases) {
+    it(`converts ${remoteUrl} to a browser URL`, () => {
+      assert.equal(parseGitRemote(remoteUrl)?.url, expectedUrl);
+    });
+  }
+
+  const webTransportCases = [
+    ["http://host.example.com:8080/group/project.git", "http://host.example.com:8080/group/project"],
+    ["https://host.example.com:8443/group/project.git", "https://host.example.com:8443/group/project"],
+    ["git+https://host.example.com:8443/group/project.git", "https://host.example.com:8443/group/project"],
+  ] as const;
+  for (const [remoteUrl, expectedUrl] of webTransportCases) {
+    it(`preserves the HTTP transport and web port for ${remoteUrl}`, () => {
+      assert.equal(parseGitRemote(remoteUrl)?.url, expectedUrl);
+    });
+  }
+
+  const clonePortCases = [
+    ["ssh://git@host.example.com:2222/group/project.git", "https://host.example.com/group/project"],
+    ["git://host.example.com:9418/group/project.git", "https://host.example.com/group/project"],
+    ["git+ssh://git@host.example.com:2222/group/project.git", "https://host.example.com/group/project"],
+  ] as const;
+  for (const [remoteUrl, expectedUrl] of clonePortCases) {
+    it(`drops the clone-service port for ${remoteUrl}`, () => {
+      assert.equal(parseGitRemote(remoteUrl)?.url, expectedUrl);
+    });
+  }
+
+  it("removes credentials, query parameters, fragments, and a case-insensitive .git suffix", () => {
+    assert.deepEqual(parseGitRemote("https://user:password@github.com/owner/project.GIT/?ref=test#readme"), {
+      host: "github.com",
+      url: "https://github.com/owner/project",
+    });
+  });
+
+  const rejectedRemotes = [
+    "/local/repository",
+    "../relative/repository",
+    "C:\\local\\repository",
+    "\\\\server\\share\\repo",
+    "file:///local/repository",
+    "ftp://host.example.com/group/project.git",
+    "ext::command arg",
+    "not a URL",
+  ] as const;
+  for (const remoteUrl of rejectedRemotes) {
+    it(`rejects non-browser remote ${remoteUrl}`, () => {
+      assert.equal(parseGitRemote(remoteUrl), undefined);
+    });
+  }
+});

--- a/extensions/quick-open-project/src/git-remote.ts
+++ b/extensions/quick-open-project/src/git-remote.ts
@@ -9,16 +9,25 @@ export function parseGitRemote(remoteUrl: string): GitRemote | undefined {
   try {
     const parsedUrl = parseUrl(remoteUrl.trim(), false);
     const repositoryPath = parsedUrl.pathname.replace(/^\/+|\/+$/g, "").replace(/\.git$/i, "");
+    const protocols = new Set(parsedUrl.protocols);
+    const supportedProtocols = ["git", "http", "https", "ssh"];
 
-    if (!parsedUrl.resource || !repositoryPath) {
+    if (
+      !parsedUrl.resource ||
+      !repositoryPath ||
+      protocols.size === 0 ||
+      [...protocols].some((p) => !supportedProtocols.includes(p))
+    ) {
       return undefined;
     }
 
-    const host = parsedUrl.port ? `${parsedUrl.resource}:${parsedUrl.port}` : parsedUrl.resource;
+    const browserProtocol = protocols.has("http") ? "http" : "https";
+    const browserPort = protocols.has("http") || protocols.has("https") ? parsedUrl.port : undefined;
+    const host = browserPort ? `${parsedUrl.resource}:${browserPort}` : parsedUrl.resource;
 
     return {
       host,
-      url: `https://${host}/${repositoryPath}`,
+      url: `${browserProtocol}://${host}/${repositoryPath}`,
     };
   } catch {
     return undefined;

--- a/extensions/quick-open-project/src/git-remote.ts
+++ b/extensions/quick-open-project/src/git-remote.ts
@@ -1,0 +1,30 @@
+type GitRemote = {
+  host: string;
+  url: string;
+};
+
+export function parseGitRemote(remoteUrl: string): GitRemote | undefined {
+  const trimmedUrl = remoteUrl.trim();
+  const isWindowsPath = /^[a-zA-Z]:[\\/]/.test(trimmedUrl);
+  const scpLikeMatch =
+    trimmedUrl.includes("://") || isWindowsPath ? undefined : trimmedUrl.match(/^(?:([^@/]+)@)?([^:/]+):(.+)$/);
+  const normalizedUrl = scpLikeMatch
+    ? `ssh://${scpLikeMatch[1] ? `${scpLikeMatch[1]}@` : ""}${scpLikeMatch[2]}/${scpLikeMatch[3]}`
+    : trimmedUrl;
+
+  try {
+    const parsedUrl = new URL(normalizedUrl);
+    const repositoryPath = parsedUrl.pathname.replace(/^\/+|\/+$/g, "").replace(/\.git$/, "");
+
+    if (!parsedUrl.host || !repositoryPath) {
+      return undefined;
+    }
+
+    return {
+      host: parsedUrl.host,
+      url: `https://${parsedUrl.host}/${repositoryPath}`,
+    };
+  } catch {
+    return undefined;
+  }
+}

--- a/extensions/quick-open-project/src/git-remote.ts
+++ b/extensions/quick-open-project/src/git-remote.ts
@@ -1,28 +1,24 @@
+import parseUrl from "parse-url";
+
 type GitRemote = {
   host: string;
   url: string;
 };
 
 export function parseGitRemote(remoteUrl: string): GitRemote | undefined {
-  const trimmedUrl = remoteUrl.trim();
-  const isWindowsPath = /^[a-zA-Z]:[\\/]/.test(trimmedUrl);
-  const scpLikeMatch =
-    trimmedUrl.includes("://") || isWindowsPath ? undefined : trimmedUrl.match(/^(?:([^@/]+)@)?([^:/]+):(.+)$/);
-  const normalizedUrl = scpLikeMatch
-    ? `ssh://${scpLikeMatch[1] ? `${scpLikeMatch[1]}@` : ""}${scpLikeMatch[2]}/${scpLikeMatch[3]}`
-    : trimmedUrl;
-
   try {
-    const parsedUrl = new URL(normalizedUrl);
-    const repositoryPath = parsedUrl.pathname.replace(/^\/+|\/+$/g, "").replace(/\.git$/, "");
+    const parsedUrl = parseUrl(remoteUrl.trim(), false);
+    const repositoryPath = parsedUrl.pathname.replace(/^\/+|\/+$/g, "").replace(/\.git$/i, "");
 
-    if (!parsedUrl.host || !repositoryPath) {
+    if (!parsedUrl.resource || !repositoryPath) {
       return undefined;
     }
 
+    const host = parsedUrl.port ? `${parsedUrl.resource}:${parsedUrl.port}` : parsedUrl.resource;
+
     return {
-      host: parsedUrl.host,
-      url: `https://${parsedUrl.host}/${repositoryPath}`,
+      host,
+      url: `https://${host}/${repositoryPath}`,
     };
   } catch {
     return undefined;

--- a/extensions/quick-open-project/src/index.tsx
+++ b/extensions/quick-open-project/src/index.tsx
@@ -17,7 +17,7 @@ import { homedir } from "os";
 import { useMemo, useState } from "react";
 import fuzzysort = require("fuzzysort");
 import config = require("parse-git-config");
-import gh = require("parse-github-url");
+import { parseGitRemote } from "./git-remote";
 
 interface Remote {
   url: string;
@@ -52,12 +52,11 @@ class Project {
     if (gitConfig.remote != null) {
       for (const remoteName in gitConfig.remote) {
         const config = gitConfig.remote[remoteName] as Remote;
-        const parsed = gh(config.url);
-        if (parsed?.host && parsed?.repo) {
+        const parsed = parseGitRemote(config.url);
+        if (parsed) {
           repos = repos.concat({
             name: remoteName,
-            host: parsed?.host,
-            url: `https://${parsed?.host}/${parsed?.repo}`,
+            ...parsed,
           });
         }
       }


### PR DESCRIPTION
## Description

Fixes Quick Open Project browser actions for GitLab repositories that use nested groups.

The extension previously parsed every remote with `parse-github-url`, which assumes a two-segment repository path and truncates deeper GitLab namespaces. This change replaces it with the maintained, host-agnostic `parse-url` package and a thin browser URL adapter. The adapter uses only the parsed protocol, host, port, and complete pathname, preserving nested namespaces. HTTP and HTTPS remotes keep their web protocol and port, while SSH, SCP-like, and Git remotes open over HTTPS without carrying clone-service ports. Unsupported and local-only remote formats are ignored. It also removes the GitHub-specific parser dependency.

Closes #30148.

## Screencast

Not included; this is a URL parsing fix with no visual UI changes.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build`
- [x] I ran `npm run lint`
- [x] I added and ran 22 tests covering HTTPS, HTTP, SSH, SCP-like, nested groups, web and clone ports, Azure DevOps, credentials, query/fragment stripping, invalid protocols, and local paths
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)