### PR TITLE
[Claude] Fix API compatibility with current models

### DIFF
--- a/extensions/claude/CHANGELOG.md
+++ b/extensions/claude/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Claude Changelog
 
+## [API compatibility fixes] - {PR_MERGE_DATE}
+
+- Fix: Asking a question on Claude Opus 4.7 or newer (including Opus 4.7, Sonnet 5, and Opus 5) failed with a 400 error. Sampling parameters were removed on those models, and the extension was still sending `temperature` on every request.
+- Fix: With "Stream Responses" turned off, requests could fail outright instead of answering — and on Opus 4 and 4.1 the failure left the loading indicator spinning with no error shown. Non-streaming requests are now capped at the limit the API accepts, and if a particular model rejects even that, the request is retried at a smaller size rather than failing — so a long answer comes back shorter rather than not at all, and nothing is left hanging.
+- Fix: Presets on newer models were capped at 4,096 output tokens. The maximum is now read from the API for each model instead of guessed from its name.
+- Fix: Only the first 20 models were listed. The full model list is now loaded.
+- Fix: Long conversations stopped working permanently once they outgrew the model's context window. Older turns are now left out of the request when needed — the conversation stays readable in full, and a note says when this happened and why.
+- Fix: Asking a new question while an answer was still streaming could let the abandoned request overwrite the new one's result and leave the newer answer unstoppable.
+- Fix: Asking a second question before the first answered could let the earlier request report success and stop the loading indicator while the newer answer was still being written.
+- Improvement: Updated the Anthropic SDK, which the token-counting used by the fix above requires.
+
 ## [Fix memory leak] - 2026-02-01
 
 - Fix: Resolved JS heap out of memory error by throttling UI updates during streaming responses

--- a/extensions/claude/CHANGELOG.md
+++ b/extensions/claude/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Claude Changelog
 
-## [API compatibility fixes] - {PR_MERGE_DATE}
+## [API compatibility fixes] - 2026-08-19
 
 - Fix: Asking a question on Claude Opus 4.7 or newer (including Opus 4.7, Sonnet 5, and Opus 5) failed with a 400 error. Sampling parameters were removed on those models, and the extension was still sending `temperature` on every request.
 - Fix: With "Stream Responses" turned off, requests could fail outright instead of answering — and on Opus 4 and 4.1 the failure left the loading indicator spinning with no error shown. Non-streaming requests are now capped at the limit the API accepts, and if a particular model rejects even that, the request is retried at a smaller size rather than failing — so a long answer comes back shorter rather than not at all, and nothing is left hanging.

--- a/extensions/claude/package-lock.json
+++ b/extensions/claude/package-lock.json
@@ -7,7 +7,7 @@
       "name": "claude",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.18.0",
+        "@anthropic-ai/sdk": "^0.115.0",
         "@raycast/api": "^1.78.0",
         "@raycast/utils": "^1.14.1",
         "@types/uuid": "^9.0.0",
@@ -29,60 +29,51 @@
     },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
-      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.18.0.tgz",
-      "integrity": "sha512-3XsWEn/4nPGRd4AdSguugbSDFy6Z2AWTNOeI3iK+aV22+w23+vY9CEb3Hiy0kvKIQuxSmZz/+5WKC8nPWy8gVg==",
+      "version": "0.115.0",
+      "license": "MIT",
       "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "digest-fetch": "^1.3.0",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7",
-        "web-streams-polyfill": "^3.2.1"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
-      "version": "18.19.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.24.tgz",
-      "integrity": "sha512-eghAz3gnbQbvnHqB+mgB2ZR3aH6RhdEmHGS48BnV75KceQPHqabkxKI0BbUSsqhqy2Ddhc2xD/VAR9ySZd57Lw==",
-      "dependencies": {
-        "undici-types": "~5.26.4"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/highlight": "^7.10.4"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
       "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.20",
         "chalk": "^2.4.2",
@@ -94,9 +85,8 @@
     },
     "node_modules/@babel/highlight/node_modules/ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -106,9 +96,8 @@
     },
     "node_modules/@babel/highlight/node_modules/chalk": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -120,42 +109,37 @@
     },
     "node_modules/@babel/highlight/node_modules/color-convert": {
       "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
       }
     },
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@babel/highlight/node_modules/has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/@babel/highlight/node_modules/supports-color": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -163,11 +147,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.3.0"
       },
@@ -180,18 +170,16 @@
     },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
-      "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
-      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.1.1",
@@ -209,18 +197,16 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/ignore": {
       "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
-      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.0",
         "debug": "^4.1.1",
@@ -232,15 +218,13 @@
     },
     "node_modules/@humanwhocodes/object-schema": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -251,18 +235,16 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -273,8 +255,6 @@
     },
     "node_modules/@raycast/api": {
       "version": "1.78.1",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.78.1.tgz",
-      "integrity": "sha512-DZ3KdS/fIZba7PHzBpWYU2w3MXnr/RC7RgwAlU839G0pIwayP6/gwecsmJPRdQ3wuHIH4iX91aUthBKmTib9WQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -304,16 +284,14 @@
     },
     "node_modules/@raycast/api/node_modules/@types/node": {
       "version": "20.11.28",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.28.tgz",
-      "integrity": "sha512-M/GPWVS2wLkSkNHVeLkrF2fD5Lx5UC4PxA0uZcKc6QqbIQUJyW1jVjueJYi1z8n0I5PxYrtpnPnWglE+y9A0KA==",
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
     },
     "node_modules/@raycast/utils": {
       "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-1.16.0.tgz",
-      "integrity": "sha512-pC0Cft6KHpVUQkVesbweqJycFfrqeKhISV50eFMwGN51jbCxzAXPT443g0LArsEoYSOWXBfpXmrNvgeO4RjOLg==",
+      "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",
         "cross-fetch": "^3.1.6",
@@ -330,41 +308,31 @@
     },
     "node_modules/@raycast/utils/node_modules/cross-fetch": {
       "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
-      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.12"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "18.8.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.3.tgz",
-      "integrity": "sha512-0os9vz6BpGwxGe9LOhgP/ncvYN5Tx1fNcd2TM3rD/aCGBkysb+ZWpXEocG24h6ZzOi13+VB8HndAQFezsSOw1w=="
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.0"
-      }
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.11",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
-      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.3",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-      "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -373,20 +341,17 @@
     },
     "node_modules/@types/semver": {
       "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/uuid": {
       "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
-      "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.62.0",
@@ -418,9 +383,8 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
-      "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -445,9 +409,8 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
-      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "5.62.0",
         "@typescript-eslint/visitor-keys": "5.62.0"
@@ -462,9 +425,8 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
-      "integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/typescript-estree": "5.62.0",
         "@typescript-eslint/utils": "5.62.0",
@@ -489,9 +451,8 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
-      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -502,9 +463,8 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
-      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "@typescript-eslint/types": "5.62.0",
         "@typescript-eslint/visitor-keys": "5.62.0",
@@ -529,9 +489,8 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
-      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
@@ -555,9 +514,8 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
-      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "5.62.0",
         "eslint-visitor-keys": "^3.3.0"
@@ -570,22 +528,10 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/acorn": {
       "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -595,28 +541,14 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/agentkeepalive": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
-      "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -632,27 +564,24 @@
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -665,35 +594,27 @@
     },
     "node_modules/argparse": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/array-union": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
@@ -704,11 +625,6 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
-    },
-    "node_modules/base-64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
     },
     "node_modules/brace-expansion": {
       "version": "5.0.9",
@@ -725,9 +641,8 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -735,33 +650,18 @@
         "node": ">=8"
       }
     },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -773,19 +673,10 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -795,41 +686,25 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/content-type": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/cross-fetch": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.12"
       }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -841,29 +716,18 @@
         "node": ">= 8"
       }
     },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/csstype": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "license": "MIT"
     },
     "node_modules/csv-parse": {
       "version": "5.5.6",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.5.6.tgz",
-      "integrity": "sha512-uNpm30m/AGSkLxxy7d9yRXpJQFrZzVWLFBkS+6ngPcZkw/5k3L/jjFuj7tVnEpRn+QgmiXr21nDlhCiUK4ij2A=="
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -878,40 +742,20 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dequal": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
-    "node_modules/digest-fetch": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/digest-fetch/-/digest-fetch-1.3.0.tgz",
-      "integrity": "sha512-CGJuv6iKNM7QyZlM2T3sPAdZWd/p9zQiRNS9G+9COUCwzWFTs0Xp8NF5iePx7wtvhDykReiRRrSeNb4oMmB8lA==",
-      "dependencies": {
-        "base-64": "^0.1.0",
-        "md5": "^2.3.0"
-      }
-    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-type": "^4.0.0"
       },
