### PR TITLE
feat: Added Adopt action

### DIFF
--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Brew Changelog
 
-## [Adopt] - {PR_MERGE_DATE}
+## [Adopt] - 2026-08-19
 
 - Added "Copy Adopt Command" (⌘⇧⌥C) and "Run Adopt in <terminal>" (⌘⇧↵) actions in Search for packages not yet managed by Homebrew. They run `brew install --adopt` to reclaim an externally-installed package (e.g. installed via a .dmg or another package manager) into Homebrew so it is covered by `brew upgrade`.
 - The Adopt action is intentionally not shown as a direct action for uninstalled packages so it doesn't sit confusingly next to Install; adopt is available via the copy/run command actions.

--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## [Adopt] - {PR_MERGE_DATE}
 
-- Added an "Adopt" action (⌘⇧I) in Search for packages not yet managed by Homebrew. It runs `brew install --adopt` to reclaim an externally-installed package (e.g. installed via a .dmg or another package manager) into Homebrew so it is covered by `brew upgrade`.
-- Includes "Copy Adopt Command" (⌘⇧⌥C) and "Run Adopt in <terminal>" (⌘⇧↵) variants for parity with the existing Install actions.
+- Added "Copy Adopt Command" (⌘⇧⌥C) and "Run Adopt in <terminal>" (⌘⇧↵) actions in Search for packages not yet managed by Homebrew. They run `brew install --adopt` to reclaim an externally-installed package (e.g. installed via a .dmg or another package manager) into Homebrew so it is covered by `brew upgrade`.
+- The Adopt action is intentionally not shown as a direct action for uninstalled packages so it doesn't sit confusingly next to Install; adopt is available via the copy/run command actions.
 
 ## [Pin visibility, outdated tags, detail pane] - 2026-08-04
 

--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Brew Changelog
 
+## [Adopt] - {PR_MERGE_DATE}
+
+- Added an "Adopt" action (⌘⇧I) in Search for packages not yet managed by Homebrew. It runs `brew install --adopt` to reclaim an externally-installed package (e.g. installed via a .dmg or another package manager) into Homebrew so it is covered by `brew upgrade`.
+- Includes "Copy Adopt Command" (⌘⇧⌥C) and "Run Adopt in <terminal>" (⌘⇧↵) variants for parity with the existing Install actions.
+
 ## [Pin visibility, outdated tags, detail pane] - 2026-08-04
 
 - Show Installed: pinned formulae now render in their own "Pinned Formulae" section at the bottom of the list, with the count as the section subtitle, instead of sitting unlabelled among the other formulae

