### PR TITLE
Torbox: Make View Files default for multi-file downloads

### DIFF
--- a/extensions/torbox/src/components/DownloadListItem.tsx
+++ b/extensions/torbox/src/components/DownloadListItem.tsx
@@ -81,6 +81,14 @@ export const DownloadListItem = ({ download, apiKey, videoPlayers, onRefresh }: 
       actions={
         <ActionPanel>
           <ActionPanel.Section>
+            {hasMultipleFiles && (
+              <Action.Push
+                title="View Files"
+                icon={Icon.List}
+                shortcut={{ modifiers: ["cmd"], key: "return" }}
+                target={<DownloadFiles download={download} apiKey={apiKey} />}
+              />
+            )}
             {isDownloadReady &&
               isSingleVideoFile &&
               players.map((player) => (
@@ -93,14 +101,6 @@ export const DownloadListItem = ({ download, apiKey, videoPlayers, onRefresh }: 
               ))}
             {isDownloadReady && (
               <Action title="Copy Download Link" icon={Icon.Link} onAction={() => copyDownloadLink(apiKey, download)} />
-            )}
-            {hasMultipleFiles && (
-              <Action.Push
-                title="View Files"
-                icon={Icon.List}
-                shortcut={{ modifiers: ["cmd"], key: "return" }}
-                target={<DownloadFiles download={download} apiKey={apiKey} />}
-              />
             )}
           </ActionPanel.Section>
           {isSingleVideoFile && players.length > 1 && (


### PR DESCRIPTION
## Summary
- make `View Files` the default action for multi-file search-download entries
- retain `Copy Download Link` as a secondary action

## Validation
- `npm run lint`