### PR TITLE
[Super Productivity] require access token

### DIFF
--- a/extensions/super-productivity/CHANGELOG.md
+++ b/extensions/super-productivity/CHANGELOG.md
@@ -1,9 +1,13 @@
-# Changelog
+# Super Productivity Changelog
 
 All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Require API Token] - {PR_MERGE_DATE}
+
+- Extension now requires API Token to use the local API (ref: [Issue #30157](https://github.com/raycast/extensions/issues/30157))
 
 ## [Initial Release] - 2026-08-04
 

--- a/extensions/super-productivity/CHANGELOG.md
+++ b/extensions/super-productivity/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Require API Token] - {PR_MERGE_DATE}
+## [Require API Token] - 2026-08-13
 
 - Extension now requires API Token to use the local API (ref: [Issue #30157](https://github.com/raycast/extensions/issues/30157))
 

--- a/extensions/super-productivity/README.md
+++ b/extensions/super-productivity/README.md
@@ -37,6 +37,8 @@ npm run dev   # opens Raycast dev with the extension live-reloading
 
 The default preference `apiBaseUrl` is `http://127.0.0.1:3876`. Change it in Raycast preferences if your SP instance runs elsewhere.
 
+🔑 You will also need to enter the "Access Token" from local REST API settings.
+
 ---
 
 ## Auto-focus on tracking

--- a/extensions/super-productivity/package-lock.json
+++ b/extensions/super-productivity/package-lock.json
@@ -1362,9 +1362,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1382,9 +1379,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1402,9 +1396,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1422,9 +1413,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1442,9 +1430,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1462,9 +1447,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3165,9 +3147,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3189,9 +3168,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3213,9 +3189,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3237,9 +3210,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/extensions/super-productivity/package.json
+++ b/extensions/super-productivity/package.json
@@ -41,6 +41,14 @@
       "required": false,
       "default": "http://127.0.0.1:3876",
       "placeholder": "http://127.0.0.1:3876"
+    },
+    {
+      "name": "accessToken",
+      "title": "Access Token",
+      "description": "Access Token for the Super Productivity Local REST API",
+      "type": "password",
+      "required": true,
+      "placeholder": "xXX...XXX"
     }
   ],
   "commands": [
@@ -183,6 +191,7 @@
   ],
   "title": "Super Productivity",
   "author": "pvnkmnk",
+  "contributors": ["xmok"],
   "platforms": [
     "macOS",
     "Windows"

--- a/extensions/super-productivity/src/api.test.ts
+++ b/extensions/super-productivity/src/api.test.ts
@@ -91,6 +91,24 @@ beforeEach(() => {
   mockShowHUD.mockReset();
 });
 
+describe("request authentication", () => {
+  it("sends Authorization Bearer header with the access token", async () => {
+    mockFetch.mockResolvedValue(okResponse({ server: "SP", rendererReady: true }));
+
+    await checkHealth();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://test:3876/health",
+      expect.objectContaining({
+        headers: {
+          Authorization: `Bearer ${mockPreferences.accessToken}`,
+          "Content-Type": "application/json",
+        },
+      }),
+    );
+  });
+});
+
 describe("checkHealth", () => {
   it("returns health data on success", async () => {
     mockFetch.mockResolvedValue(okResponse({ server: "SP", rendererReady: true }));

--- a/extensions/super-productivity/src/api.test.ts
+++ b/extensions/super-productivity/src/api.test.ts
@@ -4,7 +4,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // vi.hoisted ensures mock fns are created before the mock factory runs
 const mockShowToast = vi.hoisted(() => vi.fn());
 const mockShowHUD = vi.hoisted(() => vi.fn());
-const mockPreferences = vi.hoisted(() => ({ apiBaseUrl: "http://test:3876" }));
+const mockPreferences = vi.hoisted(() => ({
+  apiBaseUrl: "http://test:3876",
+  accessToken: "xXXxxxXXxXXXXXXxXXXxxXxxxxxXxXXX",
+}));
 
 vi.mock("@raycast/api", () => ({
   getPreferenceValues: () => mockPreferences,
@@ -82,6 +85,7 @@ function apiErrorResponse(message: string) {
 
 beforeEach(() => {
   mockPreferences.apiBaseUrl = "http://test:3876";
+  mockPreferences.accessToken = "xXXxxxXXxXXXXXXxXXXxxXxxxxxXxXXX";
   mockFetch.mockReset();
   mockShowToast.mockReset();
   mockShowHUD.mockReset();

--- a/extensions/super-productivity/src/api.ts
+++ b/extensions/super-productivity/src/api.ts
@@ -21,12 +21,14 @@ function getBaseUrl(): string {
 }
 
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
+  const { accessToken } = getPreferenceValues<Preferences>();
   const baseUrl = getBaseUrl();
   const url = `${baseUrl}${path}`;
 
   try {
     const res = await fetch(url, {
       headers: {
+        Authorization: `Bearer ${accessToken}`,
         "Content-Type": "application/json",
       },
       ...options,


### PR DESCRIPTION
## Description

- Extension now requires API Token to use the local API (close #30157)

## Screencast

https://github.com/user-attachments/assets/30c10896-8d69-43ef-a295-d89c94b416fa

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
