### PR TITLE
Add Windows support for Mozilla Firefox extension

### DIFF
--- a/extensions/mozilla-firefox/CHANGELOG.md
+++ b/extensions/mozilla-firefox/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Mozilla Firefox Changelog
 
+## [Windows Support] - {PR_MERGE_DATE}
+
+- Added Windows support for all three commands: New Tab, Search History, Search Bookmarks
+- Firefox profile directory is resolved from `%APPDATA%\Mozilla\Firefox\Profiles` on Windows
+- URLs and new tabs are opened by spawning the Firefox executable directly via `child_process.spawn` on Windows
+- All Firefox variants (Firefox, Firefox Nightly, Firefox ESR, Firefox Developer Edition) are supported on Windows via known install path detection with automatic fallback to PATH
+- "Install with Winget" action replaces "Install with Homebrew" when Firefox is not detected on Windows
+
 ## [1.0.1] - 2026-04-23
 
 ### What's Changed

--- a/extensions/mozilla-firefox/CHANGELOG.md
+++ b/extensions/mozilla-firefox/CHANGELOG.md
@@ -5,8 +5,9 @@
 - Added Windows support for all three commands: New Tab, Search History, Search Bookmarks
 - Firefox profile directory is resolved from `%APPDATA%\Mozilla\Firefox\Profiles` on Windows
 - URLs and new tabs are opened by spawning the Firefox executable directly via `child_process.spawn` on Windows
-- All Firefox variants (Firefox, Firefox Nightly, Firefox ESR, Firefox Developer Edition) are supported on Windows via known install path detection with automatic fallback to PATH
-- "Install with Winget" action replaces "Install with Homebrew" when Firefox is not detected on Windows
+- All Firefox variants (Firefox, Firefox Nightly, Firefox ESR, Firefox Developer Edition) are supported on Windows via known install path detection with automatic fallback to PATH for release Firefox
+- Non-release variants (Firefox Nightly, Firefox ESR, Firefox Developer Edition) no longer silently fall back to launching release Firefox when not detected at their known install location; an actionable error is shown instead
+- "Install with Winget" action replaces "Install with Homebrew" when Firefox is not detected on Windows, with a longer timeout to accommodate the install
 
 ## [1.0.1] - 2026-04-23
 

--- a/extensions/mozilla-firefox/CHANGELOG.md
+++ b/extensions/mozilla-firefox/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Mozilla Firefox Changelog
 
-## [Windows Support] - {PR_MERGE_DATE}
+## [Windows Support] - 2026-09-09
 
 - Added Windows support for all three commands: New Tab, Search History, Search Bookmarks
 - Firefox profile directory is resolved from `%APPDATA%\Mozilla\Firefox\Profiles` on Windows

--- a/extensions/mozilla-firefox/README.md
+++ b/extensions/mozilla-firefox/README.md
@@ -9,6 +9,6 @@ New Tab search can be configured to search from the following sources:
 - Brave
 - Baidu
 
-Limitations (due to limited AppleScript support in Firefox):
+Limitations on macOS (due to limited AppleScript support in Firefox):
 - When searching open tabs, the session file is read and parsed to get the list of open tabs. This means that the list of open tabs will not be updated until the session file is updated. This is done by Firefox when it checkpoints itself or when Firefox is closed.
 - Selecting an open tab will result in cycling through open tabs until desired tab. This is due to the fact that AppleScript does not support opening a specific tab in Firefox.

--- a/extensions/mozilla-firefox/package-lock.json
+++ b/extensions/mozilla-firefox/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "mozilla-firefox",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mozilla-firefox",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.104.12",
@@ -1290,9 +1292,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1310,9 +1309,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1330,9 +1326,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1350,9 +1343,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1370,9 +1360,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1390,9 +1377,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3002,9 +2986,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3026,9 +3007,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3050,9 +3028,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3074,9 +3049,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/extensions/mozilla-firefox/package.json
+++ b/extensions/mozilla-firefox/package.json
@@ -9,7 +9,8 @@
   "contributors": [
     "serhii_kravchenko",
     "Laptop765",
-    "kud"
+    "kud",
+    "BryanG02"
   ],
   "categories": [
     "Applications",
@@ -132,6 +133,7 @@
     "test:run": "vitest run"
   },
   "platforms": [
-    "macOS"
+    "macOS",
+    "Windows"
   ]
 }

--- a/extensions/mozilla-firefox/src/actions/__tests__/index.test.ts
+++ b/extensions/mozilla-firefox/src/actions/__tests__/index.test.ts
@@ -1,0 +1,147 @@
+import { EventEmitter } from "events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@raycast/api", () => ({
+  getPreferenceValues: vi.fn(() => ({ browserApp: "Firefox", searchEngine: "Google" })),
+  popToRoot: vi.fn(),
+  closeMainWindow: vi.fn(),
+  showToast: vi.fn(),
+  Toast: { Style: { Failure: "FAILURE" } },
+}));
+
+vi.mock("fs", () => ({
+  existsSync: vi.fn(),
+}));
+
+vi.mock("child_process", () => ({
+  exec: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+import { getPreferenceValues, showToast } from "@raycast/api";
+import { existsSync } from "fs";
+import { spawn } from "child_process";
+
+// Import after the mocks are in place so the module under test picks them up.
+import { openNewTab } from "../index";
+
+const setBrowserApp = (browserApp: string) =>
+  vi.mocked(getPreferenceValues).mockReturnValue({ browserApp, searchEngine: "Google" });
+
+// Makes existsSync resolve `true` only for the given set of paths.
+const mockExistingPaths = (existingPaths: string[]) =>
+  vi.mocked(existsSync).mockImplementation((candidate) => existingPaths.includes(String(candidate)));
+
+// Simulates a Firefox process that spawns successfully.
+const mockSpawnSuccess = () =>
+  vi.mocked(spawn).mockImplementation(() => {
+    const child = new EventEmitter() as never;
+    (child as { unref: () => void }).unref = vi.fn();
+    queueMicrotask(() => (child as EventEmitter).emit("spawn"));
+    return child;
+  });
+
+describe("launchFirefox on Windows (via openNewTab)", () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    vi.clearAllMocks();
+  });
+
+  it("spawns the release Firefox executable when found at a known install path", async () => {
+    setBrowserApp("Firefox");
+    mockExistingPaths(["C:\\Program Files\\Mozilla Firefox\\firefox.exe"]);
+    mockSpawnSuccess();
+
+    const result = await openNewTab(null);
+
+    expect(result).toBe("success");
+    expect(spawn).toHaveBeenCalledWith(
+      "C:\\Program Files\\Mozilla Firefox\\firefox.exe",
+      expect.any(Array),
+      expect.anything(),
+    );
+  });
+
+  it("falls back to the bare firefox.exe (PATH) for release Firefox when not found at known paths", async () => {
+    setBrowserApp("Firefox");
+    mockExistingPaths([]);
+    mockSpawnSuccess();
+
+    const result = await openNewTab(null);
+
+    expect(result).toBe("success");
+    expect(spawn).toHaveBeenCalledWith("firefox.exe", expect.any(Array), expect.anything());
+  });
+
+  it("spawns the Firefox Nightly executable when found at its known install path", async () => {
+    setBrowserApp("Firefox Nightly");
+    mockExistingPaths(["C:\\Program Files\\Firefox Nightly\\firefox.exe"]);
+    mockSpawnSuccess();
+
+    const result = await openNewTab(null);
+
+    expect(result).toBe("success");
+    expect(spawn).toHaveBeenCalledWith(
+      "C:\\Program Files\\Firefox Nightly\\firefox.exe",
+      expect.any(Array),
+      expect.anything(),
+    );
+  });
+
+  it("does not fall back to firefox.exe and shows an actionable error when Nightly is not found", async () => {
+    setBrowserApp("Firefox Nightly");
+    mockExistingPaths([]);
+    mockSpawnSuccess();
+
+    const result = await openNewTab(null);
+
+    expect(result).toBe("error");
+    expect(spawn).not.toHaveBeenCalled();
+    expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        style: "FAILURE",
+        message: expect.stringContaining("Firefox Nightly"),
+      }),
+    );
+  });
+
+  it("does not fall back to firefox.exe and shows an actionable error when ESR is not found", async () => {
+    setBrowserApp("Firefox ESR");
+    mockExistingPaths([]);
+    mockSpawnSuccess();
+
+    const result = await openNewTab(null);
+
+    expect(result).toBe("error");
+    expect(spawn).not.toHaveBeenCalled();
+    expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        style: "FAILURE",
+        message: expect.stringContaining("Firefox ESR"),
+      }),
+    );
+  });
+
+  it("does not fall back to firefox.exe and shows an actionable error when Developer Edition is not found", async () => {
+    setBrowserApp("Firefox Developer Edition");
+    mockExistingPaths([]);
+    mockSpawnSuccess();
+
+    const result = await openNewTab(null);
+
+    expect(result).toBe("error");
+    expect(spawn).not.toHaveBeenCalled();
+    expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        style: "FAILURE",
+        message: expect.stringContaining("Firefox Developer Edition"),
+      }),
+    );
+  });
+});

