### PR TITLE
Update Twos extension - find things by the text in their photos

### DIFF
--- a/extensions/twos/CHANGELOG.md
+++ b/extensions/twos/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Twos Changelog
 
-## [Open results in the desktop app] - 2026-08-15
+## [Photo results and opening in the desktop app] - {PR_MERGE_DATE}
 
+- **Search Things** now finds things by the text inside their photos. A
+  receipt, whiteboard, or screenshot is searchable by what it says.
+- Photo results are labelled with the text read out of the image (or "Photo"
+  when the picture has no readable text) instead of showing as "(empty)", and
+  carry an image icon. **Copy Text** copies what the row displays.
 - **Search Things** now opens results in the NewTwos desktop app when it's
   installed, instead of always going to the browser. Opening a thing lands on
   its list scrolled to that row, and the browser stays available on `⌘↵`.

--- a/extensions/twos/CHANGELOG.md
+++ b/extensions/twos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Twos Changelog
 
-## [Photo results and opening in the desktop app] - {PR_MERGE_DATE}
+## [Photo results and opening in the desktop app] - 2026-08-16
 
 - **Search Things** now finds things by the text inside their photos. A
   receipt, whiteboard, or screenshot is searchable by what it says.

--- a/extensions/twos/package-lock.json
+++ b/extensions/twos/package-lock.json
@@ -18,6 +18,70 @@
         "typescript": "^5.8.2"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.27.7",
       "cpu": [
@@ -27,6 +91,342 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"

--- a/extensions/twos/src/api.ts
+++ b/extensions/twos/src/api.ts
@@ -47,6 +47,14 @@ export interface TwosThing {
   completed: boolean;
   created?: string;
   updated?: string;
+  /** Hosted image URLs attached to this thing. */
+  photos?: string[];
+  /**
+   * Text a vision model read out of `photos` (read-only, server-written).
+   * Search matches on it, so a thing can come back whose own `text` is empty —
+   * use this to label the row instead of rendering it blank.
+   */
+  photo_text?: string;
 }
 
 // Web URL for a list. Passing a thing id appends ?focus=<id>, which the list

--- a/extensions/twos/src/search-things.tsx
+++ b/extensions/twos/src/search-things.tsx
@@ -271,7 +271,7 @@ export default function SearchThings() {
                       ))}
                     {/* Copy whatever the row is actually showing — on a photo-only
                       thing `text` is empty, so copying it silently yielded "". */}
-                    <Action.CopyToClipboard content={thing.text?.trim() || ocr} title="Copy Text" />
+                    <Action.CopyToClipboard content={title} title="Copy Text" />
                     {thing.url ? <Action.OpenInBrowser url={thing.url} title="Open Hyperlink" /> : null}
                   </ActionPanel>
                 }