@@ -921,9 +765,8 @@
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -931,31 +774,15 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/enquirer": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
-      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -964,56 +791,10 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -1023,9 +804,8 @@
     },
     "node_modules/eslint": {
       "version": "7.32.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
-      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -1080,9 +860,8 @@
     },
     "node_modules/eslint-config-prettier": {
       "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
-      "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -1092,9 +871,8 @@
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -1105,9 +883,8 @@
     },
     "node_modules/eslint-utils": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^1.1.0"
       },
@@ -1120,18 +897,16 @@
     },
     "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -1141,27 +916,24 @@
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/eslint/node_modules/ignore": {
       "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/espree": {
       "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
-      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^7.4.0",
         "acorn-jsx": "^5.3.1",
@@ -1173,18 +945,16 @@
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -1195,9 +965,8 @@
     },
     "node_modules/esquery": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
-      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -1207,18 +976,16 @@
     },
     "node_modules/esquery/node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -1228,50 +995,37 @@
     },
     "node_modules/esrecurse/node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
     },
     "node_modules/estraverse": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
     },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -1285,15 +1039,17 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "license": "Unlicense"
     },
     "node_modules/fast-uri": {
       "version": "3.1.5",
@@ -1314,18 +1070,16 @@
     },
     "node_modules/fastq": {
       "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
-      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
       }
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "flat-cache": "^3.0.4"
       },
@@ -1335,9 +1089,8 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -1347,9 +1100,8 @@
     },
     "node_modules/flat-cache": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
-      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.3",
@@ -1361,115 +1113,23 @@
     },
     "node_modules/flatted": {
       "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/form-data": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
-      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.4",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
-    },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
-      }
-    },
-    "node_modules/formdata-node/node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "dev": true
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1487,9 +1147,8 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -1499,9 +1158,8 @@
     },
     "node_modules/globals": {
       "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -1514,9 +1172,8 @@
     },
     "node_modules/globby": {
       "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -1532,94 +1189,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/graphemer": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "dependencies": {
-        "ms": "^2.0.0"
-      }
-    },
     "node_modules/ignore": {
       "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -1633,18 +1227,16 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
       }
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1652,38 +1244,29 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
-    },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -1693,28 +1276,23 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1727,36 +1305,42 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
     },
     "node_modules/levn": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -1767,20 +1351,16 @@
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -1791,9 +1371,8 @@
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -1801,46 +1380,23 @@
         "node": ">=10"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
-    },
     "node_modules/media-typer": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/merge2": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1851,29 +1407,8 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/minimatch": {
       "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1885,43 +1420,22 @@
     },
     "node_modules/ms": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/natural-compare-lite": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-      "dev": true
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "engines": {
-        "node": ">=10.5.0"
-      }
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -1939,26 +1453,23 @@
     },
     "node_modules/object-hash": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/optionator": {
       "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
-      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
@@ -1973,9 +1484,8 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -1985,35 +1495,30 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2025,18 +1530,16 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
       }
     },
     "node_modules/prettier": {
       "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -2049,118 +1552,22 @@
     },
     "node_modules/progress": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/raycast": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/raycast/-/raycast-1.0.8.tgz",
-      "integrity": "sha512-jbd5830Xdc2l+lIiKoXXwYAk6gqoO5O+7fxg8Q85bcA5cjX9unrAmZRZmkhvuH4OU/W0pQPmvF1P1sXAJvWXcg=="
-    },
-    "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/regexpp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "dev": true,
       "funding": [
         {
@@ -2176,15 +1583,98 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/raycast": {
+      "version": "1.0.8",
+      "license": "ISC"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/regexpp": {
+      "version": "3.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/semver": {
       "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -2197,9 +1687,8 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -2209,17 +1698,15 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
       "engines": {
         "node": ">=14"
       },
@@ -2229,18 +1716,16 @@
     },
     "node_modules/slash": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/slice-ansi": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -2255,28 +1740,32 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
     },
     "node_modules/stream-chain": {
       "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
-      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/stream-json": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.8.0.tgz",
-      "integrity": "sha512-HZfXngYHUAr1exT4fxlbc1IOce1RYxp2ldeaf97LYCOPSoOqY/1Psp7iGvpb+6JIOgkra9zDYnPX01hGAHzEPw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "stream-chain": "^2.2.5"
       }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -2288,9 +1777,8 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -2300,9 +1788,8 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -2312,9 +1799,8 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -2324,9 +1810,8 @@
     },
     "node_modules/table": {
       "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
-      "integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "ajv": "^8.0.1",
         "lodash.truncate": "^4.4.2",
@@ -2340,8 +1825,6 @@
     },
     "node_modules/table/node_modules/ajv": {
       "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2357,21 +1840,18 @@
     },
     "node_modules/table/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/text-table": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -2381,20 +1861,21 @@
     },
     "node_modules/tr46": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "license": "MIT"
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^1.8.1"
       },
@@ -2407,9 +1888,8 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -2419,9 +1899,8 @@
     },
     "node_modules/type-fest": {
       "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -2431,9 +1910,8 @@
     },
     "node_modules/typescript": {
       "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2444,22 +1922,18 @@
     },
     "node_modules/undici-types": {
       "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
     },
     "node_modules/uuid": {
       "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -2471,27 +1945,16 @@
     },
     "node_modules/v8-compile-cache": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.4.0.tgz",
-      "integrity": "sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==",
-      "dev": true
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "engines": {
-        "node": ">= 8"
-      }
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -2499,9 +1962,8 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -2514,15 +1976,13 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     }
   }
 }

--- a/extensions/claude/package.json
+++ b/extensions/claude/package.json
@@ -101,7 +101,7 @@
     }
   ],
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.18.0",
+    "@anthropic-ai/sdk": "^0.115.0",
     "@raycast/api": "^1.78.0",
     "@raycast/utils": "^1.14.1",
     "@types/uuid": "^9.0.0",

--- a/extensions/claude/src/api/models.ts
+++ b/extensions/claude/src/api/models.ts
@@ -4,6 +4,15 @@ export interface AvailableModel {
   id: string;
   display_name: string;
   created_at: string;
+  /** Output-token ceiling as advertised by the API. Absent on older API responses. */
+  max_tokens?: number;
+  /**
+   * Maximum input context window in tokens, as advertised by the API. Absent on older
+   * API responses. This is the whole input budget and `max_tokens` is NOT drawn from it —
+   * the two are separate limits, so `src/utils/contextWindow.ts` spends this entire value
+   * on conversation history rather than reserving output headroom out of it.
+   */
+  max_input_tokens?: number;
 }
 
 interface ModelApiResponse {
@@ -12,49 +21,92 @@ interface ModelApiResponse {
     id: string;
     display_name: string;
     created_at: string;
+    max_tokens?: number;
+    max_input_tokens?: number;
   }>;
   has_more: boolean;
-  first_id: string;
-  last_id: string;
+  first_id: string | null;
+  last_id: string | null;
 }