--- a/extensions/mozilla-firefox/src/actions/index.ts
+++ b/extensions/mozilla-firefox/src/actions/index.ts
@@ -1,52 +1,99 @@
-import { closeMainWindow, getPreferenceValues, popToRoot } from "@raycast/api";
-import { exec } from "child_process";
+import { closeMainWindow, getPreferenceValues, popToRoot, showToast, Toast } from "@raycast/api";
+import { exec, spawn } from "child_process";
+import { existsSync } from "fs";
 import { promisify } from "util";
 import { Preferences, Tab } from "../interfaces";
 import { SEARCH_ENGINE } from "../constants";
 
 const execAsync = promisify(exec);
 
-export async function openNewTab(queryText: string | null | undefined): Promise<boolean | string> {
-  popToRoot();
-  closeMainWindow({ clearRootSearch: true });
+const WINDOWS_FIREFOX_PATHS: Record<string, string[]> = {
+  Firefox: ["C:\\Program Files\\Mozilla Firefox\\firefox.exe", "C:\\Program Files (x86)\\Mozilla Firefox\\firefox.exe"],
+  "Firefox Nightly": [
+    "C:\\Program Files\\Firefox Nightly\\firefox.exe",
+    "C:\\Program Files (x86)\\Firefox Nightly\\firefox.exe",
+  ],
+  "Firefox ESR": [
+    "C:\\Program Files\\Mozilla Firefox ESR\\firefox.exe",
+    "C:\\Program Files (x86)\\Mozilla Firefox ESR\\firefox.exe",
+  ],
+  "Firefox Developer Edition": [
+    "C:\\Program Files\\Firefox Developer Edition\\firefox.exe",
+    "C:\\Program Files (x86)\\Firefox Developer Edition\\firefox.exe",
+  ],
+};
 
-  const preferences = getPreferenceValues<Preferences>();
-  const browserApp = preferences.browserApp || "Firefox";
+function getWindowsFirefoxExe(browserApp: string): string {
+  const candidates = WINDOWS_FIREFOX_PATHS[browserApp] ?? WINDOWS_FIREFOX_PATHS["Firefox"];
+  return candidates.find(existsSync) ?? "firefox.exe";
+}
 
-  if (queryText) {
-    const searchEngine = preferences.searchEngine?.toLowerCase() || "google";
-    const searchUrl = SEARCH_ENGINE[searchEngine] || SEARCH_ENGINE["google"];
-    const fullUrl = `${searchUrl}${encodeURIComponent(queryText)}`;
-    const command = `open -a "${browserApp}" "${fullUrl}"`;
+/**
+ * Spawns Firefox as a detached, independent process on Windows.
+ * Resolves once the child process has started successfully, or rejects
+ * with a descriptive error if the executable cannot be launched.
+ */
+function spawnFirefoxWindows(exe: string, url: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(exe, [url], { detached: true, stdio: "ignore" });
+    child.once("spawn", () => {
+      child.unref(); // let Firefox live independently of the Raycast process
+      resolve();
+    });
+    child.once("error", reject);
+  });
+}
 
-    const { stdout } = await execAsync(command);
-    return stdout || "success";
+/**
+ * Opens a URL in the configured Firefox variant, handling both Windows and macOS.
+ */
+async function launchFirefox(url: string, browserApp: string): Promise<void> {
+  if (process.platform === "win32") {
+    await spawnFirefoxWindows(getWindowsFirefoxExe(browserApp), url);
   } else {
-    const command = `open -a "${browserApp}" "about:newtab"`;
+    await execAsync(`open -a "${browserApp}" "${url}"`);
+  }
+}
 
-    const { stdout } = await execAsync(command);
-    return stdout || "success";
+function getBrowserApp(): string {
+  return getPreferenceValues<Preferences>().browserApp || "Firefox";
+}
+
+export async function openNewTab(queryText: string | null | undefined): Promise<boolean | string> {
+  const searchEngine = getPreferenceValues<Preferences>().searchEngine?.toLowerCase() || "google";
+  const url = queryText
+    ? `${SEARCH_ENGINE[searchEngine] ?? SEARCH_ENGINE["google"]}${encodeURIComponent(queryText)}`
+    : "about:newtab";
+
+  try {
+    await launchFirefox(url, getBrowserApp());
+    popToRoot();
+    closeMainWindow({ clearRootSearch: true });
+    return "success";
+  } catch (err) {
+    await showToast({ style: Toast.Style.Failure, title: "Failed to open Firefox", message: String(err) });
+    return "error";
   }
 }
 
 export async function openHistoryTab(url: string): Promise<boolean | string> {
-  popToRoot();
-  closeMainWindow({ clearRootSearch: true });
-
-  const preferences = getPreferenceValues<Preferences>();
-  const browserApp = preferences.browserApp || "Firefox";
-  const command = `open -a "${browserApp}" "${url}"`;
-
-  const { stdout } = await execAsync(command);
-  return stdout || "success";
+  try {
+    await launchFirefox(url, getBrowserApp());
+    popToRoot();
+    closeMainWindow({ clearRootSearch: true });
+    return "success";
+  } catch (err) {
+    await showToast({ style: Toast.Style.Failure, title: "Failed to open Firefox", message: String(err) });
+    return "error";
+  }
 }
 
 export async function setActiveTab(tab: Tab): Promise<void> {
-  const preferences = getPreferenceValues<Preferences>();
-  const browserApp = preferences.browserApp || "Firefox";
-
-  // Instead of trying to find and activate the existing tab,
-  // just open the URL which is more reliable and simpler
-  const command = `open -a "${browserApp}" "${tab.url}"`;
-  await execAsync(command);
+  try {
+    // Instead of trying to find and activate the existing tab,
+    // just open the URL which is more reliable and simpler
+    await launchFirefox(tab.url, getBrowserApp());
+  } catch (err) {
+    await showToast({ style: Toast.Style.Failure, title: "Failed to open Firefox", message: String(err) });
+  }
 }

