### PR TITLE
Fix Doorstopper menu bar status toast

### DIFF
--- a/extensions/doorstopper/CHANGELOG.md
+++ b/extensions/doorstopper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Doorstopper Changelog
 
+## [Fix Menu Bar Toast] - 2026-08-12
+
+- Fixed a misleading failure toast after toggling Doorstopper when the optional menu bar command is disabled.
+
 ## [Touch ID Authentication] - 2026-07-23
 
 - Added Touch ID authentication for changing Doorstopper settings when Touch ID is enabled for `sudo`

--- a/extensions/doorstopper/CHANGELOG.md
+++ b/extensions/doorstopper/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Doorstopper Changelog
 
-## [Fix Menu Bar Toast] - {PR_MERGE_DATE}
+## [Fix Menu Bar Toast] - 2026-08-12
 
 - Fixed a misleading failure toast after toggling Doorstopper when the optional menu bar command is disabled.
 

--- a/extensions/doorstopper/CHANGELOG.md
+++ b/extensions/doorstopper/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Doorstopper Changelog
 
-## [Fix Menu Bar Toast] - 2026-08-12
+## [Fix Menu Bar Toast] - {PR_MERGE_DATE}
 
 - Fixed a misleading failure toast after toggling Doorstopper when the optional menu bar command is disabled.
 

--- a/extensions/doorstopper/src/util.ts
+++ b/extensions/doorstopper/src/util.ts
@@ -8,6 +8,8 @@ type Updates = {
   status: boolean;
 };
 
+const optionalUpdateCommands = new Set(["statusmenu"]);
+
 async function update(updates: Updates, enabled: boolean) {
   if (updates.menubar) {
     await tryLaunchCommand("statusmenu", { enabled });
@@ -21,6 +23,10 @@ async function tryLaunchCommand(commandName: string, context: { enabled: boolean
   try {
     await launchCommand({ name: commandName, type: LaunchType.Background, context });
   } catch (error) {
+    if (optionalUpdateCommands.has(commandName)) {
+      return;
+    }
+
     await showFailureToast(error, { title: `Failed to launch command ${commandName}` });
   }
 }


### PR DESCRIPTION
## Description

Fixes #30133

Suppresses the optional `statusmenu` background refresh failure after Doorstopper is toggled. The main status command still reports launch failures, but a disabled menu bar command no longer shows a misleading failure toast after the toggle succeeds.

## Screencast

N/A — small background-command error-handling fix.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
