### PR TITLE
[Herdr] Fix agent naming and session selection

### DIFF
--- a/extensions/herdr/CHANGELOG.md
+++ b/extensions/herdr/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Bug Fixes] - {PR_MERGE_DATE}
+## [Bug Fixes] - 2026-08-18
 
 - Show a readable name for unnamed agents instead of the status-line glyph.
 - Select the configured session with the `--session` flag on every CLI call and terminal launch, including the default session.

--- a/extensions/herdr/CHANGELOG.md
+++ b/extensions/herdr/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [Bug Fixes] - {PR_MERGE_DATE}
+
+- Show a readable name for unnamed agents instead of the status-line glyph.
+- Select the configured session with the `--session` flag on every CLI call and terminal launch, including the default session.
+- Report a started agent or delivered prompt as successful even when a follow-up focus or history step fails.
+- Prompt and focus a newly started agent by pane id. Default names get a numeric suffix when the kind collides with a live agent.
+- Derive the Prompt Agent target from the live agents list so a refresh cannot reroute the prompt.
+- Split the pane chosen at submit time, not whichever pane the server has focused.
+- List only linked worktrees in Manage Worktrees.
+- Read renamed pane labels, keep commas in environment values, and parse integration status lines that carry both a version and a path.
+- Clear the Ghostty focus marker through the CLI so a timed-out focus cannot leave a stale title.
+- Surface menu bar action failures as toasts.
+- Expand `{command}` inside larger words in the Custom Terminal Launcher and reject embedded `{args}`.
+
 ## [Fix Tilde Paths] - 2026-08-13
 
 - Expand `~` in the configured Herdr binary path.

--- a/extensions/herdr/src/agents.tsx
+++ b/extensions/herdr/src/agents.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { AgentActions } from "./components/resource-actions";
 import { StartAgentForm } from "./components/start-agent-form";
 import { useHerdrSnapshot } from "./hooks/use-herdr-snapshot";
-import { agentIcon } from "./lib/agent-appearance";
+import { agentIcon, agentName } from "./lib/agent-appearance";
 import type { AgentStatus } from "./lib/types";
 import { ErrorView, shortcuts, statusIcon, statusTitle } from "./lib/ui";
 
@@ -47,11 +47,11 @@ export default function Command() {
       {agents.map((agent) => {
         const workspace = snapshot.data?.workspaces.find((item) => item.workspace_id === agent.workspace_id);
         const tab = snapshot.data?.tabs.find((item) => item.tab_id === agent.tab_id);
-        const name = agent.name || agent.display_agent || agent.agent || agent.pane_id;
+        const name = agentName(agent);
         return (
           <List.Item
             key={agent.pane_id}
-            icon={agentIcon(agent.agent || agent.display_agent)}
+            icon={agentIcon(agent.agent)}
             title={name}
             subtitle={`${workspace?.label || agent.workspace_id} › ${tab?.label || agent.tab_id}`}
             keywords={[

--- a/extensions/herdr/src/components/create-worktree-form.tsx
+++ b/extensions/herdr/src/components/create-worktree-form.tsx
@@ -22,7 +22,7 @@ export function CreateWorktreeForm({
   const [branchError, setBranchError] = useState<string>();
 
   if (snapshot.error && !snapshot.data) return <ErrorView error={snapshot.error} onRetry={snapshot.revalidate} />;
-  const workspaces = snapshot.data?.workspaces || [];
+  const workspaces = (snapshot.data?.workspaces || []).filter((workspace) => workspace.worktree);
   const selectedWorkspace = workspaceId || workspaces[0]?.workspace_id || "";
 
   async function submit() {

--- a/extensions/herdr/src/components/create-worktree-form.tsx
+++ b/extensions/herdr/src/components/create-worktree-form.tsx
@@ -1,4 +1,4 @@
-import { Action, ActionPanel, Form, Icon, List, useNavigation } from "@raycast/api";
+import { Action, ActionPanel, Form, Icon, List, Toast, showToast, useNavigation } from "@raycast/api";
 import { useState } from "react";
 import { useHerdrSnapshot } from "../hooks/use-herdr-snapshot";
 import { runHerdr } from "../lib/herdr";
@@ -30,6 +30,10 @@ export function CreateWorktreeForm({
       setBranchError("Enter a branch name.");
       return;
     }
+    if (!selectedWorkspace) {
+      await showToast({ style: Toast.Style.Failure, title: "Choose a source workspace" });
+      return;
+    }
     const success = await runAction(
       "Creating worktree",
       async () => {
@@ -37,7 +41,7 @@ export function CreateWorktreeForm({
         if (base.trim()) args.push("--base", base.trim());
         if (path.trim()) args.push("--path", path.trim());
         if (label.trim()) args.push("--label", label.trim());
-        args.push(focus ? "--focus" : "--no-focus", "--json");
+        args.push(focus ? "--focus" : "--no-focus");
         await runHerdr(args, { timeout: 120_000 });
       },
       { success: "Worktree Created", onSuccess: onDone },

--- a/extensions/herdr/src/components/prompt-agent-form.tsx
+++ b/extensions/herdr/src/components/prompt-agent-form.tsx
@@ -96,9 +96,8 @@ export function PromptAgentForm({ agents, initialAgentId, initialPrompt = "", on
     () => agents.find((agent) => agent.pane_id === initialAgentId)?.pane_id || agents[0]?.pane_id || "",
     [agents, initialAgentId],
   );
-  // The agents list refreshes while the form is open, so the target is derived
-  // at render: state seeded once from the mount-time list can go stale and
-  // route the prompt to the wrong agent.
+  // Derived at render: the agents list refreshes while the form is open, and
+  // state seeded at mount can go stale and route the prompt to the wrong agent.
   const [selectedPane, setSelectedPane] = useState<string>();
   const targetPane = selectedPane && agents.some((agent) => agent.pane_id === selectedPane) ? selectedPane : initial;
   const [prompt, setPrompt] = useState(initialPrompt);
@@ -122,8 +121,7 @@ export function PromptAgentForm({ agents, initialAgentId, initialPrompt = "", on
       onSuccess: onSent,
     });
     if (!sent) return;
-    // The prompt is already delivered, so a history write failure must not
-    // report the send as failed and invite a duplicate re-send.
+    // A history write failure must not report the delivered prompt as failed.
     await addPromptHistory(agent, target, text).catch(() => undefined);
 
     if (getHerdrPreferences().closeAfterPrompt !== false) {

--- a/extensions/herdr/src/components/prompt-agent-form.tsx
+++ b/extensions/herdr/src/components/prompt-agent-form.tsx
@@ -96,7 +96,11 @@ export function PromptAgentForm({ agents, initialAgentId, initialPrompt = "", on
     () => agents.find((agent) => agent.pane_id === initialAgentId)?.pane_id || agents[0]?.pane_id || "",
     [agents, initialAgentId],
   );
-  const [targetPane, setTargetPane] = useState(initial);
+  // The agents list refreshes while the form is open, so the target is derived
+  // at render: state seeded once from the mount-time list can go stale and
+  // route the prompt to the wrong agent.
+  const [selectedPane, setSelectedPane] = useState<string>();
+  const targetPane = selectedPane && agents.some((agent) => agent.pane_id === selectedPane) ? selectedPane : initial;
   const [prompt, setPrompt] = useState(initialPrompt);
   const [error, setError] = useState<string>();
   const { pop } = useNavigation();
@@ -113,15 +117,14 @@ export function PromptAgentForm({ agents, initialAgentId, initialPrompt = "", on
       return;
     }
     const target = getAgentTarget(agent);
-    const sent = await runAction(
-      `Prompting ${agentName(agent)}`,
-      async () => {
-        await sendAgentPrompt(target, text);
-        await addPromptHistory(agent, target, text);
-      },
-      { success: "Prompt Sent", onSuccess: onSent },
-    );
+    const sent = await runAction(`Prompting ${agentName(agent)}`, () => sendAgentPrompt(target, text), {
+      success: "Prompt Sent",
+      onSuccess: onSent,
+    });
     if (!sent) return;
+    // The prompt is already delivered, so a history write failure must not
+    // report the send as failed and invite a duplicate re-send.
+    await addPromptHistory(agent, target, text).catch(() => undefined);
 
     if (getHerdrPreferences().closeAfterPrompt !== false) {
       await closeMainWindow({ clearRootSearch: true });
@@ -173,7 +176,7 @@ export function PromptAgentForm({ agents, initialAgentId, initialPrompt = "", on
         </ActionPanel>
       }
     >
-      <Form.Dropdown id="agent" title="Agent" value={targetPane} onChange={setTargetPane}>
+      <Form.Dropdown id="agent" title="Agent" value={targetPane} onChange={setSelectedPane}>
         {agents.map((agent) => (
           <Form.Dropdown.Item
             key={agent.pane_id}

--- a/extensions/herdr/src/components/prompt-agent-form.tsx
+++ b/extensions/herdr/src/components/prompt-agent-form.tsx
@@ -13,7 +13,7 @@ import {
   useNavigation,
 } from "@raycast/api";
 import { useEffect, useMemo, useState } from "react";
-import { agentIcon } from "../lib/agent-appearance";
+import { agentIcon, agentName } from "../lib/agent-appearance";
 import { addPromptHistory, clearPromptHistory, getPromptHistory } from "../lib/prompt-history";
 import { getAgentTarget, sendAgentPrompt } from "../lib/herdr";
 import { getHerdrPreferences } from "../lib/preferences";
@@ -114,7 +114,7 @@ export function PromptAgentForm({ agents, initialAgentId, initialPrompt = "", on
     }
     const target = getAgentTarget(agent);
     const sent = await runAction(
-      `Prompting ${agent.name || agent.display_agent || agent.agent}`,
+      `Prompting ${agentName(agent)}`,
       async () => {
         await sendAgentPrompt(target, text);
         await addPromptHistory(agent, target, text);
@@ -178,8 +178,8 @@ export function PromptAgentForm({ agents, initialAgentId, initialPrompt = "", on
           <Form.Dropdown.Item
             key={agent.pane_id}
             value={agent.pane_id}
-            title={`${agent.name || agent.display_agent || agent.agent} — ${statusTitle(agent.agent_status)}`}
-            icon={agentIcon(agent.agent || agent.display_agent)}
+            title={`${agentName(agent)} — ${statusTitle(agent.agent_status)}`}
+            icon={agentIcon(agent.agent)}
           />
         ))}
       </Form.Dropdown>

--- a/extensions/herdr/src/components/resource-actions.tsx
+++ b/extensions/herdr/src/components/resource-actions.tsx
@@ -277,7 +277,7 @@ export function PaneActions({
   agents: AgentInfo[];
   onDone?: () => void | Promise<void>;
 }) {
-  const label = pane.title || pane.terminal_title_stripped || pane.terminal_title || pane.pane_id;
+  const label = pane.label || pane.terminal_title_stripped || pane.terminal_title || pane.pane_id;
   const agent = agents.find((candidate) => candidate.pane_id === pane.pane_id);
   if (agent) return <AgentActions agent={agent} agents={agents} onDone={onDone} />;
 
@@ -338,7 +338,7 @@ export function PaneActions({
           title="Rename Pane"
           icon={Icon.Pencil}
           shortcut={shortcuts.rename}
-          target={<RenameForm kind="pane" id={pane.pane_id} currentName={pane.title || ""} onDone={onDone} />}
+          target={<RenameForm kind="pane" id={pane.pane_id} currentName={pane.label || ""} onDone={onDone} />}
         />
         <Action.CopyToClipboard title="Copy Pane ID" content={pane.pane_id} shortcut={shortcuts.copyId} />
         {pane.foreground_cwd || pane.cwd ? (

--- a/extensions/herdr/src/components/resource-actions.tsx
+++ b/extensions/herdr/src/components/resource-actions.tsx
@@ -8,6 +8,7 @@ import {
   confirmAlert,
   openExtensionPreferences,
 } from "@raycast/api";
+import { agentName } from "../lib/agent-appearance";
 import { focusResource, getAgentTarget, runHerdr, sendAgentKeys, sendPaneKeys } from "../lib/herdr";
 import { launchHerdrInTerminal, revealFocusedHerdr } from "../lib/terminal";
 import type { AgentInfo, PaneInfo, TabInfo, WorkspaceInfo } from "../lib/types";
@@ -20,7 +21,7 @@ import { CreateWorktreeForm } from "./create-worktree-form";
 import { StartAgentForm } from "./start-agent-form";
 
 function displayAgent(agent: AgentInfo): string {
-  return agent.name || agent.display_agent || agent.agent || agent.pane_id;
+  return agentName(agent);
 }
 
 function UtilityActions({ onRefresh }: { onRefresh?: () => void | Promise<void> }) {

--- a/extensions/herdr/src/components/resource-forms.tsx
+++ b/extensions/herdr/src/components/resource-forms.tsx
@@ -1,4 +1,4 @@
-import { Action, ActionPanel, Form, Icon, useNavigation } from "@raycast/api";
+import { Action, ActionPanel, Form, Icon, Toast, showToast, useNavigation } from "@raycast/api";
 import { useState } from "react";
 import { runHerdr, runInPane } from "../lib/herdr";
 import { parseEnvironment } from "../lib/parsers";
@@ -129,7 +129,10 @@ export function SplitPaneForm({ paneId, onDone }: DoneProps & { paneId: string }
 
   async function submit() {
     const numericRatio = Number(ratio);
-    if (!Number.isFinite(numericRatio) || numericRatio <= 0.05 || numericRatio >= 0.95) return;
+    if (!Number.isFinite(numericRatio) || numericRatio <= 0.05 || numericRatio >= 0.95) {
+      await showToast({ style: Toast.Style.Failure, title: "Choose a pane size between 5% and 95%" });
+      return;
+    }
     const success = await runAction(
       "Splitting pane",
       async () => {

--- a/extensions/herdr/src/components/start-agent-form.tsx
+++ b/extensions/herdr/src/components/start-agent-form.tsx
@@ -91,9 +91,8 @@ export function StartAgentForm({
 
   async function submit(values: Form.Values) {
     if (!data) return;
-    // The kind/focusAfter fields are uncontrolled so storeValue can restore the
-    // last selection, so read the submitted values rather than closure state,
-    // which may still hold their initial defaults.
+    // kind/focusAfter are uncontrolled so storeValue can restore the last
+    // selection. Closure state may still hold their initial defaults.
     const submittedKind = (values.kind as AgentKind | undefined) ?? kind;
     const submittedFocusAfter = (values.focusAfter as boolean | undefined) ?? focusAfter;
     const agentName = name.trim() || defaultAgentName(submittedKind, data.agents);
@@ -141,8 +140,7 @@ export function StartAgentForm({
         ];
         if (extraArguments.length) args.push("--", ...extraArguments);
         await runHerdr(args, { timeout: 70_000 });
-        // The pane id resolves unambiguously, unlike a name another live agent
-        // may share.
+        // The pane id resolves unambiguously. A name may be shared.
         if (prompt.trim()) await sendAgentPrompt(startedPaneId, prompt.trim());
       },
       { success: `${agentName} Started` },
@@ -157,7 +155,7 @@ export function StartAgentForm({
         await focusResource("agent", startedPaneId);
         shouldCloseRaycast = await revealFocusedHerdr();
       } catch {
-        // Focus is cosmetic once the agent is started.
+        // Ignored.
       }
     }
 

--- a/extensions/herdr/src/components/start-agent-form.tsx
+++ b/extensions/herdr/src/components/start-agent-form.tsx
@@ -78,9 +78,14 @@ export function StartAgentForm({
 
   if (snapshot.error && !snapshot.data) return <ErrorView error={snapshot.error} onRetry={snapshot.revalidate} />;
 
-  async function submit() {
+  async function submit(values: Form.Values) {
     if (!data) return;
-    const agentName = name.trim() || kind;
+    // The kind/focusAfter fields are uncontrolled so storeValue can restore the
+    // last selection, so read the submitted values rather than closure state,
+    // which may still hold their initial defaults.
+    const submittedKind = (values.kind as AgentKind | undefined) ?? kind;
+    const submittedFocusAfter = (values.focusAfter as boolean | undefined) ?? focusAfter;
+    const agentName = name.trim() || submittedKind;
     if (!NAME_PATTERN.test(agentName)) {
       setNameError("Use 1–32 lowercase letters, numbers, underscores, or hyphens; start with a letter.");
       return;
@@ -105,18 +110,18 @@ export function StartAgentForm({
 
     let shouldCloseRaycast = false;
     const success = await runAction(
-      `Starting ${agentTitle(kind)}`,
+      `Starting ${agentTitle(submittedKind)}`,
       async () => {
         const paneId = await prepareAgentPane(destination, {
           name: agentName,
           cwd: createsDestination ? cwd[0] : undefined,
           environment: environmentValues,
         });
-        const args = ["agent", "start", agentName, "--kind", kind, "--pane", paneId, "--timeout", "60000"];
+        const args = ["agent", "start", agentName, "--kind", submittedKind, "--pane", paneId, "--timeout", "60000"];
         if (extraArguments.length) args.push("--", ...extraArguments);
         await runHerdr(args, { timeout: 70_000 });
         if (prompt.trim()) await sendAgentPrompt(agentName, prompt.trim());
-        if (focusAfter) {
+        if (submittedFocusAfter) {
           await focusResource("agent", agentName);
           shouldCloseRaycast = await revealFocusedHerdr();
         }
@@ -149,7 +154,13 @@ export function StartAgentForm({
         </ActionPanel>
       }
     >
-      <Form.Dropdown id="kind" title="Agent" value={kind} onChange={(value) => setKind(value as AgentKind)} storeValue>
+      <Form.Dropdown
+        id="kind"
+        title="Agent"
+        defaultValue={kind}
+        onChange={(value) => setKind(value as AgentKind)}
+        storeValue
+      >
         {AGENT_KINDS.map((agentKind) => (
           <Form.Dropdown.Item
             key={agentKind}
@@ -252,7 +263,7 @@ export function StartAgentForm({
       <Form.Checkbox
         id="focusAfter"
         label="Focus after starting"
-        value={focusAfter}
+        defaultValue={focusAfter}
         onChange={setFocusAfter}
         storeValue
       />

--- a/extensions/herdr/src/components/start-agent-form.tsx
+++ b/extensions/herdr/src/components/start-agent-form.tsx
@@ -22,7 +22,7 @@ function getDestinationTitle(destination: AgentDestination, snapshot?: HerdrSnap
     return `New Tab in ${workspace?.label || "Workspace"}`;
   }
   const pane = snapshot?.panes.find((item) => item.pane_id === destination.slice(5));
-  return pane?.title || pane?.terminal_title_stripped || pane?.cwd || "Selected Pane";
+  return pane?.label || pane?.terminal_title_stripped || pane?.cwd || "Selected Pane";
 }
 
 export function StartAgentForm({
@@ -194,7 +194,7 @@ export function StartAgentForm({
               <Form.Dropdown.Item
                 key={pane.pane_id}
                 value={`pane:${pane.pane_id}`}
-                title={pane.title || pane.terminal_title_stripped || pane.cwd || pane.pane_id}
+                title={pane.label || pane.terminal_title_stripped || pane.cwd || pane.pane_id}
                 icon={Icon.Terminal}
               />
             ))}

--- a/extensions/herdr/src/components/start-agent-form.tsx
+++ b/extensions/herdr/src/components/start-agent-form.tsx
@@ -8,10 +8,21 @@ import { focusResource, runHerdr, sendAgentPrompt } from "../lib/herdr";
 import { parseEnvironment, parseShellWords } from "../lib/parsers";
 import type { StartAgentPreset } from "../lib/start-agent-preset";
 import { revealFocusedHerdr } from "../lib/terminal";
-import { AGENT_KINDS, type AgentKind, type HerdrSnapshot } from "../lib/types";
+import { AGENT_KINDS, type AgentInfo, type AgentKind, type HerdrSnapshot } from "../lib/types";
 import { ErrorView, runAction } from "../lib/ui";
 
 const NAME_PATTERN = /^[a-z][a-z0-9_-]{0,31}$/;
+
+// Herdr rejects a name any live agent already holds, so a defaulted name (the
+// kind) gets a numeric suffix instead of failing the launch.
+function defaultAgentName(kind: AgentKind, agents: AgentInfo[]): string {
+  const taken = new Set(agents.map((agent) => agent.name).filter(Boolean));
+  if (!taken.has(kind)) return kind;
+  for (let suffix = 2; ; suffix++) {
+    const candidate = `${kind}-${suffix}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+}
 
 function getDestinationTitle(destination: AgentDestination, snapshot?: HerdrSnapshot): string {
   if (destination === "new-workspace") return "New Workspace";
@@ -85,7 +96,7 @@ export function StartAgentForm({
     // which may still hold their initial defaults.
     const submittedKind = (values.kind as AgentKind | undefined) ?? kind;
     const submittedFocusAfter = (values.focusAfter as boolean | undefined) ?? focusAfter;
-    const agentName = name.trim() || submittedKind;
+    const agentName = name.trim() || defaultAgentName(submittedKind, data.agents);
     if (!NAME_PATTERN.test(agentName)) {
       setNameError("Use 1–32 lowercase letters, numbers, underscores, or hyphens; start with a letter.");
       return;
@@ -108,27 +119,47 @@ export function StartAgentForm({
       return;
     }
 
-    let shouldCloseRaycast = false;
+    let startedPaneId = "";
     const success = await runAction(
       `Starting ${agentTitle(submittedKind)}`,
       async () => {
-        const paneId = await prepareAgentPane(destination, {
+        startedPaneId = await prepareAgentPane(destination, {
           name: agentName,
           cwd: createsDestination ? cwd[0] : undefined,
           environment: environmentValues,
         });
-        const args = ["agent", "start", agentName, "--kind", submittedKind, "--pane", paneId, "--timeout", "60000"];
+        const args = [
+          "agent",
+          "start",
+          agentName,
+          "--kind",
+          submittedKind,
+          "--pane",
+          startedPaneId,
+          "--timeout",
+          "60000",
+        ];
         if (extraArguments.length) args.push("--", ...extraArguments);
         await runHerdr(args, { timeout: 70_000 });
-        if (prompt.trim()) await sendAgentPrompt(agentName, prompt.trim());
-        if (submittedFocusAfter) {
-          await focusResource("agent", agentName);
-          shouldCloseRaycast = await revealFocusedHerdr();
-        }
+        // The pane id resolves unambiguously, unlike a name another live agent
+        // may share.
+        if (prompt.trim()) await sendAgentPrompt(startedPaneId, prompt.trim());
       },
       { success: `${agentName} Started` },
     );
     if (!success) return;
+
+    let shouldCloseRaycast = false;
+    if (submittedFocusAfter) {
+      // The agent is already running, so a focus failure must not surface as a
+      // launch failure: re-submitting would create a duplicate destination.
+      try {
+        await focusResource("agent", startedPaneId);
+        shouldCloseRaycast = await revealFocusedHerdr();
+      } catch {
+        // Focus is cosmetic once the agent is started.
+      }
+    }
 
     if (shouldCloseRaycast) {
       void onDone?.();

--- a/extensions/herdr/src/dashboard.tsx
+++ b/extensions/herdr/src/dashboard.tsx
@@ -11,7 +11,7 @@ import { ErrorView, abbreviatePath, statusIcon, statusTitle, tabLabel } from "./
 type Scope = "all" | "attention" | "workspaces" | "tabs" | "panes" | "agents";
 
 function paneLabel(pane: PaneInfo): string {
-  return pane.title || pane.terminal_title_stripped || pane.terminal_title || "Shell";
+  return pane.label || pane.terminal_title_stripped || pane.terminal_title || "Shell";
 }
 
 export default function Command() {

--- a/extensions/herdr/src/dashboard.tsx
+++ b/extensions/herdr/src/dashboard.tsx
@@ -4,20 +4,14 @@ import { CreateWorkspaceForm } from "./components/create-workspace-form";
 import { AgentActions, PaneActions, TabActions, WorkspaceActions } from "./components/resource-actions";
 import { StartAgentForm } from "./components/start-agent-form";
 import { useHerdrSnapshot } from "./hooks/use-herdr-snapshot";
-import { agentIcon } from "./lib/agent-appearance";
-import type { AgentInfo, PaneInfo } from "./lib/types";
-import { ErrorView, statusIcon, statusTitle } from "./lib/ui";
+import { agentIcon, agentName } from "./lib/agent-appearance";
+import type { PaneInfo } from "./lib/types";
+import { ErrorView, abbreviatePath, statusIcon, statusTitle, tabLabel } from "./lib/ui";
 
 type Scope = "all" | "attention" | "workspaces" | "tabs" | "panes" | "agents";
 
-function agentLabel(agent: AgentInfo): string {
-  return agent.name || agent.display_agent || agent.agent || agent.pane_id;
-}
-
 function paneLabel(pane: PaneInfo): string {
-  return (
-    pane.title || pane.display_agent || pane.agent || pane.terminal_title_stripped || pane.terminal_title || "Shell"
-  );
+  return pane.title || pane.terminal_title_stripped || pane.terminal_title || "Shell";
 }
 
 export default function Command() {
@@ -37,6 +31,7 @@ export default function Command() {
   const tabs = data?.tabs || [];
   const panes = data?.panes || [];
   const agents = data?.agents || [];
+  const remainingAgents = agents.filter((agent) => !attention.includes(agent));
   const listedPanes =
     scope === "agents"
       ? agents
@@ -80,9 +75,9 @@ export default function Command() {
           {attention.map((agent) => (
             <List.Item
               key={`attention-${agent.pane_id}`}
-              icon={agentIcon(agent.agent || agent.display_agent)}
-              title={agentLabel(agent)}
-              subtitle={agent.terminal_title_stripped || agent.foreground_cwd || agent.cwd}
+              icon={agentIcon(agent.agent)}
+              title={agentName(agent)}
+              subtitle={agent.terminal_title_stripped || abbreviatePath(agent.foreground_cwd || agent.cwd)}
               keywords={[agent.agent || "", agent.pane_id, agent.workspace_id, agent.tab_id, agent.cwd || ""]}
               accessories={[
                 { tag: { value: statusTitle(agent.agent_status), color: statusIcon(agent.agent_status).tintColor } },
@@ -132,7 +127,7 @@ export default function Command() {
               <List.Item
                 key={tab.tab_id}
                 icon={Icon.AppWindowList}
-                title={tab.label}
+                title={tabLabel(tab) ?? `Tab ${tab.number}`}
                 subtitle={`${workspace?.label || tab.workspace_id} · ${tab.tab_id} · ${tab.pane_count} pane${tab.pane_count === 1 ? "" : "s"}`}
                 keywords={[tab.tab_id, tab.workspace_id, workspace?.label || ""]}
                 accessories={[
@@ -155,9 +150,11 @@ export default function Command() {
             return (
               <List.Item
                 key={`${scope}-${pane.pane_id}`}
-                icon={agent ? agentIcon(agent.agent || agent.display_agent) : Icon.Terminal}
-                title={paneLabel(pane)}
-                subtitle={`${workspace?.label || pane.workspace_id} › ${tab?.label || pane.tab_id}`}
+                icon={agent ? agentIcon(agent.agent) : Icon.Terminal}
+                title={agent ? agentName(agent) : paneLabel(pane)}
+                subtitle={[workspace?.label || pane.workspace_id, tab ? tabLabel(tab) : pane.tab_id]
+                  .filter(Boolean)
+                  .join(" › ")}
                 keywords={[
                   pane.pane_id,
                   pane.cwd || "",
@@ -185,14 +182,14 @@ export default function Command() {
         </List.Section>
       ) : null}
 
-      {scope === "all" && agents.length > 0 ? (
-        <List.Section title="Agents" subtitle={`${agents.length}`}>
-          {agents.map((agent) => (
+      {scope === "all" && remainingAgents.length > 0 ? (
+        <List.Section title="Agents" subtitle={`${remainingAgents.length}`}>
+          {remainingAgents.map((agent) => (
             <List.Item
               key={`agent-${agent.pane_id}`}
-              icon={agentIcon(agent.agent || agent.display_agent)}
-              title={agentLabel(agent)}
-              subtitle={agent.foreground_cwd || agent.cwd || agent.pane_id}
+              icon={agentIcon(agent.agent)}
+              title={agentName(agent)}
+              subtitle={abbreviatePath(agent.foreground_cwd || agent.cwd) || agent.pane_id}
               keywords={[agent.agent || "", agent.pane_id, agent.name || "", agent.terminal_title || ""]}
               accessories={[
                 { tag: { value: statusTitle(agent.agent_status), color: statusIcon(agent.agent_status).tintColor } },

--- a/extensions/herdr/src/hooks/use-herdr-snapshot.ts
+++ b/extensions/herdr/src/hooks/use-herdr-snapshot.ts
@@ -1,10 +1,16 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useCachedPromise } from "@raycast/utils";
 import { getSnapshot } from "../lib/herdr";
 import { getRefreshIntervalMs } from "../lib/preferences";
 
 export function useHerdrSnapshot() {
-  const result = useCachedPromise(getSnapshot, [], { keepPreviousData: true });
+  // Aborting the in-flight snapshot on revalidate keeps refresh ticks from
+  // stacking subprocesses behind a slow server.
+  const abortable = useRef<AbortController>(null);
+  const result = useCachedPromise(() => getSnapshot(abortable.current?.signal), [], {
+    keepPreviousData: true,
+    abortable,
+  });
   const interval = getRefreshIntervalMs();
 
   useEffect(() => {

--- a/extensions/herdr/src/integrations.tsx
+++ b/extensions/herdr/src/integrations.tsx
@@ -2,27 +2,22 @@ import { Action, ActionPanel, Alert, Color, Icon, List, confirmAlert } from "@ra
 import { useCachedPromise } from "@raycast/utils";
 import { agentIcon, agentTitle } from "./lib/agent-appearance";
 import { runHerdr } from "./lib/herdr";
+import { parseIntegrationStatus } from "./lib/parsers";
 import { runAction, shortcuts } from "./lib/ui";
 
-interface IntegrationInfo {
-  name: string;
-  status: "current" | "outdated" | "not installed" | string;
-  detail?: string;
-}
-
-async function getIntegrations(): Promise<IntegrationInfo[]> {
+async function getIntegrations() {
   const output = await runHerdr(["integration", "status"]);
-  return output
-    .split(/\r?\n/)
-    .map((line) => line.match(/^([a-z0-9_-]+):\s+([^()]+?)(?:\s+\((.*)\))?$/i))
-    .filter((match): match is RegExpMatchArray => Boolean(match))
-    .map((match) => ({ name: match[1], status: match[2].trim(), detail: match[3] }));
+  return parseIntegrationStatus(output);
 }
 
 function integrationColor(status: string): Color {
   if (status === "current") return Color.Green;
   if (status === "outdated") return Color.Orange;
   return Color.SecondaryText;
+}
+
+function integrationStatusTitle(status: string): string {
+  return status.replace(/\b\w/g, (letter) => letter.toUpperCase());
 }
 
 export default function Command() {
@@ -58,7 +53,9 @@ export default function Command() {
           title={agentTitle(integration.name)}
           subtitle={integration.detail}
           keywords={[integration.name]}
-          accessories={[{ tag: { value: integration.status, color: integrationColor(integration.status) } }]}
+          accessories={[
+            { tag: { value: integrationStatusTitle(integration.status), color: integrationColor(integration.status) } },
+          ]}
           actions={
             <ActionPanel>
               {integration.status !== "current" ? (

--- a/extensions/herdr/src/lib/agent-appearance.ts
+++ b/extensions/herdr/src/lib/agent-appearance.ts
@@ -1,8 +1,10 @@
+import { homedir } from "node:os";
 import { Icon, type Image } from "@raycast/api";
-import { AGENT_KINDS, type AgentKind } from "./types";
+import { AGENT_KINDS, type AgentKind, type PaneInfo } from "./types";
 
 const AGENT_TITLES: Record<AgentKind, string> = {
   claude: "Claude Code",
+  antigravity: "Antigravity",
   codex: "Codex",
   gemini: "Gemini CLI",
   cursor: "Cursor",
@@ -28,6 +30,8 @@ const AGENT_TITLES: Record<AgentKind, string> = {
 const ALIASES: Record<string, AgentKind> = {
   claudecode: "claude",
   claude_code: "claude",
+  antigravity_cli: "antigravity",
+  antigravitycli: "antigravity",
   geminicli: "gemini",
   gemini_cli: "gemini",
   cursoragent: "cursor",
@@ -93,6 +97,20 @@ export function agentTitle(value?: string): string {
     .trim()
     .replace(/[_-]+/g, " ")
     .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+// display_agent is a Nerd Font glyph for herdr's own status line, so it never
+// works as text in Raycast. Unnamed agents are identified by their working
+// directory instead, which is usually a repo or worktree name.
+export function agentName(agent: Pick<PaneInfo, "name" | "agent" | "cwd" | "foreground_cwd">): string {
+  const name = agent.name?.trim();
+  if (name) return name;
+  const dir = (agent.foreground_cwd || agent.cwd)?.replace(/\/+$/, "");
+  if (dir && dir !== homedir()) {
+    const base = dir.slice(dir.lastIndexOf("/") + 1);
+    if (base) return base;
+  }
+  return agentTitle(agent.agent);
 }
 
 export function agentIcon(value?: string): Image.ImageLike {

--- a/extensions/herdr/src/lib/agent-appearance.ts
+++ b/extensions/herdr/src/lib/agent-appearance.ts
@@ -99,9 +99,8 @@ export function agentTitle(value?: string): string {
     .replace(/\b\w/g, (letter) => letter.toUpperCase());
 }
 
-// display_agent is a Nerd Font glyph for herdr's own status line, so it never
-// works as text in Raycast. Unnamed agents are identified by their working
-// directory instead, which is usually a repo or worktree name.
+// display_agent is a Nerd Font glyph for herdr's own status line and never
+// renders as text in Raycast, so unnamed agents show their working directory.
 export function agentName(agent: Pick<PaneInfo, "name" | "agent" | "cwd" | "foreground_cwd">): string {
   const name = agent.name?.trim();
   if (name) return name;

--- a/extensions/herdr/src/lib/agent-launch.ts
+++ b/extensions/herdr/src/lib/agent-launch.ts
@@ -23,9 +23,8 @@ export async function prepareAgentPane(destination: AgentDestination, options: T
     if (!focusedPaneId) {
       throw new HerdrError("No focused pane is available to split.", "no_focused_pane");
     }
-    // The split target is named explicitly: without it the server splits its
-    // own focused pane, which another client may have moved since the user
-    // chose this destination.
+    // Without an explicit target the server splits its own focused pane, which
+    // another client may have moved since the user chose this destination.
     args.push("pane", "split", focusedPaneId, "--direction", destination === "split-right" ? "right" : "down");
     args.push("--ratio", "0.5");
   }

--- a/extensions/herdr/src/lib/agent-launch.ts
+++ b/extensions/herdr/src/lib/agent-launch.ts
@@ -23,10 +23,11 @@ export async function prepareAgentPane(destination: AgentDestination, options: T
     if (!focusedPaneId) {
       throw new HerdrError("No focused pane is available to split.", "no_focused_pane");
     }
-    // Intentionally omit the snapshotted pane id: passing it would target a pane that may
-    // no longer be focused by the time this command executes. Herdr resolves the split
-    // target from whatever pane is focused at execution time instead.
-    args.push("pane", "split", "--direction", destination === "split-right" ? "right" : "down", "--ratio", "0.5");
+    // The split target is named explicitly: without it the server splits its
+    // own focused pane, which another client may have moved since the user
+    // chose this destination.
+    args.push("pane", "split", focusedPaneId, "--direction", destination === "split-right" ? "right" : "down");
+    args.push("--ratio", "0.5");
   }
 
   if (options.cwd) args.push("--cwd", options.cwd);

--- a/extensions/herdr/src/lib/herdr.ts
+++ b/extensions/herdr/src/lib/herdr.ts
@@ -103,11 +103,12 @@ function extractCliError(stderr: string): HerdrError | undefined {
 export async function runHerdr(args: string[], options: RunOptions = {}): Promise<string> {
   const binary = await resolveHerdrBinary();
   const preferences = getHerdrPreferences();
-  const selectedSession = options.session ?? preferences.sessionName?.trim();
-  // Session selection is the --session global flag. The CLI treats
-  // HERDR_SESSION purely as an export into panes it spawns, so setting it here
-  // would select nothing.
-  const sessionArgs = selectedSession && selectedSession !== "default" ? ["--session", selectedSession] : [];
+  const selectedSession = options.session ?? (preferences.sessionName?.trim() || "default");
+  // The session is always named explicitly with the --session global flag:
+  // without it the CLI falls back to an inherited HERDR_SESSION, so an env
+  // var leaking into the Raycast process could silently retarget every
+  // command. An empty session opts out for commands that span sessions.
+  const sessionArgs = selectedSession ? ["--session", selectedSession] : [];
 
   return new Promise<string>((resolve, reject) => {
     execFile(

--- a/extensions/herdr/src/lib/herdr.ts
+++ b/extensions/herdr/src/lib/herdr.ts
@@ -9,6 +9,7 @@ import type { HerdrSession, HerdrSnapshot, PaneInfo } from "./types";
 interface RunOptions {
   timeout?: number;
   session?: string;
+  signal?: AbortSignal;
 }
 
 interface CliEnvelope<T> {
@@ -39,9 +40,16 @@ async function isExecutable(path: string): Promise<boolean> {
   }
 }
 
+function expandHomePrefix(path: string): string {
+  if (path === "~") return homedir();
+  if (path.startsWith("~/")) return join(homedir(), path.slice(2));
+  if (path.startsWith("$HOME/")) return join(homedir(), path.slice("$HOME/".length));
+  return path;
+}
+
 export async function resolveHerdrBinary(): Promise<string> {
   const preference = getHerdrPreferences().herdrPath?.trim();
-  const configured = preference?.startsWith("~/") ? join(homedir(), preference.slice(2)) : preference;
+  const configured = preference ? expandHomePrefix(preference) : preference;
   if (configured) {
     if (await isExecutable(configured)) return configured;
     throw new HerdrError(
@@ -75,17 +83,19 @@ export async function resolveHerdrBinary(): Promise<string> {
   );
 }
 
-function extractCliError(stdout: string, stderr: string): HerdrError | undefined {
-  for (const candidate of [stderr.trim(), stdout.trim()]) {
-    if (!candidate) continue;
-    try {
-      const parsed = JSON.parse(candidate) as CliEnvelope<unknown>;
-      if (parsed.error) {
-        return new HerdrError(parsed.error.message || "Herdr command failed", parsed.error.code, candidate);
-      }
-    } catch {
-      // The CLI also returns human-readable errors. They are handled by the caller.
+// Only stderr is scanned: commands like `pane read` return raw terminal text
+// on stdout, which could itself be a JSON document with a top-level `error`
+// key. Real CLI errors always arrive as a JSON envelope on stderr.
+function extractCliError(stderr: string): HerdrError | undefined {
+  const candidate = stderr.trim();
+  if (!candidate) return undefined;
+  try {
+    const parsed = JSON.parse(candidate) as CliEnvelope<unknown>;
+    if (parsed.error) {
+      return new HerdrError(parsed.error.message || "Herdr command failed", parsed.error.code, candidate);
     }
+  } catch {
+    // The CLI also returns human-readable errors. They are handled by the caller.
   }
   return undefined;
 }
@@ -94,17 +104,23 @@ export async function runHerdr(args: string[], options: RunOptions = {}): Promis
   const binary = await resolveHerdrBinary();
   const preferences = getHerdrPreferences();
   const selectedSession = options.session ?? preferences.sessionName?.trim();
-  const env = { ...process.env };
-  if (selectedSession && selectedSession !== "default") env.HERDR_SESSION = selectedSession;
-  else delete env.HERDR_SESSION;
+  // Session selection is the --session global flag. The CLI treats
+  // HERDR_SESSION purely as an export into panes it spawns, so setting it here
+  // would select nothing.
+  const sessionArgs = selectedSession && selectedSession !== "default" ? ["--session", selectedSession] : [];
 
   return new Promise<string>((resolve, reject) => {
     execFile(
       binary,
-      args,
-      { env, timeout: options.timeout ?? 30_000, maxBuffer: 16 * 1024 * 1024, encoding: "utf8" },
+      [...sessionArgs, ...args],
+      {
+        timeout: options.timeout ?? 30_000,
+        maxBuffer: 16 * 1024 * 1024,
+        encoding: "utf8",
+        signal: options.signal,
+      },
       (error, stdout, stderr) => {
-        const cliError = extractCliError(stdout, stderr);
+        const cliError = extractCliError(stderr);
         if (cliError) return reject(cliError);
         if (error) {
           const detail = stderr.trim() || stdout.trim() || error.message;
@@ -135,8 +151,8 @@ export async function runHerdrJson<T>(args: string[], options: RunOptions = {}):
   }
 }
 
-export async function getSnapshot(): Promise<HerdrSnapshot> {
-  const result = await runHerdrJson<{ snapshot: HerdrSnapshot }>(["api", "snapshot"]);
+export async function getSnapshot(signal?: AbortSignal): Promise<HerdrSnapshot> {
+  const result = await runHerdrJson<{ snapshot: HerdrSnapshot }>(["api", "snapshot"], { signal });
   if (!result.snapshot) throw new HerdrError("Herdr did not return a session snapshot", "invalid_snapshot");
   return result.snapshot;
 }

--- a/extensions/herdr/src/lib/herdr.ts
+++ b/extensions/herdr/src/lib/herdr.ts
@@ -83,9 +83,8 @@ export async function resolveHerdrBinary(): Promise<string> {
   );
 }
 
-// Only stderr is scanned: commands like `pane read` return raw terminal text
-// on stdout, which could itself be a JSON document with a top-level `error`
-// key. Real CLI errors always arrive as a JSON envelope on stderr.
+// Only stderr is scanned. `pane read` returns raw terminal text on stdout that
+// could itself be JSON with a top-level `error` key.
 function extractCliError(stderr: string): HerdrError | undefined {
   const candidate = stderr.trim();
   if (!candidate) return undefined;
@@ -104,10 +103,9 @@ export async function runHerdr(args: string[], options: RunOptions = {}): Promis
   const binary = await resolveHerdrBinary();
   const preferences = getHerdrPreferences();
   const selectedSession = options.session ?? (preferences.sessionName?.trim() || "default");
-  // The session is always named explicitly with the --session global flag:
-  // without it the CLI falls back to an inherited HERDR_SESSION, so an env
-  // var leaking into the Raycast process could silently retarget every
-  // command. An empty session opts out for commands that span sessions.
+  // Without --session the CLI falls back to an inherited HERDR_SESSION, so the
+  // session is always named explicitly. An empty session opts out for
+  // commands that span sessions.
   const sessionArgs = selectedSession ? ["--session", selectedSession] : [];
 
   return new Promise<string>((resolve, reject) => {

--- a/extensions/herdr/src/lib/parsers.ts
+++ b/extensions/herdr/src/lib/parsers.ts
@@ -1,6 +1,8 @@
+// Entries split on newlines only: env values like NO_PROXY=localhost,127.0.0.1
+// legitimately contain commas.
 export function parseEnvironment(input: string): string[] {
   const values: string[] = [];
-  for (const rawLine of input.split(/\r?\n|,/)) {
+  for (const rawLine of input.split(/\r?\n/)) {
     const line = rawLine.trim();
     if (!line || line.startsWith("#")) continue;
     const equals = line.indexOf("=");

--- a/extensions/herdr/src/lib/parsers.ts
+++ b/extensions/herdr/src/lib/parsers.ts
@@ -70,3 +70,23 @@ export function markdownCode(value: string): string {
   const fence = "`".repeat(Math.max(3, longestRun + 1));
   return `${fence}\n${value}\n${fence}`;
 }
+
+export interface IntegrationStatusLine {
+  name: string;
+  status: string;
+  detail?: string;
+}
+
+// `herdr integration status` lines can carry a version group and a path group,
+// e.g. "claude: current (v7) (~/.claude/hooks/herdr-agent-state.sh)".
+// Both are optional parens, so this matches up to two trailing groups and
+// keeps only the last (the path) as the detail.
+const INTEGRATION_STATUS_LINE = /^([a-z0-9_-]+):\s+([^()]+?)(?:\s+\(([^()]*)\))?(?:\s+\(([^()]*)\))?$/i;
+
+export function parseIntegrationStatus(output: string): IntegrationStatusLine[] {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.match(INTEGRATION_STATUS_LINE))
+    .filter((match): match is RegExpMatchArray => Boolean(match))
+    .map((match) => ({ name: match[1], status: match[2].trim(), detail: match[4] || match[3] }));
+}

--- a/extensions/herdr/src/lib/prompt-history.ts
+++ b/extensions/herdr/src/lib/prompt-history.ts
@@ -1,7 +1,10 @@
 import { LocalStorage } from "@raycast/api";
+import { agentName } from "./agent-appearance";
 import type { AgentInfo, PromptHistoryItem } from "./types";
 
-const STORAGE_KEY = "prompt-history-v1";
+// Entries under the v1 key may hold a raw display_agent glyph as the stored
+// agent label, so they are abandoned rather than migrated.
+const STORAGE_KEY = "prompt-history-v2";
 const MAX_HISTORY = 30;
 
 export async function getPromptHistory(): Promise<PromptHistoryItem[]> {
@@ -21,7 +24,7 @@ export async function addPromptHistory(agent: AgentInfo, target: string, text: s
     id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
     text,
     target,
-    agent: agent.name || agent.display_agent || agent.agent || agent.pane_id,
+    agent: agentName(agent),
     kind: agent.agent,
     createdAt: new Date().toISOString(),
   };

--- a/extensions/herdr/src/lib/terminal-config.ts
+++ b/extensions/herdr/src/lib/terminal-config.ts
@@ -19,12 +19,13 @@ export function detectTerminalKind(application?: Pick<Application, "bundleId" | 
 export function expandCustomLauncher(template: string, binary: string, args: string[]): [string, string[]] {
   const words = parseShellWords(template);
   if (words.length === 0) throw new Error("The Custom Terminal Launcher preference is empty.");
+  const command = [binary, ...args].map(shellQuote).join(" ");
   const expanded: string[] = [];
   for (const word of words) {
-    if (word === "{herdr}") expanded.push(binary);
-    else if (word === "{args}") expanded.push(...args);
-    else if (word === "{command}") expanded.push([binary, ...args].map(shellQuote).join(" "));
-    else expanded.push(word.replaceAll("{herdr}", binary));
+    if (word === "{args}") expanded.push(...args);
+    else if (word.includes("{args}"))
+      throw new Error("{args} must be a standalone word in the Custom Terminal Launcher.");
+    else expanded.push(word.replaceAll("{herdr}", binary).replaceAll("{command}", command));
   }
   if (!template.includes("{herdr}") && !template.includes("{command}")) {
     throw new Error("Custom Terminal Launcher must contain {herdr} or {command}.");

--- a/extensions/herdr/src/lib/terminal-focus.ts
+++ b/extensions/herdr/src/lib/terminal-focus.ts
@@ -97,21 +97,6 @@ export function buildGhosttyFocusScript(title: string): string {
 end tell`;
 }
 
-export function buildGhosttyClearMarkerScript(marker: string): string {
-  const targetMarker = appleScriptString(marker);
-  return `tell application "Ghostty"
-  ignoring case
-    repeat with t in terminals
-      if (name of t as text) is ${targetMarker} then
-        set name of t to "herdr"
-        return "cleared"
-      end if
-    end repeat
-  end ignoring
-  return "miss"
-end tell`;
-}
-
 export function selectWezTermPane(output: string, ttys: string[]): string | undefined {
   let panes: WezTermPane[];
   try {

--- a/extensions/herdr/src/lib/terminal-focus.ts
+++ b/extensions/herdr/src/lib/terminal-focus.ts
@@ -11,11 +11,13 @@ function appleScriptString(value: string): string {
 }
 
 function sessionMatches(args: string, sessionName?: string): boolean {
-  const session = sessionName?.trim();
   const namedSession = args.match(/(?:^|\s)--session(?:=|\s+)([^\s]+)/)?.[1];
   const attachedSession = args.match(/(?:^|\s)session\s+attach\s+([^\s]+)/)?.[1];
-  if (!session || session === "default") return !namedSession && !attachedSession;
-  return namedSession === session || attachedSession === session;
+  // A bare client reads as default. Argv cannot reveal a client that joined a
+  // named session through an inherited HERDR_SESSION, so such clients are
+  // misread as default. Clients this extension launches always carry the flag.
+  const clientSession = namedSession || attachedSession || "default";
+  return clientSession === (sessionName?.trim() || "default");
 }
 
 export function parseHerdrClientTtys(output: string, binary: string, sessionName?: string): string[] {

--- a/extensions/herdr/src/lib/terminal-focus.ts
+++ b/extensions/herdr/src/lib/terminal-focus.ts
@@ -14,8 +14,7 @@ function sessionMatches(args: string, sessionName?: string): boolean {
   const namedSession = args.match(/(?:^|\s)--session(?:=|\s+)([^\s]+)/)?.[1];
   const attachedSession = args.match(/(?:^|\s)session\s+attach\s+([^\s]+)/)?.[1];
   // A bare client reads as default. Argv cannot reveal a client that joined a
-  // named session through an inherited HERDR_SESSION, so such clients are
-  // misread as default. Clients this extension launches always carry the flag.
+  // named session through an inherited HERDR_SESSION.
   const clientSession = namedSession || attachedSession || "default";
   return clientSession === (sessionName?.trim() || "default");
 }

--- a/extensions/herdr/src/lib/terminal.ts
+++ b/extensions/herdr/src/lib/terminal.ts
@@ -185,11 +185,15 @@ export async function launchHerdrInTerminal(
 ): Promise<void> {
   const binary = await resolveHerdrBinary();
   const application = selectedApplication();
-  const sessionName = options.includePreferredSession === false ? undefined : getHerdrPreferences().sessionName?.trim();
   // The launched client names its session explicitly, including the default:
   // terminal launchers inherit the Raycast process environment, and the CLI
   // falls back to an inherited HERDR_SESSION when no --session flag is given.
-  const sessionArgs = sessionName === undefined ? args : ["--session", sessionName || "default", ...args];
+  // The opt-out branches on the option alone, because an unset preference
+  // also reads as undefined and must still produce the flag.
+  const sessionArgs =
+    options.includePreferredSession === false
+      ? args
+      : ["--session", getHerdrPreferences().sessionName?.trim() || "default", ...args];
   const command = [binary, ...sessionArgs].map(shellQuote).join(" ");
   const customLauncher = getHerdrPreferences().customTerminalLauncher?.trim();
   if (customLauncher) {

--- a/extensions/herdr/src/lib/terminal.ts
+++ b/extensions/herdr/src/lib/terminal.ts
@@ -5,12 +5,11 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import type { Application } from "@raycast/api";
 import { getHerdrPreferences } from "./preferences";
-import { resolveHerdrBinary, runHerdrJson } from "./herdr";
+import { resolveHerdrBinary, runHerdr, runHerdrJson } from "./herdr";
 import { lookupHerdrClientTtys } from "./process-lookup";
 import { shellQuote } from "./parsers";
 import { detectTerminalKind, expandCustomLauncher } from "./terminal-config";
 import {
-  buildGhosttyClearMarkerScript,
   buildGhosttyFocusScript,
   buildITermFocusScript,
   buildTerminalFocusScript,
@@ -100,13 +99,19 @@ async function focusExistingHerdrClient(): Promise<ClientFocusResult> {
 
   if (kind === "ghostty") {
     const marker = `herdr-raycast-${randomUUID()}`;
-    let changedTitle = false;
+    // Marked before the set is awaited: a client-side timeout can leave the
+    // title changed server-side, and clearing an unchanged title is harmless
+    // while a stuck marker title is not.
+    let mustClearTitle = false;
     try {
+      mustClearTitle = true;
       const title = await runHerdrJson<{ changed: boolean; reason: string }>(["terminal", "title", "set", marker], {
         timeout: FAST_FOCUS_TIMEOUT_MS,
       });
-      if (!title.changed) return title.reason === "no_foreground_client" ? "missing" : "unavailable";
-      changedTitle = true;
+      if (!title.changed) {
+        mustClearTitle = false;
+        return title.reason === "no_foreground_client" ? "missing" : "unavailable";
+      }
 
       const script = buildGhosttyFocusScript(marker);
       const result = await tryExecCapture("/usr/bin/osascript", ["-e", script], FAST_FOCUS_TIMEOUT_MS);
@@ -115,13 +120,13 @@ async function focusExistingHerdrClient(): Promise<ClientFocusResult> {
     } catch {
       return "unavailable";
     } finally {
-      if (changedTitle) {
-        const script = buildGhosttyClearMarkerScript(marker);
-        const cleared = await tryExecCapture("/usr/bin/osascript", ["-e", script], FAST_FOCUS_TIMEOUT_MS);
-        // Fast attempt may time out if Ghostty/AppleScript is briefly slow; retry once with
-        // a generous timeout so the marker title doesn't get stuck permanently.
-        if (cleared === undefined) {
-          await tryExecCapture("/usr/bin/osascript", ["-e", script], 5_000);
+      if (mustClearTitle) {
+        try {
+          await runHerdr(["terminal", "title", "clear"], { timeout: FAST_FOCUS_TIMEOUT_MS });
+        } catch {
+          // The fast attempt can time out while the server is briefly busy;
+          // retry once generously so the marker title does not stick.
+          await runHerdr(["terminal", "title", "clear"], { timeout: 5_000 }).catch(() => undefined);
         }
       }
     }

--- a/extensions/herdr/src/lib/terminal.ts
+++ b/extensions/herdr/src/lib/terminal.ts
@@ -100,8 +100,7 @@ async function focusExistingHerdrClient(): Promise<ClientFocusResult> {
   if (kind === "ghostty") {
     const marker = `herdr-raycast-${randomUUID()}`;
     // Marked before the set is awaited: a client-side timeout can leave the
-    // title changed server-side, and clearing an unchanged title is harmless
-    // while a stuck marker title is not.
+    // title changed server-side, and clearing an unchanged title is harmless.
     let mustClearTitle = false;
     try {
       mustClearTitle = true;
@@ -124,8 +123,7 @@ async function focusExistingHerdrClient(): Promise<ClientFocusResult> {
         try {
           await runHerdr(["terminal", "title", "clear"], { timeout: FAST_FOCUS_TIMEOUT_MS });
         } catch {
-          // The fast attempt can time out while the server is briefly busy;
-          // retry once generously so the marker title does not stick.
+          // Retry generously so the marker title does not stick.
           await runHerdr(["terminal", "title", "clear"], { timeout: 5_000 }).catch(() => undefined);
         }
       }
@@ -185,11 +183,10 @@ export async function launchHerdrInTerminal(
 ): Promise<void> {
   const binary = await resolveHerdrBinary();
   const application = selectedApplication();
-  // The launched client names its session explicitly, including the default:
-  // terminal launchers inherit the Raycast process environment, and the CLI
-  // falls back to an inherited HERDR_SESSION when no --session flag is given.
-  // The opt-out branches on the option alone, because an unset preference
-  // also reads as undefined and must still produce the flag.
+  // Launched clients inherit the Raycast process environment, where a leaked
+  // HERDR_SESSION would retarget them, so the session is always named. The
+  // opt-out branches on the option alone: an unset preference is also
+  // undefined and must still produce the flag.
   const sessionArgs =
     options.includePreferredSession === false
       ? args

--- a/extensions/herdr/src/lib/terminal.ts
+++ b/extensions/herdr/src/lib/terminal.ts
@@ -186,7 +186,10 @@ export async function launchHerdrInTerminal(
   const binary = await resolveHerdrBinary();
   const application = selectedApplication();
   const sessionName = options.includePreferredSession === false ? undefined : getHerdrPreferences().sessionName?.trim();
-  const sessionArgs = sessionName && sessionName !== "default" ? ["--session", sessionName, ...args] : args;
+  // The launched client names its session explicitly, including the default:
+  // terminal launchers inherit the Raycast process environment, and the CLI
+  // falls back to an inherited HERDR_SESSION when no --session flag is given.
+  const sessionArgs = sessionName === undefined ? args : ["--session", sessionName || "default", ...args];
   const command = [binary, ...sessionArgs].map(shellQuote).join(" ");
   const customLauncher = getHerdrPreferences().customTerminalLauncher?.trim();
   if (customLauncher) {

--- a/extensions/herdr/src/lib/types.ts
+++ b/extensions/herdr/src/lib/types.ts
@@ -16,6 +16,7 @@ export interface WorkspaceInfo {
   tab_count: number;
   pane_count: number;
   agent_status?: AgentStatus;
+  tokens?: Record<string, string>;
   worktree?: {
     repo_key: string;
     repo_name: string;
@@ -49,11 +50,12 @@ export interface PaneInfo {
   agent?: string;
   name?: string;
   display_agent?: string;
-  title?: string;
+  label?: string;
   interactive_ready?: boolean;
   launch_pending?: boolean;
   agent_status?: AgentStatus;
   agent_session?: AgentSession;
+  tokens?: Record<string, string>;
   scroll?: {
     offset_from_bottom: number;
     max_offset_from_bottom: number;

--- a/extensions/herdr/src/lib/types.ts
+++ b/extensions/herdr/src/lib/types.ts
@@ -106,6 +106,7 @@ export interface PromptHistoryItem {
 
 export const AGENT_KINDS = [
   "claude",
+  "antigravity",
   "codex",
   "gemini",
   "cursor",

--- a/extensions/herdr/src/lib/ui.tsx
+++ b/extensions/herdr/src/lib/ui.tsx
@@ -1,7 +1,21 @@
+import { homedir } from "node:os";
 import { Action, ActionPanel, Color, Detail, Icon, Toast, openExtensionPreferences, showToast } from "@raycast/api";
 import { formatHerdrError } from "./herdr";
-import type { AgentStatus } from "./types";
+import type { AgentStatus, TabInfo } from "./types";
 export { shortcuts } from "./shortcuts";
+
+// Herdr defaults a tab's label to its number, which identifies nothing in
+// lists that span workspaces, so default labels are treated as unlabeled.
+export function tabLabel(tab?: TabInfo): string | undefined {
+  if (!tab || tab.label === String(tab.number)) return undefined;
+  return tab.label;
+}
+
+export function abbreviatePath(path?: string): string | undefined {
+  if (!path) return undefined;
+  const home = homedir();
+  return path === home || path.startsWith(`${home}/`) ? `~${path.slice(home.length)}` : path;
+}
 
 export function statusTitle(status?: AgentStatus): string {
   switch (status) {

--- a/extensions/herdr/src/lib/ui.tsx
+++ b/extensions/herdr/src/lib/ui.tsx
@@ -4,8 +4,7 @@ import { formatHerdrError } from "./herdr";
 import type { AgentStatus, TabInfo } from "./types";
 export { shortcuts } from "./shortcuts";
 
-// Herdr defaults a tab's label to its number, which identifies nothing in
-// lists that span workspaces, so default labels are treated as unlabeled.
+// Herdr defaults a tab's label to its number, which identifies nothing.
 export function tabLabel(tab?: TabInfo): string | undefined {
   if (!tab || tab.label === String(tab.number)) return undefined;
   return tab.label;

--- a/extensions/herdr/src/menu-bar.tsx
+++ b/extensions/herdr/src/menu-bar.tsx
@@ -1,6 +1,6 @@
 import { Icon, Keyboard, LaunchType, MenuBarExtra, launchCommand, openExtensionPreferences } from "@raycast/api";
 import { useHerdrSnapshot } from "./hooks/use-herdr-snapshot";
-import { agentIcon } from "./lib/agent-appearance";
+import { agentIcon, agentName } from "./lib/agent-appearance";
 import { focusResource, getAgentTarget } from "./lib/herdr";
 import { getHerdrPreferences } from "./lib/preferences";
 import { launchHerdrInTerminal, revealFocusedHerdr } from "./lib/terminal";
@@ -8,10 +8,6 @@ import type { AgentInfo, AgentStatus, HerdrSnapshot } from "./lib/types";
 import { statusIcon, statusTitle } from "./lib/ui";
 
 const DISPLAYED_STATUSES: AgentStatus[] = ["blocked", "done", "working", "unknown"];
-
-function agentName(agent: AgentInfo): string {
-  return agent.name || agent.display_agent || agent.agent || agent.pane_id;
-}
 
 function agentLocation(agent: AgentInfo, snapshot: HerdrSnapshot): string {
   const workspace = snapshot.workspaces.find((item) => item.workspace_id === agent.workspace_id);
@@ -29,7 +25,7 @@ async function focusAgent(agent: AgentInfo): Promise<void> {
 function AgentItem({ agent, snapshot }: { agent: AgentInfo; snapshot: HerdrSnapshot }) {
   return (
     <MenuBarExtra.Item
-      icon={agentIcon(agent.agent || agent.display_agent)}
+      icon={agentIcon(agent.agent)}
       title={agentName(agent)}
       subtitle={agentLocation(agent, snapshot)}
       tooltip={`${statusTitle(agent.agent_status)} · ${agentLocation(agent, snapshot)}`}
@@ -77,7 +73,7 @@ export default function Command() {
       tooltip={
         snapshot.error
           ? "Herdr is unavailable"
-          : `Herdr · ${blocked.length} need attention · ${done.length} done · ${working.length} working · ${idle.length} idle`
+          : `Herdr · ${blocked.length} need attention · ${done.length} done · ${working.length} working · ${idle.length} idle · ${unknown.length} unknown`
       }
     >
       {snapshot.error ? (

--- a/extensions/herdr/src/menu-bar.tsx
+++ b/extensions/herdr/src/menu-bar.tsx
@@ -5,7 +5,7 @@ import { focusResource, getAgentTarget } from "./lib/herdr";
 import { getHerdrPreferences } from "./lib/preferences";
 import { launchHerdrInTerminal, revealFocusedHerdr } from "./lib/terminal";
 import type { AgentInfo, AgentStatus, HerdrSnapshot } from "./lib/types";
-import { statusIcon, statusTitle } from "./lib/ui";
+import { runAction, statusIcon, statusTitle } from "./lib/ui";
 
 const DISPLAYED_STATUSES: AgentStatus[] = ["blocked", "done", "working", "unknown"];
 
@@ -18,8 +18,18 @@ function agentLocation(agent: AgentInfo, snapshot: HerdrSnapshot): string {
 }
 
 async function focusAgent(agent: AgentInfo): Promise<void> {
-  await focusResource("agent", getAgentTarget(agent));
-  await revealFocusedHerdr();
+  await runAction(
+    `Focusing ${agentName(agent)}`,
+    async () => {
+      await focusResource("agent", getAgentTarget(agent));
+      await revealFocusedHerdr();
+    },
+    { success: `Focused ${agentName(agent)}` },
+  );
+}
+
+function openHerdr(): Promise<boolean> {
+  return runAction("Opening Herdr", () => launchHerdrInTerminal(), { success: "Herdr Opened" });
 }
 
 function AgentItem({ agent, snapshot }: { agent: AgentInfo; snapshot: HerdrSnapshot }) {
@@ -80,7 +90,7 @@ export default function Command() {
         <MenuBarExtra.Item
           title="Herdr Unavailable — Open Herdr"
           icon={Icon.ExclamationMark}
-          onAction={() => void launchHerdrInTerminal()}
+          onAction={() => void openHerdr()}
         />
       ) : null}
 
@@ -137,7 +147,7 @@ export default function Command() {
           title="Open Herdr"
           icon={Icon.Terminal}
           shortcut={{ modifiers: ["cmd"], key: "t" }}
-          onAction={() => void launchHerdrInTerminal()}
+          onAction={() => void openHerdr()}
         />
         <MenuBarExtra.Item
           title="Refresh"

--- a/extensions/herdr/src/worktrees.tsx
+++ b/extensions/herdr/src/worktrees.tsx
@@ -29,7 +29,7 @@ export default function Command() {
     await runAction(
       "Removing worktree",
       () =>
-        runHerdr(["worktree", "remove", "--workspace", workspaceId, ...(force ? ["--force"] : []), "--json"], {
+        runHerdr(["worktree", "remove", "--workspace", workspaceId, ...(force ? ["--force"] : [])], {
           timeout: 120_000,
         }).then(() => undefined),
       {

--- a/extensions/herdr/src/worktrees.tsx
+++ b/extensions/herdr/src/worktrees.tsx
@@ -8,9 +8,7 @@ import { ErrorView, runAction, shortcuts } from "./lib/ui";
 export default function Command() {
   const snapshot = useHerdrSnapshot();
   if (snapshot.error && !snapshot.data) return <ErrorView error={snapshot.error} onRetry={snapshot.revalidate} />;
-  const worktrees = (snapshot.data?.workspaces || []).filter(
-    (workspace) => workspace.worktree?.is_linked_worktree,
-  );
+  const worktrees = (snapshot.data?.workspaces || []).filter((workspace) => workspace.worktree?.is_linked_worktree);
 
   async function remove(workspaceId: string, label: string, force: boolean) {
     if (

--- a/extensions/herdr/src/worktrees.tsx
+++ b/extensions/herdr/src/worktrees.tsx
@@ -8,7 +8,9 @@ import { ErrorView, runAction, shortcuts } from "./lib/ui";
 export default function Command() {
   const snapshot = useHerdrSnapshot();
   if (snapshot.error && !snapshot.data) return <ErrorView error={snapshot.error} onRetry={snapshot.revalidate} />;
-  const worktrees = (snapshot.data?.workspaces || []).filter((workspace) => workspace.worktree);
+  const worktrees = (snapshot.data?.workspaces || []).filter(
+    (workspace) => workspace.worktree?.is_linked_worktree,
+  );
 
   async function remove(workspaceId: string, label: string, force: boolean) {
     if (

--- a/extensions/herdr/tests/agent-appearance.test.ts
+++ b/extensions/herdr/tests/agent-appearance.test.ts
@@ -1,0 +1,51 @@
+import { homedir } from "node:os";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@raycast/api", () => ({ Icon: { Person: "person" } }));
+
+const { agentName, agentTitle, normalizeAgentKind } = await import("../src/lib/agent-appearance");
+
+describe("agentName", () => {
+  it("prefers the explicit agent name", () => {
+    expect(agentName({ name: "billing-fix", agent: "claude", cwd: "/home/user" })).toBe("billing-fix");
+  });
+
+  // Regression: unnamed agents rendered the display_agent Nerd Font glyph
+  // ("󰚩") as their title because the fallback chain used it as text.
+  // agentName's parameter type omits display_agent entirely, so this also
+  // documents that the glyph field can no longer reach the label.
+  it("labels unnamed agents by their working directory", () => {
+    const name = agentName({ agent: "claude", cwd: "/home/user/src/project" });
+    expect(name).toBe("project");
+  });
+
+  it("uses the foreground cwd over the pane cwd", () => {
+    const name = agentName({
+      agent: "claude",
+      cwd: "/home/user/src/repo",
+      foreground_cwd: "/home/user/src/repo/.worktrees/feature",
+    });
+    expect(name).toBe("feature");
+  });
+
+  it("falls back to the humanized agent kind in the home directory", () => {
+    expect(agentName({ agent: "claude", cwd: homedir() })).toBe("Claude Code");
+  });
+
+  it("falls back to a generic label without any identifying fields", () => {
+    expect(agentName({})).toBe("Agent");
+  });
+});
+
+describe("agentTitle", () => {
+  it("humanizes known agent kinds", () => {
+    expect(agentTitle("claude")).toBe("Claude Code");
+    expect(agentTitle("claude_code")).toBe("Claude Code");
+  });
+});
+
+describe("normalizeAgentKind", () => {
+  it("ignores glyph values", () => {
+    expect(normalizeAgentKind("󰚩")).toBeUndefined();
+  });
+});

--- a/extensions/herdr/tests/agent-appearance.test.ts
+++ b/extensions/herdr/tests/agent-appearance.test.ts
@@ -12,8 +12,6 @@ describe("agentName", () => {
 
   // Regression: unnamed agents rendered the display_agent Nerd Font glyph
   // ("󰚩") as their title because the fallback chain used it as text.
-  // agentName's parameter type omits display_agent entirely, so this also
-  // documents that the glyph field can no longer reach the label.
   it("labels unnamed agents by their working directory", () => {
     const name = agentName({ agent: "claude", cwd: "/home/user/src/project" });
     expect(name).toBe("project");

--- a/extensions/herdr/tests/agent-launch.test.ts
+++ b/extensions/herdr/tests/agent-launch.test.ts
@@ -51,14 +51,13 @@ describe("prepareAgentPane", () => {
     await expect(prepareAgentPane("new-workspace", { name: "Review", environment: [] })).resolves.toBe("pane-created");
   });
 
-  it("uses the pane returned by a split instead of inferring from focus", async () => {
+  it("splits the snapshotted focused pane explicitly", async () => {
     vi.mocked(getSnapshot).mockResolvedValue({ ...snapshot, focused_pane_id: "pane-current" });
     vi.mocked(runHerdrJson).mockResolvedValue({ pane: createdPane });
 
     await expect(prepareAgentPane("split-right", { name: "Review", environment: [] })).resolves.toBe("pane-created");
     const [args] = vi.mocked(runHerdrJson).mock.calls[0];
-    expect(args).toEqual(expect.arrayContaining(["pane", "split", "--direction", "right"]));
-    expect(args).not.toContain("pane-current");
+    expect(args).toEqual(expect.arrayContaining(["pane", "split", "pane-current", "--direction", "right"]));
   });
 
   it("throws when splitting without a focused pane", async () => {

--- a/extensions/herdr/tests/herdr.test.ts
+++ b/extensions/herdr/tests/herdr.test.ts
@@ -1,24 +1,74 @@
+import { execFile } from "node:child_process";
 import { constants } from "node:fs";
 import { access } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { resolveHerdrBinary } from "../src/lib/herdr";
+import { resolveHerdrBinary, runHerdr } from "../src/lib/herdr";
 
 vi.mock("node:fs/promises", () => ({ access: vi.fn() }));
+vi.mock("node:child_process", () => ({ execFile: vi.fn() }));
+
+const preferences: { herdrPath?: string; sessionName?: string } = {};
 vi.mock("../src/lib/preferences", () => ({
-  getHerdrPreferences: () => ({ herdrPath: "~/.local/bin/herdr" }),
+  getHerdrPreferences: () => preferences,
 }));
 
-describe("resolveHerdrBinary", () => {
-  beforeEach(() => {
-    vi.mocked(access).mockReset().mockResolvedValue();
-  });
+beforeEach(() => {
+  preferences.herdrPath = "~/.local/bin/herdr";
+  preferences.sessionName = undefined;
+  vi.mocked(access).mockReset().mockResolvedValue();
+  vi.mocked(execFile).mockReset();
+});
 
+describe("resolveHerdrBinary", () => {
   it("expands a leading tilde in the configured binary path", async () => {
     const expected = join(homedir(), ".local", "bin", "herdr");
 
     await expect(resolveHerdrBinary()).resolves.toBe(expected);
     expect(access).toHaveBeenCalledWith(expected, constants.X_OK);
+  });
+
+  it("expands a $HOME prefix in the configured binary path", async () => {
+    preferences.herdrPath = "$HOME/.local/bin/herdr";
+    const expected = join(homedir(), ".local", "bin", "herdr");
+
+    await expect(resolveHerdrBinary()).resolves.toBe(expected);
+    expect(access).toHaveBeenCalledWith(expected, constants.X_OK);
+  });
+});
+
+describe("runHerdr", () => {
+  function mockExecFileSuccess() {
+    // execFile's promisify-compatible callback signature: the callback is the
+    // last argument after (file, args, options).
+    vi.mocked(execFile).mockImplementation(((...callArgs: unknown[]) => {
+      const callback = callArgs.at(-1) as (error: Error | null, stdout: string, stderr: string) => void;
+      callback(null, "{}", "");
+      return {};
+    }) as never);
+  }
+
+  function executedArgs(): unknown {
+    return vi.mocked(execFile).mock.calls[0][1];
+  }
+
+  // Regression: the extension used to select the session by setting the
+  // HERDR_SESSION environment variable, which the CLI only exports into panes
+  // it spawns, so the preference silently targeted the default session.
+  it("selects the configured session with the --session flag", async () => {
+    preferences.sessionName = "work";
+    mockExecFileSuccess();
+
+    await runHerdr(["pane", "list"]);
+    expect(executedArgs()).toEqual(["--session", "work", "pane", "list"]);
+  });
+
+  it("omits the session flag for the default session", async () => {
+    preferences.sessionName = "default";
+    mockExecFileSuccess();
+
+    await runHerdr(["pane", "list"]);
+    expect(executedArgs()).toEqual(["pane", "list"]);
   });
 });

--- a/extensions/herdr/tests/herdr.test.ts
+++ b/extensions/herdr/tests/herdr.test.ts
@@ -53,9 +53,10 @@ describe("runHerdr", () => {
     return vi.mocked(execFile).mock.calls[0][1];
   }
 
-  // Regression: the extension used to select the session by setting the
-  // HERDR_SESSION environment variable, which the CLI only exports into panes
-  // it spawns, so the preference silently targeted the default session.
+  // Regression: without a --session flag the CLI falls back to an inherited
+  // HERDR_SESSION, so a value leaking into the Raycast process environment
+  // could silently retarget every command. Each command names its session
+  // explicitly, including the default.
   it("selects the configured session with the --session flag", async () => {
     preferences.sessionName = "work";
     mockExecFileSuccess();
@@ -64,11 +65,19 @@ describe("runHerdr", () => {
     expect(executedArgs()).toEqual(["--session", "work", "pane", "list"]);
   });
 
-  it("omits the session flag for the default session", async () => {
-    preferences.sessionName = "default";
+  it("names the default session explicitly when no session is configured", async () => {
+    preferences.sessionName = undefined;
     mockExecFileSuccess();
 
     await runHerdr(["pane", "list"]);
-    expect(executedArgs()).toEqual(["pane", "list"]);
+    expect(executedArgs()).toEqual(["--session", "default", "pane", "list"]);
+  });
+
+  it("omits the session flag when a command opts out with an empty session", async () => {
+    preferences.sessionName = "work";
+    mockExecFileSuccess();
+
+    await runHerdr(["session", "list", "--json"], { session: "" });
+    expect(executedArgs()).toEqual(["session", "list", "--json"]);
   });
 });

--- a/extensions/herdr/tests/herdr.test.ts
+++ b/extensions/herdr/tests/herdr.test.ts
@@ -55,8 +55,7 @@ describe("runHerdr", () => {
 
   // Regression: without a --session flag the CLI falls back to an inherited
   // HERDR_SESSION, so a value leaking into the Raycast process environment
-  // could silently retarget every command. Each command names its session
-  // explicitly, including the default.
+  // could silently retarget every command.
   it("selects the configured session with the --session flag", async () => {
     preferences.sessionName = "work";
     mockExecFileSuccess();

--- a/extensions/herdr/tests/parsers.test.ts
+++ b/extensions/herdr/tests/parsers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { markdownCode, parseEnvironment, parseShellWords, shellQuote } from "../src/lib/parsers";
+import { markdownCode, parseEnvironment, parseIntegrationStatus, parseShellWords, shellQuote } from "../src/lib/parsers";
 
 describe("parseEnvironment", () => {
   it("accepts lines, commas, comments, and values containing equals", () => {
@@ -44,5 +44,26 @@ describe("shellQuote", () => {
 describe("markdownCode", () => {
   it("uses a fence longer than any fence in the output", () => {
     expect(markdownCode("before\n```\nafter")).toMatch(/^````\n/);
+  });
+});
+
+describe("parseIntegrationStatus", () => {
+  // Regression: a version group before the path group ("current (v7) (/path)")
+  // made the greedy trailing-paren match swallow both groups into detail,
+  // producing "v7) (/path" instead of the version and path separately.
+  it("keeps the trailing path as detail when a version group precedes it", () => {
+    expect(parseIntegrationStatus("claude: current (v7) (/home/user/.claude/hooks/herdr-agent-state.sh)")).toEqual([
+      { name: "claude", status: "current", detail: "/home/user/.claude/hooks/herdr-agent-state.sh" },
+    ]);
+  });
+
+  it("handles a single trailing path group with no version", () => {
+    expect(parseIntegrationStatus("pi: not installed (/home/user/.pi/agent/extensions/herdr-agent-state.ts)")).toEqual([
+      { name: "pi", status: "not installed", detail: "/home/user/.pi/agent/extensions/herdr-agent-state.ts" },
+    ]);
+  });
+
+  it("skips lines that do not match the expected shape", () => {
+    expect(parseIntegrationStatus("not a status line")).toEqual([]);
   });
 });

--- a/extensions/herdr/tests/parsers.test.ts
+++ b/extensions/herdr/tests/parsers.test.ts
@@ -2,12 +2,16 @@ import { describe, expect, it } from "vitest";
 import { markdownCode, parseEnvironment, parseIntegrationStatus, parseShellWords, shellQuote } from "../src/lib/parsers";
 
 describe("parseEnvironment", () => {
-  it("accepts lines, commas, comments, and values containing equals", () => {
-    expect(parseEnvironment("FOO=one\n# comment\nBAR=two=three, EMPTY=")).toEqual([
+  it("accepts lines, comments, and values containing equals", () => {
+    expect(parseEnvironment("FOO=one\n# comment\nBAR=two=three\nEMPTY=")).toEqual([
       "FOO=one",
       "BAR=two=three",
       "EMPTY=",
     ]);
+  });
+
+  it("keeps commas inside values", () => {
+    expect(parseEnvironment("NO_PROXY=localhost,127.0.0.1")).toEqual(["NO_PROXY=localhost,127.0.0.1"]);
   });
 
   it("rejects invalid keys and missing equals signs", () => {

--- a/extensions/herdr/tests/terminal-config.test.ts
+++ b/extensions/herdr/tests/terminal-config.test.ts
@@ -37,6 +37,19 @@ describe("expandCustomLauncher", () => {
     ).toEqual(["launcher", ["--command", "'/path with space/herdr' 'agent' 'attach' 'reviewer'"]]);
   });
 
+  it("expands {command} embedded inside a larger word", () => {
+    expect(expandCustomLauncher(`sh -c "cd /work && {command}"`, "/opt/herdr", ["attach"])).toEqual([
+      "sh",
+      ["-c", "cd /work && '/opt/herdr' 'attach'"],
+    ]);
+  });
+
+  it("rejects {args} embedded inside a larger word", () => {
+    expect(() => expandCustomLauncher(`sh -c "{herdr} {args}"`, "/opt/herdr", ["attach"])).toThrow(
+      "standalone word",
+    );
+  });
+
   it("requires a command placeholder", () => {
     expect(() => expandCustomLauncher("terminal -e", "/herdr", [])).toThrow("must contain");
   });

--- a/extensions/herdr/tests/terminal-focus.test.ts
+++ b/extensions/herdr/tests/terminal-focus.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  buildGhosttyClearMarkerScript,
   buildGhosttyFocusScript,
   buildITermFocusScript,
   buildTerminalFocusScript,
@@ -41,12 +40,6 @@ describe("terminal focus adapters", () => {
     expect(script).toContain('if (name of t as text) is "herdr-raycast-session"');
     expect(script).not.toContain('is "herdr"');
     expect(script).not.toContain("id of t");
-  });
-
-  it("clears the Ghostty marker title on the matching terminal only", () => {
-    const script = buildGhosttyClearMarkerScript("herdr-raycast-session");
-    expect(script).toContain('if (name of t as text) is "herdr-raycast-session"');
-    expect(script).toContain('set name of t to "herdr"');
   });
 
   it("selects the first WezTerm pane with an exact Herdr TTY", () => {

--- a/extensions/herdr/tests/terminal-focus.test.ts
+++ b/extensions/herdr/tests/terminal-focus.test.ts
@@ -15,10 +15,11 @@ ttys001  herdr     herdr
 ttys002  herdr     herdr --session work
 ttys003  herdr     herdr session attach review
 ttys004  zsh       zsh
+ttys005  herdr     herdr --session default
 `;
 
-  it("finds only default-session Herdr clients", () => {
-    expect(parseHerdrClientTtys(processes, "/opt/herdr", "default")).toEqual(["/dev/ttys001"]);
+  it("finds bare and explicitly default-session Herdr clients", () => {
+    expect(parseHerdrClientTtys(processes, "/opt/herdr", "default")).toEqual(["/dev/ttys001", "/dev/ttys005"]);
   });
 
   it("finds the requested named session", () => {

--- a/extensions/herdr/tests/terminal.test.ts
+++ b/extensions/herdr/tests/terminal.test.ts
@@ -1,0 +1,62 @@
+import { spawn } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { launchHerdrInTerminal } from "../src/lib/terminal";
+
+vi.mock("node:child_process", () => ({ execFile: vi.fn(), spawn: vi.fn() }));
+vi.mock("node:fs/promises", () => ({
+  access: vi.fn().mockResolvedValue(undefined),
+  chmod: vi.fn(),
+  mkdtemp: vi.fn(),
+  rm: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+const preferences: { herdrPath?: string; sessionName?: string; customTerminalLauncher?: string } = {};
+vi.mock("../src/lib/preferences", () => ({
+  getHerdrPreferences: () => preferences,
+}));
+
+const binary = join(homedir(), ".local", "bin", "herdr");
+
+beforeEach(() => {
+  preferences.herdrPath = "~/.local/bin/herdr";
+  preferences.sessionName = undefined;
+  preferences.customTerminalLauncher = "term -e {herdr} {args}";
+  vi.mocked(spawn).mockReset();
+  const child = {
+    once(event: string, callback: () => void) {
+      if (event === "spawn") callback();
+      return child;
+    },
+    unref() {},
+  };
+  vi.mocked(spawn).mockReturnValue(child as never);
+});
+
+function spawnedArgs(): unknown {
+  return vi.mocked(spawn).mock.calls[0][1];
+}
+
+describe("launchHerdrInTerminal", () => {
+  // Regression: the launched client inherits the Raycast process environment,
+  // and without a --session flag the CLI falls back to an inherited
+  // HERDR_SESSION, so an unset preference must still name the default session.
+  it("names the default session explicitly when no session is configured", async () => {
+    await launchHerdrInTerminal();
+    expect(spawnedArgs()).toEqual(["-e", binary, "--session", "default"]);
+  });
+
+  it("names the configured session explicitly", async () => {
+    preferences.sessionName = "work";
+
+    await launchHerdrInTerminal();
+    expect(spawnedArgs()).toEqual(["-e", binary, "--session", "work"]);
+  });
+
+  it("omits the session flag when the caller opts out with its own argv", async () => {
+    await launchHerdrInTerminal(["session", "attach", "review"], { includePreferredSession: false });
+    expect(spawnedArgs()).toEqual(["-e", binary, "session", "attach", "review"]);
+  });
+});

--- a/extensions/herdr/tests/ui.test.ts
+++ b/extensions/herdr/tests/ui.test.ts
@@ -1,0 +1,43 @@
+import { homedir } from "node:os";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@raycast/api", () => ({
+  Color: { Blue: "blue", Red: "red", Green: "green", SecondaryText: "secondary", Yellow: "yellow" },
+  Icon: { Bolt: "bolt", ExclamationMark: "exclamation", CircleFilled: "circle" },
+}));
+
+const { abbreviatePath, tabLabel } = await import("../src/lib/ui");
+
+describe("tabLabel", () => {
+  // Regression: herdr defaults an unrenamed tab's label to its number, so
+  // "1" rendered as if it were a real name and disambiguated nothing between
+  // tabs in different workspaces.
+  it("treats a label equal to the tab number as unlabeled", () => {
+    expect(tabLabel({ tab_id: "w1:t1", workspace_id: "w1", label: "1", number: 1, focused: false, pane_count: 1 })).toBeUndefined();
+  });
+
+  it("keeps a real label", () => {
+    expect(
+      tabLabel({ tab_id: "w1:t1", workspace_id: "w1", label: "main", number: 1, focused: false, pane_count: 1 }),
+    ).toBe("main");
+  });
+
+  it("returns undefined without a tab", () => {
+    expect(tabLabel(undefined)).toBeUndefined();
+  });
+});
+
+describe("abbreviatePath", () => {
+  it("collapses the home directory to a tilde", () => {
+    expect(abbreviatePath(`${homedir()}/src/dotfiles`)).toBe("~/src/dotfiles");
+    expect(abbreviatePath(homedir())).toBe("~");
+  });
+
+  it("leaves paths outside the home directory untouched", () => {
+    expect(abbreviatePath("/opt/homebrew/bin/herdr")).toBe("/opt/homebrew/bin/herdr");
+  });
+
+  it("returns undefined without a path", () => {
+    expect(abbreviatePath(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Description

Update to the Herdr extension fixing bugs across agent naming, session selection, and command actions, found by auditing the extension against a live herdr 0.8.0 server and the herdr CLI source.

The visible bug: the Prompt Agent dropdown and dashboard rendered unnamed agents as a box glyph. The extension fell back to `display_agent`, a Nerd Font icon herdr renders in its own status line, which Raycast cannot display as text. Unnamed agents now show their working directory basename, falling back to the agent kind, and prompt history moves to a new storage key so saved glyph entries do not resurface.

The deepest bug: the extension selected the configured session by setting the `HERDR_SESSION` environment variable, which the CLI reads only as a fallback after the `--session` flag and socket overrides. Every CLI call and terminal launch now passes `--session` explicitly, including for the default session, because launched terminal clients inherit the Raycast process environment where a leaked `HERDR_SESSION` would otherwise retarget them. Focus detection normalizes the session it parses from a client's argv the same way, so the extension's own clients still match.

Also fixed:

- A started agent or delivered prompt no longer reports as failed when a follow-up focus or history write fails. That failure invited a re-submit that duplicated the workspace or prompt.
- Newly started agents are prompted and focused by pane id, which herdr resolves unambiguously, and a defaulted agent name gets a numeric suffix instead of failing when a live agent of the same kind exists.
- The Prompt Agent target derives from the live agents list at render, so a background refresh cannot reroute a prompt.
- Splits pass the snapshotted pane explicitly instead of splitting whatever pane the server has focused at execution time.
- Manage Worktrees lists only linked worktrees. It previously offered Remove on main checkouts.
- Renamed panes read the `label` field the CLI sends, environment values keep commas, and integration status lines carrying both a version and a path parse correctly.
- The Ghostty focus marker clears through `herdr terminal title clear`, including when the set call times out client-side.
- Menu bar actions surface errors as toasts. Custom terminal launcher templates expand `{command}` inside larger words and reject embedded `{args}`.

CLI behaviors were verified against a running herdr server (error envelopes on stderr, `label` on renamed panes, `--session default` resolving to the same running server) and against the CLI source where observation was not enough (session resolution precedence, agent target resolution, duplicate name rejection). Added unit tests covering the name fallback, session flag construction, terminal launches, launcher template expansion, and the parsers.

## Screencast

No new UI. The fixes change the behavior of existing commands.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
