### PR TITLE
[Agent Usage] Fix Antigravity detection on 2.7+ (suffix-less language_server binary)

### DIFF
--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Agent Usage Changelog
 
-## [Fix Antigravity detection on 2.7+] - {PR_MERGE_DATE}
+## [Fix Antigravity detection on 2.7+] - 2026-08-13
 
 ### Bug Fixes
 

--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Agent Usage Changelog
 
+## [Fix Antigravity detection on 2.7+] - {PR_MERGE_DATE}
+
+### Bug Fixes
+
+- Detect the suffix-less `language_server` binary shipped by Antigravity 2.7+, which left the Antigravity row stuck on "Not Running" while the app was running
+
 ## [Fix ClinePass usage limits windows] - 2026-08-12
 
 ### Bug Fixes

--- a/extensions/agent-usage/src/antigravity/probe.test.ts
+++ b/extensions/agent-usage/src/antigravity/probe.test.ts
@@ -18,6 +18,35 @@ test("parseProcessInfoFromPsOutput extracts pid, csrf token and extension port",
   assert.equal(parsed.processInfo?.extensionPort, 48765);
 });
 
+test("parseProcessInfoFromPsOutput detects the suffix-less language_server binary (Antigravity 2.7+)", async () => {
+  const { parseProcessInfoFromPsOutput } = await import("./probe.ts");
+
+  const output = `
+  14265 /Applications/Antigravity.app/Contents/Resources/bin/language_server --standalone --override_ide_name antigravity --https_server_port 0 --csrf_token d49cf160-19c7-4601-97f3-56694388220f --app_data_dir antigravity
+  `;
+
+  const parsed = parseProcessInfoFromPsOutput(output);
+
+  assert.equal(parsed.sawAntigravityProcess, true);
+  assert.ok(parsed.processInfo);
+  assert.equal(parsed.processInfo?.pid, 14265);
+  assert.equal(parsed.processInfo?.csrfToken, "d49cf160-19c7-4601-97f3-56694388220f");
+  assert.equal(parsed.processInfo?.extensionPort, null);
+});
+
+test("parseProcessInfoFromPsOutput ignores a Windsurf language server that is not Antigravity", async () => {
+  const { parseProcessInfoFromPsOutput } = await import("./probe.ts");
+
+  const output = `
+  41540 /Applications/Devin.app/Contents/Resources/app/extensions/windsurf/bin/language_server_macos_arm --ide_name windsurf --extension_server_port 57388
+  `;
+
+  const parsed = parseProcessInfoFromPsOutput(output);
+
+  assert.equal(parsed.sawAntigravityProcess, false);
+  assert.equal(parsed.processInfo, null);
+});
+
 test("parseProcessInfoFromPsOutput prefers the Antigravity app over agy fallback", async () => {
   const { parseProcessInfoFromPsOutput } = await import("./probe.ts");
 
@@ -67,6 +96,27 @@ test("parseProcessInfoFromWindowsProcessList extracts pid, csrf token and extens
   assert.equal(parsed.processInfo?.pid, 444);
   assert.equal(parsed.processInfo?.csrfToken, "token-456");
   assert.equal(parsed.processInfo?.extensionPort, 51234);
+});
+
+test("parseProcessInfoFromWindowsProcessList detects the suffix-less language_server.exe binary", async () => {
+  const { parseProcessInfoFromWindowsProcessList } = await import("./probe.ts");
+
+  const parsed = parseProcessInfoFromWindowsProcessList([
+    {
+      ProcessId: 445,
+      Name: "language_server.exe",
+      ExecutablePath:
+        "C:\\Users\\me\\AppData\\Local\\Programs\\Antigravity\\resources\\app\\extensions\\antigravity\\bin\\language_server.exe",
+      CommandLine:
+        '"C:\\Users\\me\\AppData\\Local\\Programs\\Antigravity\\resources\\app\\extensions\\antigravity\\bin\\language_server.exe" --app_data_dir C:\\Users\\me\\AppData\\Roaming\\Antigravity --csrf_token token-789 --extension_server_port 51235',
+    },
+  ]);
+
+  assert.equal(parsed.sawAntigravityProcess, true);
+  assert.ok(parsed.processInfo);
+  assert.equal(parsed.processInfo?.pid, 445);
+  assert.equal(parsed.processInfo?.csrfToken, "token-789");
+  assert.equal(parsed.processInfo?.extensionPort, 51235);
 });
 
 test("parseProcessInfoFromWindowsProcessList prefers the Antigravity app over agy fallback", async () => {

--- a/extensions/agent-usage/src/antigravity/probe.ts
+++ b/extensions/agent-usage/src/antigravity/probe.ts
@@ -185,7 +185,7 @@ async function detectProcessInfoOnWindows(timeoutMs: number): Promise<ParseProce
       "-NoProfile",
       "-NonInteractive",
       "-Command",
-      "$ErrorActionPreference='Stop'; Get-CimInstance Win32_Process | Where-Object { $_.Name -like 'language_server_windows*' -or $_.Name -like 'agy*' -or $_.CommandLine -match 'language_server_windows|antigravity|antigravity-cli|(^|[\\\\/\\s])agy(\\.exe)?($|\\s)|csrf_token' } | Select-Object ProcessId,Name,ExecutablePath,CommandLine | ConvertTo-Json -Compress",
+      "$ErrorActionPreference='Stop'; Get-CimInstance Win32_Process | Where-Object { $_.Name -like 'language_server*' -or $_.Name -like 'agy*' -or $_.CommandLine -match 'language_server|antigravity|antigravity-cli|(^|[\\\\/\\s])agy(\\.exe)?($|\\s)|csrf_token' } | Select-Object ProcessId,Name,ExecutablePath,CommandLine | ConvertTo-Json -Compress",
     ],
     {
       timeout: timeoutMs,
@@ -622,9 +622,9 @@ function createAntigravityProcessCandidate(
 
 function isSupportedLanguageServerCommand(command: string): boolean {
   const lower = command.toLowerCase();
-  return (
-    lower.includes("language_server_macos") || lower.includes("language_server_windows") || isAgyCliExecutable(command)
-  );
+  // Antigravity 2.7+ ships the binary as plain `language_server` (older builds and
+  // Windows still use the `_macos` / `_windows` suffixes), so match the common prefix.
+  return lower.includes("language_server") || isAgyCliExecutable(command);
 }
 
 function isAntigravityCommandLine(command: string): boolean {


### PR DESCRIPTION
## Description

Antigravity 2.7 renamed its language server binary from `language_server_macos` to plain `language_server`. The process filter in `src/antigravity/probe.ts` only matched the suffixed names, so the running process was dropped at the very first gate and the Antigravity row stayed stuck on **"Not Running"** while the app was up. (The standalone "Antigravity Quota" extension keeps working because it filters on the app marker rather than on the binary name.)

This PR matches the common `language_server` prefix in both the macOS detection and the Windows pre-filter. Selection is otherwise unchanged: the Antigravity-specific gate (`--app_data_dir antigravity` / `antigravity` in the command line) still rejects Windsurf and Devin language servers, which ship a binary with the same prefix — I have a Devin language server running on the same machine (`language_server_macos_arm`) and it is still rejected.

Verified on macOS 26.5.1 with Antigravity 2.8.0: the probe now returns both quota groups with percentages and reset times, and the row renders the quota it already knew how to render.

Added unit tests cover three cases: the suffix-less binary, the legacy `_macos` / `_windows` names, and the rejection of a foreign (Windsurf/Devin) language server.

`npm test` (211 tests), `npm run typecheck`, `npm run lint` and `npm run build` all pass.

## Screencast

Detection-only fix with no UI change — the row simply stops reporting "Not Running" and shows the quota groups instead.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
