### PR TITLE
Update karakeep extension

### DIFF
--- a/extensions/karakeep/AGENTS.md
+++ b/extensions/karakeep/AGENTS.md
@@ -118,3 +118,5 @@ Raycast List pagination is wired directly via the `pagination` object returned f
 
 - [Raycast Extensions](https://developers.raycast.com/)
 - [Karakeep API](https://docs.karakeep.app/api/)
+- `docs/solutions/` — documented solutions to past problems (bugs, best practices, workflow patterns), organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when implementing or debugging in documented areas.
+- `CONCEPTS.md` — shared domain vocabulary (entities, named processes, status concepts). Relevant when orienting to the codebase or discussing domain concepts.

--- a/extensions/karakeep/CHANGELOG.md
+++ b/extensions/karakeep/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Karakeep Changelog
 
-## [2.4.4] - {PR_MERGE_DATE}
+## [2.4.4] - 2026-08-17
 
 - Fixed a custom title being applied to an existing bookmark even when the rest of the submission failed. Adding a bookmark whose URL is already saved renames it, and that rename now happens only after the list and tag steps have succeeded, so a failure leaves the existing bookmark untouched
 - Create Bookmark no longer reports "Creation failed" when the bookmark was saved and only a later step failed. The toast now says which part didn't apply (the list, the tags, or the title) and the form stays open so you can retry without retyping anything

--- a/extensions/karakeep/CHANGELOG.md
+++ b/extensions/karakeep/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Karakeep Changelog
 
+## [2.4.4] - {PR_MERGE_DATE}
+
+- Fixed a custom title being applied to an existing bookmark even when the rest of the submission failed. Adding a bookmark whose URL is already saved renames it, and that rename now happens only after the list and tag steps have succeeded, so a failure leaves the existing bookmark untouched
+- Create Bookmark no longer reports "Creation failed" when the bookmark was saved and only a later step failed. The toast now says which part didn't apply (the list, the tags, or the title) and the form stays open so you can retry without retyping anything
+- Fixed the Update Karakeep command offering to copy a Docker command for a previously-detected instance after a re-check had failed, and carrying the earlier result's state into the next check
+- Added a "Use Page Title" action (⌘T) to Create Bookmark, which fills the Title field from the active browser tab. It appears only when the Raycast browser extension is available, since that is the only source of a page title. The field is still empty by default, because a title you set overrides the one Karakeep reads from the page and keeps it from ever updating
+- Fixed the Safari entry under "Add to Browser" opening an App Store listing that no longer exists. It now opens the Karakeep app
+- Keyboard shortcuts now follow Raycast's standard bindings, so they match what you already know from other extensions. Delete moved to ⌃D, Edit to ⌘E, Open to ⌘O, Copy ID to ⌘⇧C, and Clear Cache to ⌃⇧D; every shortcut also declares an explicit Windows binding
+- Backing out of the "Delete list" confirmation no longer shows a red "Delete cancelled" error, matching every other confirmation in the extension
+- Error toasts that report a failure with no underlying exception — a browser tab that couldn't be read, a bookmark the server returned empty, a backup that failed on its own — now let you copy the details, so every error toast can be turned into a bug report
+
 ## [2.4.3] - 2026-08-13
 
 - Added an optional Title field to Create Bookmark. Leave it empty to use the page title detected by Karakeep. Custom titles are also applied when the submitted URL already exists in Karakeep.

--- a/extensions/karakeep/CONCEPTS.md
+++ b/extensions/karakeep/CONCEPTS.md
@@ -1,0 +1,27 @@
+# Concepts
+
+Shared domain vocabulary for this project — entities, named processes, and status concepts with project-specific meaning. Seeded with core domain vocabulary, then accretes as ce-compound and ce-compound-refresh process learnings; direct edits are fine. Glossary only, not a spec or catch-all.
+
+## Content and enrichment
+
+### Bookmark
+The single saved item this system is built around. A Bookmark is not necessarily a link — it may be a saved URL, a plain-text note, or an uploaded asset, and the type determines which enrichment steps apply to it. A text note has no source to fetch and so never enters the crawl pipeline at all.
+
+### Crawl
+The pass that fetches a Bookmark's source URL, renders it, and extracts its readable content into stored fields.
+
+A Crawl's **success is the dispatch point for downstream enrichment** — embedding and tagging are triggered by a completed Crawl, not by the presence of content. A Bookmark can therefore hold good extracted content from an earlier Crawl and still be missing its enrichment, if a later Crawl failed. Crawls retry a fixed number of times and then stop. The failure is durably recorded as the Bookmark's crawl status, so it is queryable after the fact — but no downstream enrichment is dispatched and nothing announces it, so the practical symptom is a Bookmark that quietly never gains an Embedding.
+
+### Embedding
+The vector representation of a Bookmark's extracted text, produced by an external model and used to answer semantic queries.
+
+An Embedding is **stored only in the search engine, never in the primary database** — though the text it is computed from is held locally, so regenerating one needs no network fetch, only a fresh paid call to the external model. This is the most consequential asymmetry in the system: full-text search data can be rebuilt from the primary database for free, while Embeddings must be re-purchased. Deleting search-engine storage is therefore destructive to Embeddings and merely inconvenient for everything else.
+
+### Reindex
+The administrative operation that rebuilds search data for the whole library from the primary database.
+
+Reindex covers **full-text data only**. It does not regenerate Embeddings, and it reports success on completion regardless — so a green Reindex is evidence about one half of the search data and says nothing about the other. Restoring Embeddings is a **separate administrative operation** that re-runs enrichment per Bookmark, and it can be scoped to only those whose embedding previously failed.
+
+## Flagged ambiguities
+
+- "Rebuildable" had been applied to search storage as a whole. It is a property of an individual dataset, not of the storage that holds them: full-text data is rebuildable, Embeddings are not, and both live in the same place.

--- a/extensions/karakeep/TODO.md
+++ b/extensions/karakeep/TODO.md
@@ -1,5 +1,33 @@
 # TODO
 
+## Unshipped — on `main`, not in the Store
+
+Two changes are on `main` and not in the Store. 2.4.3 was taken by a
+contributor's PR (raycast/extensions#30194, merged 2026-08-13), so these ship
+together as **2.4.4** under the existing `{PR_MERGE_DATE}` entry.
+
+- [ ] `f033b94` — reset detection state at the start of `detect()` in
+      `/Users/messina/Developer/GitHub/chrismessina/raycast-karakeep/src/updateKarakeep.tsx`.
+      Two parts, from a Greptile finding:
+  - `identityProven` / `container` were only assigned on the success path, so
+    an early return kept the previous run's values. Not exploitable — the
+    destructive action is gated on `phase`, which only reaches `ready` via the
+    path that assigns them — but the invariant lived far from the state.
+  - **Live and user-visible:** `Copy Docker Command` had no phase gate, so a
+    failed re-check rendered "Docker daemon isn't responding" while still
+    offering to copy the previously-found project's compose invocation.
+
+- [ ] Ordering fix in
+      `/Users/messina/Developer/GitHub/chrismessina/raycast-karakeep/src/createBookmark.tsx`,
+      from a code-review comment on #30194. When the submitted URL already
+      exists, the title PATCH renames the user's existing bookmark; it used to
+      run *before* the list and tag requests, so a failure in either left the
+      rename committed behind a "failed" toast. The rename now runs last.
+  - Also replaced the single pass/fail toast: saving is up to four writes with
+    no transaction, so any failure after the create call used to report
+    "Creation failed" on a bookmark that had in fact been saved. The submit
+    path now tracks which step threw and names it in the toast.
+
 ## P0 - Critical Fixes (Must Have)
 
 - [x] When creating a Note, action should be "Create Note" not "Create Bookmark"

--- a/extensions/karakeep/docs/solutions/database-issues/meilisearch-version-upgrade-destroys-vector-embeddings.md
+++ b/extensions/karakeep/docs/solutions/database-issues/meilisearch-version-upgrade-destroys-vector-embeddings.md
@@ -1,0 +1,205 @@
+---
+title: "Deleting Karakeep's Meilisearch volume destroys embeddings, which no reindex restores"
+date: 2026-08-12
+category: database-issues
+module: karakeep-self-hosted-deployment
+problem_type: database_issue
+component: database
+symptoms:
+  - Meilisearch container crash-restart loops after a docker-compose image version bump
+  - Meilisearch refuses to open a database written by engine 1.13.3 while running engine 1.41.0
+  - "Admin 'Reindex all bookmarks' reports success but the vector index stays empty"
+  - Semantic search returns nothing while keyword search works because the 1536-dim embeddings index is empty
+  - 15 of 913 bookmarks never regain embeddings because their crawl exhausted 6 retries
+root_cause: config_error
+resolution_type: environment_setup
+severity: high
+related_components:
+  - background_job
+  - tooling
+tags:
+  - meilisearch
+  - karakeep
+  - docker-compose
+  - vector-embeddings
+  - data-loss
+  - liteque
+  - job-queue
+  - self-hosted
+---
+
+# Deleting Karakeep's Meilisearch volume destroys embeddings, which no reindex restores
+
+> **Where the code lives.** This learning is about the self-hosted Karakeep deployment at
+> `/Users/messina/Developer/Docker/karakeep-app/`, which is **not** in this git repository
+> (the compose file is untracked and holds live credentials). Source citations marked
+> _(container path)_ live inside the running `karakeep-app-web-1` container and are reachable
+> only via `docker exec` — they will not resolve on the host filesystem. Line numbers were
+> verified against the running container on 2026-08-12 and are specific to that image build.
+> Live counts are as of that date on a ~913-bookmark library.
+
+## Problem
+
+A Meilisearch image version bump put `karakeep-app-meilisearch-1` into a crash-restart loop: Meilisearch refuses to open a database written by a different engine version (DB written by 1.13.3, engine 1.41.0).
+
+The volume was then characterized as "derived data, rebuildable." On that basis it was deleted and the stack brought up on v1.53.0 to reindex from scratch.
+
+That characterization was **half right, and the wrong half was the expensive one.** The single Meilisearch instance holds two indexes with completely different provenance:
+
+| Index               | Source of truth          | Restored by admin "Reindex all bookmarks"?     |
+| ------------------- | ------------------------ | ---------------------------------------------- |
+| `bookmarks`         | Karakeep's SQLite DB     | **Yes** — restored the full library in minutes |
+| `bookmarks_vectors` | Embeddings API, 1536-dim | **No** — Reindex touches only full-text data   |
+
+Post-deletion vector count: **1**. Roughly 900 paid embeddings were destroyed.
+
+The two indexes are indistinguishable from outside the container. They live in one volume, are served by one process, and the admin button most people reach for restores only one of them — while reporting success.
+
+## Symptoms
+
+- `karakeep-app-meilisearch-1` in a restart loop after an image bump; logs report the DB was written by a different engine version.
+- Semantic search returns nothing while keyword search works fine — the tell that `bookmarks` came back and `bookmarks_vectors` did not.
+- Admin "Reindex all bookmarks" reports success while the vector index still holds 1 document.
+- Meilisearch is not reachable from the host: port `7700/tcp` is container-internal only, so every diagnostic query has to be issued from inside `karakeep-app-web-1` against `http://meilisearch:7700`. Anything that "checks the index from your laptop" will appear to be down when it is merely unpublished.
+
+## What Didn't Work
+
+**Deleting the volume and reindexing.** This is the action the wrong classification licensed. It recovered `bookmarks` completely and `bookmarks_vectors` not at all. No warning, no partial-restore message, and nothing in the UI distinguishes the two.
+
+**Admin "Reindex all bookmarks" as a recovery mechanism for vectors.** `reindexAllBookmarks` selects bookmark ids and calls `triggerSearchReindex` on each — the full-text path only. It never enqueues an embedding job. Vectors are not in SQLite, so there is nothing for it to read.
+
+**Reaching for a full library re-crawl as the recovery.** This _did_ work — embedding jobs are dispatched off the crawl-success path, so re-crawling the library regenerated the vectors, settling at 898 with zero embedding failures and zero 401s. But it is the sledgehammer, and **it was not necessary** (see Solution): it re-fetches every URL over the network, re-pays for every embedding, and saturates the single headless-Chrome container (`karakeep-app-chrome-1`) with ~913 concurrent crawl jobs. Two bookmarks with perfectly good stored content failed their recrawl for what looks like exactly that contention, and so never got an embedding — the recovery mechanism manufacturing its own new gap.
+
+**Hand-writing job rows into the queue database.** The two stragglers were repaired by inserting rows directly into liteque's `tasks` table. It worked, and it was **reinventing a first-party admin button** that issues the identical payload (see Solution). Kept below only as a fallback and for the queue-schema details, which are genuinely non-obvious.
+
+**Concluding "no embedding job was ever dispatched" from a log grep.** Grepping the container log for each of the 15 ids showed only `[Crawler][<job>:0..5] Will crawl …` and no `[embeddings]` lines. That is correct _for the retained log window_, but it cannot support "ever" — the log only covers the current container lifetime. All 13 still-vectorless bookmarks in fact carry a persisted `bookmarks.embeddingStatus = 'failure'`, a value only the embeddings worker writes, which implies an attempt did run at some earlier point. The operational conclusion (the crawler is upstream and never handed anything off) still holds; the absolute phrasing did not.
+
+## Solution
+
+Three parts: the upgrade that should have happened, the supported repair, and the manual fallback.
+
+### 1. The upgrade that should have been done first
+
+Meilisearch has documented in-place migration paths. Neither requires deleting anything:
+
+- **Engines below 1.51** — `--experimental-dumpless-upgrade`, or env `MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE=true`.
+- **1.51 and onward** — `--upgrade-db`.
+- **DBs older than v1.12** cannot be upgraded at all; those need a dump/restore, which is still not the same thing as deleting the volume.
+
+Snapshot or copy the volume first regardless. Reaching for either flag on a 1.13.3 database would have made this whole incident a five-minute restart.
+
+### 2. The supported repair: admin → regenerate embeddings
+
+**This is the answer, and it was available the entire time.** The admin router exposes `regenerateAllBookmarkEmbeddings` directly beside `reindexAllBookmarks`, with a button in the admin Background Jobs panel. It takes a `status` filter:
+
+```js
+regenerateAllBookmarkEmbeddings: … input(z.object({
+  status: z.enum(["failure","pending","all"]).default("all"),
+  modifiedWithinSeconds: …optional()
+}).optional())
+// clearIndex() fires ONLY when status === "all" AND modifiedWithinSeconds is undefined
+// then, in batches of 1000:
+EmbeddingsQueue.enqueue({ bookmarkId, type: "embed", force: true, runTaggingOnComplete: false },
+                        { priority: QueuePriority.Low, groupId: "admin" })
+```
+
+_(container path: `/app/apps/web/.next/server/chunks/ssr/_18-l02z._.js`)_
+
+Two things make this the right tool:
+
+- **`status: "failure"` targets exactly the bookmarks whose embedding failed** and skips the `clearIndex()` — so it repairs the gap without destroying the vectors you still have. `status: "all"` with no time window _does_ clear the index first, so reach for `failure` unless you truly want a full rebuild.
+- **The enqueued payload is `force: true, runTaggingOnComplete: false`** — identical to what a careful manual repair would write, including leaving hand-curated tags alone.
+
+If the whole vector index is empty after a volume loss, `status: "all"` regenerates the library without re-crawling anything. A full re-crawl is only needed when the _content_ is missing, not the vector.
+
+### 3. Fallback: hand-enqueue a job
+
+Only when the admin path is unavailable. The `embed` handler enqueues the `index` step with no flag gating it — unlike tagging, which sits behind `shouldTag` — at `/app/apps/workers/dist/index.js:87960-87969` _(container path)_:
+
+```js
+await EmbeddingsQueue.enqueue(
+  { type: "index", bookmarkId, userId: bookmark.userId, embedding },
+  { priority: job.priority, groupId: bookmark.userId },
+);
+if (shouldTag) await enqueueTagging(bookmarkId, bookmark.userId, job.priority, embedding);
+```
+
+with `const shouldTag = data$1.runTaggingOnComplete !== false;` at `:87927`. That enqueue is still reachable only past **four early returns** at `:87928-87950` — auto-indexing disabled without `force`, bookmark deleted, no embedding client configured, and `if (!embeddingText)` (no content to embed, which is the guard the 15-bookmark gap actually sits under). `force:true` clears the first; the other three are real preconditions.
+
+The payload contract is enforced by zod at `…/@karakeep/shared-server/src/queues.ts:145-173` _(container path, under `/app/apps/workers/node_modules/.pnpm/`)_:
+
+```ts
+export const zEmbeddingsRequestSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("embed"),
+    bookmarkId: z.string(),
+    force: z.boolean().optional(),
+    runTaggingOnComplete: z.boolean().optional().default(true),
+  }),
+  z.object({ type: z.literal("index"), bookmarkId: z.string(), userId: z.string(), embedding: z.array(z.number()) }),
+  z.object({ type: z.literal("delete"), bookmarkId: z.string() }),
+]);
+export const EmbeddingsQueue = createDeferredQueue<ZEmbeddingsRequest>("embeddings_queue", {
+  defaultJobArgs: { numRetries: 3 },
+  keepFailedJobs: false,
+});
+```
+
+#### The queue-table gotcha that will silently eat the job
+
+liteque's `tasks` table (SQLite at `/data/queue.db`, `journal_mode = delete`) uses **different drizzle timestamp modes on two columns of the same table**:
+
+```js
+createdAt: integer("createdAt", { mode: "timestamp" }); // SECONDS
+availableAt: integer("availableAt", { mode: "timestamp_ms" }); // MILLISECONDS
+```
+
+The dequeue query orders by `asc(priority), asc(createdAt)` and filters on `availableAt`, so mixing the units is accepted on write and then corrupts ordering or scheduling — a row that exists and a worker that ignores it. Also: liteque inserts `numRunsLeft` and `maxNumRuns` as a literal `numRetries + 1` (**4** for this queue, per `numRetries: 3` above), `allocationId` is a generated UUID, and `status` defaults to `'pending'`.
+
+```sql
+INSERT INTO tasks (queue,payload,createdAt,status,allocationId,numRunsLeft,maxNumRuns,priority,availableAt)
+VALUES ('embeddings_queue', '{"type":"embed","bookmarkId":"…","force":true,"runTaggingOnComplete":false}',
+        <nowSeconds>, 'pending', <uuid>, 4, 4, 0, <nowMillis>);
+```
+
+Run it **inside** `karakeep-app-web-1`, and put the script somewhere under `/app/apps/workers/` — `better-sqlite3` does not resolve from `/tmp`. Remove the script afterward.
+
+**Verified outcome:** both hand-enqueued jobs ran within roughly a minute and logged `Generated embedding … dispatched indexing`, then `Indexed embedding … with 1536 dimensions`, then `Completed successfully`. Vector count moved 898 → 900.
+
+## Why This Works
+
+The re-crawl path regenerates embeddings only as a _side effect_ of crawl success — the crawler fetches, stores content, and the success path dispatches an embed job. That coupling makes the network fetch mandatory even when the content that would be embedded is already sitting in the database. An `embed` job severs the coupling: the handler reads the bookmark, builds embedding text from stored content, calls the embedding client, and enqueues `index` — the crawler is never consulted. That is why it fixes the two failure classes re-crawling could not: bookmarks whose source URL is now unfetchable, and bookmarks whose recrawl lost a race with Chrome contention despite having good content on disk.
+
+`force:true` matters because `enableAutoIndexing` gates the whole handler; without it a job on a config where auto-indexing is off returns immediately and logs at `debug`, indistinguishable from nothing happening. `runTaggingOnComplete:false` matters because the tagger is the one downstream step that writes to hand-curated data — leaving it at its `default(true)` would let a repair job rewrite tags chosen by hand. The admin mutation sets both for you, which is a good sign it is the intended path.
+
+## Prevention
+
+**The headline: "derived data" is a property of a dataset, not of a volume.** Before deleting any volume on the grounds that it is rebuildable, enumerate every logical dataset inside it and answer, per dataset, _what specific process rebuilds this, reading from what specific source of truth?_ If the answer for any one of them is "an external paid API" or "I'm not sure," the volume is not derived data. Two datasets sharing a process, a port, and a restore button share none of their provenance.
+
+**The runner-up, which cost more effort than the data loss did: look for the admin button before building the clever thing.** The repair path here was reverse-engineered out of a minified worker bundle and hand-written as SQL into a job queue — while `regenerateAllBookmarkEmbeddings` sat in the admin panel issuing the identical payload. Reading the admin router's mutation list is cheap and should come before reading the worker.
+
+Concretely, for this stack:
+
+1. **Enumerate the indexes before touching the volume.** From inside the web container, list Meilisearch's indexes and their document counts against `http://meilisearch:7700`. Two indexes appear. Write both counts down — the count diff is what turned "reindex worked!" into "the vectors are gone."
+2. **Trace the rebuild path for each one.** `bookmarks` ← SQLite, restored by admin Reindex. `bookmarks_vectors` ← the embeddings API, restored by admin _Regenerate embeddings_ — a **different button**, not Reindex.
+3. **Karakeep's SQLite has no embeddings table** — 35 tables, none storing vectors. Be careful grepping for one: the only embedding-shaped column is `bookmarks.embeddingStatus`, a status enum (`success` / `failure` / `pending`), which is _not_ the vector and reads like a hit.
+4. **Exhaust in-place upgrade before destructive recovery.** `MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE` below 1.51, `--upgrade-db` from 1.51 on, dump/restore for pre-1.12 DBs. Snapshot the volume first either way. Version-mismatch crash loops are a migration problem, not a corruption problem.
+5. **Treat a green "Reindex all" as evidence about one index only.** Re-check the vector count after any reindex. A success toast that covers a subset of your data is a UI lying about its state.
+6. **Query the persisted status columns, not just the log.** `bookmarks.embeddingStatus` and `bookmarkLinks.crawlStatus` are durable and queryable; container logs are a rolling window that cannot answer "ever." Both were `failure` for exactly the 13 unresolved bookmarks — a cleaner signal than any grep, and the one that tells you which `status` filter to hand the admin mutation.
+7. **Hand-writing a liteque job: check the column mode per column, not per table.** `createdAt` is seconds, `availableAt` is milliseconds, in the same `tasks` table.
+
+## Appendix: the 15-bookmark gap
+
+Recorded because the decomposition is a useful worked example of separating a crawler problem from an embeddings problem.
+
+After the re-crawl, 15 of 913 bookmarks had no vector: 911 links − 898 with `crawlStatus = 'success'` = 13 failed links, plus 2 text notes that have no URL and never enter the crawl pipeline at all.
+
+The 13 link failures broke down as 4 with no extracted content (paywalled or bot-blocked), 1 that fetched only a block page (title literally "Access Denied"), 6 thin JS-only landing pages, and 2 content-rich bookmarks whose recrawl simply failed. Character counts quoted during the investigation were measured on **Meilisearch's indexed `content` field**, not `bookmarkLinks.htmlContent` — for these bookmarks the extracted text lives in a `linkHtmlContent` asset, so the column reads 0 while real content exists. Checking the wrong field here makes a healthy bookmark look empty.
+
+The 2 content-rich failures were repaired by embed jobs; the other 11 need their content fixed first, since there is nothing to embed.
+
+## Related Issues
+
+- [karakeep-app/karakeep#2991](https://github.com/karakeep-app/karakeep/issues/2991) (closed) — same observable surface, an empty vector index, different root cause: Karakeep generates 192-dim vectors (exactly 768/4) reporting `0 tokens` from a provider that returns correct 768-dim vectors, so Meilisearch rejects the write. The issue argues explicitly that the provider is _not_ at fault — it is a response-parsing bug on Karakeep's side. Worth knowing that an empty vector index has more than one cause.
+- [karakeep-app/karakeep#346](https://github.com/karakeep-app/karakeep/issues/346) (open) — a repeating `MDB_KEYEXIST: Key/data pair already exists` failure when indexing a bookmark. Adjacent symptom class (Meilisearch indexing failure), not a corrupt data directory.
+- `/Users/messina/Developer/GitHub/chrismessina/raycast-karakeep/AGENTS.md:53` — the only other place in this repo documenting the web + meilisearch + chrome Compose coupling. Still accurate; not made stale by this incident.

--- a/extensions/karakeep/package-lock.json
+++ b/extensions/karakeep/package-lock.json
@@ -9,15 +9,15 @@
       "dependencies": {
         "@chrismessina/raycast-logger": "^1.3.0",
         "@raycast/api": "^1.104.24",
-        "@raycast/utils": "^2.2.3"
+        "@raycast/utils": "^2.3.0"
       },
       "devDependencies": {
-        "@raycast/eslint-config": "^2.1.1",
-        "@types/node": "^25.5.0",
-        "@types/react": "^19.2.14",
-        "@types/react-dom": "^19.2.3",
-        "eslint": "^9.35.0",
-        "prettier": "^3.8.1",
+        "@raycast/eslint-config": "^2.2.0",
+        "@types/node": "^25.9.5",
+        "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.4",
+        "eslint": "^9.39.5",
+        "prettier": "^3.9.6",
         "typescript": "^5.9.2"
       }
     },
@@ -548,9 +548,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -560,7 +560,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
         "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
@@ -616,9 +616,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1186,41 +1186,41 @@
       "license": "MIT"
     },
     "node_modules/@raycast/eslint-config": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@raycast/eslint-config/-/eslint-config-2.1.1.tgz",
-      "integrity": "sha512-W0kxF+FJ+BYQn0EKIV739j2ZrHEtjo/LclsoZgUWg3t364Dq75XKcjqYFYx+59/DBaamY0amdajlfuDAf6veAg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@raycast/eslint-config/-/eslint-config-2.2.0.tgz",
+      "integrity": "sha512-uS/UDvM+3HfABgYhLYnIv0y+IVu+rGiZZIMwQsO5EGrcf2/TX/yioTzfezAQqhdszW4ViCuHbv8BddIagDKZvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint/js": "^9.36.0",
-        "@raycast/eslint-plugin": "^2.1.1",
+        "@eslint/js": "^9.39.4",
+        "@raycast/eslint-plugin": "^2.2.0",
         "eslint-config-prettier": "^10.1.8",
-        "globals": "^16.4.0",
-        "typescript-eslint": "^8.45.0"
+        "globals": "^17.7.0",
+        "typescript-eslint": "^8.62.0"
       },
       "peerDependencies": {
-        "eslint": ">=8.23.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "prettier": ">=2",
-        "typescript": ">=4"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@raycast/eslint-plugin": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@raycast/eslint-plugin/-/eslint-plugin-2.1.1.tgz",
-      "integrity": "sha512-r2gs8uIlNp6I2mLOyN/kReGlvigzEeuyQPl4yw7nwLy8Zxjfjhg8txMViaBux8juBWBxbSWq/IfW6ZA50oeOHQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@raycast/eslint-plugin/-/eslint-plugin-2.2.0.tgz",
+      "integrity": "sha512-ixO3PoRAEAZZcSQeRPvvDS/vs09D47tXdyXrs7hctoxxPtweXgJ6I24kjCD5GuuuQS5hGTiuL+Uy6hIg6a/a4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "^8.26.1"
+        "@typescript-eslint/utils": "^8.62.0"
       },
       "peerDependencies": {
-        "eslint": ">=8.23.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/@raycast/utils": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.3.tgz",
-      "integrity": "sha512-YwqleVl0Wk/FOq+672gtvswuwMqjNqIr+c63FhouTEHc1LJ3zaohLSkW4+UcfBjPU8HySKQm+kJqZW1iOM9fnA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.3.0.tgz",
+      "integrity": "sha512-997ANn0aaYBZjlAb94d8qXLXPRGxFen86741ZkTEKwpXosq/GaRlfKzw/T09v0/CzYUjiqT0LhU5VXQ4DeGc+A==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -1250,19 +1250,19 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1270,9 +1270,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1280,17 +1280,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.0.tgz",
-      "integrity": "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.0.tgz",
+      "integrity": "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.58.0",
-        "@typescript-eslint/type-utils": "8.58.0",
-        "@typescript-eslint/utils": "8.58.0",
-        "@typescript-eslint/visitor-keys": "8.58.0",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/type-utils": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1303,15 +1303,15 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.58.0",
+        "@typescript-eslint/parser": "^8.67.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1319,16 +1319,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.0.tgz",
-      "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
+      "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.58.0",
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/typescript-estree": "8.58.0",
-        "@typescript-eslint/visitor-keys": "8.58.0",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1344,14 +1344,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.0.tgz",
-      "integrity": "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
+      "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.0",
-        "@typescript-eslint/types": "^8.58.0",
+        "@typescript-eslint/tsconfig-utils": "^8.67.0",
+        "@typescript-eslint/types": "^8.67.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1366,14 +1366,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.0.tgz",
-      "integrity": "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
+      "integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/visitor-keys": "8.58.0"
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1384,9 +1384,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.0.tgz",
-      "integrity": "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
+      "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1401,15 +1401,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.0.tgz",
-      "integrity": "sha512-aGsCQImkDIqMyx1u4PrVlbi/krmDsQUs4zAcCV6M7yPcPev+RqVlndsJy9kJ8TLihW9TZ0kbDAzctpLn5o+lOg==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
+      "integrity": "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/typescript-estree": "8.58.0",
-        "@typescript-eslint/utils": "8.58.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1426,9 +1426,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.0.tgz",
-      "integrity": "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
+      "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1440,16 +1440,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.0.tgz",
-      "integrity": "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
+      "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.0",
-        "@typescript-eslint/tsconfig-utils": "8.58.0",
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/visitor-keys": "8.58.0",
+        "@typescript-eslint/project-service": "8.67.0",
+        "@typescript-eslint/tsconfig-utils": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1468,16 +1468,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.0.tgz",
-      "integrity": "sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.67.0.tgz",
+      "integrity": "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.0",
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/typescript-estree": "8.58.0"
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1492,13 +1492,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.0.tgz",
-      "integrity": "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
+      "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/types": "8.67.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1523,9 +1523,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1546,9 +1546,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1880,9 +1880,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1891,8 +1891,8 @@
         "@eslint/config-array": "^0.21.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -2265,9 +2265,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
-      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
+      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2432,9 +2432,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -2690,9 +2690,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2910,16 +2910,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.0.tgz",
-      "integrity": "sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.67.0.tgz",
+      "integrity": "sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.58.0",
-        "@typescript-eslint/parser": "8.58.0",
-        "@typescript-eslint/typescript-estree": "8.58.0",
-        "@typescript-eslint/utils": "8.58.0"
+        "@typescript-eslint/eslint-plugin": "8.67.0",
+        "@typescript-eslint/parser": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2934,9 +2934,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "devOptional": true,
       "license": "MIT"
     },

--- a/extensions/karakeep/package.json
+++ b/extensions/karakeep/package.json
@@ -114,7 +114,7 @@
       "type": "checkbox",
       "label": "Use the Current Browser Tab",
       "title": "Creating Bookmarks",
-      "description": "Fill in the URL from your frontmost tab when creating a bookmark. Requires the Raycast browser extension.",
+      "description": "Fill in the URL from your frontmost tab when creating a bookmark. Uses the Raycast browser extension when available, and falls back to AppleScript on macOS.",
       "default": true,
       "required": false
     },
