### PR TITLE
[Agent Usage] Show Cursor Auto and API percentages together

### DIFF
--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Agent Usage Changelog
 
+## [Show Cursor Auto and API percentages] - 2026-08-15
+
+### Improvements
+
+- Show Auto and API remaining percentages together on the Cursor list and menu bar when both windows are available
+- Color the Cursor usage pie from the tighter of the two windows
+
 ## [Add support for multiple CODEX_HOME] - 2026-08-15
 
 - Support additional CODEX_HOME in preferences, letting users read from multiple active codex account

--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Agent Usage Changelog
 
-## [Show Cursor Auto and API percentages] - {PR_MERGE_DATE}
+## [Show Cursor Auto and API percentages] - 2026-08-16
 
 ### Improvements
 

--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Agent Usage Changelog
 
-## [Show Cursor Auto and API percentages] - 2026-08-15
+## [Show Cursor Auto and API percentages] - {PR_MERGE_DATE}
 
 ### Improvements
 

--- a/extensions/agent-usage/src/cursor/accessory.test.ts
+++ b/extensions/agent-usage/src/cursor/accessory.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { formatCursorAccessory } from "./accessory.ts";
+import type { CursorRateWindow, CursorUsage } from "./types.ts";
+
+function window(usedPercent: number): CursorRateWindow {
+  return { usedPercent, percentageRemaining: 100 - usedPercent, resetsAt: null };
+}
+
+function usage(overrides: Partial<CursorUsage> = {}): CursorUsage {
+  return {
+    account: "user@example.com",
+    source: "test",
+    total: window(18),
+    auto: null,
+    api: null,
+    onDemand: null,
+    legacyRequests: null,
+    planUsedUsd: 18,
+    planLimitUsd: 100,
+    billingCycleStart: null,
+    billingCycleEnd: null,
+    membershipType: "pro",
+    accountEmail: "user@example.com",
+    accountName: null,
+    ...overrides,
+  };
+}
+
+test("formatCursorAccessory shows Auto and API remaining together", () => {
+  const badge = formatCursorAccessory(
+    usage({
+      auto: window(10),
+      api: window(50),
+    }),
+  );
+
+  assert.equal(badge.text, "Auto 90%  API 50%");
+  assert.equal(badge.tooltip, "Auto: 90% remaining | API: 50% remaining");
+  assert.equal(badge.remainingForIcon, 50);
+});
+
+test("formatCursorAccessory falls back to a single Auto or API window", () => {
+  assert.deepEqual(formatCursorAccessory(usage({ auto: window(10) })), {
+    remainingForIcon: 90,
+    text: "Auto 90%",
+    tooltip: "Auto: 90% remaining",
+  });
+  assert.deepEqual(formatCursorAccessory(usage({ api: window(25) })), {
+    remainingForIcon: 75,
+    text: "API 75%",
+    tooltip: "API: 75% remaining",
+  });
+});
+
+test("formatCursorAccessory keeps a single Total or Requests badge otherwise", () => {
+  assert.deepEqual(formatCursorAccessory(usage()), {
+    remainingForIcon: 82,
+    text: "82%",
+    tooltip: "Total: 82% remaining",
+  });
+  assert.deepEqual(
+    formatCursorAccessory(
+      usage({
+        total: window(48),
+        legacyRequests: { used: 240, limit: 500, usedPercent: 48 },
+      }),
+    ),
+    {
+      remainingForIcon: 52,
+      text: "52%",
+      tooltip: "Requests: 52% remaining",
+    },
+  );
+});

--- a/extensions/agent-usage/src/cursor/accessory.ts
+++ b/extensions/agent-usage/src/cursor/accessory.ts
@@ -1,0 +1,47 @@
+import type { CursorUsage } from "./types.ts";
+
+export function formatPercent(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1).replace(/\.0$/, "");
+}
+
+export function formatCursorAccessory(usage: CursorUsage): {
+  remainingForIcon: number;
+  text: string;
+  tooltip: string;
+} {
+  if (usage.auto && usage.api) {
+    const auto = formatPercent(usage.auto.percentageRemaining);
+    const api = formatPercent(usage.api.percentageRemaining);
+    return {
+      remainingForIcon: Math.min(usage.auto.percentageRemaining, usage.api.percentageRemaining),
+      text: `Auto ${auto}%  API ${api}%`,
+      tooltip: `Auto: ${auto}% remaining | API: ${api}% remaining`,
+    };
+  }
+
+  if (usage.auto) {
+    const remaining = usage.auto.percentageRemaining;
+    return {
+      remainingForIcon: remaining,
+      text: `Auto ${formatPercent(remaining)}%`,
+      tooltip: `Auto: ${formatPercent(remaining)}% remaining`,
+    };
+  }
+
+  if (usage.api) {
+    const remaining = usage.api.percentageRemaining;
+    return {
+      remainingForIcon: remaining,
+      text: `API ${formatPercent(remaining)}%`,
+      tooltip: `API: ${formatPercent(remaining)}% remaining`,
+    };
+  }
+
+  const remaining = usage.total.percentageRemaining;
+  const label = usage.legacyRequests ? "Requests" : "Total";
+  return {
+    remainingForIcon: remaining,
+    text: `${formatPercent(remaining)}%`,
+    tooltip: `${label}: ${formatPercent(remaining)}% remaining`,
+  };
+}

--- a/extensions/agent-usage/src/cursor/renderer.tsx
+++ b/extensions/agent-usage/src/cursor/renderer.tsx
@@ -10,6 +10,7 @@ import {
   getNoDataAccessory,
   renderErrorOrNoData,
 } from "../agents/ui.tsx";
+import { formatCursorAccessory, formatPercent } from "./accessory.ts";
 import type { CursorError, CursorRateWindow, CursorUsage } from "./types.ts";
 
 const usdFormatter = new Intl.NumberFormat("en-US", {
@@ -17,10 +18,6 @@ const usdFormatter = new Intl.NumberFormat("en-US", {
   currency: "USD",
   maximumFractionDigits: 2,
 });
-
-function formatPercent(value: number): string {
-  return Number.isInteger(value) ? String(value) : value.toFixed(1).replace(/\.0$/, "");
-}
 
 function formatUsd(value: number): string {
   return usdFormatter.format(value);
@@ -169,11 +166,10 @@ export function getCursorAccessory(
     return getNoDataAccessory();
   }
 
-  const remaining = usage.total.percentageRemaining;
-  const label = usage.legacyRequests ? "Requests" : "Total";
+  const badge = formatCursorAccessory(usage);
   return {
-    icon: generatePieIcon(remaining),
-    text: `${formatPercent(remaining)}%`,
-    tooltip: `${label}: ${formatPercent(remaining)}% remaining`,
+    icon: generatePieIcon(badge.remainingForIcon),
+    text: badge.text,
+    tooltip: badge.tooltip,
   };
 }


### PR DESCRIPTION

## Description

Display Auto and API remaining percentages side by side on the Cursor list and menu bar when both windows are available, and color the pie from the tighter of the two.


## Screencast

<img width="582" height="946" alt="image" src="https://github.com/user-attachments/assets/db424fae-75ac-46de-b1cf-e705f9c1e23d" />

<img width="1482" height="922" alt="image" src="https://github.com/user-attachments/assets/442d478f-e75c-4427-ba7e-0d4a4f131615" />



<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
