### PR TITLE
[Herdr] Expand tilde in binary path

### DIFF
--- a/extensions/herdr/CHANGELOG.md
+++ b/extensions/herdr/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Fix Tilde Paths] - {PR_MERGE_DATE}
+## [Fix Tilde Paths] - 2026-08-13
 
 - Expand `~` in the configured Herdr binary path.
 

--- a/extensions/herdr/CHANGELOG.md
+++ b/extensions/herdr/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Fix Tilde Paths] - {PR_MERGE_DATE}
+
+- Expand `~` in the configured Herdr binary path.
+
 ## [Initial Release] - 2026-07-23
 
 - Browse and control Herdr workspaces, tabs, panes, and agents.

--- a/extensions/herdr/src/lib/herdr.ts
+++ b/extensions/herdr/src/lib/herdr.ts
@@ -40,7 +40,8 @@ async function isExecutable(path: string): Promise<boolean> {
 }
 
 export async function resolveHerdrBinary(): Promise<string> {
-  const configured = getHerdrPreferences().herdrPath?.trim();
+  const preference = getHerdrPreferences().herdrPath?.trim();
+  const configured = preference?.startsWith("~/") ? join(homedir(), preference.slice(2)) : preference;
   if (configured) {
     if (await isExecutable(configured)) return configured;
     throw new HerdrError(

--- a/extensions/herdr/tests/herdr.test.ts
+++ b/extensions/herdr/tests/herdr.test.ts
@@ -1,0 +1,24 @@
+import { constants } from "node:fs";
+import { access } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveHerdrBinary } from "../src/lib/herdr";
+
+vi.mock("node:fs/promises", () => ({ access: vi.fn() }));
+vi.mock("../src/lib/preferences", () => ({
+  getHerdrPreferences: () => ({ herdrPath: "~/.local/bin/herdr" }),
+}));
+
+describe("resolveHerdrBinary", () => {
+  beforeEach(() => {
+    vi.mocked(access).mockReset().mockResolvedValue();
+  });
+
+  it("expands a leading tilde in the configured binary path", async () => {
+    const expected = join(homedir(), ".local", "bin", "herdr");
+
+    await expect(resolveHerdrBinary()).resolves.toBe(expected);
+    expect(access).toHaveBeenCalledWith(expected, constants.X_OK);
+  });
+});


### PR DESCRIPTION
## Description

The Herdr Binary preference advertises paths such as `~/.local/bin/herdr`, but Node filesystem APIs treat `~` literally.

This expands a leading `~/` before checking executability and adds a regression test.

## Validation

- `npm run check`
- 39 tests passed

Fixes #29992
