### PR TITLE
[Deepcast] Preserve hyperlinks in translated text

### DIFF
--- a/extensions/deepcast/CHANGELOG.md
+++ b/extensions/deepcast/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Deepcast Changelog
 
-## [Hyperlinks] - {PR_MERGE_DATE}
+## [Hyperlinks] - 2026-08-17
 
 - Preserve original HTML formatting and hyperlinks when translating copied rich text, then copy the result as rich text so it can be pasted back with ⌘V.
 

--- a/extensions/deepcast/CHANGELOG.md
+++ b/extensions/deepcast/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Hyperlinks] - {PR_MERGE_DATE}
 
-- Preserve hyperlinks when translating copied HTML or markdown links, including copy and paste as rich text.
+- Preserve original HTML formatting and hyperlinks when translating copied rich text, then copy the result as rich text so it can be pasted back with ⌘V.
 
 ## [Newlines] - 2025-12-16
 

--- a/extensions/deepcast/CHANGELOG.md
+++ b/extensions/deepcast/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Deepcast Changelog
 
+## [Hyperlinks] - {PR_MERGE_DATE}
+
+- Preserve hyperlinks when translating copied HTML or markdown links, including copy and paste as rich text.
+
 ## [Newlines] - 2025-12-16
+
 - Fixed issue where newlines in translations were not displayed correctly in the Raycast detail view because markdown requires double newlines for line breaks.
 
 ## [Maintenance] - 2025-11-12

--- a/extensions/deepcast/package-lock.json
+++ b/extensions/deepcast/package-lock.json
@@ -1294,6 +1294,7 @@
       "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1354,6 +1355,7 @@
       "integrity": "sha512-6m1I5RmHBGTnUGS113G04DMu3CpSdxCAU/UvtjNWL4Nuf3MW9tQhiJqRlHzChIkhy6kZSAQmc+I1bcGjE3yNKg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.3",
         "@typescript-eslint/types": "8.46.3",
@@ -1559,6 +1561,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1661,9 +1664,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -1976,6 +1979,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2982,6 +2986,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3253,6 +3258,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3317,6 +3323,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/deepcast/package.json
+++ b/extensions/deepcast/package.json
@@ -21,7 +21,8 @@
     "islam_hassan",
     "shashank_rm",
     "heyflorentin",
-    "ridemountainpig"
+    "ridemountainpig",
+    "12ian34"
   ],
   "platforms": [
     "macOS",
@@ -791,6 +792,7 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
-    "publish": "npx @raycast/api@latest publish"
+    "publish": "npx @raycast/api@latest publish",
+    "test": "node --test tests/hyperlinks.test.ts"
   }
 }

--- a/extensions/deepcast/src/components/TranslationView.tsx
+++ b/extensions/deepcast/src/components/TranslationView.tsx
@@ -1,9 +1,17 @@
-import { Action, ActionPanel, Detail, getPreferenceValues, Clipboard, showToast, Toast } from "@raycast/api";
-import { SourceLanguage, source_languages, delayedCloseWindow } from "../utils";
+import { Action, ActionPanel, Detail, getPreferenceValues, showToast, Toast } from "@raycast/api";
+import { htmlToDisplayText } from "../hyperlinks";
+import {
+  SourceLanguage,
+  copyTranslatedText,
+  delayedCloseWindow,
+  pasteTranslatedText,
+  source_languages,
+} from "../utils";
 
