### PR TITLE
Done Bear: Fix Create Task GraphQL 400

### DIFF
--- a/extensions/done-bear/CHANGELOG.md
+++ b/extensions/done-bear/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Done Bear Changelog
 
+## [Bug Fixes] - {PR_MERGE_DATE}
+
+- Fixed creating tasks failing with a GraphQL 400 because the teams query typed workspace ID as a String instead of an ID
+
 ## [GraphQL API Migration] - 2026-03-30
 
 - Migrated workspace, task, project, and team fetches from deprecated REST endpoints to GraphQL API

--- a/extensions/done-bear/src/api/queries.ts
+++ b/extensions/done-bear/src/api/queries.ts
@@ -99,7 +99,7 @@ export const PROJECTS_ALL_QUERY = `
 `;
 
 export const TEAMS_QUERY = `
-  query DonebearTeams($first: Int!, $after: String, $workspaceId: String!) {
+  query DonebearTeams($first: Int!, $after: String, $workspaceId: ID!) {
     teams(first: $first, after: $after, filter: { workspaceId: { eq: $workspaceId } }) {
       nodes {
         id


### PR DESCRIPTION
## Description

Create Task 400s against the current API because `DonebearTeams` still declares `$workspaceId: String!` while the Team `workspaceId` filter is an `ID` comparator, same as tasks and projects. This flips that variable to `ID!` so the form can load teams and create tasks again.

## Screencast

N/A — GraphQL variable type fix, no UI changes.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)