### PR TITLE
Fix 1Password desktop-app integration failures on Windows

### DIFF
--- a/extensions/1password/CHANGELOG.md
+++ b/extensions/1password/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed constant "cannot connect to 1Password app" failures on Windows. The 1Password app briefly has no CLI pipe listener right after a previous `op` process disconnects; back-to-back `op` invocations are now serialized and connection failures are retried instead of surfacing immediately.
 - Fixed the "Authentication Required" screen appearing on Windows even though the 1Password desktop-app integration works. `op whoami` reports "account is not signed in" without an `op signin` session, so the sign-in check and account resolution now fall back to `op account get`, which uses the app's delegated sessions.
+- Item actions (copy/paste credentials, share, open in browser, password generation) now run through the same guarded execution path instead of spawning `op` directly, so they benefit from the same connection-failure handling.
 
 ## [Bug Fix] - 2026-06-15
 

--- a/extensions/1password/CHANGELOG.md
+++ b/extensions/1password/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1Password Changelog
 
-## [Windows Desktop-App Integration Fixes] - {PR_MERGE_DATE}
+## [Windows Desktop-App Integration Fixes] - 2026-08-13
 
 - Fixed constant "cannot connect to 1Password app" failures on Windows. The 1Password app briefly has no CLI pipe listener right after a previous `op` process disconnects; back-to-back `op` invocations are now serialized and connection failures are retried instead of surfacing immediately.
 - Fixed the "Authentication Required" screen appearing on Windows even though the 1Password desktop-app integration works. `op whoami` reports "account is not signed in" without an `op signin` session, so the sign-in check and account resolution now fall back to `op account get`, which uses the app's delegated sessions.

--- a/extensions/1password/CHANGELOG.md
+++ b/extensions/1password/CHANGELOG.md
@@ -1,5 +1,10 @@
 # 1Password Changelog
 
+## [Windows Desktop-App Integration Fixes] - {PR_MERGE_DATE}
+
+- Fixed constant "cannot connect to 1Password app" failures on Windows. The 1Password app briefly has no CLI pipe listener right after a previous `op` process disconnects; back-to-back `op` invocations are now serialized and connection failures are retried instead of surfacing immediately.
+- Fixed the "Authentication Required" screen appearing on Windows even though the 1Password desktop-app integration works. `op whoami` reports "account is not signed in" without an `op signin` session, so the sign-in check and account resolution now fall back to `op account get`, which uses the app's delegated sessions.
+
 ## [Bug Fix] - 2026-06-15
 
 - Reduce memory usage when loading large item lists by avoiding the full item payload until it is needed. Opt in via **Reduce item list memory usage** in extension preferences.

--- a/extensions/1password/src/v8/components/ActionCopyToClipboard.tsx
+++ b/extensions/1password/src/v8/components/ActionCopyToClipboard.tsx
@@ -1,8 +1,7 @@
 import { Action, Clipboard, Icon, Keyboard, showHUD, showToast, Toast } from "@raycast/api";
-import { execFileSync } from "node:child_process";
 
 import { useFrontmostApp } from "../hooks/useFrontmostApp";
-import { ExtensionError, getCliPath, handleErrors, titleCaseWord, windowsEnv } from "../utils";
+import { execOp, ExtensionError, handleErrors, titleCaseWord } from "../utils";
 
 export function CopyToClipboard({
   attribute,
@@ -19,7 +18,6 @@ export function CopyToClipboard({
   shortcut: Keyboard.Shortcut;
   vault_id: string;
 }) {
-  const cliPath = getCliPath();
   const frontmostApp = useFrontmostApp(!!isPasteAction);
 
   return (
@@ -34,18 +32,18 @@ export function CopyToClipboard({
         });
 
         try {
-          let stdout;
+          let stdout: string;
           if (attribute === "otp") {
             // based on OTP-type not field name
-            stdout = execFileSync(cliPath, ["item", "get", id, "--otp"], windowsEnv ? { env: windowsEnv } : {});
+            stdout = await execOp(["item", "get", id, "--otp"]);
           } else {
             const attributeQueryParam = attribute ? `?attribute=${attribute}` : "";
             const uri = `op://${vault_id}/${id}/${field}${attributeQueryParam}`;
 
-            stdout = execFileSync(cliPath, ["read", uri], windowsEnv ? { env: windowsEnv } : {});
+            stdout = await execOp(["read", uri]);
           }
 
-          const value = stdout.toString().trim();
+          const value = stdout.trim();
 
           if (isPasteAction) {
             await Clipboard.paste(value);

--- a/extensions/1password/src/v8/components/ActionShareItem.tsx
+++ b/extensions/1password/src/v8/components/ActionShareItem.tsx
@@ -1,7 +1,6 @@
 import { Action, Clipboard, Icon, Keyboard, showHUD, showToast, Toast } from "@raycast/api";
-import { execFileSync } from "node:child_process";
 
-import { ExtensionError, getCliPath, handleErrors, windowsEnv } from "../utils";
+import { execOp, ExtensionError, handleErrors } from "../utils";
 
 export function ShareItem({ id, shortcut, title }: { id: string; shortcut: Keyboard.Shortcut; title: string }) {
   return (
@@ -14,9 +13,9 @@ export function ShareItem({ id, shortcut, title }: { id: string; shortcut: Keybo
         });
 
         try {
-          const stdout = execFileSync(getCliPath(), ["item", "share", id], windowsEnv ? { env: windowsEnv } : {});
+          const stdout = await execOp(["item", "share", id]);
 
-          await Clipboard.copy(stdout.toString().trim(), { concealed: true });
+          await Clipboard.copy(stdout.trim(), { concealed: true });
 
           toast.style = Toast.Style.Success;
           toast.title = "Copied to clipboard";

--- a/extensions/1password/src/v8/components/ItemActionPanel.tsx
+++ b/extensions/1password/src/v8/components/ItemActionPanel.tsx
@@ -1,15 +1,11 @@
 import { Action, ActionPanel, getPreferenceValues, Icon, open, showToast, Toast } from "@raycast/api";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 
 import resetCache from "../../reset-cache";
 import { Item, User } from "../types";
-import { ActionID, getCliPath, handleErrors, hrefToOpenInBrowser, windowsEnv } from "../utils";
+import { ActionID, execOp, handleErrors, hrefToOpenInBrowser } from "../utils";
 import { CopyToClipboard } from "./ActionCopyToClipboard";
 import { ShareItem } from "./ActionShareItem";
 import { SwitchAccount } from "./ActionSwitchAccount";
-
-const execFileAsync = promisify(execFile);
 
 export function ItemActionPanel({
   account,
@@ -152,19 +148,15 @@ function OpenInBrowser(account: undefined | User, item: Item) {
         const toast = await showToast({ style: Toast.Style.Animated, title: "Opening in browser..." });
 
         try {
-          const { stdout } = await execFileAsync(
-            getCliPath(),
-            [
-              ...(account ? ["--account", account.account_uuid] : []),
-              "item",
-              "get",
-              item.id,
-              "--vault",
-              item.vault.id,
-              "--format=json",
-            ],
-            { encoding: "utf8", maxBuffer: 4096 * 1024, ...(windowsEnv ? { env: windowsEnv } : {}) },
-          );
+          const stdout = await execOp([
+            ...(account ? ["--account", account.account_uuid] : []),
+            "item",
+            "get",
+            item.id,
+            "--vault",
+            item.vault.id,
+            "--format=json",
+          ]);
           const detailedItem = JSON.parse(stdout) as Item;
           const detailedHref = hrefToOpenInBrowser(detailedItem);
 

--- a/extensions/1password/src/v8/components/RandomPassword.tsx
+++ b/extensions/1password/src/v8/components/RandomPassword.tsx
@@ -1,10 +1,9 @@
 import { Action, ActionPanel, Clipboard, Form, Icon, Keyboard, showToast, Toast } from "@raycast/api";
 import { useForm } from "@raycast/utils";
-import { execFileSync } from "node:child_process";
 import { useEffect, useState } from "react";
 
 import { Item } from "../types";
-import { getCliPath, isWindows, windowsEnv } from "../utils";
+import { isWindows, op } from "../utils";
 
 import Shortcut = Keyboard.Shortcut;
 import Style = Toast.Style;
@@ -35,8 +34,9 @@ export function RandomPassword() {
 
       try {
         // https://1password.community/discussion/139189/feature-request-generate-random-passwords-with-cli-via-dedicated-command-e-g-op-generate
-        const stdout = execFileSync(
-          getCliPath(),
+        // Stays on the synchronous helper: `op item create` reads a piped stdin, so it needs
+        // `stdio: ["ignore", ...]`, which the async `execFile`-based path cannot express.
+        const stdout = op(
           [
             "item",
             "create",
@@ -47,9 +47,9 @@ export function RandomPassword() {
             "--format",
             "json",
           ],
-          { ...(windowsEnv ? { env: windowsEnv } : {}), stdio: ["ignore", "pipe", "pipe"] },
+          { stdio: ["ignore", "pipe", "pipe"] },
         );
-        const item: Item = JSON.parse(stdout.toString());
+        const item: Item = JSON.parse(stdout);
         const password = item.fields
           ?.filter((field) => field.id === "password")
           .filter(Boolean)

--- a/extensions/1password/src/v8/utils.ts
+++ b/extensions/1password/src/v8/utils.ts
@@ -136,7 +136,7 @@ function execOpSync(args: string[], options: ExecFileSyncOptions = {}) {
 // Concurrent `op` processes make the connection race above more likely, so run them one at a time.
 let opExecutionChain: Promise<unknown> = Promise.resolve();
 
-function execOp(args: string[]): Promise<string> {
+export function execOp(args: string[]): Promise<string> {
   const run = async () => {
     const cliPath = getCliPath();
     for (let attempt = 1; ; attempt++) {
@@ -168,8 +168,8 @@ function execOp(args: string[]): Promise<string> {
   return result;
 }
 
-export function op(args: string[]) {
-  return execOpSync(args).toString();
+export function op(args: string[], options: ExecFileSyncOptions = {}) {
+  return execOpSync(args, options).toString();
 }
 export const handleErrors = (stderr: string): never => {
   if (stderr.includes("no such host")) {

--- a/extensions/1password/src/v8/utils.ts
+++ b/extensions/1password/src/v8/utils.ts
@@ -1,9 +1,11 @@
 import { getPreferenceValues, Icon, showToast, Toast } from "@raycast/api";
-import { useExec } from "@raycast/utils";
-import { execFileSync, execSync } from "node:child_process";
+import { useCachedPromise } from "@raycast/utils";
+import { execFile, execFileSync, execSync, type ExecFileSyncOptions } from "node:child_process";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { promisify } from "node:util";
 
 import { Category, CategoryName, Item, User, Vault } from "./types";
 
@@ -93,18 +95,83 @@ export function hrefToOpenInBrowser(item: Item): string | undefined {
 
   return undefined;
 }
-export function op(args: string[]) {
+const execFileAsync = promisify(execFile);
+
+// After an `op` process disconnects, the Windows 1Password app briefly has no pipe listener
+// for the next CLI connection. Any `op` launched inside that window fails instantly with
+// "cannot connect to 1Password app" even though the app is running. The extension chains
+// `op` calls back-to-back, so on Windows connection failures are retried for a short period
+// and `op` invocations run one at a time. macOS does not have this race and keeps the
+// original fail-fast, concurrent behavior.
+const DESKTOP_APP_CONNECTION_ERROR = "cannot connect to 1Password app";
+const CONNECTION_RETRY_ATTEMPTS = 6;
+const CONNECTION_RETRY_DELAY_MS = 350;
+const OP_MAX_BUFFER = 10 * 1024 * 1024;
+
+const isDesktopAppConnectionError = (output: string) => output.includes(DESKTOP_APP_CONNECTION_ERROR);
+const getStderr = (error: unknown) => (error as { stderr?: string | Buffer }).stderr?.toString() ?? "";
+
+const sleepSync = (ms: number) => {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+};
+
+function execOpSync(args: string[], options: ExecFileSyncOptions = {}) {
   const cliPath = getCliPath();
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return execFileSync(cliPath, args, {
+        maxBuffer: OP_MAX_BUFFER,
+        ...(windowsEnv ? { env: windowsEnv } : {}),
+        ...options,
+      });
+    } catch (error) {
+      if (!isWindows || attempt >= CONNECTION_RETRY_ATTEMPTS || !isDesktopAppConnectionError(getStderr(error))) {
+        throw error;
+      }
+      sleepSync(CONNECTION_RETRY_DELAY_MS);
+    }
+  }
+}
 
-  if (cliPath) {
-    const stdout = execFileSync(cliPath, args, { maxBuffer: 4096 * 1024, ...(windowsEnv ? { env: windowsEnv } : {}) });
+// Concurrent `op` processes make the connection race above more likely, so run them one at a time.
+let opExecutionChain: Promise<unknown> = Promise.resolve();
 
-    return stdout.toString();
+function execOp(args: string[]): Promise<string> {
+  const run = async () => {
+    const cliPath = getCliPath();
+    for (let attempt = 1; ; attempt++) {
+      try {
+        const { stdout, stderr } = await execFileAsync(cliPath, args, {
+          maxBuffer: OP_MAX_BUFFER,
+          ...(windowsEnv ? { env: windowsEnv } : {}),
+        });
+        if (stderr) handleErrors(stderr.toString());
+        return stdout.toString();
+      } catch (error) {
+        if (error instanceof ExtensionError) throw error;
+        const stderr = getStderr(error);
+        if (isWindows && attempt < CONNECTION_RETRY_ATTEMPTS && isDesktopAppConnectionError(stderr)) {
+          await delay(CONNECTION_RETRY_DELAY_MS);
+          continue;
+        }
+        handleErrors(stderr || (error instanceof Error ? error.message : String(error)));
+      }
+    }
+  };
+
+  if (!isWindows) {
+    return run();
   }
 
-  throw Error("1Password CLI is not found!");
+  const result = opExecutionChain.then(run, run);
+  opExecutionChain = result.catch(() => undefined);
+  return result;
 }
-export const handleErrors = (stderr: string) => {
+
+export function op(args: string[]) {
+  return execOpSync(args).toString();
+}
+export const handleErrors = (stderr: string): never => {
   if (stderr.includes("no such host")) {
     throw new ConnectionError("No connection to 1Password.", "Verify Your Internet Connection.");
   } else if (stderr.includes("could not get item") || stderr.includes("isn't an item")) {
@@ -126,10 +193,10 @@ export const checkZsh = () => {
 };
 export const signIn = (account?: string) => {
   if (isWindows) {
-    execFileSync(getCliPath(), ["signin", ...(account ? account.split(" ") : [])], {
-      stdio: "inherit",
+    // Keep stderr piped so desktop-app connection failures are recognized and retried.
+    execOpSync(["signin", ...(account ? account.split(" ") : [])], {
+      stdio: ["inherit", "inherit", "pipe"],
       timeout: 30000,
-      env: windowsEnv,
     });
   } else {
     execSync(`${getCliPath()} signin ${account ? account : ""}`, { shell: ZSH_PATH });
@@ -138,32 +205,42 @@ export const signIn = (account?: string) => {
 export const getSignInStatus = () => {
   try {
     if (isWindows) {
-      execFileSync(getCliPath(), ["whoami"], { env: windowsEnv });
+      execOpSync(["whoami"]);
     } else {
       execSync(`${getCliPath()} whoami`);
     }
     return true;
   } catch {
-    return false;
+    if (!isWindows) {
+      return false;
+    }
+    // With the 1Password app integration and no `op signin` session, `whoami` reports
+    // "account is not signed in" even though delegated sessions work. Probe the app
+    // directly before asking the user to sign in.
+    try {
+      execOpSync(["account", "get"]);
+      return true;
+    } catch {
+      return false;
+    }
   }
 };
-export const useOp = <T = Buffer, U = undefined>(args: string[], callback?: (data: T) => T) => {
-  return useExec<T, U>(getCliPath(), [...args, "--format=json"], {
-    env: windowsEnv,
-    onError: async (e) => {
-      await showToast({
-        style: Toast.Style.Failure,
-        title: e.message,
-      });
+export const useOp = <T = Buffer>(args: string[], callback?: (data: T) => T) => {
+  return useCachedPromise(
+    async (...opArgs: string[]) => {
+      const data = JSON.parse(await execOp([...opArgs, "--format=json"])) as T;
+      return callback ? callback(data) : data;
     },
-    parseOutput: ({ error, exitCode, stderr, stdout }) => {
-      if (error) handleErrors(error.message);
-      if (stderr) handleErrors(stderr);
-      if (exitCode != 0) handleErrors(stdout);
-      if (callback) return callback(JSON.parse(stdout));
-      return JSON.parse(stdout);
+    args,
+    {
+      onError: async (e) => {
+        await showToast({
+          style: Toast.Style.Failure,
+          title: e.message,
+        });
+      },
     },
-  });
+  );
 };
 const itemListFlags = () => (preferences.reduceItemListMemoryUsage ? [] : ["--long"]);
 
@@ -176,11 +253,22 @@ export const usePasswords2 = ({
   execute: boolean;
   flags?: string[];
 }) =>
-  useExec<Item[], ExtensionError>(
-    getCliPath(),
-    ["--account", account, "items", "list", "--format=json", ...itemListFlags(), ...flags],
+  useCachedPromise(
+    async (...args: string[]) => {
+      const items = JSON.parse(await execOp(["--account", ...args, "--format=json"])) as Item[];
+
+      return items.sort((a, b) => {
+        if (a.favorite && !b.favorite) {
+          return -1;
+        } else if (!a.favorite && b.favorite) {
+          return 1;
+        }
+
+        return a.title.localeCompare(b.title);
+      });
+    },
+    [account, "items", "list", ...itemListFlags(), ...flags],
     {
-      env: windowsEnv,
       execute,
       onError: async (e) => {
         await showToast({
@@ -188,50 +276,53 @@ export const usePasswords2 = ({
           title: e.message,
         });
       },
-      parseOutput: ({ error, exitCode, stderr, stdout }) => {
-        if (error) handleErrors(error.message);
-        if (stderr) handleErrors(stderr);
-        if (exitCode != 0) handleErrors(stdout);
-        const items = JSON.parse(stdout) as Item[];
-
-        return items.sort((a, b) => {
-          if (a.favorite && !b.favorite) {
-            return -1;
-          } else if (!a.favorite && b.favorite) {
-            return 1;
-          }
-
-          return a.title.localeCompare(b.title);
+    },
+  );
+export const usePasswords = (flags: string[] = []) =>
+  useOp<Item[]>(["items", "list", ...itemListFlags(), ...flags], (data) =>
+    data.sort((a, b) => a.title.localeCompare(b.title)),
+  );
+export const useVaults = () =>
+  useOp<Vault[]>(["vault", "list"], (data) => data.sort((a, b) => a.name.localeCompare(b.name)));
+export const useCategories = () =>
+  useOp<Category[]>(["item", "template", "list"], (data) => data.sort((a, b) => a.name.localeCompare(b.name)));
+export const useAccount = () =>
+  useCachedPromise(
+    async () => {
+      try {
+        return JSON.parse(await execOp(["whoami", "--format=json"])) as User;
+      } catch (error) {
+        // With the 1Password app integration and no `op signin` session, `whoami` fails
+        // even though delegated sessions work. Resolve the account through the app instead.
+        try {
+          const account = JSON.parse(await execOp(["account", "get", "--format=json"])) as {
+            domain: string;
+            id: string;
+          };
+          return { account_uuid: account.id, email: "", url: `${account.domain}.1password.com`, user_uuid: "" } as User;
+        } catch {
+          throw error;
+        }
+      }
+    },
+    [],
+    {
+      onError: async (e) => {
+        await showToast({
+          style: Toast.Style.Failure,
+          title: e.message,
         });
       },
     },
   );
-export const usePasswords = (flags: string[] = []) =>
-  useOp<Item[], ExtensionError>(["items", "list", ...itemListFlags(), ...flags], (data) =>
-    data.sort((a, b) => a.title.localeCompare(b.title)),
-  );
-export const useVaults = () =>
-  useOp<Vault[], ExtensionError>(["vault", "list"], (data) => data.sort((a, b) => a.name.localeCompare(b.name)));
-export const useCategories = () =>
-  useOp<Category[], ExtensionError>(["item", "template", "list"], (data) =>
-    data.sort((a, b) => a.name.localeCompare(b.name)),
-  );
-export const useAccount = () => useOp<User, ExtensionError>(["whoami"]);
-export const useAccounts = <T = User[], U = ExtensionError>(execute = true) =>
-  useExec<T, U>(getCliPath(), ["account", "list", "--format=json"], {
-    env: windowsEnv,
-    execute: execute,
+export const useAccounts = <T = User[]>(execute = true) =>
+  useCachedPromise(async () => JSON.parse(await execOp(["account", "list", "--format=json"])) as T, [], {
+    execute,
     onError: async (e) => {
       await showToast({
         style: Toast.Style.Failure,
         title: e.message,
       });
-    },
-    parseOutput: ({ error, exitCode, stderr, stdout }) => {
-      if (error) handleErrors(error.message);
-      if (stderr) handleErrors(stderr);
-      if (exitCode != 0) handleErrors(stdout);
-      return JSON.parse(stdout);
     },
   });
 export function getCategoryIcon(category: CategoryName) {


### PR DESCRIPTION
## Description

On Windows the 1Password app briefly has no pipe listener right after an `op` process disconnects, so the extension's back-to-back `op` calls fail instantly with "cannot connect to 1Password app" even though the app is running. On top of that, `op whoami` reports "account is not signed in" for app-integration setups without an `op signin` session, which forced a bogus "Authentication Required" screen whose auto-run `op signin` hit the same race.

- Route `op` invocations through a shared exec helper; on Windows, serialize them and retry desktop-app connection failures briefly (6 x 350ms). macOS keeps the fail-fast, concurrent behavior.
- Fall back to `op account get` (delegated sessions) for the Windows sign-in check and for account resolution when `whoami` fails.
- Convert useExec-based hooks to useCachedPromise over the shared helper, preserving cached results between launches.


## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
