### PR TITLE
[Agent Usage] Support multiple CODEX_HOME to view additional accounts

### DIFF
--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Agent Usage Changelog
 
-## [Add support for multiple CODEX_HOME] - {PR_MERGE_DATE}
+## [Add support for multiple CODEX_HOME] - 2026-08-15
 
 - Support additional CODEX_HOME in preferences, letting users read from multiple active codex account
 

--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Agent Usage Changelog
 
+## [Add support for multiple CODEX_HOME] - {PR_MERGE_DATE}
+
+- Support additional CODEX_HOME in preferences, letting users read from multiple active codex account
+
 ## [Add DeepSeek Usage] - 2026-08-14
 
 - Add DeepSeek balance monitoring to the main list and menu bar

--- a/extensions/agent-usage/README.md
+++ b/extensions/agent-usage/README.md
@@ -24,7 +24,7 @@ Track usage across your AI coding agents in one place.
 | **Amp**         | Local SQLite database       |     —      |    —     |    —    |       —       | Auto-detected from local database                                                                |
 | **Claude**      | Anthropic OAuth Usage API   |     —      |    ✓     |    —    |       —       | Auto-detected after `claude` login                                                               |
 | **ClinePass**   | Cline API                   |     ✓      |    —     |    —    |       ✓       | Auto-detected from the local Cline login, or add a user ID and API key via Manage Accounts       |
-| **Codex**       | OpenAI API                  |     ✓      |    —     |    —    |       ✓       | Run `codex login`, or paste token in preferences                                                 |
+| **Codex**       | OpenAI API                  |     ✓      |    —     |    —    |       ✓       | Run `codex login`, add additional `CODEX_HOME` paths in preferences, or paste a token manually   |
 | **Copilot**     | GitHub Copilot internal API |     —      |    —     |    ✓    |       —       | Auto-detected from `GH_TOKEN`/`GITHUB_TOKEN`, or paste token in preferences                      |
 | **Cursor**      | Cursor API                  |     ✓      |    —     |    —    |       —       | Auto-detected from Cursor app login, or paste cookie header in preferences                       |
 | **DeepSeek**    | DeepSeek balance API        |     ✓      |    ✓     |    ✓    |       —       | Use OpenCode `deepseek`, set `DEEPSEEK_API_KEY`/`DEEPSEEK_KEY`, or paste an API key              |

--- a/extensions/agent-usage/package-lock.json
+++ b/extensions/agent-usage/package-lock.json
@@ -1580,9 +1580,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -1930,9 +1930,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/extensions/agent-usage/package.json
+++ b/extensions/agent-usage/package.json
@@ -11,7 +11,8 @@
     "alexi.build",
     "adrianbonpin",
     "garrick_zhang",
