### PR TITLE
[Zed] Fix project launch order

### DIFF
--- a/extensions/zed-recent-projects/CHANGELOG.md
+++ b/extensions/zed-recent-projects/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Zed Recent Projects Changelog
 
-## [Fix Project Launch in Raycast 2] - {PR_MERGE_DATE}
+## [Fix Project Launch in Raycast 2] - 2026-08-15
 
 - Open projects before closing Raycast so CLI launches complete reliably.
 

--- a/extensions/zed-recent-projects/CHANGELOG.md
+++ b/extensions/zed-recent-projects/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zed Recent Projects Changelog
 
+## [Fix Project Launch in Raycast 2] - {PR_MERGE_DATE}
+
+- Open projects before closing Raycast so CLI launches complete reliably.
+
 ## [Fix Nix aware `$PATH` lookup] - 2026-07-21
 
 - Fix an issue where nix-managed language tooling (e.g. LSPs) could never be resolved from `$PATH` due to the missing `$USER` env var

--- a/extensions/zed-recent-projects/src/lib/open-project.test.ts
+++ b/extensions/zed-recent-projects/src/lib/open-project.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from "vitest";
+import { openProject } from "./open-project";
+
+describe("openProject", () => {
+  it("opens the project before closing Raycast", async () => {
+    const calls: string[] = [];
+    const open = vi.fn(async () => {
+      calls.push("open");
+    });
+    const close = vi.fn(async () => {
+      calls.push("close");
+    });
+
+    await openProject(open, close);
+
+    expect(calls).toEqual(["open", "close"]);
+  });
+});

--- a/extensions/zed-recent-projects/src/lib/open-project.ts
+++ b/extensions/zed-recent-projects/src/lib/open-project.ts
@@ -1,0 +1,4 @@
+export async function openProject(open: () => Promise<void>, close: () => Promise<void>): Promise<void> {
+  await open();
+  await close();
+}

--- a/extensions/zed-recent-projects/src/search.tsx
+++ b/extensions/zed-recent-projects/src/search.tsx
@@ -11,6 +11,7 @@ import { closeZedWindow, getZedBundleId, openWithZedCli, ZedBuild } from "./lib/
 import { showOpenStatus } from "./lib/preferences";
 import { execWindowsZed } from "./lib/windows";
 import { platform } from "os";
+import { openProject } from "./lib/open-project";
 
 const isMac = platform() === "darwin";
 
@@ -213,8 +214,7 @@ function OpenInZedAction({ entry, revalidate }: { entry: Entry; revalidate: () =
   if (isEntryMultiFolder(entry) && cliPath) {
     const openMultiFolder = async () => {
       try {
-        await closeMainWindow();
-        await openWithZedCli(cliPath, entry.paths);
+        await openProject(() => openWithZedCli(cliPath, entry.paths), closeMainWindow);
         triggerRevalidation();
       } catch (error) {
         await showToast({
@@ -245,8 +245,7 @@ function OpenInZedAction({ entry, revalidate }: { entry: Entry; revalidate: () =
   if (cliPath) {
     const openSingleFolder = async () => {
       try {
-        await closeMainWindow();
-        await openWithZedCli(cliPath!, [entry.paths[0]]);
+        await openProject(() => openWithZedCli(cliPath!, [entry.paths[0]]), closeMainWindow);
         triggerRevalidation();
       } catch (error) {
         await showToast({


### PR DESCRIPTION
Fixes #30060

Root cause: Raycast 2 can tear down the extension before the Zed CLI launch starts because `closeMainWindow()` runs first.

Change: launch Zed before closing Raycast for single- and multi-folder CLI paths. Add an ordering regression test and changelog entry.

Validation:
- `npm test -- --run` (42 passed, 3 skipped)
- `npm run lint`
- `npm run build`