### PR TITLE
fix(spotify-player): limit liked songs library fetch

### DIFF
--- a/extensions/spotify-player/CHANGELOG.md
+++ b/extensions/spotify-player/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Spotify Player Changelog
 
+## [Fix Your Library Memory Usage] - {PR_MERGE_DATE}
+
+- Load only liked songs when rendering the liked songs entry instead of fetching every library category.
+
 ## [Copy Embed Code Action] - 2026-07-10
 
 - Add a "Copy Embed Code" action to the action panel and the menu bar

--- a/extensions/spotify-player/CHANGELOG.md
+++ b/extensions/spotify-player/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Spotify Player Changelog
 
-## [Fix Your Library Memory Usage] - {PR_MERGE_DATE}
+## [Fix Your Library Memory Usage] - 2026-08-16
 
 - Load only liked songs when rendering the liked songs entry instead of fetching every library category.
 

--- a/extensions/spotify-player/src/components/PlaylistLikedTracksItem.tsx
+++ b/extensions/spotify-player/src/components/PlaylistLikedTracksItem.tsx
@@ -17,6 +17,7 @@ export default function PlaylistLikedTracksItem({ type }: PlaylistLikedTracksIte
   const icon: Image.ImageLike = { source: "https://misc.scdn.co/liked-songs/liked-songs-64.png" };
   const uri = `spotify:user:${meData?.id}:collection`;
   const { myLibraryData } = useYourLibrary({
+    category: "tracks",
     keepPreviousData: true,
   });
 


### PR DESCRIPTION
## Summary

I noticed that the liked songs entry calls `useYourLibrary()` without selecting a category. Since the hook defaults to `all`, opening the Your Library command can fetch unrelated library categories again even though this component only needs tracks.

I changed the component to request the `tracks` category explicitly. This keeps the visible behavior the same while avoiding unnecessary library data and reducing the chance of contributing to the extension's 100 MB heap failures.

## Validation

- `npm run lint --prefix extensions/spotify-player`
- `npm run build --prefix extensions/spotify-player`

I have not been able to reproduce the memory-limit crash locally, so I kept this change intentionally small and limited to the redundant library fetch.

Related issue: #30218

Related reports: #27607, #23405
