### PR TITLE
Add recent downloads section

### DIFF
--- a/extensions/torbox/CHANGELOG.md
+++ b/extensions/torbox/CHANGELOG.md
@@ -1,6 +1,6 @@
 # TorBox Changelog
 
-## [Recent downloads and improved file navigation] - {PR_MERGE_DATE}
+## [Recent downloads and improved file navigation] - 2026-08-12
 
 - Add a Recent section for recently opened downloads, folders, and video files
 

--- a/extensions/torbox/CHANGELOG.md
+++ b/extensions/torbox/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## [Recent downloads and improved file navigation] - {PR_MERGE_DATE}
 
 - Add a Recent section for recently opened downloads, folders, and video files
-- Make View Files the default action for multi-file downloads
 
 ## [Stream video files in external players] - 2026-03-14
 

--- a/extensions/torbox/CHANGELOG.md
+++ b/extensions/torbox/CHANGELOG.md
@@ -1,5 +1,10 @@
 # TorBox Changelog
 
+## [Recent downloads and improved file navigation] - 2026-08-12
+
+- Add a Recent section for recently opened downloads, folders, and video files
+- Make View Files the default action for multi-file downloads
+
 ## [Stream video files in external players] - 2026-03-14
 
 - Stream video files directly in VLC, IINA, Infuse, or mpv

--- a/extensions/torbox/CHANGELOG.md
+++ b/extensions/torbox/CHANGELOG.md
@@ -1,6 +1,6 @@
 # TorBox Changelog
 
-## [Recent downloads and improved file navigation] - 2026-08-12
+## [Recent downloads and improved file navigation] - {PR_MERGE_DATE}
 
 - Add a Recent section for recently opened downloads, folders, and video files
 - Make View Files the default action for multi-file downloads

--- a/extensions/torbox/package.json
+++ b/extensions/torbox/package.json
@@ -10,7 +10,9 @@
     "Windows"
   ],
   "license": "MIT",
-  "categories": ["Media"],
+  "categories": [
+    "Media"
+  ],
   "preferences": [
     {
       "name": "apiKey",
@@ -59,5 +61,8 @@
     "lint": "ray lint",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "contributors": [
+    "ohivan"
+  ]
 }

--- a/extensions/torbox/src/components/DownloadFiles.tsx
+++ b/extensions/torbox/src/components/DownloadFiles.tsx
@@ -5,13 +5,15 @@ import { isVideoFile } from "../utils/video";
 import { openInPlayer } from "../utils/video";
 import { copyDownloadLink } from "../utils/downloads";
 import { useVideoPlayers } from "../hooks/useVideoPlayers";
+import { RecentDownload } from "../hooks/useRecentDownloads";
 
 interface DownloadFilesProps {
   download: Download;
   apiKey: string;
+  onOpen?: (recent: RecentDownload) => void;
 }
 
-export const DownloadFiles = ({ download, apiKey }: DownloadFilesProps) => {
+export const DownloadFiles = ({ download, apiKey, onOpen }: DownloadFilesProps) => {
   const isDownloadReady = download.download_finished || download.progress >= 1;
   const { players, setDefaultPlayer } = useVideoPlayers();
 
@@ -35,7 +37,15 @@ export const DownloadFiles = ({ download, apiKey }: DownloadFilesProps) => {
                         key={player.name}
                         title={`Open in ${player.name}`}
                         icon={Icon.Play}
-                        onAction={() => openInPlayer(apiKey, download, player, file.id)}
+                        onAction={() =>
+                          openInPlayer(apiKey, download, player, file.id, () =>
+                            onOpen?.({
+                              downloadId: download.id,
+                              type: download.type,
+                              fileId: file.id,
+                            }),
+                          )
+                        }
                       />
                     ))}
                   {isDownloadReady && (

--- a/extensions/torbox/src/components/DownloadListItem.tsx
+++ b/extensions/torbox/src/components/DownloadListItem.tsx
@@ -6,12 +6,14 @@ import { isVideoFile, openInPlayer } from "../utils/video";
 import { copyDownloadLink } from "../utils/downloads";
 import { VideoPlayers } from "../hooks/useVideoPlayers";
 import { DownloadFiles } from "./DownloadFiles";
+import { RecentDownload } from "../hooks/useRecentDownloads";
 
 interface DownloadListItemProps {
   download: Download;
   apiKey: string;
   videoPlayers: VideoPlayers;
   onRefresh: () => void;
+  onOpen?: (recent: RecentDownload) => void;
 }
 
 const isFailed = (state: string): boolean => state.toLowerCase().startsWith("failed");
@@ -64,7 +66,7 @@ const handleDelete = async (apiKey: string, download: Download, onRefresh: () =>
   }
 };
 
-export const DownloadListItem = ({ download, apiKey, videoPlayers, onRefresh }: DownloadListItemProps) => {
+export const DownloadListItem = ({ download, apiKey, videoPlayers, onRefresh, onOpen }: DownloadListItemProps) => {
   const status = getStatus(download);
   const isDownloadReady = !download.isQueued && (download.download_finished || download.progress >= 1);
   const hasMultipleFiles = download.files.length > 1;
@@ -88,19 +90,28 @@ export const DownloadListItem = ({ download, apiKey, videoPlayers, onRefresh }: 
                   key={player.name}
                   title={`Open in ${player.name}`}
                   icon={Icon.Play}
-                  onAction={() => openInPlayer(apiKey, download, player)}
+                  onAction={() =>
+                    openInPlayer(apiKey, download, player, undefined, () =>
+                      onOpen?.({
+                        downloadId: download.id,
+                        type: download.type,
+                        fileId: download.files[0]?.id,
+                      }),
+                    )
+                  }
                 />
               ))}
-            {isDownloadReady && (
-              <Action title="Copy Download Link" icon={Icon.Link} onAction={() => copyDownloadLink(apiKey, download)} />
-            )}
             {hasMultipleFiles && (
               <Action.Push
                 title="View Files"
                 icon={Icon.List}
                 shortcut={{ modifiers: ["cmd"], key: "return" }}
-                target={<DownloadFiles download={download} apiKey={apiKey} />}
+                target={<DownloadFiles download={download} apiKey={apiKey} onOpen={onOpen} />}
+                onPush={() => onOpen?.({ downloadId: download.id, type: download.type })}
               />
+            )}
+            {isDownloadReady && (
+              <Action title="Copy Download Link" icon={Icon.Link} onAction={() => copyDownloadLink(apiKey, download)} />
             )}
           </ActionPanel.Section>
           {isSingleVideoFile && players.length > 1 && (

--- a/extensions/torbox/src/components/DownloadListItem.tsx
+++ b/extensions/torbox/src/components/DownloadListItem.tsx
@@ -101,6 +101,9 @@ export const DownloadListItem = ({ download, apiKey, videoPlayers, onRefresh, on
                   }
                 />
               ))}
+            {isDownloadReady && (
+              <Action title="Copy Download Link" icon={Icon.Link} onAction={() => copyDownloadLink(apiKey, download)} />
+            )}
             {hasMultipleFiles && (
               <Action.Push
                 title="View Files"
@@ -109,9 +112,6 @@ export const DownloadListItem = ({ download, apiKey, videoPlayers, onRefresh, on
                 target={<DownloadFiles download={download} apiKey={apiKey} onOpen={onOpen} />}
                 onPush={() => onOpen?.({ downloadId: download.id, type: download.type })}
               />
-            )}
-            {isDownloadReady && (
-              <Action title="Copy Download Link" icon={Icon.Link} onAction={() => copyDownloadLink(apiKey, download)} />
             )}
           </ActionPanel.Section>
           {isSingleVideoFile && players.length > 1 && (

--- a/extensions/torbox/src/components/RecentDownloadListItem.tsx
+++ b/extensions/torbox/src/components/RecentDownloadListItem.tsx
@@ -1,0 +1,97 @@
+import { Action, ActionPanel, Icon, List, useNavigation } from "@raycast/api";
+import { Download } from "../types";
+import { formatBytes } from "../utils/formatters";
+import { copyDownloadLink } from "../utils/downloads";
+import { isVideoFile, openInPlayer } from "../utils/video";
+import { RecentDownload } from "../hooks/useRecentDownloads";
+import { VideoPlayers } from "../hooks/useVideoPlayers";
+import { DownloadFiles } from "./DownloadFiles";
+
+interface RecentDownloadListItemProps {
+  recent: RecentDownload;
+  download: Download;
+  apiKey: string;
+  videoPlayers: VideoPlayers;
+  onOpen: (recent: RecentDownload) => void;
+}
+
+export const RecentDownloadListItem = ({
+  recent,
+  download,
+  apiKey,
+  videoPlayers,
+  onOpen,
+}: RecentDownloadListItemProps) => {
+  const { push } = useNavigation();
+  const isDownloadReady = !download.isQueued && (download.download_finished || download.progress >= 1);
+  const { players, setDefaultPlayer } = videoPlayers;
+
+  if (recent.fileId === undefined) {
+    return (
+      <List.Item
+        title={download.name}
+        subtitle={`${download.files.length} ${download.files.length === 1 ? "file" : "files"}`}
+        icon={Icon.Folder}
+        actions={
+          <ActionPanel>
+            <Action
+              title="View Files"
+              icon={Icon.List}
+              onAction={() => {
+                onOpen(recent);
+                push(<DownloadFiles download={download} apiKey={apiKey} onOpen={onOpen} />);
+              }}
+            />
+            {isDownloadReady && (
+              <Action title="Copy Download Link" icon={Icon.Link} onAction={() => copyDownloadLink(apiKey, download)} />
+            )}
+          </ActionPanel>
+        }
+      />
+    );
+  }
+
+  const file = download.files.find((downloadFile) => downloadFile.id === recent.fileId);
+  if (!file) return null;
+
+  const filename = file.short_name || file.name;
+  const isVideo = isVideoFile(filename);
+
+  return (
+    <List.Item
+      title={filename}
+      subtitle={`${download.name} · ${formatBytes(file.size)}`}
+      icon={Icon.Document}
+      actions={
+        <ActionPanel>
+          {isDownloadReady &&
+            isVideo &&
+            players.map((player) => (
+              <Action
+                key={player.name}
+                title={`Open in ${player.name}`}
+                icon={Icon.Play}
+                onAction={() => openInPlayer(apiKey, download, player, file.id, () => onOpen(recent))}
+              />
+            ))}
+          {isDownloadReady && (
+            <Action
+              title="Copy Download Link"
+              icon={Icon.Link}
+              onAction={() => copyDownloadLink(apiKey, download, file.id)}
+            />
+          )}
+          {isVideo && players.length > 1 && (
+            <ActionPanel.Section>
+              <ActionPanel.Submenu title="Set Default Player" icon={Icon.Star}>
+                {players.map((player) => (
+                  <Action key={player.name} title={player.name} onAction={() => setDefaultPlayer(player)} />
+                ))}
+              </ActionPanel.Submenu>
+            </ActionPanel.Section>
+          )}
+        </ActionPanel>
+      }
+    />
+  );
+};

--- a/extensions/torbox/src/hooks/useRecentDownloads.ts
+++ b/extensions/torbox/src/hooks/useRecentDownloads.ts
@@ -1,0 +1,102 @@
+import { LocalStorage } from "@raycast/api";
+import { createHash } from "node:crypto";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { DownloadType } from "../types";
+
+const MAX_RECENT_DOWNLOADS = 8;
+
+export interface RecentDownload {
+  downloadId: number;
+  type: DownloadType;
+  fileId?: number;
+}
+
+const isRecentDownload = (value: unknown): value is RecentDownload => {
+  if (!value || typeof value !== "object") return false;
+
+  const recent = value as Partial<RecentDownload>;
+  return (
+    typeof recent.downloadId === "number" &&
+    (recent.type === "torrent" || recent.type === "webdl" || recent.type === "usenet") &&
+    (recent.fileId === undefined || typeof recent.fileId === "number")
+  );
+};
+
+const getRecentKey = ({ downloadId, type, fileId }: RecentDownload) => `${type}-${downloadId}-${fileId ?? "folder"}`;
+
+const mergeRecentDownloads = (...lists: RecentDownload[][]): RecentDownload[] => {
+  const seenKeys = new Set<string>();
+
+  return lists
+    .flat()
+    .filter((recent) => {
+      const key = getRecentKey(recent);
+      if (seenKeys.has(key)) return false;
+      seenKeys.add(key);
+      return true;
+    })
+    .slice(0, MAX_RECENT_DOWNLOADS);
+};
+
+const getStorageKey = (apiKey: string) => {
+  const accountHash = createHash("sha256").update(apiKey).digest("hex");
+  return `recentDownloads-${accountHash}`;
+};
+
+export function useRecentDownloads(apiKey: string) {
+  const [recentDownloads, setRecentDownloads] = useState<RecentDownload[]>([]);
+  const recentDownloadsRef = useRef<RecentDownload[]>([]);
+  const writeQueue = useRef(Promise.resolve());
+  const storageKey = useMemo(() => getStorageKey(apiKey), [apiKey]);
+
+  const saveRecentDownloads = useCallback((key: string, recents: RecentDownload[]) => {
+    writeQueue.current = writeQueue.current
+      .then(() => LocalStorage.setItem(key, JSON.stringify(recents)))
+      .catch(() => undefined);
+  }, []);
+
+  useEffect(() => {
+    let isCurrentAccount = true;
+    recentDownloadsRef.current = [];
+    setRecentDownloads([]);
+
+    LocalStorage.getItem<string>(storageKey).then((storedRecents) => {
+      if (!isCurrentAccount) return;
+
+      let parsedRecents: RecentDownload[] = [];
+      if (!storedRecents) return;
+
+      try {
+        const parsedValue: unknown = JSON.parse(storedRecents);
+        parsedRecents = Array.isArray(parsedValue) ? parsedValue.filter(isRecentDownload) : [];
+      } catch {
+        // Ignore values written by an older or invalid version of the extension.
+      }
+
+      const mergedRecents = mergeRecentDownloads(recentDownloadsRef.current, parsedRecents);
+      const hasNewRecents = recentDownloadsRef.current.length > 0;
+      recentDownloadsRef.current = mergedRecents;
+      setRecentDownloads(mergedRecents);
+
+      if (hasNewRecents) {
+        saveRecentDownloads(storageKey, mergedRecents);
+      }
+    });
+
+    return () => {
+      isCurrentAccount = false;
+    };
+  }, [saveRecentDownloads, storageKey]);
+
+  const recordRecent = useCallback(
+    (recent: RecentDownload) => {
+      const nextRecents = mergeRecentDownloads([recent], recentDownloadsRef.current);
+      recentDownloadsRef.current = nextRecents;
+      setRecentDownloads(nextRecents);
+      saveRecentDownloads(storageKey, nextRecents);
+    },
+    [saveRecentDownloads, storageKey],
+  );
+
+  return { recentDownloads, recordRecent };
+}

--- a/extensions/torbox/src/search-downloads.tsx
+++ b/extensions/torbox/src/search-downloads.tsx
@@ -3,12 +3,15 @@ import { useState, useMemo } from "react";
 import { useDownloads } from "./hooks/useDownloads";
 import { useVideoPlayers } from "./hooks/useVideoPlayers";
 import { DownloadListItem } from "./components/DownloadListItem";
+import { RecentDownloadListItem } from "./components/RecentDownloadListItem";
+import { useRecentDownloads } from "./hooks/useRecentDownloads";
 
 export default function SearchDownloads() {
   const preferences = getPreferenceValues<ExtensionPreferences>();
   const [searchText, setSearchText] = useState("");
   const { data, isLoading, error, revalidate } = useDownloads();
   const videoPlayers = useVideoPlayers();
+  const { recentDownloads, recordRecent } = useRecentDownloads(preferences.apiKey);
 
   const filteredDownloads = useMemo(() => {
     if (!data) return [];
@@ -17,6 +20,18 @@ export default function SearchDownloads() {
     const query = searchText.toLowerCase();
     return data.filter((download) => download.name.toLowerCase().includes(query));
   }, [data, searchText]);
+
+  const availableRecents = useMemo(() => {
+    if (!data || searchText) return [];
+
+    return recentDownloads.flatMap((recent) => {
+      const download = data.find((item) => item.id === recent.downloadId && item.type === recent.type);
+      if (!download || (recent.fileId !== undefined && !download.files.some((file) => file.id === recent.fileId))) {
+        return [];
+      }
+      return [{ recent, download }];
+    });
+  }, [data, recentDownloads, searchText]);
 
   if (error) {
     showToast({
@@ -33,6 +48,20 @@ export default function SearchDownloads() {
       searchBarPlaceholder="Search your TorBox downloads..."
       throttle
     >
+      {availableRecents.length > 0 && (
+        <List.Section title="Recent" subtitle={`${availableRecents.length}`}>
+          {availableRecents.map(({ recent, download }) => (
+            <RecentDownloadListItem
+              key={`${recent.type}-${recent.downloadId}-${recent.fileId ?? "folder"}`}
+              recent={recent}
+              download={download}
+              apiKey={preferences.apiKey}
+              videoPlayers={videoPlayers}
+              onOpen={recordRecent}
+            />
+          ))}
+        </List.Section>
+      )}
       <List.Section title={searchText ? "Search Results" : "All Downloads"} subtitle={`${filteredDownloads.length}`}>
         {filteredDownloads.map((download) => (
           <DownloadListItem
@@ -41,6 +70,7 @@ export default function SearchDownloads() {
             apiKey={preferences.apiKey}
             videoPlayers={videoPlayers}
             onRefresh={revalidate}
+            onOpen={recordRecent}
           />
         ))}
       </List.Section>

--- a/extensions/torbox/src/utils/video.ts
+++ b/extensions/torbox/src/utils/video.ts
@@ -35,11 +35,18 @@ export async function findVideoPlayers(): Promise<Application[]> {
   });
 }
 
-export const openInPlayer = async (apiKey: string, download: Download, player: Application, fileId?: number) => {
+export const openInPlayer = async (
+  apiKey: string,
+  download: Download,
+  player: Application,
+  fileId?: number,
+  onOpened?: () => void,
+) => {
   try {
     await showToast({ style: Toast.Style.Animated, title: `Opening in ${player.name}...` });
     const link = await getDownloadLink(apiKey, download.type, download.id, fileId);
     await open(link, player);
+    onOpened?.();
     await showToast({ style: Toast.Style.Success, title: `Opened in ${player.name}` });
   } catch (error) {
     await showToast({


### PR DESCRIPTION
## Summary
- Add a persistent Recent section above All Downloads for recently opened folders and video files
- Scope recents per TorBox account and handle storage-loading races
- Make View Files the default action for multi-file downloads

## Verification
- `npm run lint`
- `npm run build`