-export const TranslationView = (props: { translation: string | null; sourceLanguage?: string }) => {
+export const TranslationView = (props: { translation: string | null; sourceLanguage?: string; isHtml?: boolean }) => {
   const translation = props.translation;
-  const displayedTranslation = translation ? translation.replace(/\n/g, "\n\n") : null;
+  const displayTranslation = translation && props.isHtml ? htmlToDisplayText(translation) : translation;
+  const displayedTranslation = displayTranslation ? displayTranslation.replace(/\n/g, "\n\n") : null;
   const sourceLanguage = source_languages[props.sourceLanguage as SourceLanguage] ?? "unknown language";
   const sourceLanguageMessage = `Translated from ${sourceLanguage}`;
   const { closeRaycastAfterTranslation } = getPreferenceValues<Preferences>();
@@ -12,7 +20,7 @@ export const TranslationView = (props: { translation: string | null; sourceLangu
 
   const handleCopyToClipboard = async () => {
     try {
-      await Clipboard.copy(translation);
+      await copyTranslatedText(translation, Boolean(props.isHtml));
       await showToast(Toast.Style.Success, "Translation copied to clipboard!");
       await delayedCloseWindow(closeRaycastAfterTranslation);
     } catch (error) {
@@ -23,7 +31,7 @@ export const TranslationView = (props: { translation: string | null; sourceLangu
 
   const handlePasteInFrontmostApp = async () => {
     try {
-      await Clipboard.paste(translation);
+      await pasteTranslatedText(translation, Boolean(props.isHtml));
       await showToast(Toast.Style.Success, "Translation pasted!");
       await delayedCloseWindow(closeRaycastAfterTranslation);
     } catch (error) {

--- a/extensions/deepcast/src/components/TranslationView.tsx
+++ b/extensions/deepcast/src/components/TranslationView.tsx
@@ -1,4 +1,4 @@
-import { Action, ActionPanel, Detail, getPreferenceValues, showToast, Toast } from "@raycast/api";
+import { Action, ActionPanel, Detail, getPreferenceValues, Icon, showToast, Toast } from "@raycast/api";
 import { htmlToDisplayText } from "../hyperlinks";
 import {
   SourceLanguage,
@@ -46,8 +46,8 @@ export const TranslationView = (props: { translation: string | null; sourceLangu
       markdown={displayedTranslation}
       actions={
         <ActionPanel>
-          <Action title="Copy to Clipboard" onAction={handleCopyToClipboard} />
-          <Action title="Paste in Frontmost App" onAction={handlePasteInFrontmostApp} />
+          <Action icon={Icon.CopyClipboard} title="Copy Rich Text" onAction={handleCopyToClipboard} />
+          <Action icon={Icon.Document} title="Paste Translation" onAction={handlePasteInFrontmostApp} />
         </ActionPanel>
       }
     />

--- a/extensions/deepcast/src/hyperlinks.ts
+++ b/extensions/deepcast/src/hyperlinks.ts
@@ -17,10 +17,6 @@ export function containsMarkdownHyperlinks(text: string): boolean {
   return MARKDOWN_HYPERLINK_PATTERN.test(text);
 }
 
-export function normalizeForCompare(text: string): string {
-  return text.replace(/\s+/g, " ").trim();
-}
-
 export function extractHtmlFragment(html: string): string {
   const fragment = html.match(/<!--StartFragment-->([\s\S]*?)<!--EndFragment-->/);
   if (fragment?.[1]) {
@@ -89,31 +85,6 @@ export function htmlToDisplayText(html: string): string {
 
 export function toRichClipboardContent(fragment: string): { html: string } {
   return { html: extractHtmlFragment(fragment) };
-}
-
-export function clipboardMarkupForText(
-  text: string,
-  clipboardText: string | undefined,
-  clipboardHtml: string | undefined,
-): string | undefined {
-  if (!clipboardHtml || !normalizeForCompare(text)) {
-    return undefined;
-  }
-
-  const fragment = extractHtmlFragment(clipboardHtml);
-  if (!containsHtmlMarkup(fragment)) {
-    return undefined;
-  }
-
-  const textNorm = normalizeForCompare(text);
-  const clipboardNorm = clipboardText ? normalizeForCompare(clipboardText) : "";
-  const visibleNorm = normalizeForCompare(htmlToPlainText(fragment));
-
-  if (clipboardNorm === textNorm || visibleNorm === textNorm) {
-    return fragment;
-  }
-
-  return undefined;
 }
 
 export function prepareFromText(text: string): { text: string; isHtml: boolean } {

--- a/extensions/deepcast/src/hyperlinks.ts
+++ b/extensions/deepcast/src/hyperlinks.ts
@@ -1,0 +1,113 @@
+const HTML_HYPERLINK_PATTERN = /<a\b[^>]*\bhref\s*=/i;
+const MARKDOWN_HYPERLINK_PATTERN = /(?<!!)\[([^\]]+)\]\((https?:\/\/[^)\s]+|mailto:[^)\s]+|www\.[^)\s]+)\)/;
+const MARKDOWN_HYPERLINK_GLOBAL_PATTERN = /(?<!!)\[([^\]]+)\]\((https?:\/\/[^)\s]+|mailto:[^)\s]+|www\.[^)\s]+)\)/g;
+const HTML_ANCHOR_GLOBAL_PATTERN = /<a\b[^>]*\bhref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))[^>]*>([\s\S]*?)<\/a>/gi;
+
+export function containsHtmlHyperlinks(text: string): boolean {
+  return HTML_HYPERLINK_PATTERN.test(text);
+}
+
+export function containsMarkdownHyperlinks(text: string): boolean {
+  return MARKDOWN_HYPERLINK_PATTERN.test(text);
+}
+
+export function normalizeForCompare(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+export function extractHtmlFragment(html: string): string {
+  const fragment = html.match(/<!--StartFragment-->([\s\S]*?)<!--EndFragment-->/);
+  if (fragment?.[1]) {
+    return fragment[1].trim();
+  }
+
+  const body = html.match(/<body[^>]*>([\s\S]*)<\/body>/i);
+  if (body?.[1]) {
+    return body[1].trim();
+  }
+
+  const htmlStart = html.search(/<html[\s>]/i);
+  if (htmlStart > 0) {
+    return html.slice(htmlStart).trim();
+  }
+
+  return html.trim();
+}
+
+export function escapeHtml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+export function unescapeHtml(text: string): string {
+  return text
+    .replace(/&nbsp;/g, " ")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+
+export function stripHtmlTags(html: string): string {
+  return unescapeHtml(
+    html
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(/<\/(?:p|div|h[1-6]|li|tr)>/gi, "\n")
+      .replace(/<[^>]+>/g, ""),
+  ).replace(/[ \t]+\n/g, "\n");
+}
+
+export function markdownLinksToHtml(text: string): string {
+  return text.replace(MARKDOWN_HYPERLINK_GLOBAL_PATTERN, (_match, label: string, url: string) => {
+    return `<a href="${escapeHtml(url)}">${escapeHtml(label)}</a>`;
+  });
+}
+
+export function htmlLinksToMarkdown(html: string): string {
+  return html.replace(HTML_ANCHOR_GLOBAL_PATTERN, (_match, doubleQuoted, singleQuoted, unquoted, inner) => {
+    const href = unescapeHtml(doubleQuoted || singleQuoted || unquoted || "");
+    const label = stripHtmlTags(inner).replace(/\s+/g, " ").trim();
+    return `[${label}](${href})`;
+  });
+}
+
+export function htmlToPlainText(html: string): string {
+  return stripHtmlTags(html)
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+export function htmlToDisplayText(html: string): string {
+  return htmlToPlainText(htmlLinksToMarkdown(html));
+}
+
+export function toClipboardHtml(fragment: string): string {
+  if (/<html[\s>]/i.test(fragment)) {
+    return fragment;
+  }
+  return `<html><body>${fragment}</body></html>`;
+}
+
+export function prepareFromText(text: string): { text: string; isHtml: boolean } {
+  if (containsHtmlHyperlinks(text)) {
+    return { text, isHtml: true };
+  }
+  if (containsMarkdownHyperlinks(text)) {
+    return { text: markdownLinksToHtml(text), isHtml: true };
+  }
+  return { text, isHtml: false };
+}
+
+export function prepareFromClipboardHtml(
+  text: string,
+  clipboardText: string | undefined,
+  clipboardHtml: string | undefined,
+): { text: string; isHtml: boolean } {
+  if (clipboardHtml && clipboardText && normalizeForCompare(text) === normalizeForCompare(clipboardText)) {
+    const fragment = extractHtmlFragment(clipboardHtml);
+    if (containsHtmlHyperlinks(fragment)) {
+      return { text: fragment, isHtml: true };
+    }
+  }
+  return prepareFromText(text);
+}

--- a/extensions/deepcast/src/hyperlinks.ts
+++ b/extensions/deepcast/src/hyperlinks.ts
@@ -1,7 +1,13 @@
 const HTML_HYPERLINK_PATTERN = /<a\b[^>]*\bhref\s*=/i;
+const HTML_MARKUP_PATTERN =
+  /<\/?(?:a|abbr|b|br|div|em|font|h[1-6]|i|li|ol|p|span|strong|table|td|th|tr|u|ul|blockquote|pre|code|img|sub|sup)(?:\s|\/|>)/i;
 const MARKDOWN_HYPERLINK_PATTERN = /(?<!!)\[([^\]]+)\]\((https?:\/\/[^)\s]+|mailto:[^)\s]+|www\.[^)\s]+)\)/;
 const MARKDOWN_HYPERLINK_GLOBAL_PATTERN = /(?<!!)\[([^\]]+)\]\((https?:\/\/[^)\s]+|mailto:[^)\s]+|www\.[^)\s]+)\)/g;
 const HTML_ANCHOR_GLOBAL_PATTERN = /<a\b[^>]*\bhref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))[^>]*>([\s\S]*?)<\/a>/gi;