--- a/extensions/mozilla-firefox/src/actions/index.ts
+++ b/extensions/mozilla-firefox/src/actions/index.ts
@@ -23,9 +23,26 @@ const WINDOWS_FIREFOX_PATHS: Record<string, string[]> = {
   ],
 };
 
+const RELEASE_VARIANT = "Firefox";
+
+/**
+ * Resolves the Firefox executable path for the given variant on Windows.
+ * Release Firefox falls back to the bare "firefox.exe" (resolved via PATH) when
+ * not found at its known install locations. Non-release variants (Nightly, ESR,
+ * Developer Edition) must resolve to a verified install path — falling back to
+ * "firefox.exe" would silently launch Release instead, so an actionable error
+ * is thrown instead.
+ */
 function getWindowsFirefoxExe(browserApp: string): string {
-  const candidates = WINDOWS_FIREFOX_PATHS[browserApp] ?? WINDOWS_FIREFOX_PATHS["Firefox"];
-  return candidates.find(existsSync) ?? "firefox.exe";
+  const candidates = WINDOWS_FIREFOX_PATHS[browserApp] ?? WINDOWS_FIREFOX_PATHS[RELEASE_VARIANT];
+  const resolved = candidates.find(existsSync);
+  if (resolved) return resolved;
+
+  if (browserApp === RELEASE_VARIANT || !WINDOWS_FIREFOX_PATHS[browserApp]) return "firefox.exe";
+
+  throw new Error(
+    `${browserApp} was not found. Please verify it is installed, or change the Firefox Application preference.`,
+  );
 }
 
 /**

--- a/extensions/mozilla-firefox/src/components/FirefoxActions.tsx
+++ b/extensions/mozilla-firefox/src/components/FirefoxActions.tsx
@@ -2,11 +2,7 @@ import { Action, ActionPanel, closeMainWindow, Icon } from "@raycast/api";
 import { openHistoryTab, openNewTab, setActiveTab } from "../actions";
 import { HistoryEntry, Tab } from "../interfaces";
 
-export const NewTabAction = NewTabActionComponent;
-export const HistoryItemAction = HistoryItemActionComponent;
-export const TabListItemAction = TabListItemActionComponent;
-
-function NewTabActionComponent({ query }: { query?: string }) {
+export function NewTabAction({ query }: { query?: string }) {
   return (
     <ActionPanel title="New Tab">
       <ActionPanel.Item onAction={() => openNewTab(query)} title={query ? `Search "${query}"` : "Open Empty Tab"} />
@@ -14,7 +10,7 @@ function NewTabActionComponent({ query }: { query?: string }) {
   );
 }
 
-function HistoryItemActionComponent({ entry: { title, url } }: { entry: HistoryEntry }) {
+export function HistoryItemAction({ entry: { title, url } }: { entry: HistoryEntry }) {
   return (
     <ActionPanel title={title}>
       <MozillaFirefoxHistoryTab url={url} />
@@ -24,7 +20,7 @@ function HistoryItemActionComponent({ entry: { title, url } }: { entry: HistoryE
   );
 }
 
-function TabListItemActionComponent(props: { tab: Tab }) {
+export function TabListItemAction(props: { tab: Tab }) {
   return (
     <ActionPanel title={props.tab.title}>
       <MozillaFirefoxGoToTab tab={props.tab} />
@@ -42,9 +38,5 @@ function MozillaFirefoxGoToTab(props: { tab: Tab }) {
 }
 
 function MozillaFirefoxHistoryTab({ url }: { url: string }) {
-  async function handleAction() {
-    await openHistoryTab(url);
-    await closeMainWindow();
-  }
-  return <ActionPanel.Item title="Open in Firefox" icon={{ source: Icon.Eye }} onAction={handleAction} />;
+  return <ActionPanel.Item title="Open in Firefox" icon={{ source: Icon.Eye }} onAction={() => openHistoryTab(url)} />;
 }

--- a/extensions/mozilla-firefox/src/components/error/NotInstalledError.tsx
+++ b/extensions/mozilla-firefox/src/components/error/NotInstalledError.tsx
@@ -1,43 +1,51 @@
 import { useState } from "react";
 import { ActionPanel, Detail, showToast, Toast } from "@raycast/api";
-import { execSync } from "child_process";
-import { DEFAULT_ERROR_TITLE, DownloadText } from "../../constants";
+import { exec } from "child_process";
+import { runPowerShellScript } from "@raycast/utils";
+import { promisify } from "util";
+import { DEFAULT_ERROR_TITLE, DownloadText, DownloadTextWindows } from "../../constants";
+
+const execAsync = promisify(exec);
 
 export function NotInstalledError() {
   const [isLoading, setIsLoading] = useState(false);
+  const isWindows = process.platform === "win32";
+
+  async function handleInstall() {
+    if (isLoading) return;
+
+    setIsLoading(true);
+
+    const toast = new Toast({ style: Toast.Style.Animated, title: "Installing..." });
+    await toast.show();
+
+    try {
+      if (isWindows) {
+        await runPowerShellScript("winget install Mozilla.Firefox");
+      } else {
+        await execAsync("brew install --cask firefox");
+      }
+      await toast.hide();
+    } catch {
+      await toast.hide();
+      await showToast(Toast.Style.Failure, DEFAULT_ERROR_TITLE, "An unknown error occurred while trying to install");
+    }
+    setIsLoading(false);
+  }
+
   return (
     <Detail
       actions={
         <ActionPanel>
           {!isLoading && (
             <ActionPanel.Item
-              title="Install with Homebrew"
-              onAction={async () => {
-                if (isLoading) return;
-
-                setIsLoading(true);
-
-                const toast = new Toast({ style: Toast.Style.Animated, title: "Installing..." });
-                await toast.show();
-
-                try {
-                  execSync(`brew install --cask firefox`);
-                  await toast.hide();
-                } catch {
-                  await toast.hide();
-                  await showToast(
-                    Toast.Style.Failure,
-                    DEFAULT_ERROR_TITLE,
-                    "An unknown error occurred while trying to install",
-                  );
-                }
-                setIsLoading(false);
-              }}
+              title={isWindows ? "Install with Winget" : "Install with Homebrew"}
+              onAction={handleInstall}
             />
           )}
         </ActionPanel>
       }
-      markdown={DownloadText}
+      markdown={isWindows ? DownloadTextWindows : DownloadText}
     />
   );
 }

--- a/extensions/mozilla-firefox/src/components/error/NotInstalledError.tsx
+++ b/extensions/mozilla-firefox/src/components/error/NotInstalledError.tsx
@@ -21,7 +21,7 @@ export function NotInstalledError() {
 
     try {
       if (isWindows) {
-        await runPowerShellScript("winget install Mozilla.Firefox");
+        await runPowerShellScript("winget install Mozilla.Firefox", { timeout: 300_000 });
       } else {
         await execAsync("brew install --cask firefox");
       }

--- a/extensions/mozilla-firefox/src/constants.ts
+++ b/extensions/mozilla-firefox/src/constants.ts
@@ -6,15 +6,18 @@ export const SEARCH_ENGINE: { [key: string]: string } = {
   duckduckgo: `https://duckduckgo.com/?q=`,
 };
 
-export const DownloadText = `
+const makeDownloadText = (installer: string, installerUrl: string) => `
   # 🚨Error: Mozilla Firefox browser is not installed
   ## This extension depends on Mozilla Firefox browser. You must install it to continue.
   
-  If you have [Homebrew](https://brew.sh/) installed then press ⏎ (Enter Key) to install Mozilla Firefox browser.
+  If you have [${installer}](${installerUrl}) installed then press ⏎ (Enter Key) to install Mozilla Firefox browser.
   [Click here](https://www.mozilla.org/en-US/firefox/new/) if you want to download manually.
   
   [![Mozilla Firefox](https://mozilla.design/files/2019/10/logo-firefox.svg)]()
 `;
+
+export const DownloadText = makeDownloadText("Homebrew", "https://brew.sh/");
+export const DownloadTextWindows = makeDownloadText("Winget", "https://aka.ms/winget");
 
 export const NoBookmarksText = `
 # 🚨Error: Mozilla Firefox browser has no bookmarks. Please add some bookmarks to continue using this command.

--- a/extensions/mozilla-firefox/src/util/__tests__/index.test.ts
+++ b/extensions/mozilla-firefox/src/util/__tests__/index.test.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import os from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -34,13 +35,16 @@ const mockStatIsDir = (dirs: string[]) =>
 // ---------------------------------------------------------------------------
 
 describe("getProfileName (via getHistoryDbPath)", () => {
+  const originalPlatform = process.platform;
   const originalHome = process.env.HOME;
 
   beforeEach(() => {
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
     process.env.HOME = "/fake-home";
   });
 
   afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
     process.env.HOME = originalHome;
     vi.restoreAllMocks();
   });
@@ -181,5 +185,131 @@ describe("getProfileName (via getHistoryDbPath)", () => {
     const result = getBookmarksDirectoryPath();
 
     expect(result).toBe(path.join(PROFILES_BASE, "abc123.default-release", "bookmarkbackups"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Windows platform tests
+// ---------------------------------------------------------------------------
+
+describe("getProfileName on Windows (via getHistoryDbPath)", () => {
+  const originalPlatform = process.platform;
+  const originalHome = process.env.HOME;
+  const originalAppData = process.env.APPDATA;
+
+  const PROFILES_BASE_WIN = path.join("C:\\Users\\test\\AppData\\Roaming", "Mozilla", "Firefox", "Profiles");
+
+  beforeEach(() => {
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    process.env.APPDATA = "C:\\Users\\test\\AppData\\Roaming";
+    // Unset HOME so we can confirm the Windows branch doesn't rely on it
+    delete process.env.HOME;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    process.env.HOME = originalHome;
+    process.env.APPDATA = originalAppData;
+    vi.restoreAllMocks();
+  });
+
+  it("resolves the profile path from APPDATA on Windows", () => {
+    setPrefs("default-release");
+    mockProfiles(["abc123.default-release"]);
+
+    const result = getHistoryDbPath();
+
+    expect(result).toBe(path.join(PROFILES_BASE_WIN, "abc123.default-release", "places.sqlite"));
+  });
+
+  it("falls back to os.homedir() when APPDATA is not set on Windows", () => {
+    delete process.env.APPDATA;
+    vi.spyOn(os, "homedir").mockReturnValue("C:\\Users\\test");
+    setPrefs("default-release");
+    mockProfiles(["abc123.default-release"]);
+
+    const result = getHistoryDbPath();
+
+    const fallbackBase = path.join("C:\\Users\\test", "AppData", "Roaming", "Mozilla", "Firefox", "Profiles");
+    expect(result).toBe(path.join(fallbackBase, "abc123.default-release", "places.sqlite"));
+  });
+
+  it("falls back to .default-release on Windows when custom suffix doesn't match", () => {
+    setPrefs("nonexistent");
+    mockProfiles(["abc.default-release", "def.default-nightly"]);
+
+    const result = getHistoryDbPath();
+
+    expect(result).toBe(path.join(PROFILES_BASE_WIN, "abc.default-release", "places.sqlite"));
+  });
+
+  it("falls back to .default-nightly on Windows when only nightly profile is present", () => {
+    setPrefs("nonexistent");
+    mockProfiles(["abc123.default-nightly"]);
+
+    const result = getHistoryDbPath();
+
+    expect(result).toBe(path.join(PROFILES_BASE_WIN, "abc123.default-nightly", "places.sqlite"));
+  });
+
+  it("falls back to .default-esr on Windows when only ESR profile is present", () => {
+    setPrefs("nonexistent");
+    mockProfiles(["abc123.default-esr"]);
+
+    const result = getHistoryDbPath();
+
+    expect(result).toBe(path.join(PROFILES_BASE_WIN, "abc123.default-esr", "places.sqlite"));
+  });
+
+  it("getBookmarksDirectoryPath uses APPDATA on Windows", () => {
+    setPrefs("default-release");
+    mockProfiles(["abc123.default-release"]);
+
+    const result = getBookmarksDirectoryPath();
+
+    expect(result).toBe(path.join(PROFILES_BASE_WIN, "abc123.default-release", "bookmarkbackups"));
+  });
+
+  it("returns an empty path segment when the Profiles directory does not exist on Windows", () => {
+    setPrefs("default-release");
+    vi.spyOn(fs, "readdirSync").mockImplementation(() => {
+      throw new Error("ENOENT: no such file or directory");
+    });
+
+    const result = getHistoryDbPath();
+
+    expect(result).toBe(path.join(PROFILES_BASE_WIN, "places.sqlite"));
+  });
+
+  it("returns an empty path segment when the Profiles directory is empty on Windows", () => {
+    setPrefs("nonexistent");
+    mockProfiles([]);
+
+    const result = getHistoryDbPath();
+
+    expect(result).toBe(path.join(PROFILES_BASE_WIN, "places.sqlite"));
+  });
+
+  it("returns an empty path segment when all entries are non-profile files on Windows", () => {
+    setPrefs("nonexistent");
+    mockProfiles(["installs.ini", "profiles.ini"]);
+    vi.spyOn(fs, "statSync").mockReturnValue({ isDirectory: () => false } as fs.Stats);
+
+    const result = getHistoryDbPath();
+
+    expect(result).toBe(path.join(PROFILES_BASE_WIN, "places.sqlite"));
+  });
+
+  it("skips a catch-all candidate when statSync throws on Windows (e.g. a dangling symlink)", () => {
+    setPrefs("nonexistent");
+    mockProfiles(["broken-link", "good.profile"]);
+    vi.spyOn(fs, "statSync").mockImplementation((filePath) => {
+      if (String(filePath).endsWith("broken-link")) throw new Error("ENOENT");
+      return { isDirectory: () => true } as fs.Stats;
+    });
+
+    const result = getHistoryDbPath();
+
+    expect(result).toBe(path.join(PROFILES_BASE_WIN, "good.profile", "places.sqlite"));
   });
 });

--- a/extensions/mozilla-firefox/src/util/__tests__/index.test.ts
+++ b/extensions/mozilla-firefox/src/util/__tests__/index.test.ts
@@ -229,8 +229,9 @@ describe("getProfileName (via getHistoryDbPath)", () => {
 
     const result = getHistoryDbPath();
 
-    // abc.default-release is excluded by catch-all (variant-specific suffix); xyz.default is picked.
-    expect(result).toBe(path.join(PROFILES_BASE, "xyz.default", "places.sqlite"));
+    // Both abc.default-release (variant-specific suffix) and xyz.default (legacy release profile)
+    // are excluded from the catch-all for non-release variants; no valid profile remains.
+    expect(result).toBe(path.join(PROFILES_BASE, "places.sqlite"));
   });
 
   it("does not fall back to the release profile when Firefox ESR has no ESR profile", () => {
@@ -240,7 +241,8 @@ describe("getProfileName (via getHistoryDbPath)", () => {
 
     const result = getHistoryDbPath();
 
-    expect(result).toBe(path.join(PROFILES_BASE, "xyz.default", "places.sqlite"));
+    // Both abc.default-release and xyz.default are excluded; no valid profile remains.
+    expect(result).toBe(path.join(PROFILES_BASE, "places.sqlite"));
   });
 
   it("does not fall back to the release profile when Firefox Developer Edition has no dev profile", () => {
@@ -250,7 +252,8 @@ describe("getProfileName (via getHistoryDbPath)", () => {
 
     const result = getHistoryDbPath();
 
-    expect(result).toBe(path.join(PROFILES_BASE, "xyz.default", "places.sqlite"));
+    // Both abc.default-release and xyz.default are excluded; no valid profile remains.
+    expect(result).toBe(path.join(PROFILES_BASE, "places.sqlite"));
   });
 
   it("falls back to catch-all excluding other-variant profiles when non-release has no matching or default profile", () => {
@@ -399,8 +402,9 @@ describe("getProfileName on Windows (via getHistoryDbPath)", () => {
 
     const result = getHistoryDbPath();
 
-    // abc.default-release is excluded by catch-all (variant-specific suffix); xyz.default is picked.
-    expect(result).toBe(path.join(PROFILES_BASE_WIN, "xyz.default", "places.sqlite"));
+    // Both abc.default-release (variant-specific suffix) and xyz.default (legacy release profile)
+    // are excluded from the catch-all for non-release variants; no valid profile remains.
+    expect(result).toBe(path.join(PROFILES_BASE_WIN, "places.sqlite"));
   });
 
   it("does not fall back to the release profile when Firefox ESR has no ESR profile on Windows", () => {
@@ -410,7 +414,8 @@ describe("getProfileName on Windows (via getHistoryDbPath)", () => {
 
     const result = getHistoryDbPath();
 
-    expect(result).toBe(path.join(PROFILES_BASE_WIN, "xyz.default", "places.sqlite"));
+    // Both abc.default-release and xyz.default are excluded; no valid profile remains.
+    expect(result).toBe(path.join(PROFILES_BASE_WIN, "places.sqlite"));
   });
 
   it("does not fall back to the release profile when Firefox Developer Edition has no dev profile on Windows", () => {
@@ -420,7 +425,8 @@ describe("getProfileName on Windows (via getHistoryDbPath)", () => {
 
     const result = getHistoryDbPath();
 
-    expect(result).toBe(path.join(PROFILES_BASE_WIN, "xyz.default", "places.sqlite"));
+    // Both abc.default-release and xyz.default are excluded; no valid profile remains.
+    expect(result).toBe(path.join(PROFILES_BASE_WIN, "places.sqlite"));
   });
 
   it("falls back to catch-all excluding other-variant profiles when non-release has no matching or default profile on Windows", () => {

--- a/extensions/mozilla-firefox/src/util/__tests__/index.test.ts
+++ b/extensions/mozilla-firefox/src/util/__tests__/index.test.ts
@@ -218,6 +218,49 @@ describe("getProfileName (via getHistoryDbPath)", () => {
     expect(result).toBe(path.join(PROFILES_BASE, "def.my-custom-profile", "places.sqlite"));
   });
 
+  // --- Variant fallback isolation -------------------------------------------
+  // When the user selects a non-release variant but its profile is absent, the
+  // release profile must NOT be used — it belongs to a different installation.
+
+  it("does not fall back to the release profile when Firefox Nightly has no nightly profile", () => {
+    setPrefs("default-release", "Firefox Nightly");
+    mockProfiles(["abc.default-release", "xyz.default"]);
+
+    const result = getHistoryDbPath();
+
+    expect(result).toBe(path.join(PROFILES_BASE, "xyz.default", "places.sqlite"));
+  });
+
+  it("does not fall back to the release profile when Firefox ESR has no ESR profile", () => {
+    setPrefs("default-release", "Firefox ESR");
+    mockProfiles(["abc.default-release", "xyz.default"]);
+
+    const result = getHistoryDbPath();
+
+    expect(result).toBe(path.join(PROFILES_BASE, "xyz.default", "places.sqlite"));
+  });
+
+  it("does not fall back to the release profile when Firefox Developer Edition has no dev profile", () => {
+    setPrefs("default-release", "Firefox Developer Edition");
+    mockProfiles(["abc.default-release", "xyz.default"]);
+
+    const result = getHistoryDbPath();
+
+    expect(result).toBe(path.join(PROFILES_BASE, "xyz.default", "places.sqlite"));
+  });
+
+  it("falls back to catch-all when a non-release variant has no matching or default profile", () => {
+    setPrefs("default-release", "Firefox Nightly");
+    mockProfiles(["abc.default-release", "real.profile"]);
+    mockStatIsDir(["abc.default-release", "real.profile"]);
+
+    const result = getHistoryDbPath();
+
+    // .default-release is a real directory but belongs to the release variant;
+    // catch-all picks alphabetically first — "abc.default-release" sorts before "real.profile"
+    expect(result).toBe(path.join(PROFILES_BASE, "abc.default-release", "places.sqlite"));
+  });
+
   // --- Public API surface (bookmarks path delegates to same logic) ----------
 
   it("getBookmarksDirectoryPath uses the same profile resolution", () => {
@@ -330,6 +373,35 @@ describe("getProfileName on Windows (via getHistoryDbPath)", () => {
     const result = getHistoryDbPath();
 
     expect(result).toBe(path.join(PROFILES_BASE_WIN, "def.dev-edition-default", "places.sqlite"));
+  });
+
+  // --- Variant fallback isolation (Windows) ----------------------------------
+
+  it("does not fall back to the release profile when Firefox Nightly has no nightly profile on Windows", () => {
+    setPrefs("default-release", "Firefox Nightly");
+    mockProfiles(["abc.default-release", "xyz.default"]);
+
+    const result = getHistoryDbPath();
+
+    expect(result).toBe(path.join(PROFILES_BASE_WIN, "xyz.default", "places.sqlite"));
+  });
+
+  it("does not fall back to the release profile when Firefox ESR has no ESR profile on Windows", () => {
+    setPrefs("default-release", "Firefox ESR");
+    mockProfiles(["abc.default-release", "xyz.default"]);
+
+    const result = getHistoryDbPath();
+
+    expect(result).toBe(path.join(PROFILES_BASE_WIN, "xyz.default", "places.sqlite"));
+  });
+
+  it("does not fall back to the release profile when Firefox Developer Edition has no dev profile on Windows", () => {
+    setPrefs("default-release", "Firefox Developer Edition");
+    mockProfiles(["abc.default-release", "xyz.default"]);
+
+    const result = getHistoryDbPath();
+
+    expect(result).toBe(path.join(PROFILES_BASE_WIN, "xyz.default", "places.sqlite"));
   });
 
   it("getBookmarksDirectoryPath uses APPDATA on Windows", () => {

--- a/extensions/mozilla-firefox/src/util/__tests__/index.test.ts
+++ b/extensions/mozilla-firefox/src/util/__tests__/index.test.ts
@@ -333,7 +333,7 @@ describe("getProfileName on Windows (via getHistoryDbPath)", () => {
   });
 
   it("getBookmarksDirectoryPath uses APPDATA on Windows", () => {
-    setPrefs("default-release")
+    setPrefs("default-release");
     mockProfiles(["abc123.default-release"]);
 
     const result = getBookmarksDirectoryPath();

--- a/extensions/mozilla-firefox/src/util/__tests__/index.test.ts
+++ b/extensions/mozilla-firefox/src/util/__tests__/index.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // getPreferenceValues is imported by the module under test — stub it before the
 // module is loaded so every call returns a controllable value.
 vi.mock("@raycast/api", () => ({
-  getPreferenceValues: vi.fn(() => ({ profileDirectorySuffix: "default-release" })),
+  getPreferenceValues: vi.fn(() => ({ profileDirectorySuffix: "default-release", browserApp: "Firefox" })),
 }));
 
 import { getPreferenceValues } from "@raycast/api";
@@ -20,7 +20,8 @@ import { getBookmarksDirectoryPath, getHistoryDbPath } from "../index";
 
 const PROFILES_BASE = "/fake-home/Library/Application Support/Firefox/Profiles";
 
-const setPrefs = (suffix: string) => vi.mocked(getPreferenceValues).mockReturnValue({ profileDirectorySuffix: suffix });
+const setPrefs = (suffix: string, browserApp = "Firefox") =>
+  vi.mocked(getPreferenceValues).mockReturnValue({ profileDirectorySuffix: suffix, browserApp });
 
 const mockProfiles = (entries: string[]) => vi.spyOn(fs, "readdirSync").mockReturnValue(entries as never);
 
@@ -176,6 +177,47 @@ describe("getProfileName (via getHistoryDbPath)", () => {
     expect(result).toBe(path.join(PROFILES_BASE, "good.profile", "places.sqlite"));
   });
 
+  // --- browserApp variant selection -----------------------------------------
+  // These tests verify that selecting a non-release variant always reads from
+  // that variant's own profile, even when a release profile is also present on
+  // disk and the suffix preference has not been customised.
+
+  it("selects the nightly profile when browserApp is Firefox Nightly", () => {
+    setPrefs("default-release", "Firefox Nightly");
+    mockProfiles(["abc.default-release", "def.default-nightly"]);
+
+    const result = getHistoryDbPath();
+
+    expect(result).toBe(path.join(PROFILES_BASE, "def.default-nightly", "places.sqlite"));
+  });
+
+  it("selects the ESR profile when browserApp is Firefox ESR", () => {
+    setPrefs("default-release", "Firefox ESR");
+    mockProfiles(["abc.default-release", "def.default-esr"]);
+
+    const result = getHistoryDbPath();
+
+    expect(result).toBe(path.join(PROFILES_BASE, "def.default-esr", "places.sqlite"));
+  });
+
+  it("selects the dev-edition profile when browserApp is Firefox Developer Edition", () => {
+    setPrefs("default-release", "Firefox Developer Edition");
+    mockProfiles(["abc.default-release", "def.dev-edition-default"]);
+
+    const result = getHistoryDbPath();
+
+    expect(result).toBe(path.join(PROFILES_BASE, "def.dev-edition-default", "places.sqlite"));
+  });
+
+  it("explicit custom suffix overrides browserApp variant selection", () => {
+    setPrefs("my-custom-profile", "Firefox Nightly");
+    mockProfiles(["abc.default-nightly", "def.my-custom-profile"]);
+
+    const result = getHistoryDbPath();
+
+    expect(result).toBe(path.join(PROFILES_BASE, "def.my-custom-profile", "places.sqlite"));
+  });
+
   // --- Public API surface (bookmarks path delegates to same logic) ----------
 
   it("getBookmarksDirectoryPath uses the same profile resolution", () => {
@@ -261,8 +303,37 @@ describe("getProfileName on Windows (via getHistoryDbPath)", () => {
     expect(result).toBe(path.join(PROFILES_BASE_WIN, "abc123.default-esr", "places.sqlite"));
   });
 
+  // --- browserApp variant selection (Windows) --------------------------------
+
+  it("selects the nightly profile when browserApp is Firefox Nightly on Windows", () => {
+    setPrefs("default-release", "Firefox Nightly");
+    mockProfiles(["abc.default-release", "def.default-nightly"]);
+
+    const result = getHistoryDbPath();
+
+    expect(result).toBe(path.join(PROFILES_BASE_WIN, "def.default-nightly", "places.sqlite"));
+  });
+
+  it("selects the ESR profile when browserApp is Firefox ESR on Windows", () => {
+    setPrefs("default-release", "Firefox ESR");
+    mockProfiles(["abc.default-release", "def.default-esr"]);
+
+    const result = getHistoryDbPath();
+
+    expect(result).toBe(path.join(PROFILES_BASE_WIN, "def.default-esr", "places.sqlite"));
+  });
+
+  it("selects the dev-edition profile when browserApp is Firefox Developer Edition on Windows", () => {
+    setPrefs("default-release", "Firefox Developer Edition");
+    mockProfiles(["abc.default-release", "def.dev-edition-default"]);
+
+    const result = getHistoryDbPath();
+
+    expect(result).toBe(path.join(PROFILES_BASE_WIN, "def.dev-edition-default", "places.sqlite"));
+  });
+
   it("getBookmarksDirectoryPath uses APPDATA on Windows", () => {
-    setPrefs("default-release");
+    setPrefs("default-release")
     mockProfiles(["abc123.default-release"]);
 
     const result = getBookmarksDirectoryPath();

--- a/extensions/mozilla-firefox/src/util/__tests__/index.test.ts
+++ b/extensions/mozilla-firefox/src/util/__tests__/index.test.ts
@@ -225,15 +225,18 @@ describe("getProfileName (via getHistoryDbPath)", () => {
   it("does not fall back to the release profile when Firefox Nightly has no nightly profile", () => {
     setPrefs("default-release", "Firefox Nightly");
     mockProfiles(["abc.default-release", "xyz.default"]);
+    mockStatIsDir(["abc.default-release", "xyz.default"]);
 
     const result = getHistoryDbPath();
 
+    // abc.default-release is excluded by catch-all (variant-specific suffix); xyz.default is picked.
     expect(result).toBe(path.join(PROFILES_BASE, "xyz.default", "places.sqlite"));
   });
 
   it("does not fall back to the release profile when Firefox ESR has no ESR profile", () => {
     setPrefs("default-release", "Firefox ESR");
     mockProfiles(["abc.default-release", "xyz.default"]);
+    mockStatIsDir(["abc.default-release", "xyz.default"]);
 
     const result = getHistoryDbPath();
 
@@ -243,6 +246,7 @@ describe("getProfileName (via getHistoryDbPath)", () => {
   it("does not fall back to the release profile when Firefox Developer Edition has no dev profile", () => {
     setPrefs("default-release", "Firefox Developer Edition");
     mockProfiles(["abc.default-release", "xyz.default"]);
+    mockStatIsDir(["abc.default-release", "xyz.default"]);
 
     const result = getHistoryDbPath();
 
@@ -391,15 +395,18 @@ describe("getProfileName on Windows (via getHistoryDbPath)", () => {
   it("does not fall back to the release profile when Firefox Nightly has no nightly profile on Windows", () => {
     setPrefs("default-release", "Firefox Nightly");
     mockProfiles(["abc.default-release", "xyz.default"]);
+    mockStatIsDir(["abc.default-release", "xyz.default"]);
 
     const result = getHistoryDbPath();
 
+    // abc.default-release is excluded by catch-all (variant-specific suffix); xyz.default is picked.
     expect(result).toBe(path.join(PROFILES_BASE_WIN, "xyz.default", "places.sqlite"));
   });
 
   it("does not fall back to the release profile when Firefox ESR has no ESR profile on Windows", () => {
     setPrefs("default-release", "Firefox ESR");
     mockProfiles(["abc.default-release", "xyz.default"]);
+    mockStatIsDir(["abc.default-release", "xyz.default"]);
 
     const result = getHistoryDbPath();
 
@@ -409,6 +416,7 @@ describe("getProfileName on Windows (via getHistoryDbPath)", () => {
   it("does not fall back to the release profile when Firefox Developer Edition has no dev profile on Windows", () => {
     setPrefs("default-release", "Firefox Developer Edition");
     mockProfiles(["abc.default-release", "xyz.default"]);
+    mockStatIsDir(["abc.default-release", "xyz.default"]);
 
     const result = getHistoryDbPath();
 

--- a/extensions/mozilla-firefox/src/util/__tests__/index.test.ts
+++ b/extensions/mozilla-firefox/src/util/__tests__/index.test.ts
@@ -249,16 +249,27 @@ describe("getProfileName (via getHistoryDbPath)", () => {
     expect(result).toBe(path.join(PROFILES_BASE, "xyz.default", "places.sqlite"));
   });
 
-  it("falls back to catch-all when a non-release variant has no matching or default profile", () => {
+  it("falls back to catch-all excluding other-variant profiles when non-release has no matching or default profile", () => {
     setPrefs("default-release", "Firefox Nightly");
     mockProfiles(["abc.default-release", "real.profile"]);
     mockStatIsDir(["abc.default-release", "real.profile"]);
 
     const result = getHistoryDbPath();
 
-    // .default-release is a real directory but belongs to the release variant;
-    // catch-all picks alphabetically first — "abc.default-release" sorts before "real.profile"
-    expect(result).toBe(path.join(PROFILES_BASE, "abc.default-release", "places.sqlite"));
+    // .default-release belongs to the release variant and must be excluded from
+    // the catch-all when a non-release variant is selected; "real.profile" is picked.
+    expect(result).toBe(path.join(PROFILES_BASE, "real.profile", "places.sqlite"));
+  });
+
+  it("returns empty when non-release variant has no matching profile and only other-variant directories exist", () => {
+    setPrefs("default-release", "Firefox Nightly");
+    mockProfiles(["abc.default-release"]);
+    mockStatIsDir(["abc.default-release"]);
+
+    const result = getHistoryDbPath();
+
+    // No valid profile for Nightly — safer to return empty than silently read release data.
+    expect(result).toBe(path.join(PROFILES_BASE, "places.sqlite"));
   });
 
   // --- Public API surface (bookmarks path delegates to same logic) ----------
@@ -402,6 +413,29 @@ describe("getProfileName on Windows (via getHistoryDbPath)", () => {
     const result = getHistoryDbPath();
 
     expect(result).toBe(path.join(PROFILES_BASE_WIN, "xyz.default", "places.sqlite"));
+  });
+
+  it("falls back to catch-all excluding other-variant profiles when non-release has no matching or default profile on Windows", () => {
+    setPrefs("default-release", "Firefox Nightly");
+    mockProfiles(["abc.default-release", "real.profile"]);
+    mockStatIsDir(["abc.default-release", "real.profile"]);
+
+    const result = getHistoryDbPath();
+
+    // .default-release belongs to the release variant and must be excluded from
+    // the catch-all when a non-release variant is selected; "real.profile" is picked.
+    expect(result).toBe(path.join(PROFILES_BASE_WIN, "real.profile", "places.sqlite"));
+  });
+
+  it("returns empty when non-release variant has no matching profile and only other-variant directories exist on Windows", () => {
+    setPrefs("default-release", "Firefox Nightly");
+    mockProfiles(["abc.default-release"]);
+    mockStatIsDir(["abc.default-release"]);
+
+    const result = getHistoryDbPath();
+
+    // No valid profile for Nightly — safer to return empty than silently read release data.
+    expect(result).toBe(path.join(PROFILES_BASE_WIN, "places.sqlite"));
   });
 
   it("getBookmarksDirectoryPath uses APPDATA on Windows", () => {

--- a/extensions/mozilla-firefox/src/util/index.ts
+++ b/extensions/mozilla-firefox/src/util/index.ts
@@ -1,8 +1,14 @@
 import fs from "fs";
+import os from "os";
 import path from "path";
 import { getPreferenceValues } from "@raycast/api";
 
 const userDataDirectoryPath = () => {
+  if (process.platform === "win32") {
+    const appData = process.env.APPDATA ?? path.join(os.homedir(), "AppData", "Roaming");
+    return path.join(appData, "Mozilla", "Firefox", "Profiles");
+  }
+
   if (!process.env.HOME) {
     throw new Error("$HOME environment variable is not set.");
   }
@@ -76,16 +82,16 @@ export const getSessionManagerExtensionPath = (extensionId: string) => {
   );
 };
 
-export const getSessionInactivePath = async () => {
+export const getSessionInactivePath = (): string => {
   const userDirectoryPath = userDataDirectoryPath();
   return path.join(userDirectoryPath, getProfileName(userDirectoryPath), "sessionstore.jsonlz4");
 };
 
-export const getSessionActivePath = async () => {
+export const getSessionActivePath = (): string => {
   const userDirectoryPath = userDataDirectoryPath();
   return path.join(
     userDirectoryPath,
-    await getProfileName(userDirectoryPath),
+    getProfileName(userDirectoryPath),
     "sessionstore-backups",
     "recovery.jsonlz4",
   );

--- a/extensions/mozilla-firefox/src/util/index.ts
+++ b/extensions/mozilla-firefox/src/util/index.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { getPreferenceValues } from "@raycast/api";
+import { getPreferenceValues, Preferences } from "@raycast/api";
 
 const userDataDirectoryPath = () => {
   if (process.platform === "win32") {
@@ -18,6 +18,8 @@ const userDataDirectoryPath = () => {
 
 const NON_PROFILE_ENTRIES = new Set(["Crash Reports", "Pending Pings", "installs.ini", "profiles.ini"]);
 
+const DEFAULT_PROFILE_SUFFIX = "default-release";
+
 const getProfileName = (userDirectoryPath: string) => {
   let profiles: string[];
   try {
@@ -28,14 +30,17 @@ const getProfileName = (userDirectoryPath: string) => {
 
   const preferences = getPreferenceValues<Preferences>();
 
-  const customProfile = profiles.filter((profile) => profile.endsWith(preferences.profileDirectorySuffix))[0];
-  if (customProfile) return customProfile;
+  const suffix = preferences.profileDirectorySuffix;
+  if (suffix && suffix !== DEFAULT_PROFILE_SUFFIX) {
+    const customProfile = profiles.find((profile) => profile.endsWith(suffix));
+    if (customProfile) return customProfile;
+  }
 
-  const releaseProfile = profiles.filter((profile) => profile.endsWith(".default-release"))[0];
-  const nightlyProfile = profiles.filter((profile) => profile.endsWith(".default-nightly"))[0];
-  const esrProfile = profiles.filter((profile) => profile.endsWith(".default-esr"))[0];
-  const devProfile = profiles.filter((profile) => profile.endsWith(".dev-edition-default"))[0];
-  const defaultProfile = profiles.filter((profile) => profile.endsWith(".default"))[0];
+  const releaseProfile = profiles.find((profile) => profile.endsWith(".default-release"));
+  const nightlyProfile = profiles.find((profile) => profile.endsWith(".default-nightly"));
+  const esrProfile = profiles.find((profile) => profile.endsWith(".default-esr"));
+  const devProfile = profiles.find((profile) => profile.endsWith(".dev-edition-default"));
+  const defaultProfile = profiles.find((profile) => profile.endsWith(".default"));
 
   const browserApp = preferences.browserApp;
   if (browserApp === "Firefox Nightly" && nightlyProfile) return nightlyProfile;

--- a/extensions/mozilla-firefox/src/util/index.ts
+++ b/extensions/mozilla-firefox/src/util/index.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { getPreferenceValues, Preferences } from "@raycast/api";
+import { getPreferenceValues } from "@raycast/api";
 
 const userDataDirectoryPath = () => {
   if (process.platform === "win32") {

--- a/extensions/mozilla-firefox/src/util/index.ts
+++ b/extensions/mozilla-firefox/src/util/index.ts
@@ -52,7 +52,7 @@ const getProfileName = (userDirectoryPath: string) => {
   const isNonReleaseVariant =
     browserApp === "Firefox Nightly" || browserApp === "Firefox ESR" || browserApp === "Firefox Developer Edition";
   const variantProfile = isNonReleaseVariant
-    ? defaultProfile
+    ? undefined
     : (releaseProfile ?? nightlyProfile ?? esrProfile ?? devProfile ?? defaultProfile);
   if (variantProfile) return variantProfile;
 

--- a/extensions/mozilla-firefox/src/util/index.ts
+++ b/extensions/mozilla-firefox/src/util/index.ts
@@ -47,7 +47,11 @@ const getProfileName = (userDirectoryPath: string) => {
   if (browserApp === "Firefox ESR" && esrProfile) return esrProfile;
   if (browserApp === "Firefox Developer Edition" && devProfile) return devProfile;
 
-  const variantProfile = releaseProfile ?? nightlyProfile ?? esrProfile ?? devProfile ?? defaultProfile;
+  const isNonReleaseVariant =
+    browserApp === "Firefox Nightly" || browserApp === "Firefox ESR" || browserApp === "Firefox Developer Edition";
+  const variantProfile = isNonReleaseVariant
+    ? defaultProfile
+    : releaseProfile ?? nightlyProfile ?? esrProfile ?? devProfile ?? defaultProfile;
   if (variantProfile) return variantProfile;
 
   const fallback = profiles

--- a/extensions/mozilla-firefox/src/util/index.ts
+++ b/extensions/mozilla-firefox/src/util/index.ts
@@ -51,7 +51,7 @@ const getProfileName = (userDirectoryPath: string) => {
     browserApp === "Firefox Nightly" || browserApp === "Firefox ESR" || browserApp === "Firefox Developer Edition";
   const variantProfile = isNonReleaseVariant
     ? defaultProfile
-    : releaseProfile ?? nightlyProfile ?? esrProfile ?? devProfile ?? defaultProfile;
+    : (releaseProfile ?? nightlyProfile ?? esrProfile ?? devProfile ?? defaultProfile);
   if (variantProfile) return variantProfile;
 
   const fallback = profiles

--- a/extensions/mozilla-firefox/src/util/index.ts
+++ b/extensions/mozilla-firefox/src/util/index.ts
@@ -18,6 +18,8 @@ const userDataDirectoryPath = () => {
 
 const NON_PROFILE_ENTRIES = new Set(["Crash Reports", "Pending Pings", "installs.ini", "profiles.ini"]);
 
+const VARIANT_SPECIFIC_SUFFIXES = [".default-release", ".default-nightly", ".default-esr", ".dev-edition-default"];
+
 const DEFAULT_PROFILE_SUFFIX = "default-release";
 
 const getProfileName = (userDirectoryPath: string) => {
@@ -56,6 +58,10 @@ const getProfileName = (userDirectoryPath: string) => {
 
   const fallback = profiles
     .filter((entry) => !NON_PROFILE_ENTRIES.has(entry))
+    .filter((entry) => {
+      if (isNonReleaseVariant && VARIANT_SPECIFIC_SUFFIXES.some((s) => entry.endsWith(s))) return false;
+      return true;
+    })
     .filter((entry) => {
       try {
         return fs.statSync(path.join(userDirectoryPath, entry)).isDirectory();

--- a/extensions/mozilla-firefox/src/util/index.ts
+++ b/extensions/mozilla-firefox/src/util/index.ts
@@ -60,6 +60,7 @@ const getProfileName = (userDirectoryPath: string) => {
     .filter((entry) => !NON_PROFILE_ENTRIES.has(entry))
     .filter((entry) => {
       if (isNonReleaseVariant && VARIANT_SPECIFIC_SUFFIXES.some((s) => entry.endsWith(s))) return false;
+      if (isNonReleaseVariant && entry.endsWith(".default")) return false;
       return true;
     })
     .filter((entry) => {

--- a/extensions/mozilla-firefox/src/util/index.ts
+++ b/extensions/mozilla-firefox/src/util/index.ts
@@ -29,22 +29,21 @@ const getProfileName = (userDirectoryPath: string) => {
   const preferences = getPreferenceValues<Preferences>();
 
   const customProfile = profiles.filter((profile) => profile.endsWith(preferences.profileDirectorySuffix))[0];
+  if (customProfile) return customProfile;
+
   const releaseProfile = profiles.filter((profile) => profile.endsWith(".default-release"))[0];
   const nightlyProfile = profiles.filter((profile) => profile.endsWith(".default-nightly"))[0];
   const esrProfile = profiles.filter((profile) => profile.endsWith(".default-esr"))[0];
+  const devProfile = profiles.filter((profile) => profile.endsWith(".dev-edition-default"))[0];
   const defaultProfile = profiles.filter((profile) => profile.endsWith(".default"))[0];
 
-  if (customProfile) {
-    return customProfile;
-  } else if (releaseProfile) {
-    return releaseProfile;
-  } else if (nightlyProfile) {
-    return nightlyProfile;
-  } else if (esrProfile) {
-    return esrProfile;
-  } else if (defaultProfile) {
-    return defaultProfile;
-  }
+  const browserApp = preferences.browserApp;
+  if (browserApp === "Firefox Nightly" && nightlyProfile) return nightlyProfile;
+  if (browserApp === "Firefox ESR" && esrProfile) return esrProfile;
+  if (browserApp === "Firefox Developer Edition" && devProfile) return devProfile;
+
+  const variantProfile = releaseProfile ?? nightlyProfile ?? esrProfile ?? devProfile ?? defaultProfile;
+  if (variantProfile) return variantProfile;
 
   const fallback = profiles
     .filter((entry) => !NON_PROFILE_ENTRIES.has(entry))
@@ -89,12 +88,7 @@ export const getSessionInactivePath = (): string => {
 
 export const getSessionActivePath = (): string => {
   const userDirectoryPath = userDataDirectoryPath();
-  return path.join(
-    userDirectoryPath,
-    getProfileName(userDirectoryPath),
-    "sessionstore-backups",
-    "recovery.jsonlz4",
-  );
+  return path.join(userDirectoryPath, getProfileName(userDirectoryPath), "sessionstore-backups", "recovery.jsonlz4");
 };
 
 export function decodeLZ4(buffer: Buffer) {


### PR DESCRIPTION
## Description

Adds Windows support to the Mozilla Firefox extension. All three commands
(New Tab, Search History, Search Bookmarks) now work on Windows.

- Profile directory resolved from `%APPDATA%\Mozilla\Firefox\Profiles`
- URLs opened by spawning the Firefox executable directly via `child_process.spawn`
- All Firefox variants (Firefox, Nightly, ESR, Developer Edition) detected via known install paths with PATH fallback
- "Install with Winget" replaces "Install with Homebrew" on Windows
- Unit tests added for Windows profile path resolution
- `platforms` field updated to `["macOS", "Windows"]` in package.json

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder