### PR TITLE
fix: conclude speech stream so sessions release after playback

### DIFF
--- a/extensions/elevenlabs-tts/CHANGELOG.md
+++ b/extensions/elevenlabs-tts/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Raycast ElevenLabs TTS Changelog
 
-## [Fix Repeated Already Reading] - {PR_MERGE_DATE}
+## [Fix Repeated Already Reading] - 2026-08-17
 
 ### Fixed
 

--- a/extensions/elevenlabs-tts/CHANGELOG.md
+++ b/extensions/elevenlabs-tts/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Raycast ElevenLabs TTS Changelog
 
+## [Fix Repeated Already Reading] - {PR_MERGE_DATE}
+
+### Fixed
+
+- Speech commands never finishing after playback because the final stream marker was ignored, leaving every next run reporting "Already reading" until the command was launched twice
+
 ## [Fix Stuck Playback Sessions] - 2026-08-10
 
 ### Fixed

--- a/extensions/elevenlabs-tts/package.json
+++ b/extensions/elevenlabs-tts/package.json
@@ -7,7 +7,8 @@
   "icon": "extension-icon.png",
   "author": "lachie_james",
   "contributors": [
-    "thierrygrimm"
+    "thierrygrimm",
+    "DaleSeo"
   ],
   "categories": [
     "Productivity",

--- a/extensions/elevenlabs-tts/src/audio/AudioManager.test.ts
+++ b/extensions/elevenlabs-tts/src/audio/AudioManager.test.ts
@@ -75,14 +75,17 @@ describe("AudioManager stream completion", () => {
     await expect(failure).resolves.toEqual(new Error("Connection closed unexpectedly (code 1006)"));
   });
 
-  it("completes when the socket closes normally before playback starts", async () => {
+  it("defers completion to playback when the socket closes normally before playback starts", () => {
     const { manager, internals } = createManager();
     internals.streamState.chunksReceived = 3;
 
-    const complete = completion(manager);
+    const listener = jest.fn();
+    manager.once("complete", listener);
+    manager.once("error", listener);
     internals.handleWebSocketClose(1000);
 
-    await complete;
+    expect(internals.streamState.streamComplete).toBe(true);
+    expect(listener).not.toHaveBeenCalled();
   });
 
   it("ignores the close after the final marker when playback has not started yet", async () => {

--- a/extensions/elevenlabs-tts/src/audio/AudioManager.test.ts
+++ b/extensions/elevenlabs-tts/src/audio/AudioManager.test.ts
@@ -1,0 +1,67 @@
+import { AudioManager } from "./AudioManager";
+import { StreamConfig } from "./types";
+
+const config: StreamConfig = {
+  sessionId: "test-session",
+  text: "Hello there",
+  voiceId: "voice",
+  apiKey: "key",
+  settings: { stability: 0.5, similarity_boost: 0.5 },
+  playbackSpeed: "1.00",
+};
+
+interface AudioManagerInternals {
+  streamState: { isPlaying: boolean; chunksReceived: number; streamComplete: boolean; playbackComplete: boolean };
+  handleWebSocketMessage(data: Buffer): Promise<void>;
+  handleWebSocketClose(): void;
+}
+
+function createManager(): { manager: AudioManager; internals: AudioManagerInternals } {
+  const manager = new AudioManager(config);
+  return { manager, internals: manager as unknown as AudioManagerInternals };
+}
+
+function completion(manager: AudioManager): Promise<void> {
+  return new Promise((resolve) => manager.once("complete", () => resolve()));
+}
+
+describe("AudioManager stream completion", () => {
+  it("completes when the final marker arrives without audio", async () => {
+    const { manager, internals } = createManager();
+    internals.streamState.isPlaying = true;
+    internals.streamState.playbackComplete = true;
+    internals.streamState.chunksReceived = 3;
+
+    const complete = completion(manager);
+    await internals.handleWebSocketMessage(Buffer.from(JSON.stringify({ isFinal: true })));
+
+    await complete;
+    expect(internals.streamState.streamComplete).toBe(true);
+  });
+
+  it("completes when the socket closes during playback without a final marker", async () => {
+    const { manager, internals } = createManager();
+    internals.streamState.isPlaying = true;
+    internals.streamState.playbackComplete = true;
+    internals.streamState.chunksReceived = 3;
+
+    const complete = completion(manager);
+    internals.handleWebSocketClose();
+
+    await complete;
+    expect(internals.streamState.streamComplete).toBe(true);
+  });
+
+  it("waits for playback to finish when the final marker arrives first", async () => {
+    const { manager, internals } = createManager();
+    internals.streamState.isPlaying = true;
+    internals.streamState.chunksReceived = 3;
+
+    const listener = jest.fn();
+    manager.once("complete", listener);
+    await internals.handleWebSocketMessage(Buffer.from(JSON.stringify({ isFinal: true })));
+
+    expect(internals.streamState.streamComplete).toBe(true);
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/elevenlabs-tts/src/audio/AudioManager.test.ts
+++ b/extensions/elevenlabs-tts/src/audio/AudioManager.test.ts
@@ -13,7 +13,7 @@ const config: StreamConfig = {
 interface AudioManagerInternals {
   streamState: { isPlaying: boolean; chunksReceived: number; streamComplete: boolean; playbackComplete: boolean };
   handleWebSocketMessage(data: Buffer): Promise<void>;
-  handleWebSocketClose(): void;
+  handleWebSocketClose(code: number): void;
 }
 
 function createManager(): { manager: AudioManager; internals: AudioManagerInternals } {
@@ -39,17 +39,63 @@ describe("AudioManager stream completion", () => {
     expect(internals.streamState.streamComplete).toBe(true);
   });
 
-  it("completes when the socket closes during playback without a final marker", async () => {
+  it("completes when the socket closes normally during playback without a final marker", async () => {
     const { manager, internals } = createManager();
     internals.streamState.isPlaying = true;
     internals.streamState.playbackComplete = true;
     internals.streamState.chunksReceived = 3;
 
     const complete = completion(manager);
-    internals.handleWebSocketClose();
+    internals.handleWebSocketClose(1000);
 
     await complete;
     expect(internals.streamState.streamComplete).toBe(true);
+  });
+
+  it.each([1005, 1006])("fails when the socket closes with code %i during playback", async (code) => {
+    const { manager, internals } = createManager();
+    internals.streamState.isPlaying = true;
+    internals.streamState.playbackComplete = true;
+    internals.streamState.chunksReceived = 3;
+
+    const failure = new Promise<Error>((resolve) => manager.once("error", resolve));
+    internals.handleWebSocketClose(code);
+
+    await expect(failure).resolves.toEqual(new Error(`Connection closed unexpectedly (code ${code})`));
+    expect(internals.streamState.streamComplete).toBe(false);
+  });
+
+  it("fails when the socket closes abnormally before playback starts", async () => {
+    const { manager, internals } = createManager();
+    internals.streamState.chunksReceived = 3;
+
+    const failure = new Promise<Error>((resolve) => manager.once("error", resolve));
+    internals.handleWebSocketClose(1006);
+
+    await expect(failure).resolves.toEqual(new Error("Connection closed unexpectedly (code 1006)"));
+  });
+
+  it("completes when the socket closes normally before playback starts", async () => {
+    const { manager, internals } = createManager();
+    internals.streamState.chunksReceived = 3;
+
+    const complete = completion(manager);
+    internals.handleWebSocketClose(1000);
+
+    await complete;
+  });
+
+  it("ignores the close after the final marker when playback has not started yet", async () => {
+    const { manager, internals } = createManager();
+    internals.streamState.chunksReceived = 3;
+    internals.streamState.streamComplete = true;
+
+    const listener = jest.fn();
+    manager.once("error", listener);
+    manager.once("complete", listener);
+    internals.handleWebSocketClose(1005);
+
+    expect(listener).not.toHaveBeenCalled();
   });
 
   it("waits for playback to finish when the final marker arrives first", async () => {

--- a/extensions/elevenlabs-tts/src/audio/AudioManager.ts
+++ b/extensions/elevenlabs-tts/src/audio/AudioManager.ts
@@ -236,8 +236,17 @@ export class AudioManager extends EventEmitter {
         return;
       }
 
-      // Skip non-audio messages (e.g., acknowledgments)
       if (!message.audio) {
+        // The final stream marker arrives without audio, so conclude before the audio guard
+        if (message.isFinal) {
+          console.log(`Stream complete after ${this.streamState.chunksReceived} chunks`);
+          this.streamState.streamComplete = true;
+          this.ws?.close();
+          this.checkAndEmitComplete();
+          return;
+        }
+
+        // Skip other non-audio messages (e.g., acknowledgments)
         console.log("Received non-audio message:", JSON.stringify(message));
         return;
       }
@@ -391,18 +400,24 @@ export class AudioManager extends EventEmitter {
    */
   private handleWebSocketClose(): void {
     console.log("WebSocket connection closed");
-    if (!this.streamState.isPlaying) {
-      // If connection closed without receiving any audio chunks, emit error
-      // chunksReceived = -1 means an error was already emitted
-      if (this.streamState.chunksReceived === 0) {
-        console.error("Connection closed without receiving any audio chunks");
-        this.emit("error", new Error("No audio received"));
-      } else if (this.streamState.chunksReceived > 0) {
-        // Stream completed but playback never started - mark as complete
-        this.emit("complete");
-      }
-      // If chunksReceived is -1, error was already emitted, do nothing
+    if (this.streamState.isPlaying) {
+      // The server may close without sending isFinal; treat the close as end of stream
+      // so the command can finish (and release its speech session) once playback ends
+      this.streamState.streamComplete = true;
+      this.checkAndEmitComplete();
+      return;
     }
+
+    // If connection closed without receiving any audio chunks, emit error
+    // chunksReceived = -1 means an error was already emitted
+    if (this.streamState.chunksReceived === 0) {
+      console.error("Connection closed without receiving any audio chunks");
+      this.emit("error", new Error("No audio received"));
+    } else if (this.streamState.chunksReceived > 0) {
+      // Stream completed but playback never started - mark as complete
+      this.emit("complete");
+    }
+    // If chunksReceived is -1, error was already emitted, do nothing
   }
 
   /**

--- a/extensions/elevenlabs-tts/src/audio/AudioManager.ts
+++ b/extensions/elevenlabs-tts/src/audio/AudioManager.ts
@@ -396,45 +396,34 @@ export class AudioManager extends EventEmitter {
 
   /**
    * Handles WebSocket connection close
-   * Ensures cleanup if playback hasn't started
+   * Concludes the stream so the command always settles and releases its session
    */
   private handleWebSocketClose(code: number): void {
     console.log(`WebSocket connection closed (code ${code})`);
-    if (this.streamState.isPlaying) {
-      if (this.streamState.streamComplete) return;
+    // The close is expected once the stream concluded; completion arrives when playback finishes
+    if (this.streamState.streamComplete) return;
 
-      // Anything but a normal closure (1000) means the stream may have been truncated
-      // — including 1005, a close without a status code — so surface it as a failure
-      if (code !== 1000) {
-        this.emit("error", new Error(`Connection closed unexpectedly (code ${code})`));
-        return;
-      }
-
-      // The server may close normally without sending isFinal; treat the close as end
-      // of stream so the command can finish (and release its speech session)
-      this.streamState.streamComplete = true;
-      this.checkAndEmitComplete();
-      return;
-    }
-
-    // If connection closed without receiving any audio chunks, emit error
     // chunksReceived = -1 means an error was already emitted
+    if (this.streamState.chunksReceived === -1) return;
+
     if (this.streamState.chunksReceived === 0) {
       console.error("Connection closed without receiving any audio chunks");
       this.emit("error", new Error("No audio received"));
-    } else if (this.streamState.chunksReceived > 0) {
-      // A pending audio write may not have started playback yet; once isFinal was
-      // received the close is expected and completion arrives when playback finishes
-      if (this.streamState.streamComplete) return;
-
-      if (code !== 1000) {
-        this.emit("error", new Error(`Connection closed unexpectedly (code ${code})`));
-      } else {
-        // Stream completed but playback never started - mark as complete
-        this.emit("complete");
-      }
+      return;
     }
-    // If chunksReceived is -1, error was already emitted, do nothing
+
+    // Anything but a normal closure (1000) means the stream may have been truncated
+    // — including 1005, a close without a status code — so surface it as a failure
+    if (code !== 1000) {
+      this.emit("error", new Error(`Connection closed unexpectedly (code ${code})`));
+      return;
+    }
+
+    // The server may close normally without sending isFinal; mark the stream complete
+    // and let the complete event fire once playback (started or pending a chunk write,
+    // which always follows a received chunk) finishes
+    this.streamState.streamComplete = true;
+    this.checkAndEmitComplete();
   }
 
   /**

--- a/extensions/elevenlabs-tts/src/audio/AudioManager.ts
+++ b/extensions/elevenlabs-tts/src/audio/AudioManager.ts
@@ -398,11 +398,20 @@ export class AudioManager extends EventEmitter {
    * Handles WebSocket connection close
    * Ensures cleanup if playback hasn't started
    */
-  private handleWebSocketClose(): void {
-    console.log("WebSocket connection closed");
+  private handleWebSocketClose(code: number): void {
+    console.log(`WebSocket connection closed (code ${code})`);
     if (this.streamState.isPlaying) {
-      // The server may close without sending isFinal; treat the close as end of stream
-      // so the command can finish (and release its speech session) once playback ends
+      if (this.streamState.streamComplete) return;
+
+      // Anything but a normal closure (1000) means the stream may have been truncated
+      // — including 1005, a close without a status code — so surface it as a failure
+      if (code !== 1000) {
+        this.emit("error", new Error(`Connection closed unexpectedly (code ${code})`));
+        return;
+      }
+
+      // The server may close normally without sending isFinal; treat the close as end
+      // of stream so the command can finish (and release its speech session)
       this.streamState.streamComplete = true;
       this.checkAndEmitComplete();
       return;
@@ -414,8 +423,16 @@ export class AudioManager extends EventEmitter {
       console.error("Connection closed without receiving any audio chunks");
       this.emit("error", new Error("No audio received"));
     } else if (this.streamState.chunksReceived > 0) {
-      // Stream completed but playback never started - mark as complete
-      this.emit("complete");
+      // A pending audio write may not have started playback yet; once isFinal was
+      // received the close is expected and completion arrives when playback finishes
+      if (this.streamState.streamComplete) return;
+
+      if (code !== 1000) {
+        this.emit("error", new Error(`Connection closed unexpectedly (code ${code})`));
+      } else {
+        // Stream completed but playback never started - mark as complete
+        this.emit("complete");
+      }
     }
     // If chunksReceived is -1, error was already emitted, do nothing
   }

--- a/extensions/elevenlabs-tts/src/audio/playback.test.ts
+++ b/extensions/elevenlabs-tts/src/audio/playback.test.ts
@@ -165,19 +165,33 @@ describe("stopActivePlayback", () => {
   });
 
   it("terminates the verified player and clears the record once it exits", async () => {
+    let terminated = false;
     mockedExecFile.mockImplementation((_file, _args, options, callback) => {
       const cb = typeof options === "function" ? options : callback;
-      cb?.(null, `/usr/bin/afplay ${audioFile}\n`, "");
+      if (terminated) cb?.(new Error("ps exited with code 1"), "", "");
+      else cb?.(null, `/usr/bin/afplay ${audioFile}\n`, "");
       return {} as ChildProcess;
     });
 
-    let terminated = false;
     jest.spyOn(process, "kill").mockImplementation((_pid, signal) => {
-      if (signal === "SIGTERM") {
-        terminated = true;
-        return true;
-      }
-      if (terminated) throw Object.assign(new Error("No such process"), { code: "ESRCH" });
+      if (signal === "SIGTERM") terminated = true;
+      return true;
+    });
+
+    await expect(stopActivePlayback()).resolves.toBe(true);
+    await expect(fs.access(PLAYBACK_FILE)).rejects.toThrow();
+  });
+
+  it("treats a defunct player as exited and clears the record", async () => {
+    let terminated = false;
+    mockedExecFile.mockImplementation((_file, _args, options, callback) => {
+      const cb = typeof options === "function" ? options : callback;
+      cb?.(null, terminated ? "<defunct>\n" : `/usr/bin/afplay ${audioFile}\n`, "");
+      return {} as ChildProcess;
+    });
+
+    jest.spyOn(process, "kill").mockImplementation((_pid, signal) => {
+      if (signal === "SIGTERM") terminated = true;
       return true;
     });
 

--- a/extensions/elevenlabs-tts/src/audio/playback.test.ts
+++ b/extensions/elevenlabs-tts/src/audio/playback.test.ts
@@ -168,13 +168,53 @@ describe("stopActivePlayback", () => {
     let terminated = false;
     mockedExecFile.mockImplementation((_file, _args, options, callback) => {
       const cb = typeof options === "function" ? options : callback;
-      if (terminated) cb?.(new Error("ps exited with code 1"), "", "");
+      if (terminated) cb?.(Object.assign(new Error("ps exited with code 1"), { code: 1 }), "", "");
       else cb?.(null, `/usr/bin/afplay ${audioFile}\n`, "");
       return {} as ChildProcess;
     });
 
     jest.spyOn(process, "kill").mockImplementation((_pid, signal) => {
       if (signal === "SIGTERM") terminated = true;
+      return true;
+    });
+
+    await expect(stopActivePlayback()).resolves.toBe(true);
+    await expect(fs.access(PLAYBACK_FILE)).rejects.toThrow();
+  });
+
+  it("keeps the record when the exit check fails and the player is still alive", async () => {
+    let terminated = false;
+    mockedExecFile.mockImplementation((_file, _args, options, callback) => {
+      const cb = typeof options === "function" ? options : callback;
+      if (terminated) cb?.(Object.assign(new Error("ps timed out"), { code: "ETIMEDOUT" }), "", "");
+      else cb?.(null, `/usr/bin/afplay ${audioFile}\n`, "");
+      return {} as ChildProcess;
+    });
+
+    jest.spyOn(process, "kill").mockImplementation((_pid, signal) => {
+      if (signal === "SIGTERM") terminated = true;
+      return true;
+    });
+
+    await expect(stopActivePlayback()).resolves.toBe(false);
+    await expect(fs.readFile(PLAYBACK_FILE, "utf8")).resolves.toBe(JSON.stringify({ sessionId, pid, audioFile }));
+  });
+
+  it("clears the record when the exit check fails but the player is gone", async () => {
+    let terminated = false;
+    mockedExecFile.mockImplementation((_file, _args, options, callback) => {
+      const cb = typeof options === "function" ? options : callback;
+      if (terminated) cb?.(Object.assign(new Error("ps timed out"), { code: "ETIMEDOUT" }), "", "");
+      else cb?.(null, `/usr/bin/afplay ${audioFile}\n`, "");
+      return {} as ChildProcess;
+    });
+
+    jest.spyOn(process, "kill").mockImplementation((_pid, signal) => {
+      if (signal === "SIGTERM") {
+        terminated = true;
+        return true;
+      }
+      if (terminated) throw Object.assign(new Error("No such process"), { code: "ESRCH" });
       return true;
     });
 

--- a/extensions/elevenlabs-tts/src/audio/playback.ts
+++ b/extensions/elevenlabs-tts/src/audio/playback.ts
@@ -147,7 +147,7 @@ async function stopPlaybackForSession(sessionId: string): Promise<boolean> {
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ESRCH") return false;
   }
-  if (!(await waitForProcessExit(record.pid, 1_000))) return false;
+  if (!(await waitForPlaybackExit(record, 1_000))) return false;
 
   await clearPlayback(sessionId, record.pid);
   return true;
@@ -162,13 +162,27 @@ function isProcessGone(pid: number): boolean {
   }
 }
 
-async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boolean> {
+// kill(pid, 0) also succeeds for a zombie (Raycast's host process never reaps players
+// spawned by an interrupted command), so exit is detected by ps no longer reporting
+// the owned afplay command: a reaped pid fails ps and a zombie shows <defunct>.
+async function waitForPlaybackExit(record: PlaybackRecord, timeoutMs: number): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   do {
-    if (isProcessGone(pid)) return true;
+    if (!(await isPlaybackProcessRunning(record))) return true;
     await new Promise((resolve) => setTimeout(resolve, 50));
   } while (Date.now() < deadline);
-  return isProcessGone(pid);
+  return !(await isPlaybackProcessRunning(record));
+}
+
+async function isPlaybackProcessRunning(record: PlaybackRecord): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync("ps", ["-p", String(record.pid), "-o", "command="], {
+      timeout: 1000,
+    });
+    return isOwnedPlaybackCommand(stdout, record.audioFile);
+  } catch {
+    return false;
+  }
 }
 
 async function readPlayback(): Promise<PlaybackRecord | undefined> {

--- a/extensions/elevenlabs-tts/src/audio/playback.ts
+++ b/extensions/elevenlabs-tts/src/audio/playback.ts
@@ -180,8 +180,11 @@ async function isPlaybackProcessRunning(record: PlaybackRecord): Promise<boolean
       timeout: 1000,
     });
     return isOwnedPlaybackCommand(stdout, record.audioFile);
-  } catch {
-    return false;
+  } catch (error) {
+    // ps exits 1 when the pid is gone; on any other failure (timeout, spawn error)
+    // fall back to a liveness probe instead of assuming the player exited
+    if ((error as { code?: number | string }).code === 1) return false;
+    return !isProcessGone(record.pid);
   }
 }
 


### PR DESCRIPTION
## Description

This PR fixes the command lifecycle so the session is always released:

- Handle the audio-less `isFinal` message as stream completion, and treat a socket close during playback as end of stream (safety net), so the command finishes and releases its speech session as soon as playback ends.
- Detect zombie players when waiting for playback exit: Raycast's host process doesn't reap players spawned by an interrupted command, and a zombie still answers `kill(pid, 0)`, so exit is now detected via `ps` no longer reporting the owned `afplay` command.

Added regression tests for both (stream completion lifecycle and defunct player handling).

## Screencast

<!-- TODO: add a short screencast showing repeated runs starting playback on the first launch -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)