### PR TITLE
Update github extension

### DIFF
--- a/extensions/github/CHANGELOG.md
+++ b/extensions/github/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GitHub Changelog
 
+## [Clone repositories in GitHub Desktop] - {PR_MERGE_DATE}
+
+- Added a "Clone in GitHub Desktop" action to repository actions, with a `Cmd+Shift+G` shortcut.
+
 ## [Show CI status in pull request details] - 2026-08-10
 
 - Added a "Checks" row to pull request details showing successful, failed, or pending CI status.

--- a/extensions/github/src/components/RepositoryActions.tsx
+++ b/extensions/github/src/components/RepositoryActions.tsx
@@ -145,6 +145,13 @@ export default function RepositoryActions<T = ExtendedRepositoryFieldsFragment[]
           url={`vscode://vscode.git/clone?url=${repository.url}`}
           shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
         />
+        <Action.OpenInBrowser
+          icon={{ source: "github.svg", tintColor: Color.PrimaryText }}
+          title="Clone in GitHub Desktop"
+          url={`x-github-client://openRepo/${repository.url}`}
+          onOpen={() => onVisit(repository)}
+          shortcut={{ modifiers: ["cmd", "shift"], key: "g" }}
+        />
 
         {repository.viewerHasStarred ? (
           <Action


### PR DESCRIPTION
## Description

Adds a 'Clone in GitHub Desktop' action to the repository actions, with a `Cmd+Shift+G` shortcut, which opens the selected repository in the in the GitHub Desktop app ready for cloning.

<img width="767" height="484" alt="image" src="https://github.com/user-attachments/assets/5f45f972-8f32-4d9f-b44d-226c7436eee5" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
