### PR TITLE
[MOCO] Fix malformed API base URL

### DIFF
--- a/extensions/moco/CHANGELOG.md
+++ b/extensions/moco/CHANGELOG.md
@@ -1,5 +1,9 @@
 # MOCO Changelog
 
+## [v1.1.4] - 2026-08-17
+
+- Fixed malformed API base URLs
+
 ## [v1.1.3] - 2025-12-12
  - Added copy actions for project name and ID by @el-schneider
 

--- a/extensions/moco/CHANGELOG.md
+++ b/extensions/moco/CHANGELOG.md
@@ -1,6 +1,6 @@
 # MOCO Changelog
 
-## [v1.1.4] - 2026-08-17
+## [v1.1.4] - {PR_MERGE_DATE}
 
 - Fixed malformed API base URLs
 

--- a/extensions/moco/CHANGELOG.md
+++ b/extensions/moco/CHANGELOG.md
@@ -1,6 +1,6 @@
 # MOCO Changelog
 
-## [v1.1.4] - {PR_MERGE_DATE}
+## [v1.1.4] - 2026-08-17
 
 - Fixed malformed API base URLs
 

--- a/extensions/moco/src/commands/activities/api.ts
+++ b/extensions/moco/src/commands/activities/api.ts
@@ -10,7 +10,7 @@ import { Customer } from "../customers/types";
 import { User } from "../user/types";
 
 const preferences = getPreferenceValues<Preferences>();
-axios.defaults.baseURL = `https:/${preferences.url_prefix}.mocoapp.com/api/v1`;
+axios.defaults.baseURL = `https://${preferences.url_prefix}.mocoapp.com/api/v1`;
 
 const activitySchema = z.array(
   z.object({

--- a/extensions/moco/src/commands/projects/api.ts
+++ b/extensions/moco/src/commands/projects/api.ts
@@ -29,7 +29,7 @@ const projectSchema = z.array(
 );
 
 const preferences = getPreferenceValues<Preferences>();
-axios.defaults.baseURL = `https:/${preferences.url_prefix}.mocoapp.com/api/v1`;
+axios.defaults.baseURL = `https://${preferences.url_prefix}.mocoapp.com/api/v1`;
 
 export const fetchProjects = async (): Promise<Project[]> => {
   const { data } = await axios.get("/projects/assigned", {

--- a/extensions/moco/src/commands/tasks/api.ts
+++ b/extensions/moco/src/commands/tasks/api.ts
@@ -16,7 +16,7 @@ const taskSchema = z.array(
 );
 
 const preferences = getPreferenceValues<Preferences>();
-axios.defaults.baseURL = `https:/${preferences.url_prefix}.mocoapp.com/api/v1`;
+axios.defaults.baseURL = `https://${preferences.url_prefix}.mocoapp.com/api/v1`;
 
 export const fetchProjectTasks = async (projectID: number): Promise<Task[]> => {
   const { data } = await axios.get(`/projects/${projectID}/tasks`, {

--- a/extensions/moco/src/commands/user/api.ts
+++ b/extensions/moco/src/commands/user/api.ts
@@ -9,7 +9,7 @@ const userSchema = z.object({
 });
 
 const preferences = getPreferenceValues<Preferences>();
-axios.defaults.baseURL = `https:/${preferences.url_prefix}.mocoapp.com/api/v1`;
+axios.defaults.baseURL = `https://${preferences.url_prefix}.mocoapp.com/api/v1`;
 
 export const fetchUser = async (): Promise<User> => {
   const { data } = await axios.get("/session", {


### PR DESCRIPTION
## Root cause

The MOCO API clients built `https:/<prefix>.mocoapp.com/api/v1` with one slash after the protocol. Axios 1.18 rejects this malformed URL before sending a request.

## Change

Use `https://` in all four MOCO API clients: activities, projects, tasks, and user.

## Validation

- Reproduced Axios `ERR_INVALID_URL` with the current single-slash URL
- `npm run lint`
- `npm run build`

Fixes #30296