--- a/extensions/twos/src/search-things.tsx
+++ b/extensions/twos/src/search-things.tsx
@@ -214,49 +214,70 @@ export default function SearchThings() {
       )}
       {thingRows.length > 0 && (
         <List.Section title="Things">
-          {thingRows.map(({ thing, listTitle, urlMatched }) => (
-            <List.Item
-              key={`thing-${thing.id}`}
-              icon={
-                thing.completed
-                  ? { source: Icon.CheckCircle, tintColor: Color.Green }
-                  : thing.type === "todo"
-                    ? Icon.Circle
-                    : Icon.Dot
-              }
-              title={thing.text || "(empty)"}
-              subtitle={listTitle}
-              accessories={[
-                ...(urlMatched ? [{ text: thing.url, icon: Icon.Link }] : []),
-                ...(thing.tags?.map((t) => ({ tag: `#${t}` })) || []),
-              ]}
-              actions={
-                <ActionPanel>
-                  {/* Passing the thing id opens the parent list AND scrolls to
+          {thingRows.map(({ thing, listTitle, urlMatched }) => {
+            // A thing can be JUST a photo — empty `text`. Search matches the text
+            // read out of the image, so those rows come back and rendered as
+            // "(empty)", which looks like a bug rather than a photo. Fall back to
+            // that OCR text, then to a plain "Photo" label when the image has no
+            // legible text (it matched on what the picture depicts instead).
+            const hasPhotos = (thing.photos?.length ?? 0) > 0;
+            const ocr = (thing.photo_text || "").replace(/\s+/g, " ").trim();
+            const title = thing.text?.trim() || ocr || (hasPhotos ? "Photo" : "(empty)");
+            return (
+              <List.Item
+                key={`thing-${thing.id}`}
+                icon={
+                  thing.completed
+                    ? { source: Icon.CheckCircle, tintColor: Color.Green }
+                    : hasPhotos && !thing.text?.trim()
+                      ? Icon.Image
+                      : thing.type === "todo"
+                        ? Icon.Circle
+                        : Icon.Dot
+                }
+                title={title}
+                subtitle={listTitle}
+                accessories={[
+                  ...(urlMatched ? [{ text: thing.url, icon: Icon.Link }] : []),
+                  // Mark rows carrying a photo whose own text is what's displayed,
+                  // so it's clear there's an image behind the result.
+                  ...(hasPhotos && thing.text?.trim() ? [{ icon: Icon.Image }] : []),
+                  ...(thing.tags?.map((t) => ({ tag: `#${t}` })) || []),
+                ]}
+                actions={
+                  <ActionPanel>
+                    {/* Passing the thing id opens the parent list AND scrolls to
                       + flashes this exact row, in the app or the browser. */}
-                  <OpenActions
-                    listId={thing.list_id}
-                    thingId={thing.id}
-                    target={target}
-                    app={app}
-                    browserTitle="Open in Browser"
-                  />
-                  {thing.type === "todo" &&
-                    (thing.completed ? (
-                      <Action title="Mark Incomplete" icon={Icon.Circle} onAction={() => setCompleted(thing, false)} />
-                    ) : (
-                      <Action
-                        title="Mark Complete"
-                        icon={Icon.CheckCircle}
-                        onAction={() => setCompleted(thing, true)}
-                      />
-                    ))}
-                  <Action.CopyToClipboard content={thing.text} title="Copy Text" />
-                  {thing.url ? <Action.OpenInBrowser url={thing.url} title="Open Hyperlink" /> : null}
-                </ActionPanel>
-              }
-            />
-          ))}
+                    <OpenActions
+                      listId={thing.list_id}
+                      thingId={thing.id}
+                      target={target}
+                      app={app}
+                      browserTitle="Open in Browser"
+                    />
+                    {thing.type === "todo" &&
+                      (thing.completed ? (
+                        <Action
+                          title="Mark Incomplete"
+                          icon={Icon.Circle}
+                          onAction={() => setCompleted(thing, false)}
+                        />
+                      ) : (
+                        <Action
+                          title="Mark Complete"
+                          icon={Icon.CheckCircle}
+                          onAction={() => setCompleted(thing, true)}
+                        />
+                      ))}
+                    {/* Copy whatever the row is actually showing — on a photo-only
+                      thing `text` is empty, so copying it silently yielded "". */}
+                    <Action.CopyToClipboard content={thing.text?.trim() || ocr} title="Copy Text" />
+                    {thing.url ? <Action.OpenInBrowser url={thing.url} title="Open Hyperlink" /> : null}
+                  </ActionPanel>
+                }
+              />
+            );
+          })}
         </List.Section>
       )}
       {!loading && rows.length === 0 && (


### PR DESCRIPTION
## Description

**Search Things** now matches text read out of a thing's photos, so a receipt, whiteboard, or screenshot is findable by what it says. The Twos API exposes this as a new read-only `photo_text` field on a thing.

A thing can be *just* a photo, with empty `text`. Those results already came back from search but rendered as "(empty)", which looked like a bug. They now show the extracted text, or a "Photo" label when the image has no readable text, and carry an image icon. **Copy Text** copies what the row displays instead of an empty string.

## Screencast

No UI structure changed — same list, same actions. Only the title/icon/accessory of a photo-backed result differ.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder