### PR TITLE
Transfer MuteDeck extension ownership to the MuteDeck organisation

### DIFF
--- a/.github/public_raycast_extensions.txt
+++ b/.github/public_raycast_extensions.txt
@@ -75,4 +75,5 @@ saasflow
 globalping
 mymind
 buffer
+mutedeck
 nocal

--- a/extensions/mutedeck/CHANGELOG.md
+++ b/extensions/mutedeck/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Ownership Transfer] - {PR_MERGE_DATE}
+
+- Extension ownership transferred from chad_walters to the MuteDeck organisation — now the official MuteDeck extension.
+
 ## [Meeting Deck Overhaul] - 2026-08-12
 
 Major overhaul, contributed by the MuteDeck team.

--- a/extensions/mutedeck/package.json
+++ b/extensions/mutedeck/package.json
@@ -4,8 +4,11 @@
   "title": "MuteDeck",
   "description": "Control your meetings from Raycast: toggle mute, camera, screen share and recording via MuteDeck, with a live Meeting Deck grid.",
   "icon": "icon.png",
-  "author": "chad_walters",
+  "author": "smitmartijn",
+  "owner": "mutedeck",
+  "access": "public",
   "contributors": ["smitmartijn"],
+  "pastContributors": ["chad_walters"],
   "categories": ["Applications", "Communication", "Productivity"],
   "license": "MIT",
   "commands": [

--- a/extensions/mutedeck/package.json
+++ b/extensions/mutedeck/package.json
@@ -7,8 +7,7 @@
   "author": "smitmartijn",
   "owner": "mutedeck",
   "access": "public",
-  "contributors": ["smitmartijn"],
-  "pastContributors": ["chad_walters"],
+  "contributors": ["chad_walters"],
   "categories": ["Applications", "Communication", "Productivity"],
   "license": "MIT",
   "commands": [

--- a/extensions/mutedeck/package.json
+++ b/extensions/mutedeck/package.json
@@ -7,8 +7,17 @@
   "author": "smitmartijn",
   "owner": "mutedeck",
   "access": "public",
-  "contributors": ["chad_walters"],
-  "categories": ["Applications", "Communication", "Productivity"],
+  "contributors": [
+    "chad_walters"
+  ],
+  "platforms": [
+    "macOS"
+  ],
+  "categories": [
+    "Applications",
+    "Communication",
+    "Productivity"
+  ],
   "license": "MIT",
   "commands": [
     {
@@ -126,8 +135,5 @@
     "lint": "ray lint",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
-  },
-  "platforms": [
-    "macOS"
-  ]
+  }
 }


### PR DESCRIPTION
Set owner to mutedeck with public access, author to smitmartijn, and credit original author chad_walters in pastContributors.

## Description

After the amazing work of @chad_walters and the overhaul of last week, we want to make this extension a bit more official and have the Raycast store say it's an official MuteDeck extension as we start to promote it to our users. Asked Chad before doing this PR, and he's okay with it. 🙂

I got these changes from the docs and reddit, hope it's all valid.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