+
+export function containsHtmlMarkup(text: string): boolean {
+  return HTML_MARKUP_PATTERN.test(text);
+}
 
 export function containsHtmlHyperlinks(text: string): boolean {
   return HTML_HYPERLINK_PATTERN.test(text);
@@ -81,11 +87,33 @@ export function htmlToDisplayText(html: string): string {
   return htmlToPlainText(htmlLinksToMarkdown(html));
 }
 
-export function toClipboardHtml(fragment: string): string {
-  if (/<html[\s>]/i.test(fragment)) {
+export function toRichClipboardContent(fragment: string): { html: string } {
+  return { html: extractHtmlFragment(fragment) };
+}
+
+export function clipboardMarkupForText(
+  text: string,
+  clipboardText: string | undefined,
+  clipboardHtml: string | undefined,
+): string | undefined {
+  if (!clipboardHtml || !normalizeForCompare(text)) {
+    return undefined;
+  }
+
+  const fragment = extractHtmlFragment(clipboardHtml);
+  if (!containsHtmlMarkup(fragment)) {
+    return undefined;
+  }
+
+  const textNorm = normalizeForCompare(text);
+  const clipboardNorm = clipboardText ? normalizeForCompare(clipboardText) : "";
+  const visibleNorm = normalizeForCompare(htmlToPlainText(fragment));
+
+  if (clipboardNorm === textNorm || visibleNorm === textNorm) {
     return fragment;
   }
-  return `<html><body>${fragment}</body></html>`;
+
+  return undefined;
 }
 
 export function prepareFromText(text: string): { text: string; isHtml: boolean } {
@@ -98,14 +126,10 @@ export function prepareFromText(text: string): { text: string; isHtml: boolean }
   return { text, isHtml: false };
 }
 
-export function prepareFromClipboardHtml(
-  text: string,
-  clipboardText: string | undefined,
-  clipboardHtml: string | undefined,
-): { text: string; isHtml: boolean } {
-  if (clipboardHtml && clipboardText && normalizeForCompare(text) === normalizeForCompare(clipboardText)) {
-    const fragment = extractHtmlFragment(clipboardHtml);
-    if (containsHtmlHyperlinks(fragment)) {
+export function prepareTranslationPayload(text: string, sourceHtml?: string): { text: string; isHtml: boolean } {
+  if (sourceHtml) {
+    const fragment = extractHtmlFragment(sourceHtml);
+    if (containsHtmlMarkup(fragment)) {
       return { text: fragment, isHtml: true };
     }
   }

--- a/extensions/deepcast/src/index.tsx
+++ b/extensions/deepcast/src/index.tsx
@@ -15,13 +15,16 @@ import {
   SUPPORTED_FORMALITY_LANGUAGES,
   SourceLanguage,
   TargetLanguage,
+  copyTranslatedText,
   getSelection,
+  pasteTranslatedText,
   sendTranslateRequest,
   source_languages,
   target_languages,
   delayedCloseWindow,
 } from "./utils";
 import TranslationView from "./components/TranslationView";
+import { htmlToDisplayText } from "./hyperlinks";
 import transliterate from "@sindresorhus/transliterate";
 
 interface Values {
@@ -47,6 +50,7 @@ function SwitchLanguagesAction(props: { onSwitchLanguages: () => void }) {
 type LaunchContext = {
   translation?: string;
   sourceLanguage?: SourceLanguage;
+  isHtml?: boolean;
 };
 
 const Command = (props: LaunchProps<{ launchContext?: LaunchContext }>) => {
@@ -54,7 +58,9 @@ const Command = (props: LaunchProps<{ launchContext?: LaunchContext }>) => {
   if (props?.launchContext?.translation) {
     const translation = props?.launchContext?.translation;
     const sourceLanguage = props?.launchContext?.sourceLanguage;
-    return <TranslationView translation={translation} sourceLanguage={sourceLanguage} />;
+    return (
+      <TranslationView translation={translation} sourceLanguage={sourceLanguage} isHtml={props.launchContext?.isHtml} />
+    );
   }
   const {
     defaultTargetLanguage,
@@ -66,6 +72,7 @@ const Command = (props: LaunchProps<{ launchContext?: LaunchContext }>) => {
   const [loading, setLoading] = useState(false);
   const [sourceText, setSourceText] = useState(props.fallbackText ?? "");
   const [translation, setTranslation] = useState("");
+  const [htmlTranslation, setHtmlTranslation] = useState<string>();
   const [sourceLanguage, setSourceLanguage] = useState<SourceLanguage | "">("");
   const [targetLanguage, setTargetLanguage] = useState<TargetLanguage>(defaultTargetLanguage);
   const [detectedSourceLanguage, setDetectedSourceLanguage] = useState<SourceLanguage>();
@@ -96,8 +103,9 @@ const Command = (props: LaunchProps<{ launchContext?: LaunchContext }>) => {
 
     if (!response) return;
 
-    const { translation, detectedSourceLanguage } = response;
-    setTranslation(translation);
+    const { translation, detectedSourceLanguage, isHtml } = response;
+    setTranslation(isHtml ? htmlToDisplayText(translation) : translation);
+    setHtmlTranslation(isHtml ? translation : undefined);
     setDetectedSourceLanguage(detectedSourceLanguage);
   };
 
@@ -128,6 +136,7 @@ const Command = (props: LaunchProps<{ launchContext?: LaunchContext }>) => {
       const newTranslation = sourceText;
       setSourceText(newSourceText);
       setTranslation(newTranslation);
+      setHtmlTranslation(undefined);
     } else {
       // Should never happen
       await showToast(
@@ -143,7 +152,7 @@ const Command = (props: LaunchProps<{ launchContext?: LaunchContext }>) => {
 
   const handleCopyToClipboard = async () => {
     try {
-      await Clipboard.copy(translation);
+      await copyTranslatedText(htmlTranslation ?? translation, Boolean(htmlTranslation));
       await showToast(Toast.Style.Success, "Translation copied to clipboard!");
       await delayedCloseWindow(closeRaycastAfterTranslation);
     } catch (error) {
@@ -154,7 +163,7 @@ const Command = (props: LaunchProps<{ launchContext?: LaunchContext }>) => {
 
   const handlePasteInFrontmostApp = async () => {
     try {
-      await Clipboard.paste(translation);
+      await pasteTranslatedText(htmlTranslation ?? translation, Boolean(htmlTranslation));
       await showToast(Toast.Style.Success, "Translation pasted!");
       await delayedCloseWindow(closeRaycastAfterTranslation);
     } catch (error) {

--- a/extensions/deepcast/src/index.tsx
+++ b/extensions/deepcast/src/index.tsx
@@ -8,6 +8,7 @@ import {
   LaunchProps,
   getPreferenceValues,
   Clipboard,
+  useNavigation,
 } from "@raycast/api";
 import { useEffect, useState } from "react";
 import {
@@ -24,7 +25,7 @@ import {
   delayedCloseWindow,
 } from "./utils";
 import TranslationView from "./components/TranslationView";
-import { htmlToDisplayText } from "./hyperlinks";
+import { htmlToPlainText } from "./hyperlinks";
 import transliterate from "@sindresorhus/transliterate";
 
 interface Values {
@@ -69,6 +70,7 @@ const Command = (props: LaunchProps<{ launchContext?: LaunchContext }>) => {
     closeRaycastAfterTranslation,
     defaultFormality,
   } = getPreferenceValues<Preferences>();
+  const { push } = useNavigation();
   const [loading, setLoading] = useState(false);
   const [sourceText, setSourceText] = useState(props.fallbackText ?? "");
   const [translation, setTranslation] = useState("");
@@ -83,7 +85,7 @@ const Command = (props: LaunchProps<{ launchContext?: LaunchContext }>) => {
   useEffect(() => {
     if (props.fallbackText) return;
     getSelection().then((content) => {
-      setSourceText(content ?? "");
+      setSourceText((currentText) => currentText || content || "");
     });
   }, []);
 
@@ -104,9 +106,13 @@ const Command = (props: LaunchProps<{ launchContext?: LaunchContext }>) => {
     if (!response) return;
 
     const { translation, detectedSourceLanguage, isHtml } = response;
-    setTranslation(isHtml ? htmlToDisplayText(translation) : translation);
+    setTranslation(isHtml ? htmlToPlainText(translation) : translation);
     setHtmlTranslation(isHtml ? translation : undefined);
     setDetectedSourceLanguage(detectedSourceLanguage);
+
+    if (isHtml) {
+      push(<TranslationView translation={translation} sourceLanguage={detectedSourceLanguage} isHtml={true} />);
+    }
   };
 
   const switchLanguages = async () => {
@@ -193,13 +199,13 @@ const Command = (props: LaunchProps<{ launchContext?: LaunchContext }>) => {
           <ActionPanel.Section>
             <Action
               icon={Icon.CopyClipboard}
-              title="Copy Translation"
+              title="Copy Rich Text"
               shortcut={{ modifiers: ["cmd"], key: "." }}
               onAction={handleCopyToClipboard}
             />
             <Action
               icon={Icon.Document}
-              title="Paste in Frontmost App"
+              title="Paste Translation"
               shortcut={{ modifiers: ["cmd", "shift"], key: "." }}
               onAction={handlePasteInFrontmostApp}
             />
@@ -210,6 +216,21 @@ const Command = (props: LaunchProps<{ launchContext?: LaunchContext }>) => {
               onAction={handleCopyTransliteration}
             />
           </ActionPanel.Section>
+          {translation.length > 0 && (
+            <ActionPanel.Section>
+              <Action.Push
+                icon={Icon.Eye}
+                title="View Formatted Translation"
+                target={
+                  <TranslationView
+                    translation={htmlTranslation ?? translation}
+                    sourceLanguage={detectedSourceLanguage}
+                    isHtml={Boolean(htmlTranslation)}
+                  />
+                }
+              />
+            </ActionPanel.Section>
+          )}
           <ActionPanel.Section>
             <Action.OpenInBrowser title="Free API Key" url="https://www.deepl.com/pro-api" />
             <SwitchLanguagesAction onSwitchLanguages={switchLanguages} />
@@ -259,12 +280,12 @@ const Command = (props: LaunchProps<{ launchContext?: LaunchContext }>) => {
           </Form.Dropdown>
         </>
       )}
-      <Form.TextArea id="translation" value={translation} />
+      <Form.TextArea id="translation" title="Translation" value={translation} />
+      {translation.length > 0 && (
+        <Form.Description title="Copied" text="Rich text is on the clipboard. Paste with ⌘V." />
+      )}
       {(showTransliteration == "always" || (showTransliteration == "whenProvided" && transliteration.length > 0)) && (
-        <>
-          <Form.TextArea id="translation" value={translation} />
-          <Form.Description title="Transliteration" text={transliteration} />
-        </>
+        <Form.Description title="Transliteration" text={transliteration} />
       )}
     </Form>
   );

--- a/extensions/deepcast/src/utils.ts
+++ b/extensions/deepcast/src/utils.ts
@@ -11,6 +11,7 @@ import {
 } from "@raycast/api";
 import got, { HTTPError, RequestError } from "got";
 import { StatusCodes, getReasonPhrase } from "http-status-codes";
+import { htmlToPlainText, prepareFromClipboardHtml, prepareFromText, toClipboardHtml } from "./hyperlinks";
 
 const { returnToRootState } = getPreferenceValues<Preferences>();
 function isPro(key: string) {
@@ -92,6 +93,31 @@ export async function readContent() {
   }
 }
 
+async function resolveTranslatePayload(text: string) {
+  try {
+    const clipboard = await Clipboard.read();
+    return prepareFromClipboardHtml(text, clipboard.text, clipboard.html);
+  } catch {
+    return prepareFromText(text);
+  }
+}
+
+export async function copyTranslatedText(translation: string, isHtml: boolean) {
+  if (isHtml) {
+    await Clipboard.copy({ html: toClipboardHtml(translation), text: htmlToPlainText(translation) });
+    return;
+  }
+  await Clipboard.copy(translation);
+}
+
+export async function pasteTranslatedText(translation: string, isHtml: boolean) {
+  if (isHtml) {
+    await Clipboard.paste({ html: toClipboardHtml(translation), text: htmlToPlainText(translation) });
+    return;
+  }
+  await Clipboard.paste(translation);
+}
+
 export async function sendTranslateRequest({
   text: initialText,
   sourceLanguage,
@@ -110,7 +136,8 @@ export async function sendTranslateRequest({
     const { key, closeRaycastAfterTranslation } = prefs;
     onTranslateAction ??= prefs.onTranslateAction;
 
-    const text = initialText || (await readContent());
+    const rawText = initialText || (await readContent()) || "";
+    const { text, isHtml } = await resolveTranslatePayload(rawText);
 
     const toast = await showToast(Toast.Style.Animated, "Fetching translation...");
     try {
@@ -126,12 +153,13 @@ export async function sendTranslateRequest({
             source_lang: sourceLanguage,
             target_lang: targetLanguage,
             formality,
+            ...(isHtml ? { tag_handling: "html" } : {}),
           },
         })
         .json<{ translations: { text: string; detected_source_language: SourceLanguage }[] }>();
       switch (onTranslateAction) {
         case "clipboard":
-          await Clipboard.copy(translation);
+          await copyTranslatedText(translation, isHtml);
           await showToast(Toast.Style.Success, "The translation was copied to your clipboard.");
           await delayedCloseWindow(closeRaycastAfterTranslation);
           break;
@@ -143,6 +171,7 @@ export async function sendTranslateRequest({
               context: {
                 translation,
                 sourceLanguage: detectedSourceLanguage,
+                isHtml,
               },
             });
           } catch {
@@ -156,14 +185,14 @@ export async function sendTranslateRequest({
           break;
         case "paste":
           await closeMainWindow();
-          await Clipboard.paste(translation);
+          await pasteTranslatedText(translation, isHtml);
           break;
         default:
           toast.hide();
           await delayedCloseWindow(closeRaycastAfterTranslation, 500);
           break;
       }
-      return { translation, detectedSourceLanguage };
+      return { translation, detectedSourceLanguage, isHtml };
     } catch (error) {
       await showToast(Toast.Style.Failure, "Something went wrong", gotErrorToString(error));
     }

--- a/extensions/deepcast/src/utils.ts
+++ b/extensions/deepcast/src/utils.ts
@@ -11,7 +11,7 @@ import {
 } from "@raycast/api";
 import got, { HTTPError, RequestError } from "got";
 import { StatusCodes, getReasonPhrase } from "http-status-codes";
-import { htmlToPlainText, prepareFromClipboardHtml, prepareFromText, toClipboardHtml } from "./hyperlinks";
+import { clipboardMarkupForText, prepareTranslationPayload, toRichClipboardContent } from "./hyperlinks";
 
 const { returnToRootState } = getPreferenceValues<Preferences>();
 function isPro(key: string) {
@@ -78,33 +78,43 @@ export async function getSelection() {
   }
 }
 
-// Get the text, matching preferences.
-// If selected text is the preferred source, it will try selected text but fallback to clipboard.
-// If clipboard is the preferred source, it will try clipboard but fallback to selected text.
-export async function readContent() {
-  const preferredSource = getPreferenceValues<Preferences>().source;
-  const clipboard = await Clipboard.readText();
-  const selected = await getSelection();
-
-  if (preferredSource === "clipboard") {
-    return clipboard || selected;
-  } else {
-    return selected || clipboard;
+async function readClipboard() {
+  try {
+    return await Clipboard.read();
+  } catch {
+    return { text: await Clipboard.readText(), html: undefined };
   }
 }
 
-async function resolveTranslatePayload(text: string) {
-  try {
-    const clipboard = await Clipboard.read();
-    return prepareFromClipboardHtml(text, clipboard.text, clipboard.html);
-  } catch {
-    return prepareFromText(text);
+// Get the text, matching preferences.
+// If selected text is the preferred source, it will try selected text but fallback to clipboard.
+// If clipboard is the preferred source, it will try clipboard but fallback to selected text.
+// Clipboard HTML is included when it is a marked-up rendering of the same visible text.
+export async function readContent() {
+  const preferredSource = getPreferenceValues<Preferences>().source;
+  const clipboard = await readClipboard();
+  const selected = await getSelection();
+
+  if (preferredSource === "clipboard") {
+    if (clipboard.text) {
+      return { text: clipboard.text, html: clipboard.html };
+    }
+    return { text: selected || "" };
   }
+
+  if (selected) {
+    return {
+      text: selected,
+      html: clipboardMarkupForText(selected, clipboard.text, clipboard.html),
+    };
+  }
+
+  return { text: clipboard.text || "", html: clipboard.html };
 }
 
 export async function copyTranslatedText(translation: string, isHtml: boolean) {
   if (isHtml) {
-    await Clipboard.copy({ html: toClipboardHtml(translation), text: htmlToPlainText(translation) });
+    await Clipboard.copy(toRichClipboardContent(translation));
     return;
   }
   await Clipboard.copy(translation);
@@ -112,7 +122,7 @@ export async function copyTranslatedText(translation: string, isHtml: boolean) {
 
 export async function pasteTranslatedText(translation: string, isHtml: boolean) {
   if (isHtml) {
-    await Clipboard.paste({ html: toClipboardHtml(translation), text: htmlToPlainText(translation) });
+    await Clipboard.paste(toRichClipboardContent(translation));
     return;
   }
   await Clipboard.paste(translation);
@@ -136,10 +146,16 @@ export async function sendTranslateRequest({
     const { key, closeRaycastAfterTranslation } = prefs;
     onTranslateAction ??= prefs.onTranslateAction;
 
-    const rawText = initialText || (await readContent()) || "";
-    const { text, isHtml } = await resolveTranslatePayload(rawText);
+    const clipboard = await readClipboard();
+    const source: { text: string; html?: string } = initialText
+      ? {
+          text: initialText,
+          html: clipboardMarkupForText(initialText, clipboard.text, clipboard.html),
+        }
+      : await readContent();
+    const { text, isHtml } = prepareTranslationPayload(source.text, source.html);
 
-    const toast = await showToast(Toast.Style.Animated, "Fetching translation...");
+    await showToast(Toast.Style.Animated, "Fetching translation...");
     try {
       const {
         translations: [{ text: translation, detected_source_language: detectedSourceLanguage }],
@@ -160,7 +176,7 @@ export async function sendTranslateRequest({
       switch (onTranslateAction) {
         case "clipboard":
           await copyTranslatedText(translation, isHtml);
-          await showToast(Toast.Style.Success, "The translation was copied to your clipboard.");
+          await showToast(Toast.Style.Success, "Copied as rich text", "Paste with ⌘V");
           await delayedCloseWindow(closeRaycastAfterTranslation);
           break;
         case "view":
@@ -188,8 +204,8 @@ export async function sendTranslateRequest({
           await pasteTranslatedText(translation, isHtml);
           break;
         default:
-          toast.hide();
-          await delayedCloseWindow(closeRaycastAfterTranslation, 500);
+          await copyTranslatedText(translation, isHtml);
+          await showToast(Toast.Style.Success, "Copied as rich text", "Paste with ⌘V");
           break;
       }
       return { translation, detectedSourceLanguage, isHtml };

--- a/extensions/deepcast/src/utils.ts
+++ b/extensions/deepcast/src/utils.ts
@@ -11,7 +11,7 @@ import {
 } from "@raycast/api";
 import got, { HTTPError, RequestError } from "got";
 import { StatusCodes, getReasonPhrase } from "http-status-codes";
-import { clipboardMarkupForText, prepareTranslationPayload, toRichClipboardContent } from "./hyperlinks";
+import { prepareTranslationPayload, toRichClipboardContent } from "./hyperlinks";
 
 const { returnToRootState } = getPreferenceValues<Preferences>();
 function isPro(key: string) {
@@ -89,7 +89,7 @@ async function readClipboard() {
 // Get the text, matching preferences.
 // If selected text is the preferred source, it will try selected text but fallback to clipboard.
 // If clipboard is the preferred source, it will try clipboard but fallback to selected text.
-// Clipboard HTML is included when it is a marked-up rendering of the same visible text.
+// Clipboard HTML is only used when clipboard text is the actual source, never by text matching.
 export async function readContent() {
   const preferredSource = getPreferenceValues<Preferences>().source;
   const clipboard = await readClipboard();
@@ -103,10 +103,7 @@ export async function readContent() {
   }
 
   if (selected) {
-    return {
-      text: selected,
-      html: clipboardMarkupForText(selected, clipboard.text, clipboard.html),
-    };
+    return { text: selected };
   }
 
   return { text: clipboard.text || "", html: clipboard.html };
@@ -146,13 +143,7 @@ export async function sendTranslateRequest({
     const { key, closeRaycastAfterTranslation } = prefs;
     onTranslateAction ??= prefs.onTranslateAction;
 
-    const clipboard = await readClipboard();
-    const source: { text: string; html?: string } = initialText
-      ? {
-          text: initialText,
-          html: clipboardMarkupForText(initialText, clipboard.text, clipboard.html),
-        }
-      : await readContent();
+    const source: { text: string; html?: string } = initialText ? { text: initialText } : await readContent();
     const { text, isHtml } = prepareTranslationPayload(source.text, source.html);
 
     await showToast(Toast.Style.Animated, "Fetching translation...");

--- a/extensions/deepcast/tests/hyperlinks.test.ts
+++ b/extensions/deepcast/tests/hyperlinks.test.ts
@@ -2,15 +2,17 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   containsHtmlHyperlinks,
+  containsHtmlMarkup,
   containsMarkdownHyperlinks,
   extractHtmlFragment,
   htmlLinksToMarkdown,
   htmlToDisplayText,
   htmlToPlainText,
   markdownLinksToHtml,
-  prepareFromClipboardHtml,
+  clipboardMarkupForText,
   prepareFromText,
-  toClipboardHtml,
+  prepareTranslationPayload,
+  toRichClipboardContent,
 } from "../src/hyperlinks.ts";
 
 describe("extractHtmlFragment", () => {
@@ -36,6 +38,12 @@ describe("link detection", () => {
     assert.equal(containsHtmlHyperlinks("see https://x.com"), false);
     assert.equal(containsMarkdownHyperlinks("[x](https://x.com)"), true);
     assert.equal(containsMarkdownHyperlinks("![x](https://x.com/a.png)"), false);
+  });
+
+  it("detects Gmail-style markup without treating autolinks as tags", () => {
+    assert.equal(containsHtmlMarkup(`<div dir="ltr">Hello <a href="https://x.com">x</a></div>`), true);
+    assert.equal(containsHtmlMarkup(`<span style="font-family:Arial">Hi</span>`), true);
+    assert.equal(containsHtmlMarkup("see <https://example.com>"), false);
   });
 });
 
@@ -74,37 +82,69 @@ describe("prepareFromText", () => {
   });
 });
 
-describe("prepareFromClipboardHtml", () => {
-  it("uses clipboard HTML when the plain text matches", () => {
-    const result = prepareFromClipboardHtml(
-      "Visit this site",
-      "Visit this site",
-      `<html><body><!--StartFragment-->Visit <a href="https://example.com">this site</a><!--EndFragment--></body></html>`,
-    );
-    assert.deepEqual(result, {
+describe("prepareTranslationPayload", () => {
+  it("uses source HTML only when it is provided", () => {
+    const html = `<html><body><!--StartFragment-->Visit <a href="https://example.com">this site</a><!--EndFragment--></body></html>`;
+    assert.deepEqual(prepareTranslationPayload("Visit this site", html), {
       text: `Visit <a href="https://example.com">this site</a>`,
       isHtml: true,
     });
   });
 
-  it("falls back to the typed text when clipboard content differs", () => {
-    const result = prepareFromClipboardHtml(
-      "something else [docs](https://example.com)",
-      "Visit this site",
-      `<a href="https://example.com">this site</a>`,
-    );
-    assert.deepEqual(result, {
-      text: `something else <a href="https://example.com">docs</a>`,
+  it("does not apply unrelated HTML when none was provided with the source", () => {
+    assert.deepEqual(prepareTranslationPayload("Visit this site"), {
+      text: "Visit this site",
+      isHtml: false,
+    });
+  });
+
+  it("preserves non-link HTML formatting when it is provided", () => {
+    assert.deepEqual(prepareTranslationPayload("hello", "<p>hello</p>"), {
+      text: "<p>hello</p>",
+      isHtml: true,
+    });
+  });
+
+  it("still converts markdown links in the source text", () => {
+    assert.deepEqual(prepareTranslationPayload("see [docs](https://example.com)"), {
+      text: `see <a href="https://example.com">docs</a>`,
       isHtml: true,
     });
   });
 });
 
-describe("toClipboardHtml", () => {
-  it("wraps fragments in a document", () => {
+describe("clipboardMarkupForText", () => {
+  it("uses clipboard HTML when the pasted text matches", () => {
+    const html = `<html><body><!--StartFragment-->Visit <a href="https://example.com">this site</a><!--EndFragment--></body></html>`;
     assert.equal(
-      toClipboardHtml(`<a href="https://example.com">Docs</a>`),
-      `<html><body><a href="https://example.com">Docs</a></body></html>`,
+      clipboardMarkupForText("Visit this site", "Visit this site", html),
+      `Visit <a href="https://example.com">this site</a>`,
+    );
+  });
+
+  it("uses Gmail-style HTML when clipboard text matches even if wrappers differ", () => {
+    const html = `<html><body><!--StartFragment--><div dir="ltr">Hello <a href="https://example.com">world</a></div><!--EndFragment--></body></html>`;
+    assert.equal(
+      clipboardMarkupForText("Hello world", "Hello world", html),
+      `<div dir="ltr">Hello <a href="https://example.com">world</a></div>`,
+    );
+  });
+
+  it("does not use HTML for different visible text", () => {
+    assert.equal(
+      clipboardMarkupForText("something else", "Visit this site", `<a href="https://example.com">this site</a>`),
+      undefined,
+    );
+  });
+});
+
+describe("toRichClipboardContent", () => {
+  it("publishes an HTML fragment without a plain-text flavor", () => {
+    assert.deepEqual(
+      toRichClipboardContent(
+        `<html><body><!--StartFragment--><a href="https://example.com">Docs</a><!--EndFragment--></body></html>`,
+      ),
+      { html: `<a href="https://example.com">Docs</a>` },
     );
   });
 });

--- a/extensions/deepcast/tests/hyperlinks.test.ts
+++ b/extensions/deepcast/tests/hyperlinks.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  containsHtmlHyperlinks,
+  containsMarkdownHyperlinks,
+  extractHtmlFragment,
+  htmlLinksToMarkdown,
+  htmlToDisplayText,
+  htmlToPlainText,
+  markdownLinksToHtml,
+  prepareFromClipboardHtml,
+  prepareFromText,
+  toClipboardHtml,
+} from "../src/hyperlinks.ts";
+
+describe("extractHtmlFragment", () => {
+  it("prefers the StartFragment block", () => {
+    const html = `<html><body><!--StartFragment-->Visit <a href="https://example.com">this site</a><!--EndFragment--></body></html>`;
+    assert.equal(extractHtmlFragment(html), `Visit <a href="https://example.com">this site</a>`);
+  });
+
+  it("falls back to body content", () => {
+    const html = `<html><body><a href="https://example.com">Docs</a></body></html>`;
+    assert.equal(extractHtmlFragment(html), `<a href="https://example.com">Docs</a>`);
+  });
+
+  it("strips CF_HTML headers", () => {
+    const html = `Version:0.9\nStartHTML:0000\n<html><body><a href="https://a.com">A</a></body></html>`;
+    assert.equal(extractHtmlFragment(html), `<a href="https://a.com">A</a>`);
+  });
+});
+
+describe("link detection", () => {
+  it("detects HTML and markdown hyperlinks", () => {
+    assert.equal(containsHtmlHyperlinks(`see <a href="https://x.com">x</a>`), true);
+    assert.equal(containsHtmlHyperlinks("see https://x.com"), false);
+    assert.equal(containsMarkdownHyperlinks("[x](https://x.com)"), true);
+    assert.equal(containsMarkdownHyperlinks("![x](https://x.com/a.png)"), false);
+  });
+});
+
+describe("markdown and HTML conversion", () => {
+  it("converts markdown links to anchors and back", () => {
+    const markdown = "Read [the docs](https://example.com/docs) please";
+    const html = markdownLinksToHtml(markdown);
+    assert.equal(html, `Read <a href="https://example.com/docs">the docs</a> please`);
+    assert.equal(htmlLinksToMarkdown(html), markdown);
+  });
+
+  it("keeps inner anchor text when stripping tags", () => {
+    const html = `<a href="https://example.com"><strong>Click here</strong></a>`;
+    assert.equal(htmlLinksToMarkdown(html), "[Click here](https://example.com)");
+    assert.equal(htmlToPlainText(html), "Click here");
+    assert.equal(htmlToDisplayText(html), "[Click here](https://example.com)");
+  });
+
+  it("does not convert image markdown", () => {
+    const text = "Logo ![alt](https://example.com/logo.png)";
+    assert.equal(markdownLinksToHtml(text), text);
+  });
+});
+
+describe("prepareFromText", () => {
+  it("enables HTML handling for anchors and markdown links only", () => {
+    assert.deepEqual(prepareFromText("hello"), { text: "hello", isHtml: false });
+    assert.deepEqual(prepareFromText(`see <a href="https://x.com">x</a>`), {
+      text: `see <a href="https://x.com">x</a>`,
+      isHtml: true,
+    });
+    assert.deepEqual(prepareFromText("see [x](https://x.com)"), {
+      text: `see <a href="https://x.com">x</a>`,
+      isHtml: true,
+    });
+  });
+});
+
+describe("prepareFromClipboardHtml", () => {
+  it("uses clipboard HTML when the plain text matches", () => {
+    const result = prepareFromClipboardHtml(
+      "Visit this site",
+      "Visit this site",
+      `<html><body><!--StartFragment-->Visit <a href="https://example.com">this site</a><!--EndFragment--></body></html>`,
+    );
+    assert.deepEqual(result, {
+      text: `Visit <a href="https://example.com">this site</a>`,
+      isHtml: true,
+    });
+  });
+
+  it("falls back to the typed text when clipboard content differs", () => {
+    const result = prepareFromClipboardHtml(
+      "something else [docs](https://example.com)",
+      "Visit this site",
+      `<a href="https://example.com">this site</a>`,
+    );
+    assert.deepEqual(result, {
+      text: `something else <a href="https://example.com">docs</a>`,
+      isHtml: true,
+    });
+  });
+});
+
+describe("toClipboardHtml", () => {
+  it("wraps fragments in a document", () => {
+    assert.equal(
+      toClipboardHtml(`<a href="https://example.com">Docs</a>`),
+      `<html><body><a href="https://example.com">Docs</a></body></html>`,
+    );
+  });
+});

--- a/extensions/deepcast/tests/hyperlinks.test.ts
+++ b/extensions/deepcast/tests/hyperlinks.test.ts
@@ -9,7 +9,6 @@ import {
   htmlToDisplayText,
   htmlToPlainText,
   markdownLinksToHtml,
-  clipboardMarkupForText,
   prepareFromText,
   prepareTranslationPayload,
   toRichClipboardContent,
@@ -98,6 +97,13 @@ describe("prepareTranslationPayload", () => {
     });
   });
 
+  it("does not infer HTML from matching plain text alone", () => {
+    assert.deepEqual(prepareTranslationPayload("Visit this site", undefined), {
+      text: "Visit this site",
+      isHtml: false,
+    });
+  });
+
   it("preserves non-link HTML formatting when it is provided", () => {
     assert.deepEqual(prepareTranslationPayload("hello", "<p>hello</p>"), {
       text: "<p>hello</p>",
@@ -110,31 +116,6 @@ describe("prepareTranslationPayload", () => {
       text: `see <a href="https://example.com">docs</a>`,
       isHtml: true,
     });
-  });
-});
-
-describe("clipboardMarkupForText", () => {
-  it("uses clipboard HTML when the pasted text matches", () => {
-    const html = `<html><body><!--StartFragment-->Visit <a href="https://example.com">this site</a><!--EndFragment--></body></html>`;
-    assert.equal(
-      clipboardMarkupForText("Visit this site", "Visit this site", html),
-      `Visit <a href="https://example.com">this site</a>`,
-    );
-  });
-
-  it("uses Gmail-style HTML when clipboard text matches even if wrappers differ", () => {
-    const html = `<html><body><!--StartFragment--><div dir="ltr">Hello <a href="https://example.com">world</a></div><!--EndFragment--></body></html>`;
-    assert.equal(
-      clipboardMarkupForText("Hello world", "Hello world", html),
-      `<div dir="ltr">Hello <a href="https://example.com">world</a></div>`,
-    );
-  });
-
-  it("does not use HTML for different visible text", () => {
-    assert.equal(
-      clipboardMarkupForText("something else", "Visit this site", `<a href="https://example.com">this site</a>`),
-      undefined,
-    );
   });
 });
 

--- a/extensions/deepcast/tsconfig.json
+++ b/extensions/deepcast/tsconfig.json
@@ -12,6 +12,6 @@
     "forceConsistentCasingInFileNames": true,
     "jsx": "react-jsx",
     "resolveJsonModule": true,
-    "moduleResolution": "Bundler",
+    "moduleResolution": "Bundler"
   }
 }


### PR DESCRIPTION
## Description

Closes https://github.com/raycast/extensions/issues/30120

Deepcast currently sends plain text to DeepL, so copied hyperlinks are dropped. This change:

- Reuses clipboard HTML when it matches the text being translated, and converts markdown links like `[docs](https://example.com)` to anchors
- Sends that markup to DeepL with `tag_handling: html` so link targets survive translation
- Copies and pastes the result as rich HTML, with a plain-text fallback

Plain text without links is unchanged.

## Screencast

N/A. Behaviour change for existing Translate / Translate into … commands.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the README are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

`npm run build`, `npm run lint`, and `npm test` all passed. I have not yet imported the distribution build into Raycast.

## Test plan

- [x] `npm test` in `extensions/deepcast` (11 passing)
- [x] `npm run lint`
- [x] `npm run build`
- [x] Copy linked text from a webpage, run Translate into … with clipboard source, paste into a rich-text app and confirm the link is still clickable
- [x] Paste markdown such as `See [docs](https://example.com)` into Translate and confirm the translated output keeps the URL
- [x] Translate plain text with no links and confirm behaviour is unchanged