-    "EDM115"
+    "EDM115",
+    "chingweih"
   ],
   "type": "module",
   "scripts": {
@@ -103,6 +104,14 @@
       "label": "Show Codex",
       "description": "Show Codex usage in the list",
       "default": true,
+      "required": false
+    },
+    {
+      "name": "additionalCodexHomes",
+      "type": "textfield",
+      "title": "Additional Codex Homes (Optional)",
+      "placeholder": "~/.codex-personal, ~/.codex-work",
+      "description": "Comma-separated CODEX_HOME directories to include in addition to the default Codex home",
       "required": false
     },
     {

--- a/extensions/agent-usage/src/agents/provider-hooks.ts
+++ b/extensions/agent-usage/src/agents/provider-hooks.ts
@@ -13,7 +13,7 @@ import { fetchClinePassUsage } from "../clinepass/fetcher.ts";
 import { clearClineLocalCredential, loadClineLocalCredential, saveClineLocalCredential } from "../clinepass/storage.ts";
 import type { ClinePassError, ClinePassUsage } from "../clinepass/types.ts";
 import { buildCodexAccountCandidates } from "../codex/accounts.ts";
-import { listCodexOAuthAccounts } from "../codex/auth.ts";
+import { listCodexOAuthAccounts, parseAdditionalCodexHomes } from "../codex/auth.ts";
 import { fetchCodexUsage } from "../codex/fetcher.ts";
 import type { CodexError, CodexUsage } from "../codex/types.ts";
 import { resolveCopilotAuthTokens, shouldFallbackToPreferenceToken } from "../copilot/auth.ts";
@@ -56,6 +56,7 @@ import { readOpencodeAuthToken } from "./opencode-auth.ts";
 
 // Root-level preferences shared by both commands.
 type SharedPrefs = {
+  additionalCodexHomes?: string;
   copilotAuthToken?: string;
   cursorCookieHeader?: string;
   deepseekApiKey?: string;
@@ -244,7 +245,18 @@ export const useCodexAccounts = createAccountsHook<
   ReturnType<typeof buildCodexAccountCandidates>[number]
 >({
   agentId: "codex",
-  getAccounts: async () => buildCodexAccountCandidates(listCodexOAuthAccounts(), await loadAccounts("codex")),
+  getAccounts: async () => {
+    const defaultAccounts = listCodexOAuthAccounts();
+    const additionalAccounts = parseAdditionalCodexHomes(prefValue("additionalCodexHomes")).flatMap(
+      (codexHome, homeIndex) =>
+        listCodexOAuthAccounts({ codexHome }).map((account) => ({
+          ...account,
+          id: `codex-home-${homeIndex}-${account.id}`,
+        })),
+    );
+
+    return buildCodexAccountCandidates([...defaultAccounts, ...additionalAccounts], await loadAccounts("codex"));
+  },
   fetcher: async (account) => {
     if (account.needsAccountId) {
       return {

--- a/extensions/agent-usage/src/codex/accounts.test.ts
+++ b/extensions/agent-usage/src/codex/accounts.test.ts
@@ -166,3 +166,46 @@ test("buildCodexAccountCandidates lets discovered Codex entries without account 
   assert.equal(candidates[0].accountId, null);
   assert.equal(candidates[0].needsAccountId, false);
 });
+
+test("buildCodexAccountCandidates dedupes discovered accounts that share an OAuth credential across homes", () => {
+  const aliasedHomeAccount: CodexOAuthAccount = {
+    id: "codex-home-0-codex-active",
+    label: "Active",
+    token: "active-token",
+    accountId: "acct_active",
+    userId: "user_active",
+    source: "active",
+    authFilePath: "/tmp/.codex-alias/auth.json",
+  };
+  const refreshedTokenSameIdentity: CodexOAuthAccount = {
+    id: "codex-home-1-codex-active",
+    label: "Active",
+    token: "refreshed-token",
+    accountId: "acct_active",
+    userId: "user_active",
+    source: "active",
+    authFilePath: "/tmp/.codex-other/auth.json",
+  };
+  const distinctUserSameAccount: CodexOAuthAccount = {
+    id: "codex-home-2-codex-other",
+    label: "Other User",
+    token: "other-user-token",
+    accountId: "acct_active",
+    userId: "user_other",
+    source: "stored",
+    authFilePath: "/tmp/.codex-other/accounts/other.auth.json",
+  };
+
+  const candidates = buildCodexAccountCandidates(
+    [discoveredAccount, aliasedHomeAccount, refreshedTokenSameIdentity, distinctUserSameAccount],
+    [],
+  );
+
+  assert.deepEqual(
+    candidates.map((candidate) => ({ id: candidate.id, token: candidate.token })),
+    [
+      { id: "codex-active", token: "active-token" },
+      { id: "codex-home-2-codex-other", token: "other-user-token" },
+    ],
+  );
+});

--- a/extensions/agent-usage/src/codex/accounts.ts
+++ b/extensions/agent-usage/src/codex/accounts.ts
@@ -1,5 +1,5 @@
 import type { AccountEntry } from "../accounts/types.ts";
-import type { CodexOAuthAccount } from "./auth.ts";
+import { getCodexAccountDedupeKeys, type CodexOAuthAccount } from "./auth.ts";
 
 export type CodexAccountCandidateSource = "codex-home" | "manual";
 
@@ -19,6 +19,7 @@ export function buildCodexAccountCandidates(
   const candidates: CodexAccountCandidate[] = [];
   const seenTokens = new Set<string>();
   const seenAccountIds = new Set<string>();
+  const seenDiscoveredCredentials = new Set<string>();
   // Candidates added without an account ID, keyed by token. A later entry that
   // supplies an explicit account ID for the same token enriches one of these
   // rather than adding a redundant token-default entry.
@@ -35,6 +36,16 @@ export function buildCodexAccountCandidates(
   };
 
   for (const account of discoveredAccounts) {
+    // Additional CODEX_HOME entries can alias the default home or repeat the same
+    // OAuth credential under a different discovered ID — keep the first only.
+    const dedupeKeys = getCodexAccountDedupeKeys(account);
+    if (dedupeKeys.some((key) => seenDiscoveredCredentials.has(key))) {
+      continue;
+    }
+    for (const key of dedupeKeys) {
+      seenDiscoveredCredentials.add(key);
+    }
+
     registerCandidate({
       id: account.id,
       label: account.label,

--- a/extensions/agent-usage/src/codex/auth.ts
+++ b/extensions/agent-usage/src/codex/auth.ts
@@ -129,6 +129,17 @@ export function resolveCodexHome(env: NodeJS.ProcessEnv = process.env): string |
   return isExistingDirectory(codexHome) ? codexHome : null;
 }
 
+export function parseAdditionalCodexHomes(value: string, homeDir: string = os.homedir()): string[] {
+  const homes = value
+    .split(/[\n,]/)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => (entry === "~" ? homeDir : entry.startsWith("~/") ? path.join(homeDir, entry.slice(2)) : entry))
+    .map((entry) => path.resolve(entry));
+
+  return [...new Set(homes)];
+}
+
 function readCodexLoginAuth(authFilePath: string): CodexAuthData {
   try {
     if (!fs.existsSync(authFilePath)) {

--- a/extensions/agent-usage/src/codex/auth.ts
+++ b/extensions/agent-usage/src/codex/auth.ts
@@ -170,7 +170,9 @@ function formatStoredAccountLabel(fileName: string, accountId: string, userId: s
   return normalized || accountId;
 }
 
-function getCodexAccountDedupeKeys(account: CodexOAuthAccount): string[] {
+export function getCodexAccountDedupeKeys(
+  account: Pick<CodexOAuthAccount, "token" | "userId" | "accountId">,
+): string[] {
   const keys = [`token:${account.token}`];
   if (account.userId && account.accountId) {
     keys.unshift(`user-account:${account.userId}:${account.accountId}`);


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

Third-party agent orchestrators like [T3 Code](https://github.com/pingdotgg/t3code) allow you to setup custom path to use as `CODEX_HOME`, that way you can log into multiple codex account without logging out and logging back in. The accounts' `auth.json` will be stored at their respective custom `$CODEX_HOME/auth.json`

<img width="720" height="788" alt="image" src="https://github.com/user-attachments/assets/76174b57-46c8-45e2-94e4-ad3240094fdd" />

This PR adds a preferences option to that user specify their own custom `CODEX_HOME` locations to read auth.json from, thus allowing the list to display multple codex account usage at once.

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

### Preferences

<img width="300" height="475" alt="image" src="https://github.com/user-attachments/assets/a777fb2e-2cfc-4d8e-bd0c-c256d3b7e393" />

### Usage List

<img width="1772" height="1172" alt="Screenshot 2026-08-15 at 12 47 24" src="https://github.com/user-attachments/assets/e415a9a3-d597-4fa2-9884-0a8a6cc88d32" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
