### PR TITLE
[Obsidian] Prevent searchNote OOM on oversized Markdown

### DIFF
--- a/extensions/obsidian/CHANGELOG.md
+++ b/extensions/obsidian/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Obsidian Changelog
 
-## [Fix AI searchNote OOM on oversized Markdown] - 2026-08-13
+## [Fix AI searchNote OOM on oversized Markdown] - {PR_MERGE_DATE}
 
 - Skip Markdown files larger than 1 MiB during full-content search instead of reading them into the 100 MB extension heap
-- Limit tag search on oversized files to a 64 KiB prefix so frontmatter tags still match
+- Limit tag search on oversized files to a growing prefix (64 KiB steps, 1 MiB cap) so YAML tags still match when frontmatter crosses the first chunk
 - Default the AI `searchNote` `searchContent` parameter to `false`, matching the UI Search Note command
 
 ## [Fix Delete Note Shortcut] - 2026-07-18

--- a/extensions/obsidian/CHANGELOG.md
+++ b/extensions/obsidian/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Obsidian Changelog
 
-## [Fix AI searchNote OOM on oversized Markdown] - {PR_MERGE_DATE}
+## [Fix AI searchNote OOM on oversized Markdown] - 2026-08-15
 
 - Skip Markdown files larger than 1 MiB during full-content search instead of reading them into the 100 MB extension heap
 - Limit tag search on oversized files to a growing prefix (64 KiB steps, 1 MiB cap) so YAML tags still match when frontmatter crosses the first chunk

--- a/extensions/obsidian/CHANGELOG.md
+++ b/extensions/obsidian/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Obsidian Changelog
 
+## [Fix AI searchNote OOM on oversized Markdown] - 2026-08-13
+
+- Skip Markdown files larger than 1 MiB during full-content search instead of reading them into the 100 MB extension heap
+- Limit tag search on oversized files to a 64 KiB prefix so frontmatter tags still match
+- Default the AI `searchNote` `searchContent` parameter to `false`, matching the UI Search Note command
+
 ## [Fix Delete Note Shortcut] - 2026-07-18
 
 - Update the Delete Note action to use the common `Keyboard.Shortcut.Common.Remove` shortcut

--- a/extensions/obsidian/package.json
+++ b/extensions/obsidian/package.json
@@ -25,7 +25,7 @@
     "byheaven",
     "tofrankie",
     "alexi.build",
-    "RLuf"
+    "veilwalker"
   ],
   "license": "MIT",
   "engines": {

--- a/extensions/obsidian/package.json
+++ b/extensions/obsidian/package.json
@@ -24,7 +24,8 @@
     "ErBlack",
     "byheaven",
     "tofrankie",
-    "alexi.build"
+    "alexi.build",
+    "RLuf"
   ],
   "license": "MIT",
   "engines": {
@@ -650,7 +651,7 @@
       "name": "searchNote",
       "title": "Search Note",
       "description": "Search for notes in Obsidian vaults by title, path, and optionally content.",
-      "instructions": "Use this tool to find notes. By default searches inside note content (searchContent=true) which enables tag filtering with 'tag:tagname' syntax. For faster title-only search, set searchContent=false. Returns a list of matching notes with vault name and path. Does not open Obsidian. Specifying a vault name is very important. Only keep it empty when the user did not mention anything in that direction."
+      "instructions": "Use this tool to find notes. By default searches title and path only (searchContent=false). Set searchContent=true only when the user needs full-text or tag search ('tag:tagname'). Content search skips Markdown files larger than 1 MiB to stay under the extension memory limit. Returns a list of matching notes with vault name and path. Does not open Obsidian. Specifying a vault name is very important. Only keep it empty when the user did not mention anything in that direction."
     },
     {
       "name": "createNote",

--- a/extensions/obsidian/src/api/search/simple-content-search.service.ts
+++ b/extensions/obsidian/src/api/search/simple-content-search.service.ts
@@ -238,13 +238,21 @@ async function readTagSearchContent(filePath: string, fileSize: number): Promise
 
 /**
  * A bare `\\n---\\n` closer is enough for block scalars, but a 1 MiB cut inside a
- * quoted YAML scalar leaves the document invalid and YAML.parse drops every tag
- * already read. Try cheap repairs until the existing frontmatter parser accepts
- * the prefix.
+ * quoted YAML scalar or flow collection leaves the document invalid and YAML.parse
+ * drops every tag already read. Try cheap repairs until the existing frontmatter
+ * parser accepts the prefix.
  */
 function withSyntheticFrontmatterCloser(content: string): string {
   const trimmed = content.replace(/\s*$/, "");
+  const flowClosers = unmatchedFlowCollectionClosers(trimmed);
   const candidates = [`${trimmed}\n---\n`, `${trimmed}"\n---\n`, `${trimmed}'\n---\n`];
+  if (flowClosers) {
+    candidates.push(
+      `${trimmed}${flowClosers}\n---\n`,
+      `${trimmed}"${flowClosers}\n---\n`,
+      `${trimmed}'${flowClosers}\n---\n`
+    );
+  }
 
   const lastNewline = trimmed.lastIndexOf("\n");
   if (lastNewline > 0) {
@@ -258,4 +266,55 @@ function withSyntheticFrontmatterCloser(content: string): string {
   }
 
   return candidates[0];
+}
+
+/**
+ * Return the `]` / `}` suffix needed to close flow collections opened in the
+ * prefix. Brackets inside quoted scalars are ignored so a cut like
+ * `tags: [existing, "partial` still yields `]`.
+ */
+function unmatchedFlowCollectionClosers(prefix: string): string {
+  const stack: string[] = [];
+  let inDoubleQuote = false;
+  let inSingleQuote = false;
+
+  for (let i = 0; i < prefix.length; i++) {
+    const ch = prefix[i];
+
+    if (inDoubleQuote) {
+      if (ch === "\\" && i + 1 < prefix.length) {
+        i += 1;
+        continue;
+      }
+      if (ch === '"') {
+        inDoubleQuote = false;
+      }
+      continue;
+    }
+
+    if (inSingleQuote) {
+      if (ch === "'") {
+        if (prefix[i + 1] === "'") {
+          i += 1;
+        } else {
+          inSingleQuote = false;
+        }
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      inDoubleQuote = true;
+    } else if (ch === "'") {
+      inSingleQuote = true;
+    } else if (ch === "[") {
+      stack.push("]");
+    } else if (ch === "{") {
+      stack.push("}");
+    } else if ((ch === "]" || ch === "}") && stack[stack.length - 1] === ch) {
+      stack.pop();
+    }
+  }
+
+  return stack.reverse().join("");
 }

--- a/extensions/obsidian/src/api/search/simple-content-search.service.ts
+++ b/extensions/obsidian/src/api/search/simple-content-search.service.ts
@@ -2,10 +2,17 @@ import fs from "fs";
 import Fuse from "fuse.js";
 import { Logger } from "../logger/logger.service";
 import { ObsidianUtils, Note } from "../../obsidian";
+import { BYTES_PER_KILOBYTE, BYTES_PER_MEGABYTE } from "../../utils/constants";
 
 const logger = new Logger("ContentSearch");
 
 const MIN_RESULTS = 50; // Stop content search after finding this many matches
+
+// Full-content search must stay well under the ~100 MB extension JS heap.
+// readFile() + toLowerCase() keeps two string copies live; a single oversized
+// Markdown clipping is enough to OOM the worker if we slurp it whole.
+const MAX_CONTENT_SEARCH_BYTES = BYTES_PER_MEGABYTE; // 1 MiB
+const MAX_TAG_SEARCH_BYTES = 64 * BYTES_PER_KILOBYTE;
 
 /**
  * Memory-efficient content search
@@ -63,6 +70,7 @@ export async function searchNotesWithContent(notes: Note[], query: string): Prom
   // Step 2: Search remaining notes by content (read files one at a time)
   const contentMatches: Note[] = [];
   let filesChecked = 0;
+  let skippedLargeFiles = 0;
 
   // Early exit if we already have enough matches from title/path
   if (titleMatches.length >= MIN_RESULTS) {
@@ -83,11 +91,18 @@ export async function searchNotesWithContent(notes: Note[], query: string): Prom
     }
 
     try {
-      if (!fs.existsSync(note.path)) {
+      const stat = await fs.promises.stat(note.path);
+      if (!stat.isFile()) {
         continue;
       }
 
       filesChecked++;
+
+      if (stat.size > MAX_CONTENT_SEARCH_BYTES) {
+        skippedLargeFiles++;
+        logger.debug(`Skipping oversized note during content search (${stat.size} bytes): ${note.path}`);
+        continue;
+      }
 
       // Read file content
       const content = await fs.promises.readFile(note.path, "utf-8");
@@ -105,7 +120,7 @@ export async function searchNotesWithContent(notes: Note[], query: string): Prom
   logger.info(
     `Found ${contentMatches.length} content matches in ${filesChecked} files (total: ${
       titleMatches.length + contentMatches.length
-    })`
+    }, skipped ${skippedLargeFiles} oversized)`
   );
 
   // Combine results: title/path matches first (more relevant), then content matches
@@ -121,6 +136,7 @@ async function searchNotesByTag(notes: Note[], tagQuery: string): Promise<Note[]
 
   const matches: Note[] = [];
   let filesChecked = 0;
+  let prefixOnlyFiles = 0;
 
   // Normalize tag query (remove # if present, for comparison)
   const normalizedQuery = tagQuery.startsWith("#") ? tagQuery.slice(1).toLowerCase() : tagQuery.toLowerCase();
@@ -133,14 +149,22 @@ async function searchNotesByTag(notes: Note[], tagQuery: string): Promise<Note[]
     }
 
     try {
-      if (!fs.existsSync(note.path)) {
+      const stat = await fs.promises.stat(note.path);
+      if (!stat.isFile()) {
         continue;
       }
 
       filesChecked++;
 
-      // Read file content
-      const content = await fs.promises.readFile(note.path, "utf-8");
+      // Frontmatter lives at the top. Never slurp an oversized clipping just to
+      // look for tags — read a prefix instead.
+      const usePrefixOnly = stat.size > MAX_CONTENT_SEARCH_BYTES;
+      const bytesToRead = usePrefixOnly ? Math.min(stat.size, MAX_TAG_SEARCH_BYTES) : stat.size;
+      if (usePrefixOnly) {
+        prefixOnlyFiles++;
+      }
+
+      const content = await readFilePrefix(note.path, bytesToRead);
 
       // Extract tags from the file (both inline and YAML frontmatter)
       const tags = ObsidianUtils.getAllTags(content);
@@ -156,7 +180,20 @@ async function searchNotesByTag(notes: Note[], tagQuery: string): Promise<Note[]
     }
   }
 
-  logger.info(`Found ${matches.length} notes with tag "${tagQuery}" (checked ${filesChecked} files)`);
+  logger.info(
+    `Found ${matches.length} notes with tag "${tagQuery}" (checked ${filesChecked} files, prefix-only ${prefixOnlyFiles})`
+  );
 
   return matches;
+}
+
+async function readFilePrefix(filePath: string, byteCount: number): Promise<string> {
+  const handle = await fs.promises.open(filePath, "r");
+  try {
+    const buffer = Buffer.alloc(byteCount);
+    const { bytesRead } = await handle.read(buffer, 0, byteCount, 0);
+    return buffer.toString("utf8", 0, bytesRead);
+  } finally {
+    await handle.close();
+  }
 }

--- a/extensions/obsidian/src/api/search/simple-content-search.service.ts
+++ b/extensions/obsidian/src/api/search/simple-content-search.service.ts
@@ -157,14 +157,13 @@ async function searchNotesByTag(notes: Note[], tagQuery: string): Promise<Note[]
       filesChecked++;
 
       // Frontmatter lives at the top. Never slurp an oversized clipping just to
-      // look for tags — read a prefix instead.
+      // look for tags — read a prefix, then grow only until the closing ---.
       const usePrefixOnly = stat.size > MAX_CONTENT_SEARCH_BYTES;
-      const bytesToRead = usePrefixOnly ? Math.min(stat.size, MAX_TAG_SEARCH_BYTES) : stat.size;
       if (usePrefixOnly) {
         prefixOnlyFiles++;
       }
 
-      const content = await readFilePrefix(note.path, bytesToRead);
+      const content = await readTagSearchContent(note.path, stat.size);
 
       // Extract tags from the file (both inline and YAML frontmatter)
       const tags = ObsidianUtils.getAllTags(content);
@@ -196,4 +195,42 @@ async function readFilePrefix(filePath: string, byteCount: number): Promise<stri
   } finally {
     await handle.close();
   }
+}
+
+const OPENS_WITH_FRONTMATTER = /^---\s*\r?\n/;
+const CLOSED_FRONTMATTER = /^---\s*\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/;
+
+function hasClosedFrontmatter(content: string): boolean {
+  return CLOSED_FRONTMATTER.test(content);
+}
+
+/**
+ * Tag search only needs YAML + nearby inline tags. Small files are read whole.
+ * Oversized files start at 64 KiB and grow in 64 KiB steps until the frontmatter
+ * closer is found or the 1 MiB content-search cap is hit. If the closer is still
+ * missing, append one so the existing regex parser can recover tags already read.
+ */
+async function readTagSearchContent(filePath: string, fileSize: number): Promise<string> {
+  if (fileSize <= MAX_CONTENT_SEARCH_BYTES) {
+    return readFilePrefix(filePath, fileSize);
+  }
+
+  let bytesToRead = Math.min(fileSize, MAX_TAG_SEARCH_BYTES);
+  let content = await readFilePrefix(filePath, bytesToRead);
+  const startsWithFrontmatter = OPENS_WITH_FRONTMATTER.test(content);
+
+  while (
+    startsWithFrontmatter &&
+    !hasClosedFrontmatter(content) &&
+    bytesToRead < Math.min(fileSize, MAX_CONTENT_SEARCH_BYTES)
+  ) {
+    bytesToRead = Math.min(fileSize, MAX_CONTENT_SEARCH_BYTES, bytesToRead + MAX_TAG_SEARCH_BYTES);
+    content = await readFilePrefix(filePath, bytesToRead);
+  }
+
+  if (startsWithFrontmatter && !hasClosedFrontmatter(content)) {
+    content = `${content.replace(/\s*$/, "")}\n---\n`;
+  }
+
+  return content;
 }

--- a/extensions/obsidian/src/api/search/simple-content-search.service.ts
+++ b/extensions/obsidian/src/api/search/simple-content-search.service.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import Fuse from "fuse.js";
 import { Logger } from "../logger/logger.service";
 import { ObsidianUtils, Note } from "../../obsidian";
+import { parsedYAMLFrontmatter } from "../../obsidian/internal/yaml";
 import { BYTES_PER_KILOBYTE, BYTES_PER_MEGABYTE } from "../../utils/constants";
 
 const logger = new Logger("ContentSearch");
@@ -208,7 +209,7 @@ function hasClosedFrontmatter(content: string): boolean {
  * Tag search only needs YAML + nearby inline tags. Small files are read whole.
  * Oversized files start at 64 KiB and grow in 64 KiB steps until the frontmatter
  * closer is found or the 1 MiB content-search cap is hit. If the closer is still
- * missing, append one so the existing regex parser can recover tags already read.
+ * missing, synthesize a parseable block so tags already read are not discarded.
  */
 async function readTagSearchContent(filePath: string, fileSize: number): Promise<string> {
   if (fileSize <= MAX_CONTENT_SEARCH_BYTES) {
@@ -229,8 +230,32 @@ async function readTagSearchContent(filePath: string, fileSize: number): Promise
   }
 
   if (startsWithFrontmatter && !hasClosedFrontmatter(content)) {
-    content = `${content.replace(/\s*$/, "")}\n---\n`;
+    content = withSyntheticFrontmatterCloser(content);
   }
 
   return content;
+}
+
+/**
+ * A bare `\\n---\\n` closer is enough for block scalars, but a 1 MiB cut inside a
+ * quoted YAML scalar leaves the document invalid and YAML.parse drops every tag
+ * already read. Try cheap repairs until the existing frontmatter parser accepts
+ * the prefix.
+ */
+function withSyntheticFrontmatterCloser(content: string): string {
+  const trimmed = content.replace(/\s*$/, "");
+  const candidates = [`${trimmed}\n---\n`, `${trimmed}"\n---\n`, `${trimmed}'\n---\n`];
+
+  const lastNewline = trimmed.lastIndexOf("\n");
+  if (lastNewline > 0) {
+    candidates.push(`${trimmed.slice(0, lastNewline)}\n---\n`);
+  }
+
+  for (const candidate of candidates) {
+    if (parsedYAMLFrontmatter(candidate) !== undefined) {
+      return candidate;
+    }
+  }
+
+  return candidates[0];
 }

--- a/extensions/obsidian/src/tests/content-search-large-file.spec.ts
+++ b/extensions/obsidian/src/tests/content-search-large-file.spec.ts
@@ -88,6 +88,17 @@ describe("content search large files", () => {
     expect(results[0].title).toBe("Wide Frontmatter");
   });
 
+  it("still finds YAML tags when a flow collection stays open past the 1 MiB cap", async () => {
+    const largePath = path.join(tempDir, "tagged-open-flow.md");
+    fs.writeFileSync(largePath, `---\ntags: [existing, ${"x".repeat(1024 * 1024 + 64)}]\n---\nbody`);
+
+    const notes = [noteFor(tempDir, "tagged-open-flow.md", "Open Flow Collection")];
+    const results = await searchNotesWithContent(notes, "tag:existing");
+
+    expect(results.length).toBe(1);
+    expect(results[0].title).toBe("Open Flow Collection");
+  });
+
   it("still finds YAML tags when a quoted scalar stays open past the 1 MiB cap", async () => {
     const largePath = path.join(tempDir, "tagged-quoted-open-scalar.md");
     fs.writeFileSync(

--- a/extensions/obsidian/src/tests/content-search-large-file.spec.ts
+++ b/extensions/obsidian/src/tests/content-search-large-file.spec.ts
@@ -76,7 +76,10 @@ describe("content search large files", () => {
   it("still finds YAML tags when frontmatter crosses the 64 KiB prefix", async () => {
     const largePath = path.join(tempDir, "tagged-wide-frontmatter.md");
     const padding = "x".repeat(70 * 1024);
-    fs.writeFileSync(largePath, `---\ndescription: |\n  ${padding}\ntags:\n  - widetags\n---\n${"z".repeat(1024 * 1024 + 64)}`);
+    fs.writeFileSync(
+      largePath,
+      `---\ndescription: |\n  ${padding}\ntags:\n  - widetags\n---\n${"z".repeat(1024 * 1024 + 64)}`
+    );
 
     const notes = [noteFor(tempDir, "tagged-wide-frontmatter.md", "Wide Frontmatter")];
     const results = await searchNotesWithContent(notes, "tag:widetags");

--- a/extensions/obsidian/src/tests/content-search-large-file.spec.ts
+++ b/extensions/obsidian/src/tests/content-search-large-file.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { searchNotesWithContent } from "../api/search/simple-content-search.service";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { Note } from "@/obsidian";
+
+function noteFor(tempDir: string, fileName: string, title: string): Note {
+  return {
+    title,
+    path: path.join(tempDir, fileName),
+    lastModified: new Date(),
+    bookmarked: false,
+  };
+}
+
+describe("content search large files", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "content-search-large-"));
+  });
+
+  afterEach(() => {
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips oversized markdown during content search and still matches small files", async () => {
+    const smallPath = path.join(tempDir, "small.md");
+    const largePath = path.join(tempDir, "large.md");
+
+    fs.writeFileSync(smallPath, "this small note mentions uniquetoken123");
+    // Just over the 1 MiB full-read limit. Put the token at the end so a
+    // naive full slurp would have found it — we must skip instead of OOM.
+    const largeBody = `${"x".repeat(1024 * 1024 + 64)}uniquetoken123`;
+    fs.writeFileSync(largePath, largeBody);
+
+    const notes = [noteFor(tempDir, "small.md", "Small"), noteFor(tempDir, "large.md", "Large")];
+    const results = await searchNotesWithContent(notes, "uniquetoken123");
+
+    expect(results.some((n) => n.title === "Small")).toBe(true);
+    expect(results.some((n) => n.title === "Large")).toBe(false);
+  });
+
+  it("does not throw when a missing file sits next to an oversized file", async () => {
+    const largePath = path.join(tempDir, "large.md");
+    fs.writeFileSync(largePath, `${"y".repeat(1024 * 1024 + 64)}missing-neighbor`);
+
+    const notes = [
+      noteFor(tempDir, "large.md", "Large"),
+      {
+        title: "Missing",
+        path: path.join(tempDir, "does-not-exist.md"),
+        lastModified: new Date(),
+        bookmarked: false,
+      },
+    ];
+
+    const results = await searchNotesWithContent(notes, "missing-neighbor");
+    expect(results).toEqual([]);
+  });
+
+  it("still finds YAML tags in the prefix of an oversized file", async () => {
+    const largePath = path.join(tempDir, "tagged-large.md");
+    fs.writeFileSync(largePath, `---\ntags:\n  - hugeclip\n---\n${"z".repeat(1024 * 1024 + 64)}`);
+
+    const notes = [noteFor(tempDir, "tagged-large.md", "Tagged Large")];
+    const results = await searchNotesWithContent(notes, "tag:hugeclip");
+
+    expect(results.length).toBe(1);
+    expect(results[0].title).toBe("Tagged Large");
+  });
+
+  it("does not require reading an oversized file to match its title", async () => {
+    const largePath = path.join(tempDir, "raycast-hotkeys.md");
+    fs.writeFileSync(largePath, "x".repeat(1024 * 1024 + 64));
+
+    const notes = [noteFor(tempDir, "raycast-hotkeys.md", "Raycast Hotkeys")];
+    const results = await searchNotesWithContent(notes, "Raycast Hotkeys");
+
+    expect(results.length).toBe(1);
+    expect(results[0].title).toBe("Raycast Hotkeys");
+  });
+});

--- a/extensions/obsidian/src/tests/content-search-large-file.spec.ts
+++ b/extensions/obsidian/src/tests/content-search-large-file.spec.ts
@@ -73,6 +73,32 @@ describe("content search large files", () => {
     expect(results[0].title).toBe("Tagged Large");
   });
 
+  it("still finds YAML tags when frontmatter crosses the 64 KiB prefix", async () => {
+    const largePath = path.join(tempDir, "tagged-wide-frontmatter.md");
+    const padding = "x".repeat(70 * 1024);
+    fs.writeFileSync(largePath, `---\ndescription: |\n  ${padding}\ntags:\n  - widetags\n---\n${"z".repeat(1024 * 1024 + 64)}`);
+
+    const notes = [noteFor(tempDir, "tagged-wide-frontmatter.md", "Wide Frontmatter")];
+    const results = await searchNotesWithContent(notes, "tag:widetags");
+
+    expect(results.length).toBe(1);
+    expect(results[0].title).toBe("Wide Frontmatter");
+  });
+
+  it("recovers YAML tags when the closer is past the 1 MiB tag-search cap", async () => {
+    const largePath = path.join(tempDir, "tagged-unclosed-frontmatter.md");
+    fs.writeFileSync(
+      largePath,
+      `---\ntags:\n  - unclosedclip\ndescription: |\n  ${"y".repeat(1024 * 1024 + 64)}\n---\nbody`
+    );
+
+    const notes = [noteFor(tempDir, "tagged-unclosed-frontmatter.md", "Unclosed Frontmatter")];
+    const results = await searchNotesWithContent(notes, "tag:unclosedclip");
+
+    expect(results.length).toBe(1);
+    expect(results[0].title).toBe("Unclosed Frontmatter");
+  });
+
   it("does not require reading an oversized file to match its title", async () => {
     const largePath = path.join(tempDir, "raycast-hotkeys.md");
     fs.writeFileSync(largePath, "x".repeat(1024 * 1024 + 64));

--- a/extensions/obsidian/src/tests/content-search-large-file.spec.ts
+++ b/extensions/obsidian/src/tests/content-search-large-file.spec.ts
@@ -88,6 +88,20 @@ describe("content search large files", () => {
     expect(results[0].title).toBe("Wide Frontmatter");
   });
 
+  it("still finds YAML tags when a quoted scalar stays open past the 1 MiB cap", async () => {
+    const largePath = path.join(tempDir, "tagged-quoted-open-scalar.md");
+    fs.writeFileSync(
+      largePath,
+      `---\ntags:\n  - quotedclip\ndescription: "${"x".repeat(1024 * 1024 + 64)}"\n---\nbody`
+    );
+
+    const notes = [noteFor(tempDir, "tagged-quoted-open-scalar.md", "Quoted Open Scalar")];
+    const results = await searchNotesWithContent(notes, "tag:quotedclip");
+
+    expect(results.length).toBe(1);
+    expect(results[0].title).toBe("Quoted Open Scalar");
+  });
+
   it("recovers YAML tags when the closer is past the 1 MiB tag-search cap", async () => {
     const largePath = path.join(tempDir, "tagged-unclosed-frontmatter.md");
     fs.writeFileSync(

--- a/extensions/obsidian/src/tools/searchNote.ts
+++ b/extensions/obsidian/src/tools/searchNote.ts
@@ -15,8 +15,9 @@ type Input = {
   vaultName?: string;
   /**
    * Whether to search inside note content and enable tag filtering.
-   * Set to false for faster title/path-only search.
-   * Defaults to true.
+   * Set to true only when the user needs full-text or tag search.
+   * Defaults to false (title/path only) so a single oversized Markdown
+   * file cannot OOM the extension worker.
    */
   searchContent?: boolean;
 };
@@ -43,7 +44,7 @@ export default async function tool(input: Input) {
     return `Vault "${input.vaultName}" not found. Available vaults: ${vaults.map((v) => v.name).join(", ")}`;
   }
 
-  const useContentSearch = input.searchContent !== false;
+  const useContentSearch = input.searchContent === true;
 
   logger.info(`Searching with ${useContentSearch ? "content search" : "title/path only"} for "${input.searchTerm}"`);
 


### PR DESCRIPTION
## Description

The AI `searchNote` tool still unbounded-reads Markdown during content/tag search. A single ~44 MiB clipping is enough to hit Raycast's ~100 MB extension JS heap:

```
Command terminated after reaching the extension memory limit (100 MB JS heap)
```

This is independent of vault note count. `main` already lazy-loads metadata; the remaining hole is `readFile()` + `toLowerCase()` with no size guard.

## Changes

* `stat` before reading; skip files larger than 1 MiB in full-content search
* tag search reads at most a 64 KiB prefix on oversized files (frontmatter is at the top)
* AI `searchContent` now defaults to `false`, matching the UI Search Note command
* tests for oversized files, missing files, and prefix tag matches

## Related

* Closes https://github.com/raycast/extensions/issues/30190
* Related: https://github.com/raycast/extensions/issues/22930
* Related: https://github.com/marcjulianschwarz/obsidian-raycast/issues/93

## Checklist

* [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
* [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
* [ ] I ran `npm run build`
* [ ] I tested all commands and AI tools
* [x] Updated `CHANGELOG.md`