### PR TITLE
Update search-router extension

### DIFF
--- a/extensions/search-router/CHANGELOG.md
+++ b/extensions/search-router/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Search Router Changelog
 
-## [Fix Missing Query Prompt on Shortcut Launch] - {PR_MERGE_DATE}
+## [Fix Missing Query Prompt on Shortcut Launch] - 2026-08-16
 
 - Fix the issue where executing the command "Search the Web" via a shortcut key would bypass the ability to enter a search query altogether (because the `query` argument is no longer required). It now shows a query form when "Search the Web" is launched from a keyboard shortcut, while preserving fallback search.
 

--- a/extensions/search-router/CHANGELOG.md
+++ b/extensions/search-router/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Search Router Changelog
 
+## [Fix Missing Query Prompt on Shortcut Launch] - {PR_MERGE_DATE}
+
+- Fix the issue where executing the command "Search the Web" via a shortcut key would bypass the ability to enter a search query altogether (because the `query` argument is no longer required). It now shows a query form when "Search the Web" is launched from a keyboard shortcut, while preserving fallback search.
+
 ## [Bug Fixes & Improvements] - 2026-06-03
 
 - Fix fallback search support — `query` argument is no longer required, so the command works when launched as a Raycast fallback search

--- a/extensions/search-router/package.json
+++ b/extensions/search-router/package.json
@@ -36,7 +36,7 @@
       ],
       "subtitle": "Search the Web with !bangs",
       "description": "Search the Web using any of the available search engines. Powered by Kagi's Bangs and custom search engines",
-      "mode": "no-view",
+      "mode": "view",
       "arguments": [
         {
           "name": "query",

--- a/extensions/search-router/src/search.tsx
+++ b/extensions/search-router/src/search.tsx
@@ -1,5 +1,18 @@
-import { LaunchProps, open, showToast, Toast } from "@raycast/api";
+import {
+  Action,
+  ActionPanel,
+  closeMainWindow,
+  Form,
+  Icon,
+  LaunchProps,
+  open,
+  PopToRootType,
+  showHUD,
+  showToast,
+  Toast,
+} from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
+import { useEffect, useRef } from "react";
 import { getDefaultSearchEngine } from "./data/cache";
 import { builtinSearchEngines } from "./data/builtin-search-engines";
 import { getCustomSearchEngines } from "./data/custom-search-engines";
@@ -12,10 +25,42 @@ async function safeOpenUrl(url: string): Promise<void> {
   return open(url);
 }
 
-export default async function search(props: LaunchProps<{ arguments: Arguments.Search; fallbackText?: string }>) {
-  try {
-    const rawQuery = (props.arguments.query || props.fallbackText) as string;
+type SearchProps = LaunchProps<{ arguments: Arguments.Search; fallbackText?: string }>;
 
+type SearchFormValues = {
+  query: string;
+};
+
+export default function SearchTheWeb(props: SearchProps) {
+  const initialQuery = props.arguments.query || props.fallbackText || "";
+  const didRunInitialQuery = useRef(false);
+
+  useEffect(() => {
+    if (!initialQuery || didRunInitialQuery.current) return;
+
+    didRunInitialQuery.current = true;
+    void runSearch(initialQuery);
+  }, [initialQuery]);
+
+  async function handleSubmit(values: SearchFormValues) {
+    await runSearch(values.query);
+  }
+
+  return (
+    <Form
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Search the Web" icon={Icon.MagnifyingGlass} onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.TextField id="query" title="Query" placeholder="Search with !bangs" defaultValue={initialQuery} />
+    </Form>
+  );
+}
+
+async function runSearch(rawQuery: string) {
+  try {
     const { searchEngine, finalQuery, searchEngineKey } = processQuery(rawQuery);
 
     if (!searchEngine) {
@@ -29,28 +74,30 @@ export default async function search(props: LaunchProps<{ arguments: Arguments.S
     if (!finalQuery) {
       const url = new URL(searchEngine.u);
       await safeOpenUrl(url.origin);
-      return;
-    }
+    } else {
+      const urlsToOpen = searchEngine.urls && searchEngine.urls.length > 1 ? searchEngine.urls : [searchEngine.u];
 
-    const urlsToOpen = searchEngine.urls && searchEngine.urls.length > 1 ? searchEngine.urls : [searchEngine.u];
+      for (const urlTemplate of urlsToOpen) {
+        const searchUrl = urlTemplate.replace("{{{s}}}", encodeURIComponent(finalQuery).replace(/%2F/g, "/"));
 
-    for (const urlTemplate of urlsToOpen) {
-      const searchUrl = urlTemplate.replace("{{{s}}}", encodeURIComponent(finalQuery).replace(/%2F/g, "/"));
+        if (!isValidUrl(searchUrl)) {
+          throw new Error(`Invalid URL: ${searchUrl}`);
+        }
 
-      if (!isValidUrl(searchUrl)) {
-        throw new Error(`Invalid URL: ${searchUrl}`);
+        await safeOpenUrl(searchUrl);
       }
 
-      await safeOpenUrl(searchUrl);
+      if (urlsToOpen.length > 1) {
+        // A HUD rather than a toast: toasts are rendered inside the main window, so
+        // closing the window would tear the confirmation down before it can be read.
+        await showHUD(`Opened ${urlsToOpen.length} search tabs · ${finalQuery}`, {
+          popToRootType: PopToRootType.Immediate,
+        });
+        return;
+      }
     }
 
-    if (urlsToOpen.length > 1) {
-      await showToast({
-        style: Toast.Style.Success,
-        title: `Opened ${urlsToOpen.length} search tabs`,
-        message: finalQuery,
-      });
-    }
+    await closeMainWindow({ popToRootType: PopToRootType.Immediate });
   } catch (error) {
     await showFailureToast(error);
   }


### PR DESCRIPTION
## Description

Fix the issue where executing the command "Search the Web" via a shortcut key would bypass the ability to enter a search query altogether (because the `query` argument is no longer required). It now shows a query form when "Search the Web" is launched from a keyboard shortcut, while preserving fallback search.

<img width="640" height="400" alt="Raycast search query" src="https://github.com/user-attachments/assets/f186e803-fcde-4585-ad36-4187586ffa65" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