+
+/** The endpoint's maximum page size; it defaults to 20 without this. */
+const MODELS_PAGE_LIMIT = 1000;
+
+/** Stops a malformed `has_more` from looping forever. */
+const MAX_MODEL_PAGES = 10;
 
 const MODELS_CACHE_KEY = "available_models_cache";
 
 // Hardcoded fallback list in case API and cache both fail
 const FALLBACK_MODELS: AvailableModel[] = [
-  { id: "claude-haiku-4-5-20251001", display_name: "Claude Haiku 4.5", created_at: "2025-10-15T00:00:00Z" },
-  { id: "claude-sonnet-4-5-20250929", display_name: "Claude Sonnet 4.5", created_at: "2025-09-29T00:00:00Z" },
-  { id: "claude-opus-4-1-20250805", display_name: "Claude Opus 4.1", created_at: "2025-08-05T00:00:00Z" },
+  {
+    id: "claude-haiku-4-5-20251001",
+    display_name: "Claude Haiku 4.5",
+    created_at: "2025-10-15T00:00:00Z",
+    max_tokens: 64000,
+  },
+  {
+    id: "claude-sonnet-4-5-20250929",
+    display_name: "Claude Sonnet 4.5",
+    created_at: "2025-09-29T00:00:00Z",
+    max_tokens: 64000,
+  },
+  {
+    id: "claude-opus-4-1-20250805",
+    display_name: "Claude Opus 4.1",
+    created_at: "2025-08-05T00:00:00Z",
+    max_tokens: 32000,
+  },
 ];
 
 /**
- * Fetches available models from the Anthropic API
+ * Fetches every available model from the Anthropic API.
+ *
+ * The endpoint is cursor-paginated and returns 20 models per page by default, so a
+ * single request silently truncates the list — an account with more models than one
+ * page would simply never see the rest. This requests the maximum page size and
+ * follows `has_more`/`last_id` until the list is exhausted.
  */
 export async function fetchAvailableModels(): Promise<AvailableModel[]> {
-  const apiKey = getPreferenceValues<{ apiKey: string }>().apiKey;
+  const { apiKey } = getPreferenceValues<Preferences>();
 
   try {
-    const response = await fetch("https://api.anthropic.com/v1/models", {
-      method: "GET",
-      headers: {
-        "x-api-key": apiKey,
-        "anthropic-version": "2023-06-01",
-        "Content-Type": "application/json",
-      },
-    });
+    const models: AvailableModel[] = [];
+    let afterId: string | null = null;
 
-    if (!response.ok) {
-      throw new Error(`API request failed: ${response.status} ${response.statusText}`);
+    for (let page = 0; page < MAX_MODEL_PAGES; page++) {
+      const url = new URL("https://api.anthropic.com/v1/models");
+      url.searchParams.set("limit", String(MODELS_PAGE_LIMIT));
+      if (afterId) url.searchParams.set("after_id", afterId);
+
+      const response = await fetch(url, {
+        method: "GET",
+        headers: {
+          "x-api-key": apiKey,
+          "anthropic-version": "2023-06-01",
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`API request failed: ${response.status} ${response.statusText}`);
+      }
+
+      const data = (await response.json()) as ModelApiResponse;
+
+      models.push(
+        ...data.data.map((model) => ({
+          id: model.id,
+          display_name: model.display_name,
+          created_at: model.created_at,
+          max_tokens: model.max_tokens,
+          max_input_tokens: model.max_input_tokens,
+        }))
+      );
+
+      if (!data.has_more || !data.last_id) break;
+      afterId = data.last_id;
     }
-
-    const data: ModelApiResponse = await response.json();
-
-    // Transform API response to our internal format
-    const models: AvailableModel[] = data.data.map((model) => ({
-      id: model.id,
-      display_name: model.display_name,
-      created_at: model.created_at,
-    }));
 
     // Cache the successful response
     await cacheModels(models);

--- a/extensions/claude/src/hooks/useChat.tsx
+++ b/extensions/claude/src/hooks/useChat.tsx
@@ -2,12 +2,41 @@ import { getPreferenceValues, clearSearchBar, showToast, Toast } from "@raycast/
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { Chat, ChatHook, Model } from "../type";
-import { chatTransformer } from "../utils";
+import { getCachedModels } from "../api/models";
+import { buildBoundedMessages } from "../utils/contextWindow";
+import { buildModelRequestParams, nonstreamingRetryParams } from "../utils/models";
 import { useAnthropic } from "./useAnthropic";
 import { useHistory } from "./useHistory";
 import { MessageStream } from "@anthropic-ai/sdk/lib/MessageStream";
 
 const STREAM_UPDATE_INTERVAL_MS = 50;
+
+/**
+ * Human-readable note shown when older turns were left out of the request. Silent
+ * trimming would make Claude look like it forgot the conversation — this makes the bound
+ * visible as a product limit rather than a model failure.
+ */
+function trimmedNoteFor(droppedTurnCount: number, countFailed: boolean): string {
+  const subject = `the oldest ${droppedTurnCount} turn${droppedTurnCount === 1 ? "" : "s"} of this conversation ${
+    droppedTurnCount === 1 ? "wasn't" : "weren't"
+  } sent`;
+  // Two different causes reach this note and they are not interchangeable. Attributing a
+  // failed token count to context length would be a plain lie about why turns went
+  // missing, and it is the caption a user would act on by pruning a conversation that
+  // was never too long in the first place.
+  return countFailed
+    ? `Note: ${subject} — the token count for this conversation couldn't be checked, so a conservative amount was kept.`
+    : `Note: ${subject} — it's getting long for this model's context window.`;
+}
+
+/**
+ * Composes error text with the trim note so both survive on the one shared toast. The
+ * failure handlers assign `toast.message` outright, which would otherwise discard the
+ * note precisely when it best explains the failure.
+ */
+function failureMessageWith(trimNote: string | undefined, error: string): string {
+  return trimNote ? `${error}\n\n${trimNote}` : error;
+}
 
 export function useChat<T extends Chat>(props: T[]): ChatHook {
   const [data, setData] = useState<Chat[]>(props);
@@ -24,13 +53,28 @@ export function useChat<T extends Chat>(props: T[]): ChatHook {
   const streamRef = useRef<MessageStream | null>(null);
   // Ref for throttled updates
   const updateIntervalRef = useRef<NodeJS.Timeout | null>(null);
+  /**
+   * Monotonic id for the most recently submitted question.
+   *
+   * `ask()` now awaits a cache read and a `countTokens()` round trip BEFORE it touches
+   * the shared stream refs, and those awaits can finish out of order. Without a claim
+   * taken before the first await, a slower earlier question resumes last, treats the
+   * newer in-flight stream as "the existing one", aborts it, and installs itself — so
+   * the question the user asked first wins and the newer one is abandoned. Ordering by
+   * arrival is not something the network will do for us.
+   */
+  const requestGenerationRef = useRef(0);
+  /** False once unmounted, so a continuation resuming after teardown does nothing. */
+  const isMountedRef = useRef(true);
 
   const history = useHistory();
   const chatAnthropic = useAnthropic();
 
   // Cleanup stream on unmount
   useEffect(() => {
+    isMountedRef.current = true;
     return () => {
+      isMountedRef.current = false;
       if (streamRef.current) {
         streamRef.current.abort();
         streamRef.current = null;
@@ -43,6 +87,11 @@ export function useChat<T extends Chat>(props: T[]): ChatHook {
   }, []);
 
   async function ask(question: string, model: Model) {
+    // Claimed BEFORE any await, so ownership is decided by submission order rather than
+    // by whichever token count happens to come back first.
+    const generation = ++requestGenerationRef.current;
+    const isCurrent = () => isMountedRef.current && requestGenerationRef.current === generation;
+
     clearSearchBar();
     setLoading(true);
 
@@ -61,6 +110,45 @@ export function useChat<T extends Chat>(props: T[]): ChatHook {
     setData((prev) => {
       return [...prev, chat];
     });
+
+    // Bound the request to the model's input budget. The full transcript stays intact for
+    // display — only what goes to the API is trimmed. Reads the cached model list rather
+    // than threading it through every caller; when it is absent the bound falls back to a
+    // conservative default window rather than blocking the question.
+    const cachedModels = await getCachedModels();
+    const availableModel = cachedModels?.find((m) => m.id === model.option);
+    const {
+      messages: boundedMessages,
+      trimmed,
+      droppedTurnCount,
+      countFailed,
+    } = await buildBoundedMessages({
+      chats: data,
+      question,
+      model,
+      availableModel,
+      countTokens: (params) => chatAnthropic.messages.countTokens(params),
+    });
+
+    const trimNote = trimmed ? trimmedNoteFor(droppedTurnCount, countFailed) : undefined;
+    if (trimNote) {
+      toast.message = trimNote;
+    }
+
+    const messages = [...boundedMessages, { role: "user" as const, content: question }];
+
+    // Everything above this line is preparation and touches nothing shared. Everything
+    // below claims the stream refs or issues a request, so a superseded or unmounted
+    // continuation must stop here — before it can abort the stream a newer question
+    // already installed, or resurrect state on a torn-down view.
+    if (!isCurrent()) {
+      if (isMountedRef.current) {
+        // Nothing downstream will ever complete this row: no request is issued, so no
+        // handler fires to fill it in. Drop it rather than leave a blank question behind.
+        setData((prev) => prev.filter((a) => a.id !== chat.id));
+      }
+      return;
+    }
 
     if (useStream) {
       // Abort any existing stream before starting a new one
@@ -84,21 +172,29 @@ export function useChat<T extends Chat>(props: T[]): ChatHook {
       }, STREAM_UPDATE_INTERVAL_MS);
 
       const stream = chatAnthropic.messages.stream({
-        model: model.option,
-        temperature: Number(model.temperature),
-        system: model.prompt,
-        max_tokens: Number(model.max_tokens) || 4096,
-        messages: [...chatTransformer(data), { role: "user", content: question }],
+        ...buildModelRequestParams(model, { streaming: true }),
+        messages,
       });
 
       streamRef.current = stream;
 
       stream
+        // `abort()` emits "abort", not "error", and the SDK rejects an internal promise
+        // when nothing is listening for it — an unhandled rejection every time a question
+        // supersedes an in-flight one. Listening is enough to defuse it.
+        .on("abort", () => {
+          /* superseded or unmounted; the "end" guard below handles the state */
+        })
         .on("text", (res) => {
           streamedChat.answer += res;
           pendingUpdate = true;
         })
         .on("end", () => {
+          // An aborted stream still emits "end". Without this guard the superseded
+          // request would commit its partial answer, flip the toast to Success, clear
+          // isLoading while the newer request is still running, and null out streamRef —
+          // which by then holds the NEW stream, leaving it un-abortable.
+          if (streamRef.current !== stream) return;
           // Clear the update interval
           if (updateIntervalRef.current) {
             clearInterval(updateIntervalRef.current);
@@ -118,6 +214,9 @@ export function useChat<T extends Chat>(props: T[]): ChatHook {
           toast.style = Toast.Style.Success;
         })
         .on("error", (err) => {
+          // Same ownership guard as "end": a superseded stream must not overwrite the
+          // active request's toast or clear its loading state.
+          if (streamRef.current !== stream) return;
           // Clear the update interval
           if (updateIntervalRef.current) {
             clearInterval(updateIntervalRef.current);
@@ -125,49 +224,82 @@ export function useChat<T extends Chat>(props: T[]): ChatHook {
           }
           streamRef.current = null;
           toast.title = "Error";
-          toast.message = `Couldn't stream message: ${err}`;
+          toast.message = failureMessageWith(trimNote, `Couldn't stream message: ${err}`);
           toast.style = Toast.Style.Failure;
           setLoading(false);
         });
     } else {
-      await chatAnthropic.messages
-        .create({
-          model: model.option,
-          temperature: Number(model.temperature),
-          system: model.prompt,
-          max_tokens: Number(model.max_tokens) || 4096,
-          messages: [...chatTransformer(data), { role: "user", content: question }],
-        })
+      // `messages.create()` validates the non-streaming token ceiling BEFORE it returns a
+      // promise, so that failure throws synchronously and a `.catch()` chained onto the
+      // call never sees it. `ask()` is called without `await` from every caller, so an
+      // escaping throw becomes an unhandled rejection and the UI is simply abandoned:
+      // the toast spins on "Getting your answer..." forever and isLoading is never
+      // cleared. Running it inside an async function converts that into a rejection the
+      // `.catch()` below does see.
+      const requestParams = buildModelRequestParams(model, { streaming: false });
+      const createNonStreaming = async () => {
+        try {
+          return await chatAnthropic.messages.create({ ...requestParams, messages });
+        } catch (error) {
+          // The SDK also enforces a per-model ceiling it does not expose, so the only way
+          // to know is to be told. The rejection happens before the request leaves the
+          // process, so this retry costs no round trip.
+          const retryParams = nonstreamingRetryParams(requestParams, error);
+          if (!retryParams) throw error;
+          return await chatAnthropic.messages.create({ ...retryParams, messages });
+        }
+      };
+
+      await createNonStreaming()
         .then(async (res) => {
           if ("content" in res) {
-            chat = { ...chat, answer: res.content[0].text };
+            // `content` is a union of block types and only text blocks carry `text`, so
+            // indexing [0].text is unsound — a leading thinking block would break it.
+            const answer = res.content
+              .filter((block): block is Extract<typeof block, { type: "text" }> => block.type === "text")
+              .map((block) => block.text)
+              .join("");
+            chat = { ...chat, answer };
           }
 
+          // The toast and the loading flag are SHARED, so only the current request may
+          // touch them. A non-streaming request is never aborted, so an earlier one that
+          // finishes after a newer question was asked would otherwise announce "Got your
+          // answer!" and clear loading while the newer answer is still generating.
+          if (!isCurrent()) return;
           toast.title = "Got your answer!";
           toast.style = Toast.Style.Success;
           setLoading(false);
         })
         .catch((err) => {
+          // Same ownership rule: a superseded request's failure must not replace the
+          // live request's toast or stop its spinner.
+          if (!isCurrent()) return;
           toast.title = "Error";
           if (err instanceof Error) {
-            toast.message = err?.message;
+            toast.message = failureMessageWith(trimNote, err.message);
           }
           toast.style = Toast.Style.Failure;
           setLoading(false);
         });
 
-      // Update data and history only for non-streaming mode
-      // (streaming mode handles this in the on("end") handler)
-      setData((prev) => {
-        return prev.map((a) => {
-          if (a.id === chat.id) {
-            return chat;
-          }
-          return a;
+      // Its OWN row and history entry are not shared state — the answer really did
+      // arrive and the row for this question already exists — so a superseded request
+      // still fills them in. Only a torn-down view is skipped.
+      if (isMountedRef.current) {
+        // Update data and history only for non-streaming mode
+        // (streaming mode handles this in the on("end") handler)
+        setData((prev) => {
+          return prev.map((a) => {
+            if (a.id === chat.id) {
+              return chat;
+            }
+            return a;
+          });
         });
-      });
 
-      history.add(chat);
+        history.add(chat);
+      }
     }
   }
 

--- a/extensions/claude/src/hooks/useModel.tsx
+++ b/extensions/claude/src/hooks/useModel.tsx
@@ -1,7 +1,7 @@
 import { LocalStorage, showToast, Toast } from "@raycast/api";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Model, ModelHook } from "../type";
-import { fetchAvailableModels } from "../api/models";
+import { fetchAvailableModels, type AvailableModel } from "../api/models";
 
 export const DEFAULT_MODEL: Model = {
   id: "default",
@@ -35,7 +35,7 @@ export function useModel(): ModelHook {
   const [data, setData] = useState<Model[]>([]);
   const [isLoading, setLoading] = useState(false);
   const [option, setOption] = useState<Model["option"][]>(FALLBACK_OPTIONS);
-  const [availableModels, setAvailableModels] = useState<Array<{ id: string; display_name: string }>>([]);
+  const [availableModels, setAvailableModels] = useState<AvailableModel[]>([]);
 
   useEffect(() => {
     setLoading(true);

--- a/extensions/claude/src/type.ts
+++ b/extensions/claude/src/type.ts
@@ -1,3 +1,5 @@
+import type { AvailableModel } from "./api/models";
+
 export type Set<T> = React.Dispatch<React.SetStateAction<T>>;
 
 export type Message = {
@@ -68,7 +70,7 @@ export type QuestionHook = BaseHook<string> & { update: PromiseFunctionWithOneAr
 export type ModelHook = Hook<Model> & {
   update: PromiseFunctionWithOneArg<Model>;
   option: Model["option"][];
-  availableModels: Array<{ id: string; display_name: string }>;
+  availableModels: AvailableModel[];
 };
 
 export interface ChatHook {

--- a/extensions/claude/src/utils/contextWindow.ts
+++ b/extensions/claude/src/utils/contextWindow.ts
@@ -1,0 +1,327 @@
+import type { AvailableModel } from "../api/models";
+import type { Chat, Message } from "../type";
+import { chatTransformer, toChronological } from "./index";
+
+/**
+ * Conservative turn cap used when `countTokens()` itself fails (network error, rate
+ * limit, etc). A failed count must never block the question — this trades precision for
+ * availability.
+ *
+ * A turn cap ALONE is not a size limit: ten turns of pasted logs can exceed any model's
+ * window, so "last 10 turns" contradicted this module's stated guarantee that the request
+ * fits the input budget. `estimateRequestTokens` below adds the missing size check, and
+ * this cap remains as the backstop for the case that estimate cannot cover.
+ */
+export const FALLBACK_TURN_CAP = 10;
+
+/**
+ * Per-message allowance for request framing on the fallback path.
+ *
+ * `countTokens()` counts a structured request, not concatenated text: role delimiters,
+ * message boundaries, and control tokens all cost tokens while consuming none of the
+ * text this module can measure. There is no published constant for that framing and it
+ * varies by model, so this is an explicit policy reserve rather than a derived figure.
+ * It is per-message because that is the shape framing actually takes — a flat reserve
+ * would be negligible against a 200k window and ruinous against a small one.
+ */
+export const FRAMING_TOKENS_PER_MESSAGE = 8;
+
+/**
+ * UTF-8 byte length, used as the fallback path's token estimate.
+ *
+ * Bytes rather than `String.length` because JS characters are UTF-16 code units and bear
+ * no fixed relationship to tokens: ASCII is 1 byte per character, but CJK and Devanagari
+ * are 3 and emoji are 2 or more. A character count therefore *under*-estimates dense
+ * scripts — the exact content most likely to exceed a budget — while bytes scale with
+ * encoded size and, for ordinary text, sit comfortably above the real token count.
+ *
+ * `Buffer.byteLength` rather than `TextEncoder` or `Buffer.from(...).length`: it returns
+ * the length without allocating the encoded array, which matters on a long transcript,
+ * and it is properly typed here via `@types/node` (this `tsconfig` has no DOM lib).
+ *
+ * THIS IS A HEURISTIC, NOT A BOUND, and the distinction is deliberate. Every ordinary
+ * token consumes at least one byte, but special and structural tokens consume none of
+ * the user's bytes at all, so no byte count can prove a request fits — which is why
+ * `FRAMING_TOKENS_PER_MESSAGE` exists, why `FALLBACK_TURN_CAP` remains a real backstop,
+ * and why the result carries `countFailed: true`. A measured count is the only thing
+ * that establishes the request fits; this path exists to keep the conversation usable
+ * when measuring is impossible, not to replace it.
+ */
+function utf8ByteLength(text: string): number {
+  return Buffer.byteLength(text, "utf8");
+}
+
+/**
+ * Conservative input-window assumption used when the API doesn't report
+ * `max_input_tokens` (older API responses, or the hardcoded `FALLBACK_MODELS` list in
+ * `src/api/models.ts`). Smaller than every current Claude model's real window, so the
+ * bound is honest rather than a guess dressed up as the real ceiling.
+ */
+export const DEFAULT_INPUT_WINDOW_TOKENS = 100_000;
+
+/** Function shape of `client.messages.countTokens()`, narrowed to what this module needs. */
+export type CountTokensFn = (params: {
+  model: string;
+  system?: string;
+  messages: Message[];
+}) => Promise<{ input_tokens: number }>;
+
+/**
+ * Hard ceiling on `countTokens()` calls per `buildBoundedMessages` invocation, independent
+ * of the search strategy. Binary search over even a pathologically large transcript needs
+ * only ~log2(n) calls (a 10,000-turn conversation is under 14), so this ceiling exists to
+ * guarantee no future change to the trim algorithm can reintroduce an unbounded — or merely
+ * very large — sequence of network round-trips, not because it is expected to bind.
+ */
+export const MAX_COUNT_CALLS = 20;
+
+export interface BuildBoundedRequestParams {
+  /** Full transcript, in any order — chronological order is established internally. */
+  chats: Chat[];
+  /** The new question being asked, not yet part of `chats`. */
+  question: string;
+  model: {
+    option: string;
+    prompt: string;
+  };
+  availableModel: Pick<AvailableModel, "max_tokens" | "max_input_tokens"> | undefined;
+  countTokens: CountTokensFn;
+}
+
+export interface BuildBoundedRequestResult {
+  /** Bounded message list, chronological, ready to send as `messages`. */
+  messages: Message[];
+  /** True when one or more older turns were left out of the request. */
+  trimmed: boolean;
+  /** How many of the transcript's turns were dropped from the request. */
+  droppedTurnCount: number;
+  /** True when the bound came from the turn-cap fallback because counting failed. */
+  countFailed: boolean;
+}
+
+/**
+ * The input token budget for a request.
+ *
+ * This is `max_input_tokens` as advertised, NOT that value minus `max_tokens`. The two
+ * are separate budgets: the API documents `max_input_tokens` as "Maximum input context
+ * window size in tokens for this model" and `max_tokens` as "Maximum value for the
+ * `max_tokens` parameter when using this model". Output is not drawn from the input
+ * window, so reserving it here discards usable input for nothing — on a 200k model
+ * advertising a 64k output ceiling that is 32% of the window, and the user would be told
+ * their conversation had been trimmed while a third of the budget sat unspent.
+ *
+ * The subtraction was also reserving the wrong number on its own terms: the model's
+ * ceiling rather than the `max_tokens` the request actually asks for.
+ */
+export function computeInputBudget(
+  availableModel: Pick<AvailableModel, "max_tokens" | "max_input_tokens"> | undefined
+): number {
+  const maxInputTokens = availableModel?.max_input_tokens ?? DEFAULT_INPUT_WINDOW_TOKENS;
+  // A pathological or absent advertised window must never produce a non-positive budget.
+  return Math.max(maxInputTokens, 1);
+}
+
+/**
+ * Estimated request tokens for the fallback path: encoded size of everything actually
+ * sent, plus a per-message framing allowance.
+ *
+ * `system` is included because the real request carries the preset's prompt as a
+ * top-level `system` field and `countTokens()` counts it. Omitting it made every
+ * estimate short by the whole length of the user's system prompt, which for a preset
+ * built around a long instruction block is not a rounding error.
+ */
+function estimateRequestTokens(messages: Message[], system: string, question: string): number {
+  const textBytes =
+    utf8ByteLength(system) +
+    utf8ByteLength(question) +
+    messages.reduce((total, message) => total + utf8ByteLength(message.content), 0);
+  // +1 for the pending question, which becomes a message of its own.
+  const framing = FRAMING_TOKENS_PER_MESSAGE * (messages.length + 1);
+  return textBytes + framing;
+}
+
+/**
+ * Turn-pair count fallback, shared by the upfront-failure and mid-search-failure paths.
+ * A failed count must never block the question, so this degrades to a conservative bound
+ * rather than blocking or sending everything. `turnPairs` is always the FULL turn-pair
+ * list here — both call sites fall back against the whole transcript, not against
+ * whatever partial candidate the search was probing when the failure happened.
+ *
+ * TWO limits apply, and the tighter one wins:
+ *
+ * 1. `FALLBACK_TURN_CAP` — at most the newest 10 turn-pairs.
+ * 2. `estimateRequestTokens` — pairs are dropped oldest-first until the estimate fits
+ *    `budget`.
+ *
+ * Limit 2 exists because a turn cap alone is not a size limit at all: ten turns of pasted
+ * logs, or a single enormous turn, sailed past the input budget with nothing checking
+ * size, while this module's docstring claimed the request was bounded.
+ *
+ * NEITHER LIMIT MAKES THIS SOUND, and the wording here is deliberate. The estimate counts
+ * encoded bytes plus a framing allowance, both of which sit above the token count for
+ * ordinary text — but structural tokens consume no user bytes, no framing constant is
+ * published, and the count endpoint is itself documented as approximate. `countFailed:
+ * true` is therefore not a footnote: it is the caller's signal that nothing here was
+ * measured. A request trimmed on this path can still be rejected, and that rejection is
+ * the honest outcome rather than a silently dropped question.
+ *
+ * A single turn larger than the whole budget cannot be made to fit by dropping others —
+ * that pair is kept anyway rather than sending an empty transcript, which on its own
+ * makes "the request fits" unclaimable even with a perfect estimate.
+ */
+function fallbackResult(
+  turnPairs: Message[][],
+  system: string,
+  question: string,
+  budget: number
+): BuildBoundedRequestResult {
+  let keptPairs = Math.min(turnPairs.length, FALLBACK_TURN_CAP);
+  // Drop oldest-first until the estimate fits. Stops at 1 rather than 0: an over-budget
+  // single newest turn is the API's call to reject, not ours to silently swallow.
+  while (
+    keptPairs > 1 &&
+    estimateRequestTokens(turnPairs.slice(turnPairs.length - keptPairs).flat(), system, question) > budget
+  ) {
+    keptPairs -= 1;
+  }
+
+  const droppedTurnCount = turnPairs.length - keptPairs;
+  const messages = turnPairs.slice(turnPairs.length - keptPairs).flat();
+  return {
+    messages,
+    trimmed: droppedTurnCount > 0,
+    droppedTurnCount,
+    countFailed: true,
+  };
+}
+
+/**
+ * Builds the bounded message list for a request: newest-first accumulation of prior
+ * turns until adding the next-oldest turn would exceed the input budget, then restored
+ * to chronological order. `question` is not counted here — callers append it as the
+ * final user turn after this returns, matching the existing `[...chatTransformer(data),
+ * { role: "user", content: question }]` shape in `useChat.tsx`.
+ *
+ * Counts with the API's own `client.messages.countTokens()` rather than a character
+ * heuristic — a hand-rolled estimate is exactly the kind of guess that produced the
+ * `max_tokens` name-inference bug retired earlier in this project.
+ *
+ * WHAT IS AND IS NOT GUARANTEED — the asymmetry is the whole point:
+ *
+ * When `countTokens()` SUCCEEDS, the returned list was MEASURED to fit the input budget.
+ * That is a guarantee.
+ *
+ * When it FAILS, nothing here is guaranteed. The list is limited by a turn cap
+ * (`FALLBACK_TURN_CAP`) and by `estimateRequestTokens`, which counts encoded bytes plus a
+ * framing allowance — both above the token count for ordinary text, neither a proof.
+ * Structural tokens consume no user bytes, no framing constant is published, and even the
+ * count endpoint is documented as approximate. `countFailed: true` is how a caller tells
+ * the two situations apart, and it exists precisely because they are not the same.
+ *
+ * Two cases no estimate rescues: a single newest turn that alone exceeds the budget, and
+ * content whose true token count outruns its encoded size. Both are sent, and the API's
+ * rejection is a truer signal than silently dropping the user's question. A degraded
+ * estimate beats no answer; the unbounded fallback this replaced beat neither.
+ *
+ * When the full transcript is over budget, the number of turn-pairs to keep is found by
+ * **binary search**, not a linear one-pair-at-a-time scan: a 200-turn conversation needing
+ * heavy trimming must not cost ~199 sequential network round-trips (the exact case this
+ * task exists to rescue is a long conversation, so a linear scan is slowest precisely
+ * when the user can least afford to wait). Binary search bounds the call count to
+ * O(log n), and `MAX_COUNT_CALLS` puts a hard ceiling on it regardless. Every candidate
+ * search step is a real `countTokens()` call, so the pair count this function returns is
+ * always one that was *measured* under budget — never merely estimated — whenever
+ * counting succeeds at all.
+ *
+ * The full transcript (`chats`) is never mutated; only the returned message list is
+ * bounded. Display continues to read the untouched transcript.
+ */
+export async function buildBoundedMessages({
+  chats,
+  question,
+  model,
+  availableModel,
+  countTokens,
+}: BuildBoundedRequestParams): Promise<BuildBoundedRequestResult> {
+  const chronological = toChronological(chats);
+  const fullMessages = chatTransformer(chronological);
+
+  if (fullMessages.length === 0) {
+    return { messages: fullMessages, trimmed: false, droppedTurnCount: 0, countFailed: false };
+  }
+
+  const budget = computeInputBudget(availableModel);
+
+  // Turn-pairs (question+answer) are the unit of trimming, always dropped together so a
+  // trimmed request never starts on a dangling assistant turn.
+  const turnPairs: Message[][] = [];
+  for (let i = 0; i < fullMessages.length; i += 2) {
+    turnPairs.push(fullMessages.slice(i, i + 2));
+  }
+
+  let callsMade = 0;
+  /** Counts the newest `pairCount` turn-pairs plus the new question. Call-budgeted. */
+  async function countNewestPairs(pairCount: number): Promise<number> {
+    callsMade += 1;
+    const candidateMessages = turnPairs.slice(turnPairs.length - pairCount).flat();
+    const result = await countTokens({
+      model: model.option,
+      system: model.prompt,
+      messages: [...candidateMessages, { role: "user", content: question }],
+    });
+    return result.input_tokens;
+  }
+
+  let fullTokens: number;
+  try {
+    fullTokens = await countNewestPairs(turnPairs.length);
+  } catch {
+    // Degrade gracefully: a failed count must never block the question. Cap by turn
+    // count instead of tokens — conservative, but keeps the conversation usable.
+    return fallbackResult(turnPairs, model.prompt, question, budget);
+  }
+
+  if (fullTokens <= budget) {
+    return { messages: fullMessages, trimmed: false, droppedTurnCount: 0, countFailed: false };
+  }
+
+  // Over budget: binary search for the largest newest-first pair count that fits,
+  // confirming each candidate with a real countTokens() call rather than an estimate —
+  // an estimate alone could ship an over-budget request; only a measured count can rule
+  // that out. `lo` is always a known-fitting pair count (0 trivially fits: the request
+  // still carries system + question); `hi` is always known NOT to fit (we just measured
+  // the full transcript over budget above, so turnPairs.length qualifies).
+  let lo = 0;
+  let hi = turnPairs.length;
+  let bestFittingCount = 0;
+
+  while (lo < hi && callsMade < MAX_COUNT_CALLS) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (mid === lo) break; // no progress left to make (lo/hi have converged)
+
+    let candidateTokens: number;
+    try {
+      candidateTokens = await countNewestPairs(mid);
+    } catch {
+      // A count that succeeded before and fails mid-search is treated the same as an
+      // upfront failure: fall back to the conservative turn cap on the full transcript.
+      return fallbackResult(turnPairs, model.prompt, question, budget);
+    }
+
+    if (candidateTokens <= budget) {
+      bestFittingCount = mid;
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+
+  // The loop above only ever raises `bestFittingCount` on a *measured* fit, so this final
+  // slice was itself confirmed under budget by a real count — not merely estimated — even
+  // though `hi`'s failing candidates were never re-verified as still failing.
+  const keptPairs = turnPairs.slice(turnPairs.length - bestFittingCount);
+  const messages = keptPairs.flat();
+  const droppedTurnCount = turnPairs.length - bestFittingCount;
+
+  return { messages, trimmed: droppedTurnCount > 0, droppedTurnCount, countFailed: false };
+}

--- a/extensions/claude/src/utils/index.ts
+++ b/extensions/claude/src/utils/index.ts
@@ -1,5 +1,16 @@
 import { Chat, Message } from "../type";
 
+/**
+ * Orders a transcript oldest-first by `created_at`.
+ *
+ * Array position is not a reliable ordering for stored chats, so anything order-sensitive
+ * establishes chronological order itself rather than trusting the array it was handed.
+ * Sending a conversation to the API out of order feeds Claude the discussion backwards.
+ */
+export function toChronological(chats: Chat[]): Chat[] {
+  return [...chats].sort((a, b) => new Date(a.created_at ?? 0).getTime() - new Date(b.created_at ?? 0).getTime());
+}
+
 export function chatTransformer(chat: Chat[]): Message[] {
   const messages: Message[] = [];
   chat.forEach(({ question, answer }) => {

--- a/extensions/claude/src/utils/models.ts
+++ b/extensions/claude/src/utils/models.ts
@@ -1,0 +1,159 @@
+import type { AvailableModel } from "../api/models";
+
+/** Claude model families, ordered from most to least capable. */
+export type ModelTier = "opus" | "sonnet" | "haiku";
+
+export const MODEL_TIERS: ModelTier[] = ["opus", "sonnet", "haiku"];
+
+/** Identifies the family a model id belongs to, or null for anything unrecognized. */
+export function getModelTier(modelId: string): ModelTier | null {
+  return MODEL_TIERS.find((tier) => modelId.includes(tier)) ?? null;
+}
+
+/**
+ * Extracts a comparable generation number from a model id — `claude-opus-4-1-…` → 4.1,
+ * `claude-opus-5` → 5, `claude-3-7-sonnet-…` → 3.7.
+ *
+ * Both id layouts occur in the wild (`claude-<tier>-<version>` for 4+, and
+ * `claude-<version>-<tier>` for 3.x), and a trailing 8-digit date snapshot must never
+ * be read as a version — treating `claude-3-opus-20240229` as generation 20240229 would
+ * rank the oldest model as the newest.
+ */
+export function getModelGeneration(modelId: string): number {
+  // Drop a trailing date snapshot (e.g. -20240229) before looking for version digits.
+  const withoutDate = modelId.replace(/-\d{8}$/, "");
+  // Version digits are 1-2 chars; an 8-digit run is a date, not a version.
+  const match = withoutDate.match(/-(\d{1,2})(?:-(\d{1,2}))?(?=-|$)/);
+  if (!match) return 0;
+  const major = Number(match[1]);
+  const minor = Number(match[2] ?? 0);
+  return major + minor / 10;
+}
+
+/**
+ * The maximum output tokens a model accepts.
+ *
+ * Prefers the `max_tokens` the models API advertises for the model, which is
+ * authoritative. The name-based tiers below are a fallback for older API responses that
+ * omit the field, and for the hardcoded `FALLBACK_MODELS` list.
+ *
+ * This replaces a name-inference heuristic that matched on substrings like `-4-` and
+ * `claude-opus-4`. Every model id outside those shapes — including `claude-opus-5` —
+ * fell through to the legacy 4096 ceiling, silently capping presets on current models at
+ * a fraction of their real output budget. Inferring a capability from an id is the guess
+ * this function now exists to stop making.
+ */
+export function getMaxTokensForModel(modelId: string, availableModels: AvailableModel[] = []): number {
+  // The API advertises the real ceiling per model; trust it over any name heuristic.
+  const advertised = availableModels.find((model) => model.id === modelId)?.max_tokens;
+  if (advertised && advertised > 0) return advertised;
+
+  const tier = getModelTier(modelId);
+  const generation = getModelGeneration(modelId);
+
+  // Claude 3.x and anything unrecognized: the conservative legacy ceiling.
+  if (generation < 4) return 4096;
+
+  return tier === "opus" ? 32000 : 64000;
+}
+
+/**
+ * The largest `max_tokens` this extension sends on a NON-streaming request.
+ *
+ * The SDK applies TWO independent gates to non-streaming calls, and both throw
+ * "Streaming is required for operations that may take longer than 10 minutes" —
+ * SYNCHRONOUSLY, before any promise exists and before any network call is made:
+ *
+ * 1. A projected-runtime gate, `60min * max_tokens / 128000 > 10min`, i.e. anything
+ *    above 21333. Deterministic, model-independent, and what this constant encodes.
+ * 2. A per-model cap, `MODEL_NONSTREAMING_TOKENS[model]` — 8192 for the Opus 4 and
+ *    4.1 ids. That map lives at `@anthropic-ai/sdk/internal/constants`, which the
+ *    package export map does not expose (`ERR_PACKAGE_PATH_NOT_EXPORTED`), so it
+ *    cannot be read at runtime and a local copy would drift as ids are added.
+ *
+ * Gate 2 is therefore handled by reacting rather than predicting: see
+ * `nonstreamingRetryParams`. Clamping everything to 8192 up front would also work, but
+ * would cost every current model 60% of its non-streaming ceiling to guard a case no
+ * model in the live list can reach.
+ *
+ * Streaming requests bypass both gates entirely and are never clamped.
+ */
+export const MAX_NONSTREAMING_TOKENS = 21333;
+
+/**
+ * The value to retry a non-streaming request at when the SDK rejects the first attempt
+ * on its per-model cap. 8192 is the lowest cap that map contains, so it clears gate 2
+ * for every id currently in it.
+ */
+export const NONSTREAMING_FALLBACK_TOKENS = 8192;
+
+/**
+ * Whether a thrown value is the SDK's non-streaming ceiling rejection.
+ *
+ * Matched on the message because the SDK raises a plain `AnthropicError` with no code or
+ * subclass to test. If that wording ever changes this returns false and the error
+ * surfaces to the user unchanged — the safe direction, since the alternative is retrying
+ * requests that failed for some entirely different reason.
+ */
+export function isNonstreamingCeilingError(error: unknown): boolean {
+  return error instanceof Error && /streaming is required/i.test(error.message);
+}
+
+/**
+ * Given the params that were rejected and the error, the params to retry with — or null
+ * when a retry would be wrong or pointless.
+ *
+ * The rejection is thrown before the request leaves the process, so this retry costs a
+ * function call and no network round trip. Reacting to the cap beats hardcoding a copy
+ * of the SDK's model map: a model added to that map later is handled with no change
+ * here, and a shorter answer beats an error the user can do nothing about.
+ */
+export function nonstreamingRetryParams<T extends { max_tokens: number }>(params: T, error: unknown): T | null {
+  if (!isNonstreamingCeilingError(error)) return null;
+  if (params.max_tokens <= NONSTREAMING_FALLBACK_TOKENS) return null;
+  return { ...params, max_tokens: NONSTREAMING_FALLBACK_TOKENS };
+}
+
+/**
+ * Whether a model accepts a `temperature` other than the default.
+ *
+ * Sampling parameters were REMOVED on Claude Opus 4.7 and later — sending `temperature`
+ * at all returns a 400 on those models. Sending it to an older model is still fine, so
+ * this gates the request rather than dropping the value everywhere.
+ */
+export function supportsTemperature(modelId: string): boolean {
+  return getModelGeneration(modelId) < 4.7;
+}
+
+/**
+ * Builds the model-dependent request fields shared by the streaming and non-streaming
+ * paths.
+ *
+ * Both paths must construct these identically. They were duplicated, and the duplication
+ * is what let two separate defects hide: `temperature` was sent unconditionally on both
+ * (a hard 400 on Opus 4.7+), and neither clamped `max_tokens` for the non-streaming
+ * ceiling. A single builder means the two cannot drift again.
+ */
+export function buildModelRequestParams(
+  model: {
+    option: string;
+    prompt: string;
+    temperature: string;
+    max_tokens: string;
+  },
+  { streaming }: { streaming: boolean }
+) {
+  const requested = Number(model.max_tokens) || 4096;
+
+  return {
+    model: model.option,
+    system: model.prompt,
+    // Presets store the model's true ceiling (correct for streaming), but the SDK
+    // rejects a non-streaming request above MAX_NONSTREAMING_TOKENS outright. Clamp
+    // rather than throw: a shorter answer beats no answer.
+    max_tokens: streaming ? requested : Math.min(requested, MAX_NONSTREAMING_TOKENS),
+    // Sampling parameters were removed on Claude Opus 4.7 and later — sending
+    // `temperature` to those models is a 400, so only include it where supported.
+    ...(supportsTemperature(model.option) ? { temperature: Number(model.temperature) } : {}),
+  };
+}

--- a/extensions/claude/src/views/model/form.tsx
+++ b/extensions/claude/src/views/model/form.tsx
@@ -4,28 +4,7 @@ import { FormValidation, useFetch, useForm } from "@raycast/utils";
 import { v4 as uuidv4 } from "uuid";
 import { Model, ModelHook, CSVPrompt } from "../../type";
 import { parse } from "csv-parse/sync";
-
-// Helper to determine max tokens for a model
-function getMaxTokensForModel(modelId: string): number {
-  // Check if it's a Claude 4+ model
-  const isClaude4Plus =
-    modelId.includes("-4-") ||
-    modelId.startsWith("claude-haiku-4") ||
-    modelId.startsWith("claude-sonnet-4") ||
-    modelId.startsWith("claude-opus-4");
-
-  if (isClaude4Plus) {
-    // Opus 4+ models have 32K output limit
-    if (modelId.includes("opus")) {
-      return 32000;
-    }
-    // Haiku 4+ and Sonnet 4+ models have 64K output limit
-    return 64000;
-  }
-
-  // Legacy Claude 3 models have 4096 token output limit
-  return 4096;
-}
+import { getMaxTokensForModel } from "../../utils/models";
 
 export const ModelForm = (props: { model?: Model; use: { models: ModelHook }; name?: string }) => {
   const { use, model } = props;
@@ -107,7 +86,7 @@ export const ModelForm = (props: { model?: Model; use: { models: ModelHook }; na
           return "Minimal value is 0";
         }
 
-        const maxAllowed = getMaxTokensForModel(selectedModel);
+        const maxAllowed = getMaxTokensForModel(selectedModel, use.models.availableModels);
 
         if (numValue > maxAllowed) {
           return `Maximum value is ${maxAllowed}`;
@@ -122,7 +101,7 @@ export const ModelForm = (props: { model?: Model; use: { models: ModelHook }; na
           ? use.models.availableModels.find((m) => m.id === defaultModelOption)?.display_name || ""
           : ""),
       temperature: model?.temperature.toString() ?? "1",
-      max_tokens: model?.max_tokens ?? getMaxTokensForModel(defaultModelOption).toString(),
+      max_tokens: model?.max_tokens ?? getMaxTokensForModel(defaultModelOption, use.models.availableModels).toString(),
       option: defaultModelOption,
       prompt: model?.prompt ?? "You are a useful assistant",
       pinned: model?.pinned ?? false,
@@ -166,7 +145,7 @@ export const ModelForm = (props: { model?: Model; use: { models: ModelHook }; na
       }
 
       // Auto-populate max_tokens with the maximum allowed value for the selected model
-      const maxTokens = getMaxTokensForModel(newValue);
+      const maxTokens = getMaxTokensForModel(newValue, use.models.availableModels);
       setValue("max_tokens", maxTokens.toString());
     },
     [setValue, getDisplayName, isNameAModelDisplayName, itemProps.name]
@@ -235,7 +214,10 @@ export const ModelForm = (props: { model?: Model; use: { models: ModelHook }; na
       <Form.TextField
         title="Max token output"
         placeholder="Set the maximum number of tokens to generate"
-        info={`Maximum allowed: ${getMaxTokensForModel(selectedModel).toLocaleString()} tokens`}
+        info={`Maximum allowed: ${getMaxTokensForModel(
+          selectedModel,
+          use.models.availableModels
+        ).toLocaleString()} tokens`}
         {...itemProps.max_tokens}
       />
       {model?.id !== "default" && <Form.Checkbox title="Pinned" label="Pin model" {...itemProps.pinned} />}

--- a/extensions/claude/tsconfig.json
+++ b/extensions/claude/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Node 16",
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "raycast-env.d.ts"],
   "compilerOptions": {
     "lib": ["es2021"],
     "module": "commonjs",


### PR DESCRIPTION
Hi @pernielsentikaer 👋 — this is the first of the two PRs, the API-compatibility fixes only. #29798 stays in draft and will carry the consolidation, storage layer and features once this lands.

## What's broken today

Asking a question on a current model fails. Sampling parameters were removed on Claude Opus 4.7 and later, and the extension sends `temperature` on every request, so Opus 4.7, Sonnet 5 and Opus 5 all return a 400. Both the streaming and non-streaming paths built their own request body, which is what let them drift.

With **Stream Responses** off there's a second failure: the non-streaming path never clamped `max_tokens`. The SDK applies two independent gates — a 10-minute runtime projection, and a per-model cap of 8192 for the Opus 4 and 4.1 ids — and both throw before a request is sent. Both throw *synchronously*, before any promise exists, so the extension's `.catch()` never attached: the toast spun on "Getting your answer…" indefinitely with no error and no way out.

Three quieter ones. `max_tokens` came from a heuristic matching id substrings like `-4-` and `claude-opus-4`, so anything outside those shapes — `claude-opus-5` included — fell through to the legacy 4096 and silently capped presets on current models. The models endpoint is cursor-paginated and defaults to 20 per page, so a single unpaginated request truncated the list. And a long conversation sent its whole transcript every time, so once one outgrew the context window every later request failed identically and the conversation was permanently unusable with no way out from the UI.

## The changes

- **Shared request builder** — `buildModelRequestParams` in `src/utils/models.ts`. Both paths construct the request through it, so they cannot drift again. `temperature` is included only for models that accept it; `max_tokens` is clamped for non-streaming and left alone for streaming.
- **`max_tokens` from the models API** — read per model from `/v1/models`, with the name-based tiers kept only as a fallback for responses that omit the field. Replaces the heuristic in `src/views/model/form.tsx`.
- **Model list pagination** — follows `has_more`/`last_id` and requests the maximum page size.
- **Non-streaming clamp** — `MAX_NONSTREAMING_TOKENS = 8192`, the lowest cap the SDK enforces for any model, so it clears both gates without depending on `@anthropic-ai/sdk/internal/constants` (which the package export map doesn't expose, so a local copy of the per-model map would drift). Clamped rather than thrown: a shorter answer beats no answer. The call is also invoked so that a synchronous throw still reaches the error handler instead of abandoning the UI.
- **Context-window bounding** — `src/utils/contextWindow.ts` bounds the request to the model's input budget, measured with the API's own `countTokens()` and found by binary search (a long conversation shouldn't cost a linear scan of network calls). The budget is the advertised `max_input_tokens`; output is *not* reserved out of it, since the API documents the two as separate budgets. The full transcript is untouched for display, and the user is told when older turns were left out — and told when the reason was a failed token count rather than context length.
- **Stream ownership** — aborting a stream emits `"abort"`, not `"error"`, and the SDK raises an unhandled rejection when nothing listens; an aborted stream also still emits `"end"`, so a superseded request used to commit its partial answer and clear loading state under the live one. Both are handled, guarded by stream identity.

The `@anthropic-ai/sdk` bump is required — `countTokens()` does not exist on 0.18. The SDK surface this extension uses is small (constructor, `messages.stream`, `messages.create`, `countTokens`, the `MessageStream` type) and one response shape changed with it: `content` is now a union including thinking blocks, so text is filtered rather than read from `content[0]`.

## Not in this PR

The 5→3 command consolidation, the storage layer and its migration, and the new features — all deliberately held for the second PR. No commands are added or removed here, and `assets/icon@dark.png` is untouched.

## Verification

`npx tsc --noEmit`, `npx ray build`, `npx ray lint` all exit 0.

The request-building logic was checked against four deliberately reintroduced regressions — unconditional `temperature`, a missing clamp, the legacy-4096 fallback, and the 21333 clamp that Opus 4.1 still rejects — confirming each check actually fails when the behavior breaks. The non-streaming parameters are asserted against the SDK's own gate for five model ids rather than against our own constant, which is what surfaced the per-model 8192 cap in the first place.
