### PR TITLE
[Brave] Fix missing history database crash

### DIFF
--- a/extensions/brave/CHANGELOG.md
+++ b/extensions/brave/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Brave Changelog
 
+## [Fix Missing History Database] - 2026-08-14
+
+- Fixed New Brave Tab crashing when the selected Brave profile has not created a History database yet.
+- Fixed profile discovery for Brave Beta and Brave Nightly.
+
 ## [Fix History Search] - 2026-07-19
 
 - Fixed history search failing with a "database is locked" error while Brave is running.

--- a/extensions/brave/CHANGELOG.md
+++ b/extensions/brave/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Brave Changelog
 
-## [Fix Missing History Database] - 2026-08-14
+## [Fix Missing History Database] - {PR_MERGE_DATE}
 
 - Fixed New Brave Tab crashing when the selected Brave profile has not created a History database yet.
 - Fixed profile discovery for Brave Beta and Brave Nightly.

--- a/extensions/brave/CHANGELOG.md
+++ b/extensions/brave/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Brave Changelog
 
-## [Fix Missing History Database] - {PR_MERGE_DATE}
+## [Fix Missing History Database] - 2026-08-16
 
 - Fixed New Brave Tab crashing when the selected Brave profile has not created a History database yet.
 - Fixed profile discovery for Brave Beta and Brave Nightly.

