### PR TITLE
Update `Vanguard Backup` - mention repo is archived

### DIFF
--- a/extensions/vanguard-backup/CHANGELOG.md
+++ b/extensions/vanguard-backup/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Vanguard Backup Changelog
 
+## [Mention Repository is Archived] - {PR_MERGE_DATE}
+
+- Mention in README that the GitHub repository is archived (ref: [Issue #30244](https://github.com/raycast/extensions/issues/30244))
+
 ## [Initial Version] - 2025-09-24
 
 - Manage **Backup Destinations**

--- a/extensions/vanguard-backup/CHANGELOG.md
+++ b/extensions/vanguard-backup/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Vanguard Backup Changelog
 
-## [Mention Repository is Archived] - {PR_MERGE_DATE}
+## [Mention Repository is Archived] - 2026-08-16
 
 - Mention in README that the GitHub repository is archived (ref: [Issue #30244](https://github.com/raycast/extensions/issues/30244))
 

--- a/extensions/vanguard-backup/README.md
+++ b/extensions/vanguard-backup/README.md
@@ -4,10 +4,13 @@
 
 # Vanguard Backup
 
-This is a Raycast extension for [Vanguard Backup](https://vanguardbackup.com/). With this extension you can:
+This is a Raycast extension for [Vanguard Backup](https://github.com/vanguardbackup/vanguard). With this extension you can:
 - Manage **Backup Destinations**
 - Manage **Backup Tasks**
 - Manage **Remote Servers**
+
+## ⚠️ Warning
+The repository was archived by the owner on Nov 22, 2025. It is now read-only. Use the service at your own risk.
 
 ## 🚀 Getting Started
 
@@ -15,7 +18,7 @@ This is a Raycast extension for [Vanguard Backup](https://vanguardbackup.com/). 
 
 2. **Enter your Vanguard Details**: The first time you use the extension, you'll need to enter the following in Preferences OR at first prompt:
 
-    a. The URL of your Vanguard instance (default: https://app.vanguardbackup.com/)
+    a. The URL of your Vanguard instance
 
     b. API Token from Vanguard Dashboard
 

--- a/extensions/vanguard-backup/package.json
+++ b/extensions/vanguard-backup/package.json
@@ -14,7 +14,6 @@
       "placeholder": "https://app.vanguardbackup.com/",
       "description": "URL of your Vanguard Instance",
       "required": true,
-      "default": "https://app.vanguardbackup.com/",
       "type": "textfield"
     },
     {


### PR DESCRIPTION
## Description

- Mention in README that the GitHub repository is archived (close #30244)

## Screencast

N/A

## Checklist

- [X] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
