### PR TITLE
Add clearly separated draft-text scrambling to RedactCast

### DIFF
--- a/extensions/redactcast/CHANGELOG.md
+++ b/extensions/redactcast/CHANGELOG.md
@@ -1,5 +1,12 @@
 # RedactCast Changelog
 
+## [Layout-Matched Draft Copy] - {PR_MERGE_DATE}
+
+- Add a non-reversible draft-copy scrambler for selected or clipboard text
+- Preserve layout structure, casing, repeated words, numbers, and approximate word width
+- Label the command explicitly as draft greeking, not reversible PII redaction
+- Keep supported rich clipboard content intact when replacing a selection
+
 ## [Initial Release] - 2026-07-15
 
 - Initial release of RedactCast

--- a/extensions/redactcast/package.json
+++ b/extensions/redactcast/package.json
@@ -59,7 +59,7 @@
           "name": "source",
           "type": "dropdown",
           "title": "Preferred Source",
-          "description": "Read the preferred source first. The other source is used only when the preferred source is empty.",
+          "description": "Read the preferred source first. The other source is used only when the preferred source is readable but empty; access errors stop safely.",
           "data": [
             {
               "title": "Selected Text",

--- a/extensions/redactcast/package.json
+++ b/extensions/redactcast/package.json
@@ -5,9 +5,19 @@
   "description": "Reversible PII Masker: Sanitize sensitive data before sending to AI, and restore it locally.",
   "icon": "extension-icon.png",
   "author": "Tomokisan",
+  "contributors": [
+    "kumail_changezi"
+  ],
   "categories": [
     "Developer Tools",
     "Security"
+  ],
+  "keywords": [
+    "anonymize",
+    "greeking",
+    "placeholder",
+    "scramble",
+    "text"
   ],
   "license": "MIT",
   "preferences": [
@@ -37,6 +47,60 @@
       "title": "Force Sync Team Rules",
       "description": "Downloads the latest masking rules from your organization.",
       "mode": "no-view"
+    },
+    {
+      "name": "scramble-draft-text",
+      "title": "Scramble Draft Text",
+      "subtitle": "Non-Security Draft Copy",
+      "description": "Create non-reversible, layout-matched draft copy; not security redaction",
+      "mode": "no-view",
+      "preferences": [
+        {
+          "name": "source",
+          "type": "dropdown",
+          "title": "Preferred Source",
+          "description": "Read the preferred source first. The other source is used only when the preferred source is empty.",
+          "data": [
+            {
+              "title": "Selected Text",
+              "value": "selected"
+            },
+            {
+              "title": "Clipboard",
+              "value": "clipboard"
+            }
+          ],
+          "default": "selected",
+          "required": false
+        },
+        {
+          "name": "action",
+          "type": "dropdown",
+          "title": "Output Action",
+          "description": "Replace the current selection or copy the scrambled text as plain text.",
+          "data": [
+            {
+              "title": "Replace Selection",
+              "value": "paste"
+            },
+            {
+              "title": "Copy to Clipboard",
+              "value": "copy"
+            }
+          ],
+          "default": "paste",
+          "required": false
+        },
+        {
+          "name": "scrambleNumbers",
+          "type": "checkbox",
+          "title": "Draft Copy",
+          "description": "Replace every decimal digit while preserving its writing system, position, and count.",
+          "label": "Scramble Numbers",
+          "default": true,
+          "required": false
+        }
+      ]
     }
   ],
   "dependencies": {

--- a/extensions/redactcast/src/clipboard-safety.ts
+++ b/extensions/redactcast/src/clipboard-safety.ts
@@ -1,7 +1,11 @@
 import type { Clipboard } from "@raycast/api";
 
-export function canSafelyRestoreClipboard(content: Clipboard.ReadContent): boolean {
-  const hasFile = typeof content.file === "string";
+export function getRestorableClipboardContent(content: Clipboard.ReadContent): string | Clipboard.Content | null {
+  if (typeof content.text !== "string" || typeof content.file === "string") return null;
+  if (typeof content.html === "string") return { html: content.html, text: content.text };
+  return content.text;
+}
 
-  return typeof content.text === "string" && !hasFile;
+export function canSafelyRestoreClipboard(content: Clipboard.ReadContent): boolean {
+  return getRestorableClipboardContent(content) !== null;
 }

--- a/extensions/redactcast/src/clipboard-safety.ts
+++ b/extensions/redactcast/src/clipboard-safety.ts
@@ -1,5 +1,8 @@
 import type { Clipboard } from "@raycast/api";
 
 export function canSafelyRestoreClipboard(content: Clipboard.ReadContent): boolean {
-  return Boolean(content.file || content.html || typeof content.text === "string");
+  const hasFile = typeof content.file === "string";
+  const hasHTML = typeof content.html === "string";
+
+  return typeof content.text === "string" && !(hasFile && hasHTML);
 }

--- a/extensions/redactcast/src/clipboard-safety.ts
+++ b/extensions/redactcast/src/clipboard-safety.ts
@@ -2,7 +2,6 @@ import type { Clipboard } from "@raycast/api";
 
 export function canSafelyRestoreClipboard(content: Clipboard.ReadContent): boolean {
   const hasFile = typeof content.file === "string";
-  const hasHTML = typeof content.html === "string";
 
-  return typeof content.text === "string" && !(hasFile && hasHTML);
+  return typeof content.text === "string" && !hasFile;
 }

--- a/extensions/redactcast/src/clipboard-safety.ts
+++ b/extensions/redactcast/src/clipboard-safety.ts
@@ -1,0 +1,5 @@
+import type { Clipboard } from "@raycast/api";
+
+export function canSafelyRestoreClipboard(content: Clipboard.ReadContent): boolean {
+  return Boolean(content.file || content.html || typeof content.text === "string");
+}

--- a/extensions/redactcast/src/clipboard-safety.ts
+++ b/extensions/redactcast/src/clipboard-safety.ts
@@ -1,5 +1,7 @@
 import type { Clipboard } from "@raycast/api";
 
+type RestorableClipboardContent = string | Clipboard.Content;
+
 export function getRestorableClipboardContent(content: Clipboard.ReadContent): string | Clipboard.Content | null {
   if (typeof content.text !== "string" || typeof content.file === "string") return null;
   if (typeof content.html === "string") return { html: content.html, text: content.text };
@@ -8,4 +10,26 @@ export function getRestorableClipboardContent(content: Clipboard.ReadContent): s
 
 export function canSafelyRestoreClipboard(content: Clipboard.ReadContent): boolean {
   return getRestorableClipboardContent(content) !== null;
+}
+
+export async function restoreClipboardWithRetry(
+  content: RestorableClipboardContent,
+  copy: (content: RestorableClipboardContent) => Promise<void>,
+  attempts = 3,
+  pause: (delayMs: number) => Promise<void> = delayMs => new Promise(resolve => setTimeout(resolve, delayMs))
+): Promise<void> {
+  const maximumAttempts = Math.max(1, attempts);
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maximumAttempts; attempt++) {
+    try {
+      await copy(content);
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt < maximumAttempts) await pause(50 * attempt);
+    }
+  }
+
+  throw lastError;
 }

--- a/extensions/redactcast/src/scramble-draft-text.ts
+++ b/extensions/redactcast/src/scramble-draft-text.ts
@@ -1,5 +1,5 @@
 import { Clipboard, getPreferenceValues, getSelectedText, showHUD } from "@raycast/api";
-import { getRestorableClipboardContent } from "./clipboard-safety";
+import { getRestorableClipboardContent, restoreClipboardWithRetry } from "./clipboard-safety";
 import { scrambleText } from "./scramble-text";
 
 class NoTextError extends Error {
@@ -16,6 +16,13 @@ class SelectionUnavailableError extends Error {
   }
 }
 
+class ClipboardUnavailableError extends Error {
+  constructor(cause: unknown) {
+    super("Clipboard text is unavailable", { cause });
+    Object.setPrototypeOf(this, ClipboardUnavailableError.prototype);
+  }
+}
+
 class ClipboardProtectionError extends Error {
   constructor() {
     super("Clipboard content cannot be restored safely");
@@ -23,11 +30,18 @@ class ClipboardProtectionError extends Error {
   }
 }
 
+class ClipboardRestoreError extends Error {
+  constructor(cause: unknown) {
+    super("Clipboard content could not be restored", { cause });
+    Object.setPrototypeOf(this, ClipboardRestoreError.prototype);
+  }
+}
+
 async function readClipboard(): Promise<string> {
   try {
     return (await Clipboard.readText()) ?? "";
-  } catch {
-    return "";
+  } catch (error) {
+    throw new ClipboardUnavailableError(error);
   }
 }
 
@@ -63,11 +77,22 @@ async function pasteWithoutChangingClipboard(text: string): Promise<void> {
   const restorableClipboard = getRestorableClipboardContent(previousClipboard);
   if (restorableClipboard === null) throw new ClipboardProtectionError();
 
+  let pasteFailed = false;
+  let pasteError: unknown;
   try {
     await Clipboard.paste(text);
-  } finally {
-    await Clipboard.copy(restorableClipboard);
+  } catch (error) {
+    pasteFailed = true;
+    pasteError = error;
   }
+
+  try {
+    await restoreClipboardWithRetry(restorableClipboard, content => Clipboard.copy(content));
+  } catch (error) {
+    throw new ClipboardRestoreError(error);
+  }
+
+  if (pasteFailed) throw pasteError;
 }
 
 export default async function Command(): Promise<void> {
@@ -96,8 +121,19 @@ export default async function Command(): Promise<void> {
       return;
     }
 
+    if (error instanceof ClipboardRestoreError) {
+      console.error("Text was replaced, but clipboard restoration failed", error);
+      await showHUD("Text replaced — restore your prior clipboard from Clipboard History");
+      return;
+    }
+
     if (error instanceof SelectionUnavailableError) {
       await showHUD("Can’t read selected text — select text or choose Clipboard");
+      return;
+    }
+
+    if (error instanceof ClipboardUnavailableError) {
+      await showHUD("Can’t read clipboard — copy text or choose Selected Text");
       return;
     }
 

--- a/extensions/redactcast/src/scramble-draft-text.ts
+++ b/extensions/redactcast/src/scramble-draft-text.ts
@@ -1,5 +1,5 @@
 import { Clipboard, getPreferenceValues, getSelectedText, showHUD } from "@raycast/api";
-import { canSafelyRestoreClipboard } from "./clipboard-safety";
+import { getRestorableClipboardContent } from "./clipboard-safety";
 import { scrambleText } from "./scramble-text";
 
 class NoTextError extends Error {
@@ -58,22 +58,15 @@ async function readText(preferredSource: Preferences.ScrambleDraftText["source"]
   throw new NoTextError();
 }
 
-async function restoreClipboard(content: Clipboard.ReadContent): Promise<void> {
-  if (content.html) {
-    await Clipboard.copy({ html: content.html, text: content.text });
-  } else {
-    await Clipboard.copy(content.text);
-  }
-}
-
 async function pasteWithoutChangingClipboard(text: string): Promise<void> {
   const previousClipboard = await Clipboard.read();
-  if (!canSafelyRestoreClipboard(previousClipboard)) throw new ClipboardProtectionError();
+  const restorableClipboard = getRestorableClipboardContent(previousClipboard);
+  if (restorableClipboard === null) throw new ClipboardProtectionError();
 
   try {
     await Clipboard.paste(text);
   } finally {
-    await restoreClipboard(previousClipboard);
+    await Clipboard.copy(restorableClipboard);
   }
 }
 

--- a/extensions/redactcast/src/scramble-draft-text.ts
+++ b/extensions/redactcast/src/scramble-draft-text.ts
@@ -1,0 +1,127 @@
+import { Clipboard, getPreferenceValues, getSelectedText, showHUD } from "@raycast/api";
+import { canSafelyRestoreClipboard } from "./clipboard-safety";
+import { scrambleText } from "./scramble-text";
+
+type DraftScramblePreferences = {
+  source: "selected" | "clipboard";
+  action: "paste" | "copy";
+  scrambleNumbers: boolean;
+};
+
+class NoTextError extends Error {
+  constructor() {
+    super("No text available");
+    Object.setPrototypeOf(this, NoTextError.prototype);
+  }
+}
+
+class SelectionUnavailableError extends Error {
+  constructor(cause: unknown) {
+    super("Selected text is unavailable", { cause });
+    Object.setPrototypeOf(this, SelectionUnavailableError.prototype);
+  }
+}
+
+class ClipboardProtectionError extends Error {
+  constructor() {
+    super("Clipboard content cannot be restored safely");
+    Object.setPrototypeOf(this, ClipboardProtectionError.prototype);
+  }
+}
+
+async function readClipboard(): Promise<string> {
+  try {
+    return (await Clipboard.readText()) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+async function readText(preferredSource: DraftScramblePreferences["source"]): Promise<string> {
+  if (preferredSource === "selected") {
+    try {
+      const selected = await getSelectedText();
+      if (selected.trim()) return selected;
+    } catch (error) {
+      throw new SelectionUnavailableError(error);
+    }
+
+    const clipboard = await readClipboard();
+    if (clipboard.trim()) return clipboard;
+    throw new NoTextError();
+  }
+
+  const clipboard = await readClipboard();
+  if (clipboard.trim()) return clipboard;
+
+  try {
+    const selected = await getSelectedText();
+    if (selected.trim()) return selected;
+  } catch {
+    // A failed fallback must not hide the useful "no text" message.
+  }
+
+  throw new NoTextError();
+}
+
+async function restoreClipboard(content: Clipboard.ReadContent): Promise<void> {
+  if (content.file) {
+    await Clipboard.copy({ file: content.file });
+  } else if (content.html) {
+    await Clipboard.copy({ html: content.html, text: content.text });
+  } else {
+    await Clipboard.copy(content.text);
+  }
+}
+
+async function pasteWithoutChangingClipboard(text: string): Promise<void> {
+  const previousClipboard = await Clipboard.read();
+  if (!canSafelyRestoreClipboard(previousClipboard)) throw new ClipboardProtectionError();
+
+  try {
+    await Clipboard.paste(text);
+  } finally {
+    await restoreClipboard(previousClipboard);
+  }
+}
+
+export default async function Command(): Promise<void> {
+  const preferences = getPreferenceValues<DraftScramblePreferences>();
+
+  try {
+    const source = await readText(preferences.source);
+    const scrambled = scrambleText(source, { scrambleNumbers: preferences.scrambleNumbers });
+
+    if (scrambled === source) {
+      await showHUD("Nothing to scramble");
+      return;
+    }
+
+    if (preferences.action === "copy") {
+      await Clipboard.copy(scrambled);
+      await showHUD("Scrambled text copied");
+      return;
+    }
+
+    await pasteWithoutChangingClipboard(scrambled);
+    await showHUD("Text scrambled");
+  } catch (error) {
+    if (error instanceof ClipboardProtectionError) {
+      await showHUD("Rich clipboard protected — save it, then retry");
+      return;
+    }
+
+    if (error instanceof SelectionUnavailableError) {
+      await showHUD("Can’t read selected text — select text or choose Clipboard");
+      return;
+    }
+
+    if (error instanceof NoTextError) {
+      await showHUD("No text — select or copy something first");
+      return;
+    }
+
+    console.error("Failed to scramble text", error);
+    await showHUD("Couldn’t scramble text");
+  }
+}

--- a/extensions/redactcast/src/scramble-draft-text.ts
+++ b/extensions/redactcast/src/scramble-draft-text.ts
@@ -2,12 +2,6 @@ import { Clipboard, getPreferenceValues, getSelectedText, showHUD } from "@rayca
 import { canSafelyRestoreClipboard } from "./clipboard-safety";
 import { scrambleText } from "./scramble-text";
 
-type DraftScramblePreferences = {
-  source: "selected" | "clipboard";
-  action: "paste" | "copy";
-  scrambleNumbers: boolean;
-};
-
 class NoTextError extends Error {
   constructor() {
     super("No text available");
@@ -37,7 +31,7 @@ async function readClipboard(): Promise<string> {
   }
 }
 
-async function readText(preferredSource: DraftScramblePreferences["source"]): Promise<string> {
+async function readText(preferredSource: Preferences.ScrambleDraftText["source"]): Promise<string> {
   if (preferredSource === "selected") {
     try {
       const selected = await getSelectedText();
@@ -65,9 +59,7 @@ async function readText(preferredSource: DraftScramblePreferences["source"]): Pr
 }
 
 async function restoreClipboard(content: Clipboard.ReadContent): Promise<void> {
-  if (content.file) {
-    await Clipboard.copy({ file: content.file });
-  } else if (content.html) {
+  if (content.html) {
     await Clipboard.copy({ html: content.html, text: content.text });
   } else {
     await Clipboard.copy(content.text);
@@ -86,7 +78,7 @@ async function pasteWithoutChangingClipboard(text: string): Promise<void> {
 }
 
 export default async function Command(): Promise<void> {
-  const preferences = getPreferenceValues<DraftScramblePreferences>();
+  const preferences = getPreferenceValues<Preferences.ScrambleDraftText>();
 
   try {
     const source = await readText(preferences.source);

--- a/extensions/redactcast/src/scramble-text.ts
+++ b/extensions/redactcast/src/scramble-text.ts
@@ -330,7 +330,7 @@ function makeCandidate(length: number, random: RandomSource): string {
 }
 
 function isUppercaseLetter(char: string): boolean {
-  return char !== char.toLowerCase() && char === char.toUpperCase();
+  return char !== char.toLowerCase();
 }
 
 interface LetterCluster {

--- a/extensions/redactcast/src/scramble-text.ts
+++ b/extensions/redactcast/src/scramble-text.ts
@@ -1,0 +1,502 @@
+export type RandomSource = () => number;
+
+export interface ScrambleOptions {
+  random?: RandomSource;
+  scrambleNumbers?: boolean;
+  candidateCount?: number;
+}
+
+const TOKEN_PATTERN = /(?:\p{L}\p{M}*)+|\p{N}+/gu;
+const LETTER_PATTERN = /^(?:\p{L}\p{M}*)+$/u;
+const LETTER_CHARACTER_PATTERN = /^\p{L}$/u;
+const COMBINING_MARK_PATTERN = /^\p{M}$/u;
+const DECIMAL_DIGIT_PATTERN = /^\p{Nd}$/u;
+const VOWEL_PATTERN = /[aeiou]/;
+const TRIPLE_VOWEL_PATTERN = /[aeiou]{3}/;
+const TRIPLE_CONSONANT_PATTERN = /[^aeiou]{3}/;
+const REPEATED_BIGRAM_PATTERN = /([a-z]{2})\1/;
+
+const VOWELS = ["a", "a", "a", "e", "e", "e", "e", "i", "i", "o", "o", "u"];
+const CONSONANTS = [
+  "b",
+  "c",
+  "d",
+  "f",
+  "g",
+  "h",
+  "l",
+  "l",
+  "l",
+  "m",
+  "m",
+  "m",
+  "n",
+  "n",
+  "n",
+  "n",
+  "p",
+  "r",
+  "r",
+  "r",
+  "r",
+  "s",
+  "s",
+  "s",
+  "t",
+  "t",
+  "t",
+  "v",
+  "v",
+  "w"
+];
+const END_CONSONANTS = ["d", "l", "l", "m", "n", "n", "r", "r", "s", "s", "t"];
+const CLUSTER_FOLLOWERS: Record<string, readonly string[]> = {
+  b: ["l", "r"],
+  c: ["h", "l", "r"],
+  d: ["r"],
+  f: ["l", "r"],
+  g: ["l", "r"],
+  p: ["l", "r"],
+  s: ["c", "h", "l", "p", "t"],
+  t: ["h", "r"]
+};
+
+const COMMON_WORDS = new Set([
+  "a",
+  "about",
+  "after",
+  "again",
+  "all",
+  "also",
+  "am",
+  "an",
+  "and",
+  "another",
+  "any",
+  "are",
+  "as",
+  "at",
+  "back",
+  "bad",
+  "be",
+  "because",
+  "before",
+  "being",
+  "best",
+  "better",
+  "big",
+  "brand",
+  "but",
+  "by",
+  "can",
+  "car",
+  "cat",
+  "clear",
+  "come",
+  "could",
+  "day",
+  "deck",
+  "design",
+  "did",
+  "do",
+  "dog",
+  "down",
+  "each",
+  "even",
+  "every",
+  "feel",
+  "first",
+  "for",
+  "from",
+  "get",
+  "give",
+  "go",
+  "good",
+  "great",
+  "had",
+  "has",
+  "have",
+  "he",
+  "her",
+  "here",
+  "him",
+  "his",
+  "how",
+  "i",
+  "if",
+  "in",
+  "into",
+  "is",
+  "it",
+  "its",
+  "just",
+  "know",
+  "last",
+  "like",
+  "light",
+  "little",
+  "look",
+  "make",
+  "man",
+  "many",
+  "may",
+  "me",
+  "more",
+  "most",
+  "my",
+  "need",
+  "new",
+  "no",
+  "not",
+  "now",
+  "of",
+  "off",
+  "old",
+  "on",
+  "once",
+  "one",
+  "only",
+  "or",
+  "other",
+  "our",
+  "out",
+  "over",
+  "own",
+  "people",
+  "put",
+  "red",
+  "same",
+  "say",
+  "see",
+  "set",
+  "shape",
+  "she",
+  "should",
+  "so",
+  "some",
+  "still",
+  "story",
+  "sun",
+  "take",
+  "text",
+  "than",
+  "that",
+  "the",
+  "their",
+  "them",
+  "then",
+  "there",
+  "these",
+  "they",
+  "thing",
+  "think",
+  "this",
+  "those",
+  "through",
+  "time",
+  "to",
+  "too",
+  "two",
+  "under",
+  "up",
+  "us",
+  "use",
+  "very",
+  "want",
+  "was",
+  "way",
+  "we",
+  "well",
+  "were",
+  "what",
+  "when",
+  "where",
+  "which",
+  "while",
+  "who",
+  "why",
+  "will",
+  "with",
+  "work",
+  "world",
+  "would",
+  "year",
+  "you",
+  "your"
+]);
+
+const UNWELCOME_FRAGMENTS = [
+  "anus",
+  "ass",
+  "cock",
+  "cunt",
+  "dick",
+  "fuck",
+  "hate",
+  "kill",
+  "nazi",
+  "porn",
+  "rape",
+  "sex",
+  "shit",
+  "slut"
+];
+
+const WIDTHS: Record<string, number> = {
+  i: 0.34,
+  j: 0.43,
+  l: 0.38,
+  f: 0.55,
+  r: 0.58,
+  t: 0.56,
+  c: 0.82,
+  s: 0.82,
+  v: 0.86,
+  x: 0.86,
+  y: 0.86,
+  z: 0.8,
+  a: 0.9,
+  b: 0.92,
+  d: 0.92,
+  e: 0.88,
+  g: 0.92,
+  h: 0.94,
+  k: 0.9,
+  n: 0.94,
+  o: 0.94,
+  p: 0.92,
+  q: 0.94,
+  u: 0.94,
+  m: 1.34,
+  w: 1.28
+};
+
+function pick<T>(items: readonly T[], random: RandomSource): T {
+  const index = Math.min(items.length - 1, Math.floor(random() * items.length));
+  return items[index];
+}
+
+function isVowel(char: string): boolean {
+  return VOWEL_PATTERN.test(char);
+}
+
+function makeCandidate(length: number, random: RandomSource): string {
+  if (length === 1) return pick(VOWELS, random);
+
+  const result: string[] = [];
+
+  for (let index = 0; index < length; index++) {
+    if (index === 0) {
+      result.push(random() < 0.18 ? pick(VOWELS, random) : pick(CONSONANTS, random));
+      continue;
+    }
+
+    const previous = result[index - 1];
+    const beforePrevious = result[index - 2];
+    const finalPosition = index === length - 1;
+
+    if (finalPosition) {
+      if (isVowel(previous)) {
+        result.push(
+          random() < 0.07
+            ? pick(
+                VOWELS.filter(letter => letter !== previous),
+                random
+              )
+            : pick(END_CONSONANTS, random)
+        );
+      } else {
+        result.push(pick(VOWELS, random));
+      }
+      continue;
+    }
+
+    if (isVowel(previous)) {
+      const mustUseConsonant = beforePrevious !== undefined && isVowel(beforePrevious);
+      result.push(mustUseConsonant || random() < 0.95 ? pick(CONSONANTS, random) : pick(VOWELS, random));
+      continue;
+    }
+
+    const followers = CLUSTER_FOLLOWERS[previous];
+    const alreadyInCluster = beforePrevious !== undefined && !isVowel(beforePrevious);
+    if (!alreadyInCluster && followers && random() < 0.18) {
+      result.push(pick(followers, random));
+    } else {
+      result.push(pick(VOWELS, random));
+    }
+  }
+
+  return result.join("");
+}
+
+function isUppercaseLetter(char: string): boolean {
+  return char !== char.toLowerCase() && char === char.toUpperCase();
+}
+
+interface LetterCluster {
+  character: string;
+  marks: string;
+}
+
+function getLetterClusters(source: string): LetterCluster[] {
+  const clusters: LetterCluster[] = [];
+
+  for (const char of source.normalize("NFD")) {
+    if (LETTER_CHARACTER_PATTERN.test(char)) {
+      clusters.push({ character: char, marks: "" });
+    } else if (COMBINING_MARK_PATTERN.test(char) && clusters.length > 0) {
+      clusters[clusters.length - 1].marks += char;
+    }
+  }
+
+  return clusters;
+}
+
+function applyCasePattern(candidate: string, sourceCharacters: readonly string[]): string {
+  return Array.from(candidate)
+    .map((char, index) => (isUppercaseLetter(sourceCharacters[index]) ? char.toUpperCase() : char))
+    .join("");
+}
+
+function restoreCombiningMarks(candidate: string, source: string): string {
+  const sourceClusters = getLetterClusters(source);
+  const candidateCharacters = Array.from(candidate);
+  const restored = sourceClusters.map(({ marks }, index) => `${candidateCharacters[index] ?? ""}${marks}`).join("");
+
+  // Keep each token's original NFC/NFD shape while making equivalent tokens
+  // render the same invented word (e.g. `é` and `e\u0301`).
+  return restored.normalize(source === source.normalize("NFC") ? "NFC" : "NFD");
+}
+
+function glyphWidth(char: string): number {
+  if (char === "\t") return 2.08;
+  if (/\s/u.test(char)) return 0.52;
+  if (/\p{N}/u.test(char)) return 0.92;
+
+  const lower = char.toLowerCase();
+  const base = WIDTHS[lower] ?? (/\p{L}/u.test(char) ? 0.94 : 0.5);
+  return isUppercaseLetter(char) ? base * 1.06 : base;
+}
+
+export function estimateVisualWidth(text: string): number {
+  return Array.from(text).reduce((total, char) => total + glyphWidth(char), 0);
+}
+
+interface SourceProfile {
+  characters: string[];
+  characterWidths: number[];
+  lower: string;
+  width: number;
+}
+
+function candidateScore(candidate: string, source: SourceProfile): number {
+  const lowerCandidate = candidate.toLowerCase();
+
+  if (lowerCandidate === source.lower) return Number.POSITIVE_INFINITY;
+  if (COMMON_WORDS.has(lowerCandidate)) return Number.POSITIVE_INFINITY;
+  if (UNWELCOME_FRAGMENTS.some(fragment => lowerCandidate.includes(fragment))) return Number.POSITIVE_INFINITY;
+  if (
+    TRIPLE_VOWEL_PATTERN.test(lowerCandidate) ||
+    TRIPLE_CONSONANT_PATTERN.test(lowerCandidate) ||
+    REPEATED_BIGRAM_PATTERN.test(lowerCandidate)
+  ) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  const styledCandidate = applyCasePattern(candidate, source.characters);
+  const candidateCharacters = Array.from(styledCandidate);
+  const totalWidthDifference = Math.abs(estimateVisualWidth(styledCandidate) - source.width) / source.width;
+
+  let profileDifference = 0;
+  let positionalMatches = 0;
+  for (let index = 0; index < source.characters.length; index++) {
+    profileDifference += Math.abs(glyphWidth(candidateCharacters[index]) - source.characterWidths[index]);
+    if (candidateCharacters[index].toLowerCase() === source.characters[index].toLowerCase()) {
+      positionalMatches++;
+    }
+  }
+
+  profileDifference /= Math.max(source.characters.length, 1);
+  const similarity = positionalMatches / Math.max(source.characters.length, 1);
+  const unusualLetters = (lowerCandidate.match(/[kwyz]/g) ?? []).length / Math.max(source.characters.length, 1);
+  const vowelPairs = (lowerCandidate.match(/[aeiou]{2}/g) ?? []).length / Math.max(source.characters.length, 1);
+  return (
+    totalWidthDifference * 6 + profileDifference * 0.34 + similarity * 0.42 + unusualLetters * 0.18 + vowelPairs * 0.08
+  );
+}
+
+function createBaseWord(source: string, random: RandomSource, requestedCandidateCount?: number): string {
+  const sourceCharacters = Array.from(source);
+  const sourceCharacterWidths = sourceCharacters.map(glyphWidth);
+  const length = sourceCharacters.length;
+  const candidateCount = requestedCandidateCount ?? (length <= 2 ? 32 : length > 40 ? 40 : 96);
+  const sourceProfile: SourceProfile = {
+    characters: sourceCharacters,
+    characterWidths: sourceCharacterWidths,
+    lower: source.toLowerCase(),
+    width: Math.max(
+      sourceCharacterWidths.reduce((total, width) => total + width, 0),
+      0.01
+    )
+  };
+  let bestCandidate = "";
+  let bestScore = Number.POSITIVE_INFINITY;
+
+  for (let index = 0; index < candidateCount; index++) {
+    const candidate = makeCandidate(length, random);
+    const score = candidateScore(candidate, sourceProfile);
+    if (score < bestScore) {
+      bestCandidate = candidate;
+      bestScore = score;
+    }
+  }
+
+  if (bestCandidate) return bestCandidate;
+
+  const fallbackLetters = ["v", "e", "l", "o", "r", "a", "n", "i"];
+  const fallback = Array.from({ length }, (_, index) => fallbackLetters[index % fallbackLetters.length]).join("");
+  return fallback.toLowerCase() === source.toLowerCase() ? Array.from(fallback).reverse().join("") : fallback;
+}
+
+function scrambleDigits(source: string, random: RandomSource): string {
+  return Array.from(source)
+    .map(char => {
+      if (!DECIMAL_DIGIT_PATTERN.test(char)) return char;
+
+      const codePoint = char.codePointAt(0);
+      if (codePoint === undefined) return char;
+
+      let runStart = codePoint;
+      while (runStart > 0 && DECIMAL_DIGIT_PATTERN.test(String.fromCodePoint(runStart - 1))) {
+        runStart--;
+      }
+
+      const original = (codePoint - runStart) % 10;
+      const zero = codePoint - original;
+      const offset = 1 + Math.floor(random() * 9);
+      return String.fromCodePoint(zero + ((original + offset) % 10));
+    })
+    .join("");
+}
+
+export function scrambleText(input: string, options: ScrambleOptions = {}): string {
+  const random = options.random ?? Math.random;
+  const wordMap = new Map<string, string>();
+
+  return input.replace(TOKEN_PATTERN, token => {
+    if (!LETTER_PATTERN.test(token)) {
+      return options.scrambleNumbers === false ? token : scrambleDigits(token, random);
+    }
+
+    const sourceCharacters = getLetterClusters(token).map(({ character }) => character);
+    const normalizedToken = token.normalize("NFKD").replace(/\p{M}/gu, "").toLowerCase();
+    const cacheKey = `${sourceCharacters.length}:${normalizedToken}`;
+    let baseWord = wordMap.get(cacheKey);
+    if (!baseWord) {
+      baseWord = createBaseWord(sourceCharacters.join(""), random, options.candidateCount);
+      wordMap.set(cacheKey, baseWord);
+    }
+
+    return restoreCombiningMarks(applyCasePattern(baseWord, sourceCharacters), token);
+  });
+}

--- a/extensions/redactcast/tests/clipboard-safety.test.ts
+++ b/extensions/redactcast/tests/clipboard-safety.test.ts
@@ -6,10 +6,10 @@ describe("Clipboard restoration safety", () => {
     expect(canSafelyRestoreClipboard({ text: "reference" })).toBe(true);
     expect(canSafelyRestoreClipboard({ text: "" })).toBe(true);
     expect(canSafelyRestoreClipboard({ text: "reference", html: "<p>reference</p>" })).toBe(true);
-    expect(canSafelyRestoreClipboard({ text: "reference", file: "/tmp/reference.png" })).toBe(true);
   });
 
-  it("rejects combined file and HTML representations", () => {
+  it("rejects file-bearing representations", () => {
+    expect(canSafelyRestoreClipboard({ text: "reference", file: "/tmp/reference.png" })).toBe(false);
     expect(
       canSafelyRestoreClipboard({ text: "reference", file: "/tmp/reference.png", html: "<p>reference</p>" }),
     ).toBe(false);

--- a/extensions/redactcast/tests/clipboard-safety.test.ts
+++ b/extensions/redactcast/tests/clipboard-safety.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { canSafelyRestoreClipboard } from "../src/clipboard-safety";
+
+describe("Clipboard restoration safety", () => {
+  it("accepts representations Raycast can restore losslessly", () => {
+    expect(canSafelyRestoreClipboard({ text: "reference" })).toBe(true);
+    expect(canSafelyRestoreClipboard({ text: "" })).toBe(true);
+    expect(canSafelyRestoreClipboard({ text: "reference", html: "<p>reference</p>" })).toBe(true);
+    expect(canSafelyRestoreClipboard({ text: "reference", file: "/tmp/reference.png" })).toBe(true);
+  });
+
+  it("rejects combined file and HTML representations", () => {
+    expect(
+      canSafelyRestoreClipboard({ text: "reference", file: "/tmp/reference.png", html: "<p>reference</p>" }),
+    ).toBe(false);
+  });
+});

--- a/extensions/redactcast/tests/clipboard-safety.test.ts
+++ b/extensions/redactcast/tests/clipboard-safety.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { canSafelyRestoreClipboard, getRestorableClipboardContent } from "../src/clipboard-safety";
+import {
+  canSafelyRestoreClipboard,
+  getRestorableClipboardContent,
+  restoreClipboardWithRetry,
+} from "../src/clipboard-safety";
 
 describe("Clipboard restoration safety", () => {
   it("returns the exact payload Raycast can restore", () => {
@@ -23,5 +27,43 @@ describe("Clipboard restoration safety", () => {
     expect(
       canSafelyRestoreClipboard({ text: "reference", file: "/tmp/reference.png", html: "<p>reference</p>" }),
     ).toBe(false);
+  });
+
+  it("retries transient restoration failures", async () => {
+    const attempts: string[] = [];
+    const pauses: number[] = [];
+
+    await restoreClipboardWithRetry(
+      "reference",
+      async (content) => {
+        attempts.push(String(content));
+        if (attempts.length < 3) throw new Error("pasteboard busy");
+      },
+      3,
+      async (delayMs) => {
+        pauses.push(delayMs);
+      },
+    );
+
+    expect(attempts).toEqual(["reference", "reference", "reference"]);
+    expect(pauses).toEqual([50, 100]);
+  });
+
+  it("surfaces a persistent restoration failure", async () => {
+    const failure = new Error("pasteboard unavailable");
+    let attempts = 0;
+
+    await expect(
+      restoreClipboardWithRetry(
+        "reference",
+        async () => {
+          attempts += 1;
+          throw failure;
+        },
+        3,
+        async () => undefined,
+      ),
+    ).rejects.toBe(failure);
+    expect(attempts).toBe(3);
   });
 });

--- a/extensions/redactcast/tests/clipboard-safety.test.ts
+++ b/extensions/redactcast/tests/clipboard-safety.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { canSafelyRestoreClipboard } from "../src/clipboard-safety";
+import { canSafelyRestoreClipboard, getRestorableClipboardContent } from "../src/clipboard-safety";
 
 describe("Clipboard restoration safety", () => {
+  it("returns the exact payload Raycast can restore", () => {
+    expect(getRestorableClipboardContent({ text: "reference" })).toBe("reference");
+    expect(getRestorableClipboardContent({ text: "" })).toBe("");
+    expect(getRestorableClipboardContent({ text: "reference", html: "<p>reference</p>" })).toEqual({
+      html: "<p>reference</p>",
+      text: "reference",
+    });
+  });
+
   it("accepts representations Raycast can restore losslessly", () => {
     expect(canSafelyRestoreClipboard({ text: "reference" })).toBe(true);
     expect(canSafelyRestoreClipboard({ text: "" })).toBe(true);
@@ -9,6 +18,7 @@ describe("Clipboard restoration safety", () => {
   });
 
   it("rejects file-bearing representations", () => {
+    expect(getRestorableClipboardContent({ text: "reference", file: "/tmp/reference.png" })).toBeNull();
     expect(canSafelyRestoreClipboard({ text: "reference", file: "/tmp/reference.png" })).toBe(false);
     expect(
       canSafelyRestoreClipboard({ text: "reference", file: "/tmp/reference.png", html: "<p>reference</p>" }),

--- a/extensions/redactcast/tests/scramble-text.test.ts
+++ b/extensions/redactcast/tests/scramble-text.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { scrambleText } from "../src/scramble-text";
+
+function seededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state += 0x6d2b79f5;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function structure(text: string): string {
+  return text
+    .normalize("NFD")
+    .replace(/\p{M}/gu, "")
+    .replace(/\p{L}/gu, "L")
+    .replace(/\p{N}/gu, "N");
+}
+
+function separators(text: string): string[] {
+  return text.normalize("NFD").replace(/\p{M}/gu, "").split(/\p{L}+|\p{N}+/gu);
+}
+
+describe("Draft text scrambler", () => {
+  it("preserves layout structure and separators", () => {
+    const source = "A quiet title\n\nDesign\twith soul — always.\nhello@example.com · 2026 ✦";
+    const result = scrambleText(source, { random: seededRandom(1) });
+
+    expect(structure(result)).toBe(structure(source));
+    expect(separators(result)).toEqual(separators(source));
+    expect(result).not.toBe(source);
+  });
+
+  it("maps repeated words consistently", () => {
+    const words = scrambleText("Shape shape SHAPE", { random: seededRandom(3) }).split(" ");
+
+    expect(words[0].toLowerCase()).toBe(words[1].toLowerCase());
+    expect(words[1].toLowerCase()).toBe(words[2].toLowerCase());
+  });
+
+  it("handles canonically equivalent accented words safely in either order", () => {
+    ["é e\u0301", "e\u0301 é"].forEach((source, index) => {
+      const words = scrambleText(source, { random: seededRandom(32 + index) }).split(" ");
+
+      expect(words[0].normalize("NFC")).toBe(words[1].normalize("NFC"));
+      expect(structure(words.join(" "))).toBe(structure(source));
+    });
+  });
+
+  it("scrambles decimal digits without changing their structure", () => {
+    const source = "2026 / 03 / 14";
+    const result = scrambleText(source, { random: seededRandom(4) });
+    const sourceDigits = Array.from(source).filter((char) => /\p{N}/u.test(char));
+    const resultDigits = Array.from(result).filter((char) => /\p{N}/u.test(char));
+
+    expect(structure(result)).toBe(structure(source));
+    expect(resultDigits.every((digit, index) => digit !== sourceDigits[index])).toBe(true);
+  });
+
+  it("leaves punctuation-only content untouched", () => {
+    const source = "  — ✦\n\t…  ";
+
+    expect(scrambleText(source, { random: seededRandom(9) })).toBe(source);
+  });
+});

--- a/extensions/redactcast/tests/scramble-text.test.ts
+++ b/extensions/redactcast/tests/scramble-text.test.ts
@@ -41,6 +41,14 @@ describe("Draft text scrambler", () => {
     expect(words[1].toLowerCase()).toBe(words[2].toLowerCase());
   });
 
+  it("treats Unicode titlecase letters as uppercase", () => {
+    const result = scrambleText("ǅuro ǈub", { random: seededRandom(33) });
+    const letters = Array.from(result).filter((char) => /\p{L}/u.test(char));
+
+    expect(letters[0]).toMatch(/^[A-Z]$/);
+    expect(letters[4]).toMatch(/^[A-Z]$/);
+  });
+
   it("handles canonically equivalent accented words safely in either order", () => {
     ["é e\u0301", "e\u0301 é"].forEach((source, index) => {
       const words = scrambleText(source, { random: seededRandom(32 + index) }).split(" ");

--- a/extensions/redactcast/tsconfig.json
+++ b/extensions/redactcast/tsconfig.json
@@ -11,5 +11,5 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "raycast-env.d.ts"]
 }


### PR DESCRIPTION
## Description

This is a functional Draft fit experiment prompted by the review on #29547, which suggested testing Text Scramble against RedactCast.

It adds a deliberately separate command, **Scramble Draft Text — Non-Security Draft Copy**. The command turns selected or clipboard copy into pronounceable invented text while preserving whitespace, punctuation, line breaks, token lengths, casing, repeated-word consistency, Unicode decimal writing systems, and approximate word width.

The distinction is material:

- RedactCast’s existing commands provide deterministic, reversible PII masking.
- Draft scrambling is non-reversible aesthetic greeking for layout previews.
- It must not be understood or marketed as secure redaction.

That boundary appears in the command title, subtitle, description, changelog, implementation, and this PR. The new command does not touch RedactCast’s masking engine or mappings. It distinguishes readable-empty sources from access errors, rejects clipboard states Raycast cannot restore losslessly, and retries transient pasteboard restoration failures. All processing remains local.

This PR remains Draft so the authors can decide whether adjacent privacy intent outweighs the risk of mixing two different safety promises.

## Validation

- `npm test` passes: 16/16 tests
- `npm run lint` passes
- `npm run build` passes
- `npx tsc --noEmit` passes
- No new runtime or development dependencies
- `package-lock.json` unchanged

The existing dependency tree reports five audit advisories (two low, one moderate, two high); this patch does not change that tree.

## Screencast

Draft fit discussion; I will add a focused screencast if the maintainers want to proceed with this direction.

## Checklist

- [x] Read the contribution guidelines
- [x] Read the Store publishing documentation
- [x] Built, linted, tested, and type-checked the extension
- [x] Checked extension and command assets
- [x] Checked README assets