--- a/extensions/brave/src/components/BraveProfileDropdown.tsx
+++ b/extensions/brave/src/components/BraveProfileDropdown.tsx
@@ -34,8 +34,9 @@ export default function BraveProfileDropDown({ onProfileSelected }: Props) {
   useEffect(() => {
     if (loadedProfiles) {
       setProfiles(loadedProfiles);
-      if (!selectedProfile) {
-        setSelectedProfile(profiles[0].id);
+      const selectedProfileExists = loadedProfiles.some((profile) => profile.id === selectedProfile);
+      if (!selectedProfile || !selectedProfileExists) {
+        setSelectedProfile(loadedProfiles[0]?.id ?? DEFAULT_BRAVE_PROFILE_ID);
       }
     }
   }, [loadedProfiles]);

--- a/extensions/brave/src/constants.ts
+++ b/extensions/brave/src/constants.ts
@@ -1,7 +1,6 @@
 export const defaultBraveProfilePath = ["Application Support", "BraveSoftware", "Brave-Browser"];
 export const defaultBraveBetaProfilePath = ["Application Support", "BraveSoftware", "Brave-Browser-Beta"];
 export const defaultBraveNightlyProfilePath = ["Application Support", "BraveSoftware", "Brave-Browser-Nightly"];
-export const defaultBraveStatePath = ["Application Support", "BraveSoftware", "Brave-Browser", "Local State"];
 export const DEFAULT_BRAVE_PROFILE_ID = "Default";
 export const BRAVE_PROFILE_KEY = "BRAVE_PROFILE_KEY";
 export const BRAVE_PROFILES_KEY = "BRAVE_PROFILES_KEY";

--- a/extensions/brave/src/hooks/useHistorySearch.tsx
+++ b/extensions/brave/src/hooks/useHistorySearch.tsx
@@ -1,8 +1,13 @@
 import { existsSync } from "fs";
 import { BraveProfile, HistoryEntry, SearchResult } from "../interfaces";
 import { getHistoryDbPath } from "../util";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useSQL } from "@raycast/utils";
+
+// useSQL validates its database path even when execution is disabled. The
+// bundled command file is a safe existing path to pass while no History
+// database is available; execute: false ensures it is never queried.
+const FALLBACK_DATABASE_PATH = __filename;
 
 const whereClauses = (tableTitle: string, terms: string[]) => {
   return terms.map((t) => `(${tableTitle}.title LIKE '%${t}%' OR ${tableTitle}.url LIKE '%${t}%')`).join(" AND ");
@@ -20,38 +25,44 @@ const getHistoryQuery = (table: string, date_field: string, terms: string[]) =>
 export function useHistorySearch(profiles: BraveProfile[], query?: string): SearchResult<HistoryEntry>[] {
   const [profileHistories, setProfileHistories] = useState<{ [id: string]: SearchResult<HistoryEntry> }>({});
   const [currentProfileIndex, setCurrentProfileIndex] = useState<number>(0);
-  const [dbPath, setDbPath] = useState<string>(getHistoryDbPath(profiles[0].id));
+
+  const availableProfiles = useMemo(
+    () => profiles.filter((profile) => existsSync(getHistoryDbPath(profile.id))),
+    [profiles],
+  );
+  const currentProfile = availableProfiles[currentProfileIndex];
+  const dbPath = currentProfile ? getHistoryDbPath(currentProfile.id) : FALLBACK_DATABASE_PATH;
 
   const terms = query ? query.trim().split(" ") : [""];
   const historyQuery = getHistoryQuery("urls", "last_visit_time", terms);
 
-  const { data, isLoading, permissionView, revalidate } = useSQL<HistoryEntry>(dbPath, historyQuery);
+  const { data, isLoading, permissionView, revalidate } = useSQL<HistoryEntry>(dbPath, historyQuery, {
+    execute: Boolean(currentProfile),
+  });
 
   useEffect(() => {
-    if (data != undefined && !isLoading) {
-      const newHistories = { ...profileHistories };
-      newHistories[profiles[currentProfileIndex].id] = {
-        data,
-        isLoading,
-        errorView: permissionView,
-        revalidate,
-        profile: profiles[currentProfileIndex],
-      };
-      setProfileHistories(newHistories);
+    setProfileHistories({});
+    setCurrentProfileIndex(0);
+  }, [profiles, query]);
 
-      if (
-        currentProfileIndex < profiles.length - 1 &&
-        existsSync(getHistoryDbPath(profiles[currentProfileIndex + 1].id))
-      ) {
-        setDbPath(getHistoryDbPath(profiles[currentProfileIndex + 1].id));
-        setCurrentProfileIndex(currentProfileIndex + 1);
+  useEffect(() => {
+    if (currentProfile && data != undefined && !isLoading) {
+      setProfileHistories((histories) => ({
+        ...histories,
+        [currentProfile.id]: {
+          data,
+          isLoading,
+          errorView: permissionView,
+          revalidate,
+          profile: currentProfile,
+        },
+      }));
+
+      if (currentProfileIndex < availableProfiles.length - 1) {
+        setCurrentProfileIndex((index) => index + 1);
       }
     }
-  }, [data, dbPath, isLoading]);
-
-  useEffect(() => {
-    revalidate();
-  }, [currentProfileIndex]);
+  }, [availableProfiles.length, currentProfile, currentProfileIndex, data, isLoading, permissionView, revalidate]);
 
   return Object.values(profileHistories);
 }

--- a/extensions/brave/src/util/index.ts
+++ b/extensions/brave/src/util/index.ts
@@ -4,7 +4,6 @@ import {
   defaultBraveProfilePath,
   defaultBraveBetaProfilePath,
   defaultBraveNightlyProfilePath,
-  defaultBraveStatePath,
 } from "../constants";
 import { getPreferenceValues } from "@raycast/api";
 
@@ -34,7 +33,7 @@ const userLibraryDirectoryPath = () => {
 export const getHistoryDbPath = (profile?: string) =>
   path.join(userLibraryDirectoryPath(), ...prefProfile, profile ?? DEFAULT_BRAVE_PROFILE_ID, "History");
 
-export const getLocalStatePath = () => path.join(userLibraryDirectoryPath(), ...defaultBraveStatePath);
+export const getLocalStatePath = () => path.join(userLibraryDirectoryPath(), ...prefProfile, "Local State");
 
 export const getBookmarksFilePath = (profile?: string) =>
   path.join(userLibraryDirectoryPath(), ...prefProfile, profile ?? DEFAULT_BRAVE_PROFILE_ID, "Bookmarks");


### PR DESCRIPTION
## Description

- Prevent New Brave Tab from crashing when a Brave profile has not created a History database.
- Skip unavailable profile databases while retaining history results from valid profiles.
- Resolve profile metadata from the selected Brave Stable, Beta, or Nightly installation.
- Replace stale cached profile selections when switching installations.

## Root Cause

`@raycast/utils` validates the database path when `useSQL` is initialized, even when SQL execution is disabled. The Brave extension passed its expected History path unconditionally, causing a synchronous error whenever that file did not exist.

Profile discovery also always read Brave Stable's Local State file, which could produce profile IDs that did not exist in the selected Beta or Nightly installation.

## User Impact

New Brave Tab remains usable when Brave is newly installed, a profile has no browsing history, or a cached profile is unavailable. Beta and Nightly profile discovery now uses the selected installation.

## Validation

- `npm run lint`
- `npm run build`

Fixes #30131
Fixes #30153