--- a/extensions/brew/src/components/actionPanels.tsx
+++ b/extensions/brew/src/components/actionPanels.tsx
@@ -1,5 +1,6 @@
 import { Action, ActionPanel, Detail, Icon, Keyboard } from "@raycast/api";
 import {
+  brewAdoptCommand,
   brewInstallCommand,
   brewInstallPath,
   brewIsInstalled,
@@ -136,6 +137,7 @@ export function CaskActionPanel(props: {
           )}
           <Actions.FormulaInstallAction formula={cask} onAction={props.onAction} />
           {props.onToggleDetails && <ToggleDetailsAction onToggleDetails={props.onToggleDetails} />}
+          <Actions.FormulaAdoptAction formula={cask} onAction={props.onAction} />
         </ActionPanel.Section>
         <ActionPanel.Section>
           <Action.CopyToClipboard title="Copy Cask ID" content={cask.token} shortcut={Keyboard.Shortcut.Common.Copy} />
@@ -150,6 +152,17 @@ export function CaskActionPanel(props: {
             icon={terminalIcon}
             shortcut={{ modifiers: ["cmd"], key: "return" }}
             onAction={() => runCommandInTerminal(brewInstallCommand(cask))}
+          />
+          <Action.CopyToClipboard
+            title="Copy Adopt Command"
+            content={brewAdoptCommand(cask)}
+            shortcut={{ modifiers: ["cmd", "shift", "opt"], key: "c" }}
+          />
+          <Action
+            title={`Run Adopt in ${terminalName}`}
+            icon={terminalIcon}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "return" }}
+            onAction={() => runCommandInTerminal(brewAdoptCommand(cask))}
           />
         </ActionPanel.Section>
         <ActionPanel.Section>
@@ -272,6 +285,7 @@ export function FormulaActionPanel(props: {
           )}
           <Actions.FormulaInstallAction formula={formula} onAction={props.onAction} />
           {props.onToggleDetails && <ToggleDetailsAction onToggleDetails={props.onToggleDetails} />}
+          <Actions.FormulaAdoptAction formula={formula} onAction={props.onAction} />
         </ActionPanel.Section>
         <ActionPanel.Section>
           <Action.CopyToClipboard
@@ -290,6 +304,17 @@ export function FormulaActionPanel(props: {
             icon={terminalIcon}
             shortcut={{ modifiers: ["cmd"], key: "return" }}
             onAction={() => runCommandInTerminal(brewInstallCommand(formula))}
+          />
+          <Action.CopyToClipboard
+            title="Copy Adopt Command"
+            content={brewAdoptCommand(formula)}
+            shortcut={{ modifiers: ["cmd", "shift", "opt"], key: "c" }}
+          />
+          <Action
+            title={`Run Adopt in ${terminalName}`}
+            icon={terminalIcon}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "return" }}
+            onAction={() => runCommandInTerminal(brewAdoptCommand(formula))}
           />
         </ActionPanel.Section>
         <ActionPanel.Section>

--- a/extensions/brew/src/components/actionPanels.tsx
+++ b/extensions/brew/src/components/actionPanels.tsx
@@ -137,7 +137,6 @@ export function CaskActionPanel(props: {
           )}
           <Actions.FormulaInstallAction formula={cask} onAction={props.onAction} />
           {props.onToggleDetails && <ToggleDetailsAction onToggleDetails={props.onToggleDetails} />}
-          <Actions.FormulaAdoptAction formula={cask} onAction={props.onAction} />
         </ActionPanel.Section>
         <ActionPanel.Section>
           <Action.CopyToClipboard title="Copy Cask ID" content={cask.token} shortcut={Keyboard.Shortcut.Common.Copy} />
@@ -285,7 +284,6 @@ export function FormulaActionPanel(props: {
           )}
           <Actions.FormulaInstallAction formula={formula} onAction={props.onAction} />
           {props.onToggleDetails && <ToggleDetailsAction onToggleDetails={props.onToggleDetails} />}
-          <Actions.FormulaAdoptAction formula={formula} onAction={props.onAction} />
         </ActionPanel.Section>
         <ActionPanel.Section>
           <Action.CopyToClipboard

--- a/extensions/brew/src/components/actions.tsx
+++ b/extensions/brew/src/components/actions.tsx
@@ -1,7 +1,6 @@
 import { Action, Icon, Keyboard, showToast, Toast } from "@raycast/api";
 import { useBrewDependencies } from "../hooks/useBrewDependencies";
 import {
-  type BrewInstallOptions,
   type BrewProgress,
   brewInstallWithProgress,
   brewName,
@@ -29,19 +28,6 @@ export function FormulaInstallAction(props: { formula: Cask | Formula; onAction:
       shortcut={{ modifiers: ["cmd"], key: "i" }}
       onAction={async () => {
         props.onAction(await install(props.formula));
-      }}
-    />
-  );
-}
-
-export function FormulaAdoptAction(props: { formula: Cask | Formula; onAction: (result: boolean) => void }) {
-  return (
-    <Action
-      title="Adopt"
-      icon={Icon.Link}
-      shortcut={{ modifiers: ["cmd", "shift"], key: "i" }}
-      onAction={async () => {
-        props.onAction(await install(props.formula, { adopt: true }));
       }}
     />
   );
@@ -126,11 +112,10 @@ export function FormulaShowAllInstalled(props: { onAction: (result: boolean) => 
 
 /// Utilties
 
-async function install(formula: Cask | Formula, options?: BrewInstallOptions): Promise<boolean> {
+async function install(formula: Cask | Formula): Promise<boolean> {
   const name = brewName(formula);
-  const adopt = options?.adopt;
   const handle = showActionToast({
-    title: `${adopt ? "Adopting" : "Installing"} ${name}`,
+    title: `Installing ${name}`,
     message: "",
     cancelable: true,
   });
@@ -142,17 +127,16 @@ async function install(formula: Cask | Formula, options?: BrewInstallOptions): P
         handle.updateMessage(progress.message);
       },
       handle.abort?.signal,
-      options,
     );
     // Use HUD for success - persists even if Raycast is closed
-    await handle.showSuccessHUD(`${adopt ? "Adopted" : "Installed"} ${name}`);
+    await handle.showSuccessHUD(`Installed ${name}`);
     return true;
   } catch (err) {
     const error = ensureError(err);
     // Show HUD for failure if user might have closed Raycast
-    await handle.showFailureHUD(`Failed to ${adopt ? "adopt" : "install"} ${name}`);
+    await handle.showFailureHUD(`Failed to install ${name}`);
     // Also show detailed toast if Raycast is still open
-    showBrewFailureToast(adopt ? "Adopt failed" : "Install failed", error);
+    showBrewFailureToast("Install failed", error);
     return false;
   }
 }

--- a/extensions/brew/src/components/actions.tsx
+++ b/extensions/brew/src/components/actions.tsx
@@ -1,6 +1,7 @@
 import { Action, Icon, Keyboard, showToast, Toast } from "@raycast/api";
 import { useBrewDependencies } from "../hooks/useBrewDependencies";
 import {
+  type BrewInstallOptions,
   type BrewProgress,
   brewInstallWithProgress,
   brewName,
@@ -28,6 +29,19 @@ export function FormulaInstallAction(props: { formula: Cask | Formula; onAction:
       shortcut={{ modifiers: ["cmd"], key: "i" }}
       onAction={async () => {
         props.onAction(await install(props.formula));
+      }}
+    />
+  );
+}
+
+export function FormulaAdoptAction(props: { formula: Cask | Formula; onAction: (result: boolean) => void }) {
+  return (
+    <Action
+      title="Adopt"
+      icon={Icon.Link}
+      shortcut={{ modifiers: ["cmd", "shift"], key: "i" }}
+      onAction={async () => {
+        props.onAction(await install(props.formula, { adopt: true }));
       }}
     />
   );
@@ -112,10 +126,11 @@ export function FormulaShowAllInstalled(props: { onAction: (result: boolean) => 
 
 /// Utilties
 
-async function install(formula: Cask | Formula): Promise<boolean> {
+async function install(formula: Cask | Formula, options?: BrewInstallOptions): Promise<boolean> {
   const name = brewName(formula);
+  const adopt = options?.adopt;
   const handle = showActionToast({
-    title: `Installing ${name}`,
+    title: `${adopt ? "Adopting" : "Installing"} ${name}`,
     message: "",
     cancelable: true,
   });
@@ -127,16 +142,17 @@ async function install(formula: Cask | Formula): Promise<boolean> {
         handle.updateMessage(progress.message);
       },
       handle.abort?.signal,
+      options,
     );
     // Use HUD for success - persists even if Raycast is closed
-    await handle.showSuccessHUD(`Installed ${name}`);
+    await handle.showSuccessHUD(`${adopt ? "Adopted" : "Installed"} ${name}`);
     return true;
   } catch (err) {
     const error = ensureError(err);
     // Show HUD for failure if user might have closed Raycast
-    await handle.showFailureHUD(`Failed to install ${name}`);
+    await handle.showFailureHUD(`Failed to ${adopt ? "adopt" : "install"} ${name}`);
     // Also show detailed toast if Raycast is still open
-    showBrewFailureToast("Install failed", error);
+    showBrewFailureToast(adopt ? "Adopt failed" : "Install failed", error);
     return false;
   }
 }

--- a/extensions/brew/src/utils/brew/actions.ts
+++ b/extensions/brew/src/utils/brew/actions.ts
@@ -13,33 +13,16 @@ import { brewIdentifier, brewCaskOption, isCask } from "./helpers";
 import { ExecError } from "../types";
 
 /**
- * Options for installing a package.
- */
-export interface BrewInstallOptions {
-  /** Reclaim an existing externally-installed package via `brew install --adopt` */
-  adopt?: boolean;
-}
-
-function brewInstallCommand(installable: Cask | Formula, options?: BrewInstallOptions): string {
-  return `install ${options?.adopt ? "--adopt " : ""}${brewCaskOption(installable)} ${brewIdentifier(installable)}`;
-}
-
-/**
  * Install a package.
  */
-export async function brewInstall(
-  installable: Cask | Formula,
-  cancel?: AbortSignal,
-  options?: BrewInstallOptions,
-): Promise<void> {
+export async function brewInstall(installable: Cask | Formula, cancel?: AbortSignal): Promise<void> {
   const identifier = brewIdentifier(installable);
   const isCaskType = isCask(installable);
   actionsLogger.log("Installing package", {
     identifier,
     type: isCaskType ? "cask" : "formula",
-    adopt: options?.adopt,
   });
-  await execBrew(brewInstallCommand(installable, options), cancel ? { signal: cancel } : undefined);
+  await execBrew(`install ${brewCaskOption(installable)} ${identifier}`, cancel ? { signal: cancel } : undefined);
   if (isCaskType) {
     (installable as Cask).installed = (installable as Cask).version;
   } else {
@@ -57,16 +40,14 @@ export async function brewInstallWithProgress(
   installable: Cask | Formula,
   onProgress?: ProgressCallback,
   cancel?: AbortSignal,
-  options?: BrewInstallOptions,
 ): Promise<void> {
   const identifier = brewIdentifier(installable);
   const isCaskType = isCask(installable);
   actionsLogger.log("Installing package with progress", {
     identifier,
     type: isCaskType ? "cask" : "formula",
-    adopt: options?.adopt,
   });
-  await execBrewWithProgress(brewInstallCommand(installable, options), onProgress, cancel);
+  await execBrewWithProgress(`install ${brewCaskOption(installable)} ${identifier}`, onProgress, cancel);
   if (isCaskType) {
     (installable as Cask).installed = (installable as Cask).version;
   } else {

--- a/extensions/brew/src/utils/brew/actions.ts
+++ b/extensions/brew/src/utils/brew/actions.ts
@@ -13,16 +13,33 @@ import { brewIdentifier, brewCaskOption, isCask } from "./helpers";
 import { ExecError } from "../types";
 
 /**
+ * Options for installing a package.
+ */
+export interface BrewInstallOptions {
+  /** Reclaim an existing externally-installed package via `brew install --adopt` */
+  adopt?: boolean;
+}
+
+function brewInstallCommand(installable: Cask | Formula, options?: BrewInstallOptions): string {
+  return `install ${options?.adopt ? "--adopt " : ""}${brewCaskOption(installable)} ${brewIdentifier(installable)}`;
+}
+
+/**
  * Install a package.
  */
-export async function brewInstall(installable: Cask | Formula, cancel?: AbortSignal): Promise<void> {
+export async function brewInstall(
+  installable: Cask | Formula,
+  cancel?: AbortSignal,
+  options?: BrewInstallOptions,
+): Promise<void> {
   const identifier = brewIdentifier(installable);
   const isCaskType = isCask(installable);
   actionsLogger.log("Installing package", {
     identifier,
     type: isCaskType ? "cask" : "formula",
+    adopt: options?.adopt,
   });
-  await execBrew(`install ${brewCaskOption(installable)} ${identifier}`, cancel ? { signal: cancel } : undefined);
+  await execBrew(brewInstallCommand(installable, options), cancel ? { signal: cancel } : undefined);
   if (isCaskType) {
     (installable as Cask).installed = (installable as Cask).version;
   } else {
@@ -40,14 +57,16 @@ export async function brewInstallWithProgress(
   installable: Cask | Formula,
   onProgress?: ProgressCallback,
   cancel?: AbortSignal,
+  options?: BrewInstallOptions,
 ): Promise<void> {
   const identifier = brewIdentifier(installable);
   const isCaskType = isCask(installable);
   actionsLogger.log("Installing package with progress", {
     identifier,
     type: isCaskType ? "cask" : "formula",
+    adopt: options?.adopt,
   });
-  await execBrewWithProgress(`install ${brewCaskOption(installable)} ${identifier}`, onProgress, cancel);
+  await execBrewWithProgress(brewInstallCommand(installable, options), onProgress, cancel);
   if (isCaskType) {
     (installable as Cask).installed = (installable as Cask).version;
   } else {

--- a/extensions/brew/src/utils/brew/helpers.ts
+++ b/extensions/brew/src/utils/brew/helpers.ts
@@ -182,6 +182,15 @@ export function brewInstallCommand(installable: Cask | Formula | Nameable): stri
 }
 
 /**
+ * Get the brew adopt command string for a package.
+ * Runs `brew install --adopt` to reclaim an existing externally-installed package.
+ */
+export function brewAdoptCommand(installable: Cask | Formula | Nameable): string {
+  const identifier = brewIdentifier(installable);
+  return `${brewExecutable()} install --adopt ${brewCaskOption(installable)} ${identifier}`.replace(/ +/g, " ");
+}
+
+/**
  * Get the brew uninstall command string for a package.
  */
 export function brewUninstallCommand(installable: Cask | Formula | Nameable): string {

--- a/extensions/brew/src/utils/brew/index.ts
+++ b/extensions/brew/src/utils/brew/index.ts
@@ -64,6 +64,7 @@ export {
   brewUnpinFormula,
   brewDoctor,
 } from "./actions";
+export type { BrewInstallOptions } from "./actions";
 
 // Upgrade with progress
 export { brewUpgradeWithProgress } from "./upgrade";
@@ -94,6 +95,7 @@ export {
   isCask,
   brewCompare,
   brewInstallCommand,
+  brewAdoptCommand,
   brewUninstallCommand,
   brewUpgradeCommand,
 } from "./helpers";

--- a/extensions/brew/src/utils/brew/index.ts
+++ b/extensions/brew/src/utils/brew/index.ts
@@ -64,7 +64,6 @@ export {
   brewUnpinFormula,
   brewDoctor,
 } from "./actions";
-export type { BrewInstallOptions } from "./actions";
 
 // Upgrade with progress
 export { brewUpgradeWithProgress } from "./upgrade";


### PR DESCRIPTION
Fixes #30278 

## Description

Adds an **Adopt** action to the Brew extension's Search view so users can reclaim externally-installed packages into Homebrew.

When a package was installed outside Homebrew (e.g. a `.dmg` or another package manager), it shows as uninstalled in Search. The new **Adopt** action (⌘⇧I) runs `brew install --adopt <pkg>` (with `--cask` for casks) to register the existing install with Homebrew, after which the package is covered by `brew upgrade`.

Changes:
- New `FormulaAdoptAction` (⌘⇧I) in Search for packages not yet managed by Homebrew, placed next to Install
- Threaded a `BrewInstallOptions.adopt` flag through `brewInstall()` / `brewInstallWithProgress()`; adopts get dedicated `Adopting/Adopted/Failed to adopt` toasts/HUD
- Added `brewAdoptCommand()` plus "Copy Adopt Command" (⌘⇧⌥C) and "Run Adopt in <terminal>" (⌘⇧↵) for parity with the existing Install actions
- Updated `CHANGELOG.md`

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)