### PR TITLE
2FAS Authenticator: fix import crash on missing algorithm field

### DIFF
--- a/extensions/2fas-authenticator/CHANGELOG.md
+++ b/extensions/2fas-authenticator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Fix Import Crash] - {PR_MERGE_DATE}
+
+- Importing a 2FAS export where a service omits the `algorithm` field no longer aborts the entire import. It now falls through to the SHA1 default, matching the RFC 6238 default.
+
 ## [Fix Author Attribution] - 2026-07-01
 
 - Correct the extension author handle so it is credited to the right Raycast account

--- a/extensions/2fas-authenticator/CHANGELOG.md
+++ b/extensions/2fas-authenticator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Fix Import Crash] - {PR_MERGE_DATE}
+## [Fix Import Crash] - 2026-08-14
 
 - Importing a 2FAS export where a service omits the `algorithm` field no longer aborts the entire import. It now falls through to the SHA1 default, matching the RFC 6238 default.
 

--- a/extensions/2fas-authenticator/src/lib/import-2fas.ts
+++ b/extensions/2fas-authenticator/src/lib/import-2fas.ts
@@ -23,7 +23,7 @@ interface TwoFASService {
     account?: string;
     digits: number;
     period: number;
-    algorithm: string;
+    algorithm?: string;
     tokenType: string;
   };
   order?: { position: number };
@@ -105,7 +105,7 @@ function mapService(svc: TwoFASService): VaultService | null {
     issuer,
     account,
     secret: svc.secret,
-    algorithm: normalizeAlgorithm(svc.otp.algorithm),
+    algorithm: normalizeAlgorithm(svc.otp.algorithm ?? ""),
     digits: svc.otp.digits || 6,
     period: svc.otp.period || 30,
   };


### PR DESCRIPTION
## Description

Some 2FAS exports omit the `otp.algorithm` field on a service entry. The type declared it as a required `string`, but `mapService()` called `normalizeAlgorithm()` on it unguarded, outside the parser's error handling. A single algorithm-less service threw a `TypeError` and aborted the entire import, instead of the service landing in the existing "Skipped" section like other malformed entries.

This makes `algorithm` optional and falls through to the SHA1 default, which matches the RFC 6238 default and real-world 2FAS export behavior.

Originally reported and fixed by @Leander250 against the standalone dev repo (LockeAG/raycast-2fas-authenticator#1); ported here for the Store release.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and confirmed that the build was successful
- [x] I ran `npm run lint` and confirmed that there were no errors or warnings