@@ -284,15 +284,15 @@
   "dependencies": {
     "@chrismessina/raycast-logger": "^1.3.0",
     "@raycast/api": "^1.104.24",
-    "@raycast/utils": "^2.2.3"
+    "@raycast/utils": "^2.3.0"
   },
   "devDependencies": {
-    "@raycast/eslint-config": "^2.1.1",
-    "@types/node": "^25.5.0",
-    "@types/react": "^19.2.14",
-    "@types/react-dom": "^19.2.3",
-    "eslint": "^9.35.0",
-    "prettier": "^3.8.1",
+    "@raycast/eslint-config": "^2.2.0",
+    "@types/node": "^25.9.5",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4",
+    "eslint": "^9.39.5",
+    "prettier": "^3.9.6",
     "typescript": "^5.9.2"
   },
   "scripts": {

--- a/extensions/karakeep/src/backups.tsx
+++ b/extensions/karakeep/src/backups.tsx
@@ -1,4 +1,4 @@
-import { Action, ActionPanel, Color, confirmAlert, Icon, List, open, showToast, Toast } from "@raycast/api";
+import { Action, ActionPanel, Color, confirmAlert, Icon, List, open, showToast, Toast, Keyboard } from "@raycast/api";
 import { useEffect, useRef } from "react";
 import { useCachedPromise } from "@raycast/utils";
 import { logger } from "@chrismessina/raycast-logger";
@@ -8,7 +8,7 @@ import { connectionGuard } from "./components/ConnectionErrorView";
 import { handleFetchError } from "./utils/fetchError";
 import { useLiveData } from "./hooks/useLiveData";
 import { formatBytes } from "./utils/formatting";
-import { runWithToast } from "./utils/toast";
+import { attachCopyDetail, runWithToast } from "./utils/toast";
 
 const log = logger.child("[Backups]");
 
@@ -60,14 +60,35 @@ export default function Backups() {
   const prevBackupsRef = useRef<typeof backups>([]);
   useEffect(() => {
     const prev = prevBackupsRef.current;
-    for (const backup of backups) {
-      const prevBackup = prev.find((b) => b.id === backup.id);
-      if (prevBackup?.status === "pending" && backup.status === "failure") {
-        log.error("Backup failed", { backupId: backup.id });
-        showToast({ style: Toast.Style.Failure, title: t("backups.toast.failure") });
+    const newlyFailed = backups.filter(
+      (backup) => prev.find((b) => b.id === backup.id)?.status === "pending" && backup.status === "failure",
+    );
+    // Advance the baseline before any early return, or a poll that shows no
+    // toast would leave the previous snapshot in place and re-report next time.
+    prevBackupsRef.current = backups;
+    if (newlyFailed.length === 0) return;
+
+    log.error("Backup failed", { backupIds: newlyFailed.map((backup) => backup.id) });
+
+    // ONE toast for the whole batch. showToast REPLACES whatever is on screen, so
+    // a toast per backup leaves only the last one visible — and awaiting it here
+    // rather than chaining .then() means the Copy Error action lands on the toast
+    // we actually showed, and a rejection can't escape as an unhandled promise.
+    // The failure arrives as a status field, not an exception, so there is nothing
+    // to unwrap — the backup ids are what make this reportable.
+    async function notifyFailed() {
+      try {
+        const toast = await showToast({ style: Toast.Style.Failure, title: t("backups.toast.failure") });
+        attachCopyDetail(
+          toast,
+          newlyFailed.map((backup) => `Backup ${backup.id} moved from pending to failure.`).join("\n"),
+        );
+      } catch (error) {
+        log.error("Could not show the backup failure toast", { error });
       }
     }
-    prevBackupsRef.current = backups;
+
+    notifyFailed();
   }, [backups, t]);
 
   async function handleCreate() {
@@ -115,7 +136,7 @@ export default function Backups() {
       title={t("backups.createBackup")}
       icon={Icon.Plus}
       onAction={handleCreate}
-      shortcut={{ modifiers: ["cmd"], key: "n" }}
+      shortcut={Keyboard.Shortcut.Common.New}
     />
   );
 
@@ -176,7 +197,7 @@ export default function Backups() {
                     icon={Icon.Trash}
                     style={Action.Style.Destructive}
                     onAction={() => handleDelete(backup.id)}
-                    shortcut={{ modifiers: ["ctrl"], key: "x" }}
+                    shortcut={Keyboard.Shortcut.Common.Remove}
                   />
                 </ActionPanel.Section>
               </ActionPanel>

--- a/extensions/karakeep/src/components/BookmarkDetail.tsx
+++ b/extensions/karakeep/src/components/BookmarkDetail.tsx
@@ -1,4 +1,4 @@
-import { Action, ActionPanel, Detail, Icon, useNavigation } from "@raycast/api";
+import { Action, ActionPanel, Detail, Icon, useNavigation, Keyboard } from "@raycast/api";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { logger } from "@chrismessina/raycast-logger";
 
@@ -250,7 +250,7 @@ export function BookmarkDetail({ bookmark: initialBookmark, onRefresh, lists: pr
               <Action.CopyToClipboard
                 content={bookmark.content.url}
                 title={t("bookmark.actions.copyLink")}
-                shortcut={{ modifiers: ["cmd"], key: "c" }}
+                shortcut={{ macOS: { modifiers: ["cmd"], key: "c" }, Windows: { modifiers: ["ctrl"], key: "c" } }}
               />
             </>
           )}
@@ -282,7 +282,7 @@ export function BookmarkDetail({ bookmark: initialBookmark, onRefresh, lists: pr
               title={t("bookmark.actions.aiSummary")}
               onAction={handleSummarize}
               icon={Icon.Wand}
-              shortcut={{ modifiers: ["ctrl"], key: "s" }}
+              shortcut={{ macOS: { modifiers: ["ctrl"], key: "s" }, Windows: { modifiers: ["ctrl"], key: "s" } }}
             />
           )}
           {lists.length > 0 && <AddToListSubmenu bookmarkId={bookmark.id} lists={lists} isLoading={isLoadingLists} />}
@@ -290,13 +290,13 @@ export function BookmarkDetail({ bookmark: initialBookmark, onRefresh, lists: pr
             title={bookmark.favourited ? t("bookmark.actions.unfavorite") : t("bookmark.actions.favorite")}
             onAction={() => handleUpdate({ favourited: !bookmark.favourited })}
             icon={bookmark.favourited ? Icon.StarCircle : Icon.Star}
-            shortcut={{ modifiers: ["ctrl"], key: "f" }}
+            shortcut={{ macOS: { modifiers: ["ctrl"], key: "f" }, Windows: { modifiers: ["ctrl"], key: "f" } }}
           />
           <Action
             title={bookmark.archived ? t("bookmark.actions.unarchive") : t("bookmark.actions.archive")}
             onAction={() => handleUpdate({ archived: !bookmark.archived })}
             icon={bookmark.archived ? Icon.BlankDocument : Icon.SaveDocument}
-            shortcut={{ modifiers: ["ctrl"], key: "a" }}
+            shortcut={{ macOS: { modifiers: ["ctrl"], key: "a" }, Windows: { modifiers: ["ctrl"], key: "a" } }}
           />
         </ActionPanel.Section>
 
@@ -305,14 +305,14 @@ export function BookmarkDetail({ bookmark: initialBookmark, onRefresh, lists: pr
             title={t("bookmark.actions.edit")}
             onAction={handleEdit}
             icon={Icon.Pencil}
-            shortcut={{ modifiers: ["ctrl"], key: "e" }}
+            shortcut={Keyboard.Shortcut.Common.Edit}
           />
           <Action
             title={t("bookmark.actions.delete")}
             style={Action.Style.Destructive}
             onAction={handleDelete}
             icon={Icon.Trash}
-            shortcut={{ modifiers: ["ctrl"], key: "x" }}
+            shortcut={Keyboard.Shortcut.Common.Remove}
           />
         </ActionPanel.Section>
       </ActionPanel>

--- a/extensions/karakeep/src/components/BookmarkItem.tsx
+++ b/extensions/karakeep/src/components/BookmarkItem.tsx
@@ -1,4 +1,4 @@
-import { Action, ActionPanel, Icon, Image, List, showToast, Toast, useNavigation } from "@raycast/api";
+import { Action, ActionPanel, Icon, Image, List, showToast, Toast, useNavigation, Keyboard } from "@raycast/api";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { logger } from "@chrismessina/raycast-logger";
 import { fetchDeleteBookmark, fetchGetSingleBookmark, fetchSummarizeBookmark, fetchUpdateBookmark } from "../apis";
@@ -333,7 +333,7 @@ function BookmarkActions({
         icon={Icon.Pencil}
         title={editTitle}
         onAction={handlers.handleEdit}
-        shortcut={{ modifiers: ["ctrl"], key: "e" }}
+        shortcut={Keyboard.Shortcut.Common.Edit}
       />
     );
 
@@ -344,7 +344,7 @@ function BookmarkActions({
             <Action.OpenInBrowser
               url={bookmark.content.url}
               title={t("bookmark.actions.openLink")}
-              shortcut={{ modifiers: ["cmd"], key: "o" }}
+              shortcut={Keyboard.Shortcut.Common.Open}
               onOpen={() => onVisit?.(bookmark)}
             />
           );
@@ -367,7 +367,7 @@ function BookmarkActions({
             <Action.CopyToClipboard
               content={bookmark.content.text}
               title={copyNoteTitle}
-              shortcut={{ modifiers: ["cmd"], key: "c" }}
+              shortcut={{ macOS: { modifiers: ["cmd"], key: "c" }, Windows: { modifiers: ["ctrl"], key: "c" } }}
               onCopy={() => onVisit?.(bookmark)}
             />
           );
@@ -422,7 +422,7 @@ function BookmarkActions({
             icon={Icon.Pencil}
             title={editTitle}
             onAction={handlers.handleEdit}
-            shortcut={{ modifiers: ["ctrl"], key: "e" }}
+            shortcut={Keyboard.Shortcut.Common.Edit}
           />
         )}
         {bookmark.content.type === "link" &&
@@ -432,13 +432,13 @@ function BookmarkActions({
               <Action.OpenInBrowser
                 url={bookmark.content.url}
                 title={t("bookmark.actions.openLink")}
-                shortcut={{ modifiers: ["cmd"], key: "o" }}
+                shortcut={Keyboard.Shortcut.Common.Open}
                 onOpen={() => onVisit?.(bookmark)}
               />
               <Action.CopyToClipboard
                 content={bookmark.content.url}
                 title={t("bookmark.actions.copyLink")}
-                shortcut={{ modifiers: ["cmd"], key: "c" }}
+                shortcut={{ macOS: { modifiers: ["cmd"], key: "c" }, Windows: { modifiers: ["ctrl"], key: "c" } }}
                 onCopy={() => onVisit?.(bookmark)}
               />
             </>
@@ -447,7 +447,7 @@ function BookmarkActions({
           <Action.CopyToClipboard
             content={bookmark.content.text}
             title={copyNoteTitle}
-            shortcut={{ modifiers: ["cmd"], key: "c" }}
+            shortcut={{ macOS: { modifiers: ["cmd"], key: "c" }, Windows: { modifiers: ["ctrl"], key: "c" } }}
             onCopy={() => onVisit?.(bookmark)}
           />
         )}
@@ -465,7 +465,7 @@ function BookmarkActions({
               title={t("bookmark.actions.aiSummary")}
               onAction={handlers.handleSummarize}
               icon={Icon.Wand}
-              shortcut={{ modifiers: ["ctrl"], key: "s" }}
+              shortcut={{ macOS: { modifiers: ["ctrl"], key: "s" }, Windows: { modifiers: ["ctrl"], key: "s" } }}
             />
           </>
         )}
@@ -476,26 +476,32 @@ function BookmarkActions({
           title={bookmark.favourited ? t("bookmark.actions.unfavorite") : t("bookmark.actions.favorite")}
           onAction={() => handlers.handleUpdate({ favourited: !bookmark.favourited })}
           icon={bookmark.favourited ? Icon.StarCircle : Icon.Star}
-          shortcut={{ modifiers: ["ctrl"], key: "f" }}
+          shortcut={{ macOS: { modifiers: ["ctrl"], key: "f" }, Windows: { modifiers: ["ctrl"], key: "f" } }}
         />
         <Action
           title={bookmark.archived ? t("bookmark.actions.unarchive") : t("bookmark.actions.archive")}
           onAction={() => handlers.handleUpdate({ archived: !bookmark.archived })}
           icon={bookmark.archived ? Icon.BlankDocument : Icon.SaveDocument}
-          shortcut={{ modifiers: ["ctrl"], key: "a" }}
+          shortcut={{ macOS: { modifiers: ["ctrl"], key: "a" }, Windows: { modifiers: ["ctrl"], key: "a" } }}
         />
         <Action
           icon={Icon.ArrowClockwise}
           title={t("bookmarkItem.actions.refresh")}
           onAction={onRefresh}
-          shortcut={{ modifiers: ["cmd"], key: "r" }}
+          shortcut={Keyboard.Shortcut.Common.Refresh}
         />
         {onCleanCache && (
           <Action
             icon={Icon.Trash}
             title={t("bookmarkItem.actions.clearCache")}
             onAction={onCleanCache}
-            shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+            // Clearing every cached preview is a remove-all, not a copy. It sat on
+            // Common.Copy because `ray lint --fix` matches the COMBO (⌘⇧C) rather
+            // than the meaning — and re-applies that match, so writing the combo
+            // out longhand does not survive the next `--fix`. The constant itself
+            // has to be the right one. RemoveAll (⌃⇧D) does not clash with the
+            // Delete action's Remove (⌃D) in this panel.
+            shortcut={Keyboard.Shortcut.Common.RemoveAll}
           />
         )}
       </ActionPanel.Section>
@@ -516,7 +522,7 @@ function BookmarkActions({
           />
           <Action.OpenInBrowser
             title={t("bookmarkItem.actions.browsers.safari")}
-            url="https://apps.apple.com/us/app/karakeeper-bookmarker/id6746722790"
+            url="https://apps.apple.com/us/app/karakeep-app/id6479258022"
             icon={Icon.Globe}
           />
         </ActionPanel.Submenu>
@@ -527,7 +533,7 @@ function BookmarkActions({
           title={deleteTitle}
           style={Action.Style.Destructive}
           onAction={handlers.handleDeleteBookmark}
-          shortcut={{ modifiers: ["ctrl"], key: "x" }}
+          shortcut={Keyboard.Shortcut.Common.Remove}
         />
       </ActionPanel.Section>
     </ActionPanel>

--- a/extensions/karakeep/src/createBookmark.tsx
+++ b/extensions/karakeep/src/createBookmark.tsx
@@ -1,6 +1,6 @@
-import { Action, ActionPanel, Form, LaunchProps, useNavigation } from "@raycast/api";
+import { Action, ActionPanel, Form, Icon, LaunchProps, showToast, Toast, useNavigation } from "@raycast/api";
 import { useForm } from "@raycast/utils";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { logger } from "@chrismessina/raycast-logger";
 import {
   fetchAddBookmarkToList,
@@ -13,9 +13,9 @@ import { useGetAllTags } from "./hooks/useGetAllTags";
 import { useTagPicker, TAG_PICKER_NOOP_VALUE } from "./hooks/useTagPicker";
 import { useTranslation } from "./hooks/useTranslation";
 import { useConfig } from "./hooks/useConfig";
-import { getBrowserLink } from "./hooks/useBrowserLink";
+import { canReadPageTitle, getBrowserLink, getBrowserTab } from "./hooks/useBrowserLink";
 import { validUrl } from "./utils/url";
-import { runWithToast } from "./utils/toast";
+import { attachCopyDetail, markToastFailed } from "./utils/toast";
 import { ensureReachable } from "./utils/submitGuard";
 import { useApiReachable } from "./hooks/useApiReachable";
 import { OfflineFormNotice, StartKarakeepAction } from "./components/OfflineFormNotice";
@@ -23,6 +23,16 @@ import CreateListView from "./createList";
 
 const log = logger.child("[CreateBookmark]");
 const MAX_TITLE_LENGTH = 1000;
+
+/** How far a submission got before it threw — the toast title depends on it. */
+type SubmitStep = "create" | "list" | "tags" | "title";
+
+const SUBMIT_FAILURE_TITLES: Record<SubmitStep, string> = {
+  create: "bookmark.createFailed", // "Couldn't create bookmark"
+  list: "bookmark.savedListFailed", // "Bookmark saved, but couldn't add to list"
+  tags: "bookmark.savedTagsFailed", // "Bookmark saved, but couldn't add tags"
+  title: "bookmark.savedTitleFailed", // "Bookmark saved, but couldn't edit title"
+};
 
 interface FormValues {
   url: string;
@@ -90,42 +100,55 @@ export default function CreateBookmarkView(props: LaunchProps<{ draftValues: Dra
         return;
       }
 
+      // Saving is up to four separate writes with no transaction around them. A single
+      // pass/fail toast for all four claims the bookmark was never created when it was in
+      // fact saved and only a tag or list call failed — so track how far we got and let
+      // the toast name what actually landed.
+      let step: SubmitStep = "create";
+      const toast = await showToast({ style: Toast.Style.Animated, title: t("bookmark.creating") });
+
       try {
-        const bookmark = await runWithToast({
-          loading: { title: t("bookmark.creating") },
-          success: { title: t("bookmark.createSuccess") },
-          failure: { title: t("bookmark.createFailed") },
-          action: async () => {
-            const title = values.title.trim();
-            const payload = {
-              type: "link",
-              url: values.url,
-              createdAt: new Date().toISOString(),
-              ...(title ? { title } : {}),
-            };
-            const result = await fetchCreateBookmarkResult(payload);
-            const created =
-              title && !result.wasCreated ? await fetchUpdateBookmark(result.bookmark.id, { title }) : result.bookmark;
+        const title = values.title.trim();
+        const payload = {
+          type: "link",
+          url: values.url,
+          createdAt: new Date().toISOString(),
+          ...(title ? { title } : {}),
+        };
+        const result = await fetchCreateBookmarkResult(payload);
+        const bookmarkId = result.bookmark.id;
 
-            if (values.list) {
-              await fetchAddBookmarkToList(values.list, created.id);
-            }
-
-            const tagsToAttach = buildTagsToAttach();
-            if (tagsToAttach.length > 0) {
-              await fetchAttachTagsToBookmark(created.id, tagsToAttach);
-            }
-
-            return created;
-          },
-        });
-
-        if (bookmark) {
-          log.info("Bookmark created", { bookmarkId: bookmark.id });
-          pop();
+        if (values.list) {
+          step = "list";
+          await fetchAddBookmarkToList(values.list, bookmarkId);
         }
+
+        const tagsToAttach = buildTagsToAttach();
+        if (tagsToAttach.length > 0) {
+          step = "tags";
+          await fetchAttachTagsToBookmark(bookmarkId, tagsToAttach);
+        }
+
+        // Renaming an EXISTING bookmark is the only step that overwrites data the user
+        // already had, so it runs last — nothing after it can fail and strand the form
+        // on a failure toast when the rename has already been committed. A bookmark we
+        // just created carries its title from the POST payload and needs no PATCH.
+        if (title && !result.wasCreated) {
+          step = "title";
+          await fetchUpdateBookmark(bookmarkId, { title });
+        }
+
+        toast.style = Toast.Style.Success;
+        toast.title = t("bookmark.createSuccess");
+        log.info("Bookmark saved", { bookmarkId, wasCreated: result.wasCreated });
+        pop();
       } catch (error) {
-        log.error("Failed to create bookmark", { url: values.url, error });
+        // The form stays mounted on every failure, so the URL, title, list and tag
+        // selection all survive for a retry. Re-submitting is safe for the steps that
+        // already succeeded: the create call returns the existing bookmark instead of a
+        // duplicate, and the list and tag calls re-apply the same values.
+        markToastFailed(toast, t(SUBMIT_FAILURE_TITLES[step]), error);
+        log.error("Failed to save bookmark", { url: values.url, step, error });
       }
     },
   });
@@ -153,6 +176,32 @@ export default function CreateBookmarkView(props: LaunchProps<{ draftValues: Dra
     loadBrowserTab();
   }, [config.prefillUrlFromBrowser, setValue, values.url]);
 
+  // Opt-in, never automatic. A filled title becomes a user override that
+  // permanently shadows the title Karakeep crawls, and — because the submit path
+  // PATCHes a non-empty title onto an existing bookmark — pre-filling it would
+  // silently rename any bookmark whose URL you already had.
+  const usePageTitle = useCallback(async () => {
+    const tab = await getBrowserTab();
+    if (!tab?.title) {
+      // The action only renders when the Browser Extension is reachable, so this
+      // is not "not installed" — it is no open tab, or a tab still loading, which
+      // has no title yet.
+      log.warn("No page title available from the active tab", { hasTab: Boolean(tab) });
+      const toast = await showToast({ style: Toast.Style.Failure, title: t("bookmark.usePageTitleFailed") });
+      attachCopyDetail(
+        toast,
+        [
+          "The browser extension returned no page title for the active tab.",
+          "Most likely the tab is still loading, or no tab is open.",
+          `tab: ${tab ? tab.url : "none found"}`,
+        ].join("\n"),
+      );
+      return;
+    }
+    log.info("Filled title from browser tab", { title: tab.title });
+    setValue("title", tab.title);
+  }, [setValue, t]);
+
   useEffect(() => {
     if (!createdListIdToSelect) return;
 
@@ -173,6 +222,20 @@ export default function CreateBookmarkView(props: LaunchProps<{ draftValues: Dra
               takes the primary slot and Submit steps down to second. */}
           <StartKarakeepAction offline={offline} canStart={canStart} isRecovering={isRecovering} onStart={start} />
           <Action.SubmitForm title={t("bookmark.create")} onSubmit={handleSubmit} />
+          {/* Titles come only from the Browser Extension, which is absent when it
+              isn't installed and on Windows, where Raycast doesn't expose the API
+              yet. Hide the action there rather than offer one that always fails. */}
+          {canReadPageTitle() && (
+            <Action
+              title={t("bookmark.usePageTitle")}
+              icon={Icon.Text}
+              shortcut={{
+                macOS: { modifiers: ["cmd"], key: "t" },
+                Windows: { modifiers: ["ctrl"], key: "t" },
+              }}
+              onAction={usePageTitle}
+            />
+          )}
           <Action
             title={t("list.createList")}
             onAction={() =>

--- a/extensions/karakeep/src/highlights.tsx
+++ b/extensions/karakeep/src/highlights.tsx
@@ -1,4 +1,4 @@
-import { Action, ActionPanel, confirmAlert, Detail, Form, Icon, List, useNavigation } from "@raycast/api";
+import { Action, ActionPanel, confirmAlert, Detail, Form, Icon, List, useNavigation, Keyboard } from "@raycast/api";
 import { useCachedPromise, useForm } from "@raycast/utils";
 import { logger } from "@chrismessina/raycast-logger";
 import { fetchDeleteHighlight, fetchGetAllHighlights, fetchGetSingleBookmark, fetchUpdateHighlight } from "./apis";
@@ -176,13 +176,13 @@ function HighlightDetail({ highlight, onRefresh }: { highlight: Highlight; onRef
             <Action.CopyToClipboard
               content={highlight.text}
               title={t("highlights.actions.copyText")}
-              shortcut={{ modifiers: ["cmd"], key: "c" }}
+              shortcut={{ macOS: { modifiers: ["cmd"], key: "c" }, Windows: { modifiers: ["ctrl"], key: "c" } }}
             />
             {highlight.note && (
               <Action.CopyToClipboard
                 content={highlight.note}
                 title={t("highlights.actions.copyNote")}
-                shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+                shortcut={Keyboard.Shortcut.Common.Copy}
               />
             )}
           </ActionPanel.Section>
@@ -191,14 +191,14 @@ function HighlightDetail({ highlight, onRefresh }: { highlight: Highlight; onRef
               title={t("highlights.actions.edit")}
               icon={Icon.Pencil}
               onAction={() => push(<EditHighlightForm highlight={highlight} onUpdated={onRefresh} />)}
-              shortcut={{ modifiers: ["cmd"], key: "e" }}
+              shortcut={Keyboard.Shortcut.Common.Edit}
             />
             <Action
               title={t("highlights.actions.delete")}
               icon={Icon.Trash}
               style={Action.Style.Destructive}
               onAction={handleDelete}
-              shortcut={{ modifiers: ["ctrl"], key: "x" }}
+              shortcut={Keyboard.Shortcut.Common.Remove}
             />
           </ActionPanel.Section>
         </ActionPanel>
@@ -238,27 +238,27 @@ export default function Highlights() {
                   title={t("bookmarkItem.actions.viewDetail")}
                   icon={Icon.Sidebar}
                   onAction={() => push(<HighlightDetail highlight={highlight} onRefresh={revalidate} />)}
-                  shortcut={{ modifiers: ["cmd"], key: "return" }}
+                  shortcut={Keyboard.Shortcut.Common.Open}
                 />
                 <OpenBookmarkAction bookmarkId={highlight.bookmarkId} t={t} />
                 <Action
                   title={t("highlights.actions.edit")}
                   icon={Icon.Pencil}
                   onAction={() => push(<EditHighlightForm highlight={highlight} onUpdated={revalidate} />)}
-                  shortcut={{ modifiers: ["cmd"], key: "e" }}
+                  shortcut={Keyboard.Shortcut.Common.Edit}
                 />
               </ActionPanel.Section>
               <ActionPanel.Section>
                 <Action.CopyToClipboard
                   content={highlight.text}
                   title={t("highlights.actions.copyText")}
-                  shortcut={{ modifiers: ["cmd"], key: "c" }}
+                  shortcut={{ macOS: { modifiers: ["cmd"], key: "c" }, Windows: { modifiers: ["ctrl"], key: "c" } }}
                 />
                 {highlight.note && (
                   <Action.CopyToClipboard
                     content={highlight.note}
                     title={t("highlights.actions.copyNote")}
-                    shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+                    shortcut={Keyboard.Shortcut.Common.Copy}
                   />
                 )}
               </ActionPanel.Section>
@@ -268,7 +268,7 @@ export default function Highlights() {
                   icon={Icon.Trash}
                   style={Action.Style.Destructive}
                   onAction={() => deleteHighlight(highlight.id, t, revalidate)}
-                  shortcut={{ modifiers: ["ctrl"], key: "x" }}
+                  shortcut={Keyboard.Shortcut.Common.Remove}
                 />
               </ActionPanel.Section>
             </ActionPanel>

--- a/extensions/karakeep/src/hooks/useApiReachable.ts
+++ b/extensions/karakeep/src/hooks/useApiReachable.ts
@@ -1,6 +1,5 @@
 import { getPreferenceValues } from "@raycast/api";
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { Preferences } from "../types";
 import { isApiReachable } from "../utils/connection";
 import { ensureReachable } from "../utils/submitGuard";
 import { useCanRecoverLocally } from "./useCanRecoverLocally";

--- a/extensions/karakeep/src/hooks/useBrowserLink.ts
+++ b/extensions/karakeep/src/hooks/useBrowserLink.ts
@@ -4,30 +4,46 @@ import { logger } from "@chrismessina/raycast-logger";
 
 const log = logger.child("[BrowserLink]");
 
+export interface BrowserTab {
+  url: string;
+  /**
+   * Only the Browser Extension can supply this. Every AppleScript fallback below
+   * reads the address bar and returns a URL alone, so callers must treat a missing
+   * title as normal rather than as a failure.
+   */
+  title?: string;
+}
+
 /**
- * Get the current URL from the active browser tab.
+ * Whether a page TITLE can be read at all.
  *
- * This function attempts to retrieve the URL using the following methods in order:
- * 1. Browser Extension API (if available) - preferred method
- * 2. AppleScript - fallback for supported browsers
- *
- * @returns {Promise<string | null>} The URL of the active browser tab, or null if unavailable
+ * Only the Browser Extension supplies titles — the AppleScript fallbacks below
+ * read the address bar and return a URL alone — and that API is unavailable
+ * both when the extension isn't installed and on Windows, where Raycast does
+ * not expose it yet. Callers should hide title-dependent UI when this is false
+ * rather than offering an action that can only fail. Synchronous, so it is safe
+ * to call during render.
  */
-export async function getBrowserLink(): Promise<string | null> {
-  // Check if Browser Extension API is available
+export function canReadPageTitle(): boolean {
+  return environment.canAccess(BrowserExtension);
+}
+
+/**
+ * Get the active browser tab.
+ *
+ * Tries the Browser Extension API first (the only source of a page title), then
+ * falls back to AppleScript per browser.
+ */
+export async function getBrowserTab(): Promise<BrowserTab | null> {
   if (environment.canAccess(BrowserExtension)) {
     try {
       const tabs = await BrowserExtension.getTabs();
-      // Find the active tab
-      const activeTab = tabs.find((tab) => tab.active);
+      const tab = tabs.find((t) => t.active) ?? tabs[0];
 
-      if (activeTab?.url) {
-        return activeTab.url;
-      }
-
-      // If no active tab found, return the first tab's URL
-      if (tabs.length > 0 && tabs[0].url) {
-        return tabs[0].url;
+      if (tab?.url) {
+        // `title` is undefined while a tab is still loading, and a whitespace-only
+        // title is no more useful than none — normalise both to undefined.
+        return { url: tab.url, title: tab.title?.trim() || undefined };
       }
     } catch (error) {
       // Fallback to AppleScript if Browser Extension API fails
@@ -35,7 +51,20 @@ export async function getBrowserLink(): Promise<string | null> {
     }
   }
 
-  // Fallback: AppleScript-based processing
+  const url = await getUrlViaAppleScript();
+  return url ? { url } : null;
+}
+
+/**
+ * Get the current URL from the active browser tab.
+ *
+ * @returns {Promise<string | null>} The URL of the active browser tab, or null if unavailable
+ */
+export async function getBrowserLink(): Promise<string | null> {
+  return (await getBrowserTab())?.url ?? null;
+}
+
+async function getUrlViaAppleScript(): Promise<string | null> {
   try {
     const app = await getFrontmostApplication();
 

--- a/extensions/karakeep/src/hooks/useCanRecoverLocally.ts
+++ b/extensions/karakeep/src/hooks/useCanRecoverLocally.ts
@@ -1,6 +1,5 @@
 import { getPreferenceValues } from "@raycast/api";
 import { useEffect, useRef, useState } from "react";
-import type { Preferences } from "../types";
 import { canRecoverLocally } from "../utils/submitGuard";
 
 /**

--- a/extensions/karakeep/src/hooks/useConfig.ts
+++ b/extensions/karakeep/src/hooks/useConfig.ts
@@ -3,7 +3,7 @@ import { useCallback, useState } from "react";
 import { logger } from "@chrismessina/raycast-logger";
 
 const log = logger.child("[useConfig]");
-import { Config, Preferences } from "../types";
+import { Config } from "../types";
 
 const getConfig = (): Config => {
   try {

--- a/extensions/karakeep/src/hooks/useConnectionRecovery.ts
+++ b/extensions/karakeep/src/hooks/useConnectionRecovery.ts
@@ -1,7 +1,6 @@
 import { getPreferenceValues } from "@raycast/api";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { logger } from "@chrismessina/raycast-logger";
-import type { Preferences } from "../types";
 import { getPortFromUrl, isLocalHost } from "../utils/connection";
 import { DockerContainer, findContainerByPort, findDockerPath, isDockerRunning } from "../utils/docker";
 import { ensureReachable } from "../utils/submitGuard";

--- a/extensions/karakeep/src/hooks/useTranslation.ts
+++ b/extensions/karakeep/src/hooks/useTranslation.ts
@@ -5,7 +5,7 @@ import { translate } from "../i18n/translate";
 
 export function useTranslation() {
   const { config } = useConfig();
-  const [language, setLanguage] = useState<Language>((config?.language as Language) || "en");
+  const [language, setLanguage] = useState<Language>(config?.language || "en");
 
   const t = useCallback(
     (
@@ -22,7 +22,7 @@ export function useTranslation() {
   );
 
   useEffect(() => {
-    const newLanguage = config?.language as Language | undefined;
+    const newLanguage = config?.language;
     if (newLanguage && newLanguage !== language) {
       setLanguage(newLanguage);
     }

--- a/extensions/karakeep/src/i18n/index.ts
+++ b/extensions/karakeep/src/i18n/index.ts
@@ -67,7 +67,6 @@ export const translations = {
       deleting: "Deleting...",
       deleteSuccess: "Deleted successfully",
       deleteFailed: "Delete failed",
-      deleteCancel: "Delete cancelled",
       viewInBrowser: "View in Browser",
       copyId: "Copy ID",
       open: "Open",
@@ -92,7 +91,12 @@ export const translations = {
       create: "Create Bookmark",
       creating: "Creating bookmark...",
       createSuccess: "Bookmark created successfully",
-      createFailed: "Creation failed",
+      createFailed: "Couldn't create bookmark",
+      // Saving is up to four separate writes. Once the bookmark itself exists,
+      // a later failure must not claim nothing was saved.
+      savedListFailed: "Bookmark saved, but couldn't add to list",
+      savedTagsFailed: "Bookmark saved, but couldn't add tags",
+      savedTitleFailed: "Bookmark saved, but couldn't edit title",
 
       // Types and Fields
       type: "Type",
@@ -116,8 +120,12 @@ export const translations = {
       customTitle: "Custom Title",
       titlePlaceholder: "Enter title",
       createTitle: "Title",
-      createTitlePlaceholder: "Leave empty to use the page title",
+      createTitlePlaceholder: "Set custom title or leave blank to use generated title",
       titleTooLong: "Title cannot exceed 1000 characters",
+      // Filling this field creates a user title that permanently shadows the one
+      // Karakeep crawls, so it stays opt-in rather than being pre-filled.
+      usePageTitle: "Use Page Title",
+      usePageTitleFailed: "Couldn't read the page title",
       list: "List",
       defaultListPlaceholder: "Default",
       defaultListFilter: "Show All Bookmarks",
@@ -722,7 +730,6 @@ export const translations = {
       deleting: "删除中...",
       deleteSuccess: "删除成功",
       deleteFailed: "删除失败",
-      deleteCancel: "已取消删除",
       viewInBrowser: "在浏览器中查看",
       copyId: "复制 ID",
       open: "打开",
@@ -747,7 +754,10 @@ export const translations = {
       create: "创建书签",
       creating: "创建中...",
       createSuccess: "创建成功",
-      createFailed: "创建失败",
+      createFailed: "无法创建书签",
+      savedListFailed: "书签已保存，但无法添加到列表",
+      savedTagsFailed: "书签已保存，但无法添加标签",
+      savedTitleFailed: "书签已保存，但无法修改标题",
 
       // 类型和字段
       type: "类型",
@@ -771,7 +781,9 @@ export const translations = {
       customTitle: "自定义标题",
       titlePlaceholder: "输入标题",
       createTitle: "标题",
-      createTitlePlaceholder: "留空即使用页面标题",
+      createTitlePlaceholder: "设置自定义标题，或留空以使用生成的标题",
+      usePageTitle: "使用页面标题",
+      usePageTitleFailed: "无法读取页面标题",
       titleTooLong: "标题长度不得超过1000个字符",
 
       list: "列表",

--- a/extensions/karakeep/src/i18n/standalone.ts
+++ b/extensions/karakeep/src/i18n/standalone.ts
@@ -1,5 +1,4 @@
 import { getPreferenceValues } from "@raycast/api";
-import type { Preferences } from "../types";
 import { Language, translations } from "./index";
 import { translate } from "./translate";
 

--- a/extensions/karakeep/src/lists.tsx
+++ b/extensions/karakeep/src/lists.tsx
@@ -1,4 +1,4 @@
-import { Action, ActionPanel, confirmAlert, Form, Icon, List, showToast, Toast, useNavigation } from "@raycast/api";
+import { Action, ActionPanel, confirmAlert, Form, Icon, List, useNavigation, Keyboard } from "@raycast/api";
 import { useForm } from "@raycast/utils";
 import React, { useCallback, useMemo } from "react";
 import { logger } from "@chrismessina/raycast-logger";
@@ -350,19 +350,19 @@ function ListItem({ list, label, level, apiUrl, onOpen, onEdit, onCreate, onDele
               title={t("list.openList")}
               onAction={() => onOpen(list)}
               icon={Icon.List}
-              shortcut={{ modifiers: ["cmd"], key: "return" }}
+              shortcut={Keyboard.Shortcut.Common.Open}
             />
             <Action
               title={t("list.editList")}
               onAction={() => onEdit(list)}
               icon={Icon.Pencil}
-              shortcut={{ modifiers: ["cmd"], key: "e" }}
+              shortcut={Keyboard.Shortcut.Common.Edit}
             />
             <Action
               title={t("list.createList")}
               onAction={onCreate}
               icon={Icon.Plus}
-              shortcut={{ modifiers: ["cmd"], key: "n" }}
+              shortcut={Keyboard.Shortcut.Common.New}
             />
           </ActionPanel.Section>
           <ActionPanel.Section>
@@ -370,7 +370,7 @@ function ListItem({ list, label, level, apiUrl, onOpen, onEdit, onCreate, onDele
             <Action.CopyToClipboard
               title={t("common.copyId")}
               content={list.id}
-              shortcut={{ modifiers: ["cmd"], key: "." }}
+              shortcut={Keyboard.Shortcut.Common.Copy}
             />
           </ActionPanel.Section>
           <ActionPanel.Section>
@@ -379,7 +379,7 @@ function ListItem({ list, label, level, apiUrl, onOpen, onEdit, onCreate, onDele
               icon={Icon.Trash}
               style={Action.Style.Destructive}
               onAction={() => onDelete(list.id)}
-              shortcut={{ modifiers: ["ctrl"], key: "x" }}
+              shortcut={Keyboard.Shortcut.Common.Remove}
             />
           </ActionPanel.Section>
         </ActionPanel>
@@ -400,34 +400,35 @@ export default function Lists() {
       const list = lists?.find((list) => list.id === id);
       const listName = list?.name;
 
+      // Declining the confirmation is a normal outcome, not an error. It used to
+      // raise a red Failure toast reading "Delete cancelled", which reports a
+      // successful no-op as a problem — and no other confirmAlert in this
+      // extension says anything when you back out. Stay silent to match.
       if (
-        await confirmAlert({
+        !(await confirmAlert({
           title: t("list.deleteList"),
           message: t("list.deleteConfirm", { name: listName || "" }),
-        })
+        }))
       ) {
-        await runWithToast({
-          loading: { title: t("common.deleting") },
-          success: { title: t("common.deleteSuccess") },
-          failure: { title: t("common.deleteFailed") },
-          action: async () => {
-            try {
-              log.info("Deleting list", { listId: id, listName });
-              await fetchDeleteList(id);
-              await revalidate();
-              log.info("List deleted", { listId: id });
-            } catch (error) {
-              log.error("Failed to delete list", { listId: id, listName, error });
-              throw error;
-            }
-          },
-        });
-      } else {
-        await showToast({
-          title: t("common.deleteCancel"),
-          style: Toast.Style.Failure,
-        });
+        return;
       }
+
+      await runWithToast({
+        loading: { title: t("common.deleting") },
+        success: { title: t("common.deleteSuccess") },
+        failure: { title: t("common.deleteFailed") },
+        action: async () => {
+          try {
+            log.info("Deleting list", { listId: id, listName });
+            await fetchDeleteList(id);
+            await revalidate();
+            log.info("List deleted", { listId: id });
+          } catch (error) {
+            log.error("Failed to delete list", { listId: id, listName, error });
+            throw error;
+          }
+        },
+      });
     },
     [lists, revalidate, t],
   );
@@ -496,7 +497,7 @@ export default function Lists() {
             title={t("list.createList")}
             onAction={handleCreateList}
             icon={Icon.Plus}
-            shortcut={{ modifiers: ["cmd"], key: "n" }}
+            shortcut={Keyboard.Shortcut.Common.New}
           />
         </ActionPanel>
       }
@@ -512,7 +513,7 @@ export default function Lists() {
                 title={t("list.createList")}
                 onAction={handleCreateList}
                 icon={Icon.Plus}
-                shortcut={{ modifiers: ["cmd"], key: "n" }}
+                shortcut={Keyboard.Shortcut.Common.New}
               />
             </ActionPanel>
           }
@@ -527,14 +528,14 @@ export default function Lists() {
               title={t("list.openFavorites")}
               onAction={handleShowFavoritedBookmarks}
               icon={Icon.List}
-              shortcut={{ modifiers: ["cmd"], key: "return" }}
+              shortcut={Keyboard.Shortcut.Common.Open}
             />
             <Action.OpenInBrowser url={`${apiUrl}/dashboard/favourites`} title={t("common.viewInBrowser")} />
             <Action
               title={t("list.createList")}
               onAction={handleCreateList}
               icon={Icon.Plus}
-              shortcut={{ modifiers: ["cmd"], key: "n" }}
+              shortcut={Keyboard.Shortcut.Common.New}
             />
           </ActionPanel>
         }
@@ -548,14 +549,14 @@ export default function Lists() {
               title={t("list.openArchived")}
               onAction={handleShowArchivedBookmarks}
               icon={Icon.List}
-              shortcut={{ modifiers: ["cmd"], key: "return" }}
+              shortcut={Keyboard.Shortcut.Common.Open}
             />
             <Action.OpenInBrowser url={`${apiUrl}/dashboard/archive`} title={t("common.viewInBrowser")} />
             <Action
               title={t("list.createList")}
               onAction={handleCreateList}
               icon={Icon.Plus}
-              shortcut={{ modifiers: ["cmd"], key: "n" }}
+              shortcut={Keyboard.Shortcut.Common.New}
             />
           </ActionPanel>
         }

--- a/extensions/karakeep/src/notes.tsx
+++ b/extensions/karakeep/src/notes.tsx
@@ -1,4 +1,4 @@
-import { Action, ActionPanel, Icon, List } from "@raycast/api";
+import { Action, ActionPanel, Icon, List, Keyboard } from "@raycast/api";
 import { BookmarkList } from "./components/BookmarkList";
 import { useGetAllBookmarks } from "./hooks/useGetAllBookmarks";
 import { useTranslation } from "./hooks/useTranslation";
@@ -46,7 +46,7 @@ export default function Notes() {
                 title={t("note.create")}
                 icon={Icon.Plus}
                 target={<CreateNoteView />}
-                shortcut={{ modifiers: ["cmd"], key: "n" }}
+                shortcut={Keyboard.Shortcut.Common.New}
               />
             </ActionPanel>
           }

--- a/extensions/karakeep/src/quickBookmark.tsx
+++ b/extensions/karakeep/src/quickBookmark.tsx
@@ -6,7 +6,7 @@ import { getBrowserLink } from "./hooks/useBrowserLink";
 import { Bookmark } from "./types";
 import { getTranslator } from "./i18n/standalone";
 import { ensureReachable } from "./utils/submitGuard";
-import { toErrorMessage } from "./utils/toast";
+import { attachCopyDetail, toErrorMessage } from "./utils/toast";
 
 const log = logger.child("[QuickBookmark]");
 
@@ -30,6 +30,10 @@ export default async function QuickBookmark() {
       toast.style = Toast.Style.Failure;
       toast.title = t("quickBookmark.failedToGetBrowserUrl.title");
       toast.message = t("quickBookmark.failedToGetBrowserUrl.message");
+      // No exception to unwrap — the browser extension simply returned nothing.
+      // House style still wants something copyable, so hand over the state needed
+      // to file the bug rather than leaving a dead-end toast.
+      attachCopyDetail(toast, "Could not read the active tab URL from any supported browser.");
       return;
     }
 
@@ -55,6 +59,7 @@ export default async function QuickBookmark() {
       log.error("Bookmark creation returned empty result", { url });
       toast.style = Toast.Style.Failure;
       toast.title = t("quickBookmark.failedToCreateBookmark");
+      attachCopyDetail(toast, `Karakeep accepted the request but returned no bookmark.\nurl: ${url}`);
       return;
     }
 

--- a/extensions/karakeep/src/stats.tsx
+++ b/extensions/karakeep/src/stats.tsx
@@ -1,4 +1,4 @@
-import { Action, ActionPanel, Detail, Icon, environment } from "@raycast/api";
+import { Action, ActionPanel, Detail, Icon, environment, Keyboard } from "@raycast/api";
 import { useMemo } from "react";
 import { useCachedPromise } from "@raycast/utils";
 import { logger } from "@chrismessina/raycast-logger";
@@ -103,7 +103,7 @@ export default function Stats() {
         title={t("stats.refresh")}
         icon={Icon.ArrowClockwise}
         onAction={revalidate}
-        shortcut={{ modifiers: ["cmd"], key: "r" }}
+        shortcut={Keyboard.Shortcut.Common.Refresh}
       />
     </ActionPanel>
   );

--- a/extensions/karakeep/src/tags.tsx
+++ b/extensions/karakeep/src/tags.tsx
@@ -1,4 +1,4 @@
-import { Action, ActionPanel, confirmAlert, Form, Icon, List, useNavigation } from "@raycast/api";
+import { Action, ActionPanel, confirmAlert, Form, Icon, List, useNavigation, Keyboard } from "@raycast/api";
 import { useForm } from "@raycast/utils";
 import { logger } from "@chrismessina/raycast-logger";
 import { fetchCreateTag, fetchDeleteTag, fetchUpdateTag } from "./apis";
@@ -182,7 +182,7 @@ export default function Tags() {
             title={t("tags.actions.createTag")}
             onAction={handleCreateTag}
             icon={Icon.Plus}
-            shortcut={{ modifiers: ["cmd"], key: "n" }}
+            shortcut={Keyboard.Shortcut.Common.New}
           />
         </ActionPanel>
       }
@@ -198,7 +198,7 @@ export default function Tags() {
                 title={t("tags.actions.createTag")}
                 onAction={handleCreateTag}
                 icon={Icon.Plus}
-                shortcut={{ modifiers: ["cmd"], key: "n" }}
+                shortcut={Keyboard.Shortcut.Common.New}
               />
             </ActionPanel>
           }
@@ -216,19 +216,19 @@ export default function Tags() {
                   onAction={() => push(<TagBookmarksView tagId={tag.id} tagName={tag.name} />)}
                   title={t("tags.actions.viewBookmarks")}
                   icon={Icon.Eye}
-                  shortcut={{ modifiers: ["cmd"], key: "return" }}
+                  shortcut={Keyboard.Shortcut.Common.Open}
                 />
                 <Action
                   title={t("tags.actions.renameTag")}
                   onAction={() => push(<RenameTagForm tag={tag} onRenamed={revalidate} />)}
                   icon={Icon.Pencil}
-                  shortcut={{ modifiers: ["cmd"], key: "e" }}
+                  shortcut={Keyboard.Shortcut.Common.Edit}
                 />
                 <Action
                   title={t("tags.actions.createTag")}
                   onAction={handleCreateTag}
                   icon={Icon.Plus}
-                  shortcut={{ modifiers: ["cmd"], key: "n" }}
+                  shortcut={Keyboard.Shortcut.Common.New}
                 />
               </ActionPanel.Section>
               <ActionPanel.Section>
@@ -237,7 +237,7 @@ export default function Tags() {
                 <Action.CopyToClipboard
                   title={t("tags.actions.copyTagId")}
                   content={tag.id}
-                  shortcut={{ modifiers: ["cmd"], key: "." }}
+                  shortcut={Keyboard.Shortcut.Common.Copy}
                 />
               </ActionPanel.Section>
               <ActionPanel.Section>
@@ -246,7 +246,7 @@ export default function Tags() {
                   icon={Icon.Trash}
                   style={Action.Style.Destructive}
                   onAction={() => handleDeleteTag(tag.id)}
-                  shortcut={{ modifiers: ["ctrl"], key: "x" }}
+                  shortcut={Keyboard.Shortcut.Common.Remove}
                 />
               </ActionPanel.Section>
             </ActionPanel>

--- a/extensions/karakeep/src/types/index.ts
+++ b/extensions/karakeep/src/types/index.ts
@@ -1,5 +1,10 @@
+import type { Language } from "../i18n";
+
 // Action types
-export type linkMainActionType = "openInBrowser" | "viewDetail" | "edit" | "copy";
+// Kept in step with `package.json > preferences`. "copy" was listed here but has
+// never been an option the manifest offers, so neither switch on this type has a
+// branch for it.
+export type linkMainActionType = "openInBrowser" | "viewDetail" | "edit";
 export type textMainActionType = "viewDetail" | "edit" | "copy";
 
 // Common display preferences for internal use
@@ -17,22 +22,19 @@ interface DisplayOptions {
 interface BaseConfig {
   apiUrl: string;
   apiKey: string;
-  language: string;
+  // Narrower than `string` so an invalid locale can't type-check its way in.
+  // The manifest offers exactly these, and the generated Preferences agrees.
+  language: Language;
   showWebsitePreview: boolean;
   linkMainAction: linkMainActionType;
   textMainAction: textMainActionType;
   prefillUrlFromBrowser: boolean;
 }
 
-export interface Preferences extends Partial<DisplayOptions> {
-  apiUrl: string;
-  apiKey: string;
-  language?: string;
-  showWebsitePreview: boolean;
-  linkMainAction?: linkMainActionType;
-  textMainAction?: textMainActionType;
-  prefillUrlFromBrowser?: boolean;
-}
+// NOTE: there is deliberately no `Preferences` interface here. Raycast generates
+// one into `raycast-env.d.ts` from the manifest, as an ambient global — so
+// `getPreferenceValues<Preferences>()` resolves without an import and cannot
+// drift from `package.json`. A hand-written copy silently did drift.
 
 export interface Config extends BaseConfig, DisplayOptions {}
 

--- a/extensions/karakeep/src/updateKarakeep.tsx
+++ b/extensions/karakeep/src/updateKarakeep.tsx
@@ -1,4 +1,15 @@
-import { Action, ActionPanel, Alert, Clipboard, confirmAlert, Detail, Icon, showToast, Toast } from "@raycast/api";
+import {
+  Action,
+  ActionPanel,
+  Alert,
+  Clipboard,
+  confirmAlert,
+  Detail,
+  Icon,
+  showToast,
+  Toast,
+  Keyboard,
+} from "@raycast/api";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { logger } from "@chrismessina/raycast-logger";
 import {
@@ -45,6 +56,14 @@ export default function UpdateKarakeep() {
 
   const detect = useCallback(async () => {
     setPhase("checking");
+    // Clear everything derived from the PREVIOUS detection before starting.
+    // Only the success path assigns these, so without this an early return
+    // leaves the last run's container and identity verdict in place. Nothing
+    // can reach them today — the destructive action is gated on `phase` — but
+    // that invariant lives thirty lines away, and the Copy Command action was
+    // already rendering a stale project's invocation on a failed re-check.
+    setContainer(undefined);
+    setIdentityProven(false);
     // Every bail below is logged: "the command says it can't update" is the
     // most likely thing to need diagnosing, and until now all five reasons
     // reached the screen but none reached the log.
@@ -330,16 +349,16 @@ export default function UpdateKarakeep() {
               title={t("update.actions.viewChangelog")}
               icon={Icon.Document}
               target={<ChangelogView image={container?.image} />}
-              shortcut={{
-                macOS: { modifiers: ["cmd"], key: "y" },
-                Windows: { modifiers: ["ctrl"], key: "y" },
-              }}
+              // Pushes a Detail view; it does not Quick Look a file. ToggleQuickLook
+              // was `ray lint --fix` matching the old ⌘Y combo, not the meaning.
+              // Open is the right constant and is otherwise unused in this panel.
+              shortcut={Keyboard.Shortcut.Common.Open}
             />
           )}
           {phase === "unavailable" && (
             <Action title={t("update.actions.recheck")} icon={Icon.ArrowClockwise} onAction={detect} />
           )}
-          {container?.configFiles?.[0] && (
+          {phase !== "unavailable" && container?.configFiles?.[0] && (
             <Action.CopyToClipboard title={t("update.actions.copyCommand")} content={composeCommandLine(container)} />
           )}
         </ActionPanel>

--- a/extensions/karakeep/src/utils/config.ts
+++ b/extensions/karakeep/src/utils/config.ts
@@ -1,5 +1,4 @@
 import { getPreferenceValues } from "@raycast/api";
-import type { Preferences } from "../types";
 
 export async function getApiConfig() {
   const preferences = getPreferenceValues<Preferences>();

--- a/extensions/karakeep/src/utils/submitGuard.ts
+++ b/extensions/karakeep/src/utils/submitGuard.ts
@@ -1,6 +1,5 @@
 import { Clipboard, getPreferenceValues, showToast, Toast } from "@raycast/api";
 import { logger } from "@chrismessina/raycast-logger";
-import type { Preferences } from "../types";
 import { getPortFromUrl, isApiReachable, isLocalHost } from "./connection";
 import { findContainerByPort, findDockerPath, isDockerRunning, startContainer, waitForApi } from "./docker";
 import { getTranslator } from "../i18n/standalone";

--- a/extensions/karakeep/src/utils/toast.ts
+++ b/extensions/karakeep/src/utils/toast.ts
@@ -29,6 +29,22 @@ export function markToastFailed(toast: Toast, title: string, error: unknown) {
   };
 }
 
+/**
+ * Give a Failure toast something to copy when there is no Error to unwrap.
+ *
+ * `markToastFailed` covers the usual case: something threw, and the message is
+ * the payload. Some failures have no exception at all — a status field flipped
+ * server-side, or a call returned an empty result. House Style still requires a
+ * Failure toast to be copyable, so the caller supplies the state worth pasting
+ * into a bug report.
+ */
+export function attachCopyDetail(toast: Toast, detail: string) {
+  toast.primaryAction = {
+    title: getTranslator()("connection.copyError"),
+    onAction: () => Clipboard.copy(detail),
+  };
+}
+
 export async function runWithToast<T>(options: {
   loading: { title: string; message?: string };
   success: { title: string; message?: string };


### PR DESCRIPTION
## Description

Maintenance update to the Karakeep extension (2.4.4). No new commands.

Most of this follows from reviewing [#30194](https://github.com/raycast/extensions/pull/30194), which added an optional Title field to Create Bookmark. When the submitted URL already exists, that field renames the user's existing bookmark — and the rename was being committed *before* the list and tag requests, so a failure in either left the bookmark renamed behind a "failed" toast. The rename now runs last.

That surfaced a second problem: saving a bookmark is up to four separate writes with no transaction around them, and a single pass/fail toast covered all four. Any failure after the create call reported that the bookmark was never created, when it had in fact been saved. The toast now names the step that failed.

### Changes

- Fixed a custom title being applied to an existing bookmark even when the rest of the submission failed
- Create Bookmark no longer reports "Couldn't create bookmark" when the bookmark was saved and only a later step failed — the toast now says which part didn't apply, and the form stays open so nothing has to be retyped
- Added a "Use Page Title" action (⌘T) that fills the Title field from the active browser tab. It renders only when `environment.canAccess(BrowserExtension)` is true, since that API is the only source of a page title and is unavailable on Windows
- Fixed the Safari entry under "Add to Browser" pointing at an App Store listing that no longer exists
- Every `Toast.Style.Failure` now offers a Copy Error action, including three that report a failure with no underlying exception (a browser tab that couldn't be read, an empty create response, a backup that failed server-side)
- Backing out of the "Delete list" confirmation no longer raises a red "Delete cancelled" error
- Fixed the Update Karakeep command offering a stale Docker command after a failed re-check

### Keyboard shortcuts — 15 bindings moved

Worth calling out, since it changes muscle memory for existing users. The extension had accumulated hand-written combos where a `Keyboard.Shortcut.Common` constant already existed. These now use the constant:

| Action | Was | Now |
| --- | --- | --- |
| Delete (×7) | ⌃X | `Common.Remove` (⌃D) |
| Edit (×3) | ⌃E | `Common.Edit` (⌘E) |
| Open / View (×5) | ⌘↵ | `Common.Open` (⌘O) |
| Copy ID (×2) | ⌘. | `Common.Copy` (⌘⇧C) |
| Clear Cache | ⌘⇧C | `Common.RemoveAll` (⌃⇧D) |

Every remaining shortcut declares an explicit `{ macOS, Windows }` pair rather than relying on inference. Verified that no two actions within a rendered `ActionPanel` resolve to the same combo.

### Housekeeping

- Removed a hand-defined `Preferences` interface in favour of the ambient type Raycast generates from the manifest. The hand-written copy had drifted — it declared `linkMainAction` could be `"copy"`, which the manifest has never offered
- Dependency bumps (non-breaking): `@raycast/utils` 2.3.0, `eslint` 9.39.5, `prettier` 3.9.6, `@raycast/eslint-config` 2.2.0, `@types/*`. The eslint bump clears a high-severity `js-yaml` advisory reached through `@eslint/eslintrc`
- `@raycast/api` is at 1.104.24 (current)

### A note on the localization layer

Automated review flagged the `en`/`zh` string catalog in `src/i18n/`, correctly citing *"please avoid introducing your custom way to localize your extension."*

That layer is **pre-existing**: it is present in this extension's initial commit and the `language` preference (`en` / `zh`) is already published. This PR does not introduce it. It adds four net strings so that the behaviour changed here — the new partial-failure toasts and the Use Page Title action — is not half-translated for users who already have the preference set to `zh`, which would be a regression against the current shipped state.

Removing the layer is a reasonable ask, but it is a breaking change to published behaviour (526 `t()` call sites across 27 files, plus retiring a live preference) and belongs in its own PR rather than a maintenance release. Happy to do that separately if maintainers would like it.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
