### PR TITLE
feat(linear): add multi-workspace support

### DIFF
--- a/extensions/linear/CHANGELOG.md
+++ b/extensions/linear/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Connect any number of Linear workspaces (Manage Workspaces command: add, switch, re-authenticate, log out)
 - Workspace dropdown on every list command, workspace field on Create Issue / Create Project (with per-workspace remembered defaults), optional one-shot `workspace` argument on Quick Add Comment to Issue, and a dedicated Create Issue for Myself in Workspace command
 - Menu bar notifications aggregate all connected workspaces
-- AI tools (including the expanded list-*/get-*/save-* tools) accept a `workspaceId` and a new `get-workspaces` tool lists the connected ones
+- AI tools (including the expanded `list-*`/`get-*`/`save-*` tools) accept a `workspaceId` and a new `get-workspaces` tool lists the connected ones
 
 ## [AI Comment Reliability] - 2026-09-02
 

--- a/extensions/linear/CHANGELOG.md
+++ b/extensions/linear/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Linear Changelog
 
+## [Multi-Workspace Support] - {PR_MERGE_DATE}
+
+- Connect any number of Linear workspaces (Manage Workspaces command: add, switch, re-authenticate, log out)
+- Workspace dropdown on every list command, workspace field on Create Issue / Create Project (with per-workspace remembered defaults), optional one-shot `workspace` argument on Quick Add Comment to Issue, and a dedicated Create Issue for Myself in Workspace command
+- Menu bar notifications aggregate all connected workspaces
+- AI tools (including the expanded list-*/get-*/save-* tools) accept a `workspaceId` and a new `get-workspaces` tool lists the connected ones
+
 ## [AI Comment Reliability] - 2026-09-02
 
 - Prevent AI comment tools from retrying successful writes and creating duplicate comments.

--- a/extensions/linear/CHANGELOG.md
+++ b/extensions/linear/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Multi-Workspace Support] - {PR_MERGE_DATE}
 
 - Connect any number of Linear workspaces (Manage Workspaces command: add, switch, re-authenticate, log out)
+- Preserve unfinished workspace connections when saving fails, and resume the same sign-in if Manage Workspaces remounts
 - Workspace dropdown on every list command, workspace field on Create Issue / Create Project (with per-workspace remembered defaults), optional one-shot `workspace` argument on Quick Add Comment to Issue, and a dedicated Create Issue for Myself in Workspace command
 - Menu bar notifications aggregate all connected workspaces
 - AI tools (including the expanded `list-*`/`get-*`/`save-*` tools) accept a `workspaceId` and a new `get-workspaces` tool lists the connected ones

--- a/extensions/linear/README.md
+++ b/extensions/linear/README.md
@@ -16,4 +16,26 @@ The Linear extension brings the speed, quality and joy of the app to every corne
 
 **Q2. How do I switch workspaces?**
 
-**Ans.** You can't switch workspaces on the fly; however, you can go to `Preferences`, `click` "Logout" then run any `command` now selecting the appropriate workspace.
+**Ans.** Connect additional workspaces with the **Manage Workspaces** command, then switch using the workspace dropdown on any list command, the Workspace field on forms, the optional `workspace` argument on **Quick Add Comment to Issue**, or the dedicated **Create Issue for Myself in Workspace** command.
+
+## Multiple Workspaces
+
+The extension supports any number of Linear workspaces — including the same workspace
+connected under two different accounts.
+
+- **Add a workspace:** open **Manage Workspaces** → **Add Workspace** (⌘N). Linear has no
+  workspace picker on its consent page: first switch to the target workspace at
+  [linear.app](https://linear.app) (top-left workspace switcher), then approve the grant.
+- **Switch:** every list command has a Workspace dropdown (visible once you have two or
+  more workspaces); forms have a Workspace field; **Quick Add Comment to Issue** accepts an
+  optional `workspace` argument (URL key, account email, or unique name prefix) that acts
+  once without changing your default, and a dedicated **Create Issue for Myself in
+  Workspace** command targets any workspace by URL key, account email, or unique name
+  prefix without changing your default.
+- **Menu bar:** unread notifications aggregate across all connected workspaces, one
+  section each.
+- **Log out:** use Manage Workspaces (its rows show the workspace and account, unlike
+  Raycast's built-in login list). Logging out removes the login from Raycast; the grant
+  at Linear expires on its own within 24 hours.
+- **Preferences** (like a preferred team key) apply per command and are matched inside
+  whichever workspace the command acts in.

--- a/extensions/linear/README.md
+++ b/extensions/linear/README.md
@@ -39,3 +39,5 @@ connected under two different accounts.
   at Linear expires on its own within 24 hours.
 - **Preferences** (like a preferred team key) apply per command and are matched inside
   whichever workspace the command acts in.
+- **AI:** ask `@linear` to act in a named workspace. Every tool accepts a `workspaceId`
+  from the `get-workspaces` tool; omit it to use the active workspace.

--- a/extensions/linear/ai.yaml
+++ b/extensions/linear/ai.yaml
@@ -2145,28 +2145,29 @@ evals:
         - workspaceId: org-a:user-1
           name: ConceptM
           urlKey: conceptm
-          userEmail: steve@conceptm.com
+          userEmail: alex@example.com
           isActive: true
         - workspaceId: org-b:user-2
           name: flox
           urlKey: floxdotdev
-          userEmail: stevemorin@flox.dev
+          userEmail: sam@example.com
           isActive: false
     expected:
       - callsTool: get-workspaces
 
   - input: '@linear create an issue titled "Test multi" in the flox workspace for team ENG'
+    usedAsExample: false
     mocks:
       get-workspaces:
         - workspaceId: org-a:user-1
           name: ConceptM
           urlKey: conceptm
-          userEmail: steve@conceptm.com
+          userEmail: alex@example.com
           isActive: true
         - workspaceId: org-b:user-2
           name: flox
           urlKey: floxdotdev
-          userEmail: stevemorin@flox.dev
+          userEmail: sam@example.com
           isActive: false
       get-teams:
         - id: team-eng
@@ -2205,12 +2206,12 @@ evals:
         - workspaceId: org-a:user-1
           name: ConceptM
           urlKey: conceptm
-          userEmail: steve@conceptm.com
+          userEmail: alex@example.com
           isActive: true
         - workspaceId: org-b:user-2
           name: flox
           urlKey: floxdotdev
-          userEmail: stevemorin@flox.dev
+          userEmail: sam@example.com
           isActive: false
       list-issues:
         nodes: []

--- a/extensions/linear/ai.yaml
+++ b/extensions/linear/ai.yaml
@@ -2179,9 +2179,21 @@ evals:
           identifier: ENG-1
           title: Test multi
           url: https://linear.app/floxdotdev/issue/ENG-1
+      save-issue:
+        success: true
+        issue:
+          id: issue-1
+          identifier: ENG-1
+          title: Test multi
+          url: https://linear.app/floxdotdev/issue/ENG-1
     expected:
       - callsTool: get-workspaces
-      - callsTool:
-          name: create-issue
-          arguments:
-            workspaceId: org-b:user-2
+      - or:
+          - callsTool:
+              name: save-issue
+              arguments:
+                workspaceId: org-b:user-2
+          - callsTool:
+              name: create-issue
+              arguments:
+                workspaceId: org-b:user-2

--- a/extensions/linear/ai.yaml
+++ b/extensions/linear/ai.yaml
@@ -14,6 +14,9 @@ instructions: |
   - For `list-comments` and new threads with `save-comment`, provide exactly one parent. Use `parentId` for replies and `id` for edits.
   - "Close" an issue by moving it to a completed status. Only use `delete-issue` when the user explicitly asks to delete or trash it.
   - "Inbox" means Linear notifications.
+  - If the user names a workspace, or more than one workspace might be connected, call `get-workspaces` once, then pass its `workspaceId` value to EVERY subsequent tool call in the conversation, and state in your answer which workspace you acted in.
+  - Never guess or construct `workspaceId` values; only use values returned by `get-workspaces`. If the named workspace is not in the list, say so and list the available ones.
+  - If no workspace is mentioned and only one is connected, omit `workspaceId`.
 
 evals:
   # Existing core behavior and routing boundaries
@@ -2134,3 +2137,51 @@ evals:
           arguments:
             type: project
             id: project-update-2
+
+  # Multi-workspace routing (PR #30314)
+  - input: "@linear list my workspaces"
+    mocks:
+      get-workspaces:
+        - workspaceId: org-a:user-1
+          name: ConceptM
+          urlKey: conceptm
+          userEmail: steve@conceptm.com
+          isActive: true
+        - workspaceId: org-b:user-2
+          name: flox
+          urlKey: floxdotdev
+          userEmail: stevemorin@flox.dev
+          isActive: false
+    expected:
+      - callsTool: get-workspaces
+
+  - input: '@linear create an issue titled "Test multi" in the flox workspace for team ENG'
+    mocks:
+      get-workspaces:
+        - workspaceId: org-a:user-1
+          name: ConceptM
+          urlKey: conceptm
+          userEmail: steve@conceptm.com
+          isActive: true
+        - workspaceId: org-b:user-2
+          name: flox
+          urlKey: floxdotdev
+          userEmail: stevemorin@flox.dev
+          isActive: false
+      get-teams:
+        - id: team-eng
+          name: Engineering
+          key: ENG
+      create-issue:
+        success: true
+        issue:
+          id: issue-1
+          identifier: ENG-1
+          title: Test multi
+          url: https://linear.app/floxdotdev/issue/ENG-1
+    expected:
+      - callsTool: get-workspaces
+      - callsTool:
+          name: create-issue
+          arguments:
+            workspaceId: org-b:user-2

--- a/extensions/linear/ai.yaml
+++ b/extensions/linear/ai.yaml
@@ -2197,3 +2197,27 @@ evals:
               name: create-issue
               arguments:
                 workspaceId: org-b:user-2
+
+  - input: "@linear list open issues assigned to me in the flox workspace"
+    usedAsExample: false
+    mocks:
+      get-workspaces:
+        - workspaceId: org-a:user-1
+          name: ConceptM
+          urlKey: conceptm
+          userEmail: steve@conceptm.com
+          isActive: true
+        - workspaceId: org-b:user-2
+          name: flox
+          urlKey: floxdotdev
+          userEmail: stevemorin@flox.dev
+          isActive: false
+      list-issues:
+        nodes: []
+    expected:
+      - callsTool: get-workspaces
+      - callsTool:
+          name: list-issues
+          arguments:
+            assignee: me
+            workspaceId: org-b:user-2

--- a/extensions/linear/package.json
+++ b/extensions/linear/package.json
@@ -82,6 +82,10 @@
           "default": "title",
           "data": [
             {
+              "title": "Workspace",
+              "value": "workspaceKey"
+            },
+            {
               "title": "Team",
               "value": "teamId"
             },
@@ -245,6 +249,59 @@
       ]
     },
     {
+      "name": "create-issue-for-myself-in-workspace",
+      "title": "Create Issue for Myself in Workspace",
+      "description": "Create and assign a new issue to yourself in a specific workspace.",
+      "mode": "no-view",
+      "preferences": [
+        {
+          "name": "preferredTeamKey",
+          "type": "textfield",
+          "title": "Preferred Team",
+          "placeholder": "RAY",
+          "description": "Specify the Key (e.g. RAY) of the preferred team. If not specified, the first team is used.",
+          "required": false
+        },
+        {
+          "name": "preferredStatusName",
+          "type": "textfield",
+          "title": "Preferred Status",
+          "placeholder": "Todo",
+          "description": "Specify the name of the preferred status for new issues (e.g. Todo, Backlog). If not specified, uses Linear's default.",
+          "required": false
+        },
+        {
+          "name": "shouldCloseMainWindow",
+          "type": "checkbox",
+          "title": "Advanced",
+          "label": "Close window immediately",
+          "description": "When enabled, the Raycast window is closed immediately, allowing you to carry on with other work.",
+          "default": false,
+          "required": false
+        }
+      ],
+      "arguments": [
+        {
+          "name": "workspace",
+          "placeholder": "Workspace",
+          "type": "text",
+          "required": true
+        },
+        {
+          "name": "title",
+          "placeholder": "Title",
+          "type": "text",
+          "required": true
+        },
+        {
+          "name": "description",
+          "placeholder": "Description",
+          "type": "text",
+          "required": false
+        }
+      ]
+    },
+    {
       "name": "quick-add-comment-to-issue",
       "title": "Quick Add Comment to Issue",
       "description": "Quickly add a comment to an issue using its ID.",
@@ -272,6 +329,12 @@
           "placeholder": "Issue ID",
           "type": "text",
           "required": true
+        },
+        {
+          "name": "workspace",
+          "placeholder": "Workspace",
+          "type": "text",
+          "required": false
         }
       ]
     },
@@ -279,6 +342,12 @@
       "name": "favorites",
       "title": "Favorites",
       "description": "Browse through your Linear favorites.",
+      "mode": "view"
+    },
+    {
+      "name": "manage-workspaces",
+      "title": "Manage Workspaces",
+      "description": "Add, switch, re-authenticate, or log out of Linear workspaces.",
       "mode": "view"
     }
   ],
@@ -447,6 +516,11 @@
       "name": "get-workspace",
       "title": "Get Workspace",
       "description": "Retrieve the connected Linear workspace"
+    },
+    {
+      "name": "get-workspaces",
+      "title": "Get Workspaces",
+      "description": "List the connected Linear workspaces with their workspaceId, name, URL key, account email, and which one is active. Call this before acting in a specific workspace and pass its workspaceId to other tools."
     },
     {
       "name": "list-release-pipelines",

--- a/extensions/linear/package.json
+++ b/extensions/linear/package.json
@@ -739,7 +739,7 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
-    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types --test tests/commentUtils.test.mts",
+    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types --test tests/*.test.mts",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
   },

--- a/extensions/linear/src/active-cycle.tsx
+++ b/extensions/linear/src/active-cycle.tsx
@@ -1,29 +1,50 @@
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { getActiveCycleIssues } from "./api/getIssues";
 import CreateIssueForm from "./components/CreateIssueForm";
 import StateIssueList from "./components/StateIssueList";
 import View from "./components/View";
+import { useWorkspaces } from "./components/WorkspaceContext";
+import {
+  isWorkspaceDropdownValue,
+  workspaceValueToKey,
+  WorkspaceDropdownSection,
+} from "./components/WorkspaceDropdown";
 import { getTeamIcon } from "./helpers/teams";
 import useIssues from "./hooks/useIssues";
 import useMe from "./hooks/useMe";
 import usePriorities from "./hooks/usePriorities";
 import useTeams from "./hooks/useTeams";
+import { useWorkspaceCachedState } from "./hooks/useWorkspaceCachedState";
 
 function ActiveCycle() {
   const [teamQuery, setTeamQuery] = useState<string>("");
   const { teams, org, supportsTeamTypeahead, isLoadingTeams } = useTeams(teamQuery);
-  const [selectedTeam, setSelectedTeam] = useState<string>("");
+  const { switchWorkspace } = useWorkspaces();
+  const [storedTeam, setStoredTeam] = useWorkspaceCachedState<string>("active-cycle-team", "");
+  // Restore validation (§4.5) runs ONCE against the initial, query-less team load —
+  // NOT against typeahead results, which would transiently "invalidate" the stored team
+  // and flip the visible cycle while the user types. State (not a ref) so a cold-cache
+  // resolution that lands after the first render still triggers a re-render to show it.
+  const [validatedTeam, setValidatedTeam] = useState<string | null>(null);
+  useEffect(() => {
+    if (validatedTeam === null && teams && teamQuery === "") {
+      setValidatedTeam(teams.some((team) => team.id === storedTeam) ? storedTeam : (teams[0]?.id ?? ""));
+    }
+    // Intentional deps: validatedTeam and storedTeam are read but not tracked —
+    // this must run only when teams/teamQuery change, not on every storedTeam update.
+  }, [teams, teamQuery]);
+  const selectedTeam = validatedTeam ?? "";
 
   const { priorities, isLoadingPriorities } = usePriorities();
   const { me, isLoadingMe } = useMe();
 
   const cycleId = useMemo(() => {
     return teams?.find((team) => team.id === selectedTeam)?.activeCycle?.id;
-  }, [selectedTeam]);
+  }, [selectedTeam, teams]);
 
-  const { issues, isLoadingIssues, mutateList } = useIssues(getActiveCycleIssues, [cycleId], {
+  const { issues, isLoadingIssues, mutateList } = useIssues((id?: string) => getActiveCycleIssues(id), [cycleId], {
     execute: !!cycleId && cycleId.trim().length > 0,
   });
 
@@ -32,15 +53,29 @@ function ActiveCycle() {
       searchBarAccessory={
         <List.Dropdown
           tooltip="Change Team"
-          onChange={setSelectedTeam}
-          storeValue
+          value={selectedTeam || "-"}
+          onChange={(value) => {
+            if (isWorkspaceDropdownValue(value)) {
+              switchWorkspace(workspaceValueToKey(value));
+              return;
+            }
+            if (value !== "-" && value !== selectedTeam) {
+              setValidatedTeam(value);
+              setStoredTeam(value); // S9: ignore mount echo (guarded by the !== check)
+            }
+          }}
           {...(supportsTeamTypeahead && {
             throttle: true,
             onSearchTextChange: setTeamQuery,
             isLoading: isLoadingTeams,
           })}
         >
-          {(!teams || teams.length === 0) && (
+          <WorkspaceDropdownSection />
+          {/* Also render during the pre-validation frame (validatedTeam === null): on a warm
+              cache teams can already be populated while selectedTeam still falls back to "-"
+              (S9) — the controlled value must always match a rendered item, or Raycast's
+              first-item snap could fire a persisted workspace switch. */}
+          {(!teams || teams.length === 0 || validatedTeam === null) && (
             <List.Dropdown.Item title="No team" value="-" key="-" icon={Icon.TwoPeople} />
           )}
           {teams?.map((team) => (

--- a/extensions/linear/src/api/attachments.ts
+++ b/extensions/linear/src/api/attachments.ts
@@ -1,9 +1,9 @@
 import { readFile } from "fs/promises";
 import path from "path";
 
-import { UploadFile } from "@linear/sdk";
+import { LinearClient, UploadFile } from "@linear/sdk";
 
-import { getLinearClient } from "./linearClient";
+import { resolveClient } from "./linearClient";
 
 const DEFAULT_CONTENT_TYPE = "application/octet-stream";
 
@@ -58,8 +58,8 @@ export type UploadedFile = {
   name: string;
 };
 
-export async function uploadFile(filePath: string): Promise<UploadedFile> {
-  const { graphQLClient } = getLinearClient();
+export async function uploadFile(filePath: string, client?: LinearClient): Promise<UploadedFile> {
+  const { graphQLClient } = resolveClient(client);
 
   const buffer = await readFile(filePath);
   const contentType = getContentType(filePath);
@@ -118,14 +118,14 @@ function escapeMarkdownLabel(value: string) {
   return value.replaceAll("\\", "\\\\").replaceAll("[", "\\[").replaceAll("]", "\\]");
 }
 
-export async function appendFileAttachments(markdown: string, attachmentPaths?: string[]) {
+export async function appendFileAttachments(markdown: string, attachmentPaths?: string[], client?: LinearClient) {
   if (!attachmentPaths?.length) {
     return markdown;
   }
 
   const files: UploadedFile[] = [];
   for (const filePath of attachmentPaths) {
-    files.push(await uploadFile(filePath));
+    files.push(await uploadFile(filePath, client));
   }
   const attachments = files.map(({ assetUrl, contentType, name }) => {
     const label = escapeMarkdownLabel(name);
@@ -140,9 +140,9 @@ export type CreateAttachmentPayload = {
   url: string;
 };
 
-export async function createAttachment(payload: CreateAttachmentPayload) {
-  const { linearClient } = getLinearClient();
-  const file = await uploadFile(payload.url);
+export async function createAttachment(payload: CreateAttachmentPayload, client?: LinearClient) {
+  const { linearClient } = resolveClient(client);
+  const file = await uploadFile(payload.url, client);
   const result = await linearClient.createAttachment({
     issueId: payload.issueId,
     title: file.name,
@@ -152,8 +152,8 @@ export async function createAttachment(payload: CreateAttachmentPayload) {
   return { success: result.success, id: result.attachmentId };
 }
 
-export async function attachLinkUrl(payload: CreateAttachmentPayload) {
-  const { linearClient } = getLinearClient();
+export async function attachLinkUrl(payload: CreateAttachmentPayload, client?: LinearClient) {
+  const { linearClient } = resolveClient(client);
   const result = await linearClient.attachmentLinkURL(payload.issueId, payload.url);
 
   return { success: result.success, id: result.attachmentId };

--- a/extensions/linear/src/api/createIssue.ts
+++ b/extensions/linear/src/api/createIssue.ts
@@ -1,4 +1,6 @@
-import { getLinearClient } from "../api/linearClient";
+import { LinearClient } from "@linear/sdk";
+
+import { resolveClient } from "../api/linearClient";
 
 import { IssueFragment, IssueResult } from "./getIssues";
 
@@ -18,8 +20,8 @@ export type CreateIssuePayload = {
   parentId?: string;
 };
 
-export async function createIssue(payload: CreateIssuePayload) {
-  const { graphQLClient } = getLinearClient();
+export async function createIssue(payload: CreateIssuePayload, client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
 
   const title = payload.title.replace(/"/g, "\\$&");
   const description = payload.description?.replace(/\n/g, "\\n")?.replace(/"/g, "\\$&");
@@ -89,8 +91,8 @@ type CreateSubIssuePayload = {
   stateId?: string;
 };
 
-export async function createSubIssue(payload: CreateSubIssuePayload) {
-  const { graphQLClient } = getLinearClient();
+export async function createSubIssue(payload: CreateSubIssuePayload, client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
 
   const title = payload.title.replace(/"/g, "\\$&");
   const description = payload.description?.replace(/\n/g, "\\n").replace(/"/g, "\\$&");

--- a/extensions/linear/src/api/deleteNotification.ts
+++ b/extensions/linear/src/api/deleteNotification.ts
@@ -1,9 +1,9 @@
-import { Notification } from "@linear/sdk";
+import { LinearClient, Notification } from "@linear/sdk";
 
-import { getLinearClient } from "../api/linearClient";
+import { resolveClient } from "../api/linearClient";
 
-export async function deleteNotification(id: Notification["id"]) {
-  const { graphQLClient } = getLinearClient();
+export async function deleteNotification(id: Notification["id"], client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
 
   const { data } = await graphQLClient.rawRequest<
     { notificationArchive: { success: boolean } },

--- a/extensions/linear/src/api/documents.ts
+++ b/extensions/linear/src/api/documents.ts
@@ -1,7 +1,9 @@
-import { getLinearClient } from "./linearClient";
+import { LinearClient } from "@linear/sdk";
 
-export async function deleteDocument(documentId: string) {
-  const { graphQLClient } = getLinearClient();
+import { resolveClient } from "./linearClient";
+
+export async function deleteDocument(documentId: string, client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
 
   const { data } = await graphQLClient.rawRequest<{ documentDelete: { success: boolean } }, Record<string, unknown>>(
     `
@@ -21,8 +23,8 @@ export type DocUpdatePayload = Partial<{
   initiativeId: string;
 }>;
 
-export async function updateDocument(documentId: string, payload: DocUpdatePayload) {
-  const { graphQLClient } = getLinearClient();
+export async function updateDocument(documentId: string, payload: DocUpdatePayload, client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
 
   let docUpdateInput = `projectId: ${payload.projectId ? `"${payload.projectId}"` : null}`;
   docUpdateInput += `, initiativeId: ${payload.initiativeId ? `"${payload.initiativeId}"` : null}`;

--- a/extensions/linear/src/api/favorites.ts
+++ b/extensions/linear/src/api/favorites.ts
@@ -4,6 +4,7 @@ import {
   Document,
   Issue,
   IssueLabel,
+  LinearClient,
   Project,
   Initiative,
   Team,
@@ -11,7 +12,7 @@ import {
   WorkflowState,
 } from "@linear/sdk";
 
-import { getLinearClient } from "../api/linearClient";
+import { resolveClient } from "../api/linearClient";
 
 export type Favorite = {
   id: string;
@@ -35,8 +36,8 @@ export type Favorite = {
   updatedAt: string;
 };
 
-export async function getFavorites() {
-  const { graphQLClient } = getLinearClient();
+export async function getFavorites(client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
   const { data } = await graphQLClient.rawRequest<
     { viewer: { organization: { urlKey: string } }; favorites: { nodes: Favorite[] } },
     Record<string, unknown>

--- a/extensions/linear/src/api/getCustomViews.ts
+++ b/extensions/linear/src/api/getCustomViews.ts
@@ -1,7 +1,7 @@
-import { CustomView, Team } from "@linear/sdk";
+import { CustomView, LinearClient, Team } from "@linear/sdk";
 
 import { IssueFragment, IssueResult } from "../api/getIssues";
-import { getLinearClient } from "../api/linearClient";
+import { resolveClient } from "../api/linearClient";
 import { getPaginated, PageInfo } from "../api/pagination";
 
 export type CustomViewResult = Pick<CustomView, "id" | "name" | "icon" | "color" | "shared"> & {
@@ -9,8 +9,8 @@ export type CustomViewResult = Pick<CustomView, "id" | "name" | "icon" | "color"
   team?: Pick<Team, "id" | "name" | "key">;
 };
 
-export async function getCustomViews(): Promise<CustomViewResult[]> {
-  const { graphQLClient } = getLinearClient();
+export async function getCustomViews(client?: LinearClient): Promise<CustomViewResult[]> {
+  const { graphQLClient } = resolveClient(client);
 
   const allViews = await getPaginated(
     async (cursor) =>
@@ -52,8 +52,8 @@ export async function getCustomViews(): Promise<CustomViewResult[]> {
   return allViews.filter((v) => v.modelName === "Issue");
 }
 
-export async function getCustomViewIssues(viewId: string): Promise<IssueResult[]> {
-  const { graphQLClient } = getLinearClient();
+export async function getCustomViewIssues(viewId: string, client?: LinearClient): Promise<IssueResult[]> {
+  const { graphQLClient } = resolveClient(client);
 
   return getPaginated(
     async (cursor) =>

--- a/extensions/linear/src/api/getIssueTemplates.ts
+++ b/extensions/linear/src/api/getIssueTemplates.ts
@@ -1,4 +1,6 @@
-import { getLinearClient } from "./linearClient";
+import { LinearClient } from "@linear/sdk";
+
+import { resolveClient } from "./linearClient";
 
 export type IssueTemplateResult = {
   id: string;
@@ -52,12 +54,12 @@ function sortIssueTemplates(a: IssueTemplateResult, b: IssueTemplateResult) {
   return (a.sortOrder ?? 0) - (b.sortOrder ?? 0) || a.name.localeCompare(b.name);
 }
 
-export async function getIssueTemplates(teamId?: string) {
+export async function getIssueTemplates(teamId?: string, client?: LinearClient) {
   if (!teamId) {
     return [];
   }
 
-  const { graphQLClient } = getLinearClient();
+  const { graphQLClient } = resolveClient(client);
 
   const { data } = await graphQLClient.rawRequest<
     IssueTemplatesResponse,

--- a/extensions/linear/src/api/getIssues.ts
+++ b/extensions/linear/src/api/getIssues.ts
@@ -4,6 +4,7 @@ import {
   Issue,
   IssueLabel,
   IssueRelation,
+  LinearClient,
   Project,
   ProjectMilestone,
   Team,
@@ -12,7 +13,7 @@ import {
 } from "@linear/sdk";
 import { getPreferenceValues } from "@raycast/api";
 
-import { getLinearClient } from "../api/linearClient";
+import { resolveClient } from "../api/linearClient";
 
 import { LabelResult } from "./getLabels";
 import { getPaginated, PageInfo } from "./pagination";
@@ -157,8 +158,8 @@ export type IssueResult = Pick<
   projectMilestone?: Pick<ProjectMilestone, "id" | "name" | "targetDate">;
 };
 
-export async function getLastUpdatedIssues(after?: string) {
-  const { graphQLClient } = getLinearClient();
+export async function getLastUpdatedIssues(after?: string, client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
   const { data } = await graphQLClient.rawRequest<
     { issues: { nodes: IssueResult[]; pageInfo: { endCursor: string; hasNextPage: boolean } } },
     Record<string, unknown>
@@ -182,8 +183,8 @@ export async function getLastUpdatedIssues(after?: string) {
   return { issues: data?.issues.nodes, pageInfo: data?.issues.pageInfo };
 }
 
-export async function searchIssues(query: string, after?: string, first = 25) {
-  const { graphQLClient } = getLinearClient();
+export async function searchIssues(query: string, after?: string, first = 25, client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
   const { data } = await graphQLClient.rawRequest<
     { searchIssues: { nodes: IssueResult[]; pageInfo: { endCursor: string; hasNextPage: boolean } } },
     { term: string; after?: string; first?: number; includeArchived?: boolean }
@@ -207,8 +208,8 @@ export async function searchIssues(query: string, after?: string, first = 25) {
   return { issues: data?.searchIssues.nodes, pageInfo: data?.searchIssues.pageInfo };
 }
 
-export async function filterIssues(filter: string, after?: string, first = 25) {
-  const { graphQLClient } = getLinearClient();
+export async function filterIssues(filter: string, after?: string, first = 25, client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
   const { data } = await graphQLClient.rawRequest<
     { issues: { nodes: IssueResult[]; pageInfo: { endCursor: string; hasNextPage: boolean } } },
     { filter: string; after?: string; first?: number }
@@ -232,8 +233,8 @@ export async function filterIssues(filter: string, after?: string, first = 25) {
   return { issues: data?.issues.nodes, pageInfo: data?.issues.pageInfo };
 }
 
-export async function getLastCreatedIssues() {
-  const { graphQLClient } = getLinearClient();
+export async function getLastCreatedIssues(client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
   const { data } = await graphQLClient.rawRequest<{ issues: { nodes: IssueResult[] } }, Record<string, unknown>>(
     `
       query {
@@ -249,8 +250,8 @@ export async function getLastCreatedIssues() {
   return data?.issues.nodes;
 }
 
-export async function getMyIssues() {
-  const { graphQLClient } = getLinearClient();
+export async function getMyIssues(client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
   const { data } = await graphQLClient.rawRequest<
     { viewer: { assignedIssues: { nodes: IssueResult[] } } },
     Record<string, unknown>
@@ -271,8 +272,8 @@ export async function getMyIssues() {
   return data?.viewer.assignedIssues.nodes;
 }
 
-export async function getCreatedIssues() {
-  const { graphQLClient } = getLinearClient();
+export async function getCreatedIssues(client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
   const { data } = await graphQLClient.rawRequest<
     { viewer: { createdIssues: { nodes: IssueResult[] } } },
     Record<string, unknown>
@@ -293,8 +294,8 @@ export async function getCreatedIssues() {
   return data?.viewer.createdIssues.nodes;
 }
 
-export async function getSubscribedIssues() {
-  const { graphQLClient } = getLinearClient();
+export async function getSubscribedIssues(client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
 
   const { pageSize, pageLimit } = getPageLimits();
 
@@ -338,12 +339,12 @@ export function getMyIssuesByView(view: MyIssuesView) {
   }
 }
 
-export async function getActiveCycleIssues(cycleId?: string) {
+export async function getActiveCycleIssues(cycleId?: string, client?: LinearClient) {
   if (!cycleId) {
     return [];
   }
 
-  const { graphQLClient } = getLinearClient();
+  const { graphQLClient } = resolveClient(client);
 
   const { pageSize, pageLimit } = getPageLimits();
 
@@ -379,8 +380,8 @@ export async function getActiveCycleIssues(cycleId?: string) {
   return nodes;
 }
 
-export async function getProjectIssues(projectId: string) {
-  const { graphQLClient } = getLinearClient();
+export async function getProjectIssues(projectId: string, client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
   const { data } = await graphQLClient.rawRequest<{ issues: { nodes: IssueResult[] } }, Record<string, unknown>>(
     `
       query($projectId: ID) {
@@ -400,8 +401,8 @@ export async function getProjectIssues(projectId: string) {
   return data?.issues.nodes;
 }
 
-export async function getProjectMilestoneIssues(milestoneId: string) {
-  const { graphQLClient } = getLinearClient();
+export async function getProjectMilestoneIssues(milestoneId: string, client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
   const { data } = await graphQLClient.rawRequest<{ issues: { nodes: IssueResult[] } }, Record<string, unknown>>(
     `
       query($milestoneId: ID) {
@@ -421,8 +422,8 @@ export async function getProjectMilestoneIssues(milestoneId: string) {
   return data?.issues.nodes;
 }
 
-export async function getSubIssues(issueId: string) {
-  const { graphQLClient } = getLinearClient();
+export async function getSubIssues(issueId: string, client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
   const { data } = await graphQLClient.rawRequest<
     { issue: { children: { nodes: IssueResult[] } } },
     Record<string, unknown>
@@ -460,7 +461,7 @@ export type IssuePromptResult = Pick<Issue, "identifier" | "title" | "branchName
 };
 
 export async function getIssuePromptData(issueId: string) {
-  const { graphQLClient } = getLinearClient();
+  const { graphQLClient } = resolveClient();
 
   const { data } = await graphQLClient.rawRequest<{ issue: IssuePromptResult }, Record<string, unknown>>(
     `
@@ -513,8 +514,8 @@ export type CommentResult = Pick<Comment, "id" | "body" | "createdAt" | "url"> &
   user: Pick<User, "id" | "displayName" | "avatarUrl" | "email">;
 };
 
-export async function getComments(issueId: string) {
-  const { graphQLClient } = getLinearClient();
+export async function getComments(issueId: string, client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
 
   const { data } = await graphQLClient.rawRequest<
     { issue: { comments: { nodes: CommentResult[] } } },
@@ -577,8 +578,8 @@ export type IssueDetailResult = IssueResult &
     };
   };
 
-export async function getIssueDetail(issueId: string) {
-  const { graphQLClient } = getLinearClient();
+export async function getIssueDetail(issueId: string, client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
 
   const { data } = await graphQLClient.rawRequest<{ issue: IssueDetailResult }, Record<string, unknown>>(
     `

--- a/extensions/linear/src/api/getLabels.ts
+++ b/extensions/linear/src/api/getLabels.ts
@@ -1,7 +1,7 @@
-import { IssueLabel } from "@linear/sdk";
+import { IssueLabel, LinearClient } from "@linear/sdk";
 import { getPreferenceValues } from "@raycast/api";
 
-import { getLinearClient } from "../api/linearClient";
+import { resolveClient } from "../api/linearClient";
 
 import { getPaginated, PageInfo } from "./pagination";
 
@@ -20,14 +20,14 @@ function getPageLimits() {
 
 export type LabelResult = Pick<IssueLabel, "id" | "name" | "color">;
 
-export async function getLabels(teamId?: string) {
+export async function getLabels(teamId?: string, client?: LinearClient) {
   if (!teamId) {
     return [];
   }
 
   const { pageSize, pageLimit } = getPageLimits();
 
-  const { graphQLClient } = getLinearClient();
+  const { graphQLClient } = resolveClient(client);
 
   return getPaginated(
     async (cursor) =>

--- a/extensions/linear/src/api/getMilestones.ts
+++ b/extensions/linear/src/api/getMilestones.ts
@@ -1,6 +1,6 @@
-import { ProjectMilestone } from "@linear/sdk";
+import { LinearClient, ProjectMilestone } from "@linear/sdk";
 
-import { getLinearClient } from "../api/linearClient";
+import { resolveClient } from "../api/linearClient";
 
 export type MilestoneResult = Pick<
   ProjectMilestone,
@@ -23,8 +23,8 @@ const milestoneFragment = `
   updatedAt
 `;
 
-export async function getMilestones(projectId?: string) {
-  const { graphQLClient } = getLinearClient();
+export async function getMilestones(projectId?: string, client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
 
   if (projectId) {
     const { data } = await graphQLClient.rawRequest<

--- a/extensions/linear/src/api/getNotifications.ts
+++ b/extensions/linear/src/api/getNotifications.ts
@@ -1,6 +1,15 @@
-import { Organization, Comment, User, IssueNotification, ProjectUpdate, Project, ActorBot } from "@linear/sdk";
+import {
+  Organization,
+  Comment,
+  User,
+  IssueNotification,
+  ProjectUpdate,
+  Project,
+  ActorBot,
+  LinearClient,
+} from "@linear/sdk";
 
-import { getLinearClient } from "../api/linearClient";
+import { resolveClient } from "../api/linearClient";
 
 import { IssueFragment, IssueResult } from "./getIssues";
 
@@ -27,8 +36,8 @@ export type NotificationResult = Pick<
 
 export type OrganizationResult = Pick<Organization, "urlKey">;
 
-export async function getNotifications() {
-  const { graphQLClient } = getLinearClient();
+export async function getNotifications(client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
   const { data } = await graphQLClient.rawRequest<
     { notifications: { nodes: NotificationResult[] } } & { organization: OrganizationResult },
     Record<string, unknown>

--- a/extensions/linear/src/api/getProjects.ts
+++ b/extensions/linear/src/api/getProjects.ts
@@ -1,6 +1,6 @@
-import { Project, ProjectStatus, ProjectUpdate, User } from "@linear/sdk";
+import { LinearClient, Project, ProjectStatus, ProjectUpdate, User } from "@linear/sdk";
 
-import { getLinearClient } from "../api/linearClient";
+import { resolveClient } from "../api/linearClient";
 
 export type ProjectResult = Pick<
   Project,
@@ -84,13 +84,11 @@ const projectFragment = `
   }
 `;
 
-export async function getProjects({
-  teamId,
-  searchText = "",
-  after = null,
-  first = null,
-}: GetProjectsOptions): Promise<GetProjectsResult> {
-  const { graphQLClient } = getLinearClient();
+export async function getProjects(
+  { teamId, searchText = "", after = null, first = null }: GetProjectsOptions,
+  client?: LinearClient,
+): Promise<GetProjectsResult> {
+  const { graphQLClient } = resolveClient(client);
 
   const projectsQueryFragment = `
     projects(first: $first, after: $after, filter: { name: { containsIgnoreCase: $searchText } }) {
@@ -161,8 +159,8 @@ const projectUpdateFragment = `
   }
 `;
 
-export async function getProjectUpdates(projectId: string) {
-  const { graphQLClient } = getLinearClient();
+export async function getProjectUpdates(projectId: string, client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
 
   const { data } = await graphQLClient.rawRequest<
     { project: { projectUpdates: { nodes: ProjectUpdateResult[] } } },

--- a/extensions/linear/src/api/getTeams.ts
+++ b/extensions/linear/src/api/getTeams.ts
@@ -1,7 +1,7 @@
-import { Cycle, Organization, Team } from "@linear/sdk";
+import { Cycle, LinearClient, Organization, Team } from "@linear/sdk";
 import { sortBy } from "lodash";
 
-import { getLinearClient } from "./linearClient";
+import { resolveClient } from "./linearClient";
 
 export type TeamResult = Pick<
   Team,
@@ -28,8 +28,8 @@ export type TeamsAndOrgResult = {
   organization: OrganizationResult;
 };
 
-export async function getTeams(query: string = "") {
-  const { graphQLClient, linearClient } = getLinearClient();
+export async function getTeams(query: string = "", client?: LinearClient) {
+  const { graphQLClient, linearClient } = resolveClient(client);
 
   const me = await linearClient.viewer;
 

--- a/extensions/linear/src/api/initiatives.ts
+++ b/extensions/linear/src/api/initiatives.ts
@@ -1,7 +1,7 @@
-import { Initiative, Project } from "@linear/sdk";
+import { Initiative, LinearClient, Project } from "@linear/sdk";
 import { sortBy } from "lodash";
 
-import { getLinearClient } from "./linearClient";
+import { resolveClient } from "./linearClient";
 
 export type InitiativeResult = Pick<Initiative, "id" | "name" | "color" | "icon" | "sortOrder" | "description"> & {
   projects?: { nodes: Pick<Project, "id">[] };
@@ -23,8 +23,8 @@ const initiativeFragment = `
   }
 `;
 
-export async function getInitiatives() {
-  const { graphQLClient } = getLinearClient();
+export async function getInitiatives(client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
   const { data } = await graphQLClient.rawRequest<InitiativeList, Record<string, unknown>>(
     `
       query {

--- a/extensions/linear/src/api/linearClient.ts
+++ b/extensions/linear/src/api/linearClient.ts
@@ -259,6 +259,25 @@ export async function activateWorkspaceInMemory(ref: EntryRef): Promise<Workspac
   return entry;
 }
 
+// AI-tool variant of activateWorkspaceInMemory (§4.3): NON-interactive, in-memory only.
+// Every AI tool call is a fresh process (spike S8), so pointing this process's sync fast
+// path at the target entry is enough for linearUtils.client() and every resolve* helper
+// to act in that workspace. A dead token throws (caller turns it into a Manage Workspaces
+// hint); nothing here ever opens a browser flow or deletes a token.
+export async function activateToolWorkspace(ref: EntryRef): Promise<WorkspaceEntry> {
+  const registry = await migrateIfNeeded({ allowWrite: false });
+  const entry = registry.workspaces.find((w) => entryKey(w) === entryKey(ref));
+  if (!entry) throw new Error(`No workspace registered for ${entryKey(ref)}`);
+  await getLinearClientFor(ref, { interactive: false });
+  activeProviderId = entry.providerId;
+  lastBootstrap = {
+    registry,
+    activeEntry: entry,
+    needsReauth: (lastBootstrap?.needsReauth ?? []).filter((key) => key !== entryKey(ref)),
+  };
+  return entry;
+}
+
 // Synchronous fast path — signature identical to today's; all 16 src/api/* callers
 // keep working unmodified in this slice.
 export function getLinearClient(): { linearClient: LinearClient; graphQLClient: LinearGraphQLClient } {

--- a/extensions/linear/src/api/linearClient.ts
+++ b/extensions/linear/src/api/linearClient.ts
@@ -1,11 +1,44 @@
 import { LinearClient, LinearGraphQLClient } from "@linear/sdk";
-import { environment } from "@raycast/api";
-import { OAuthService } from "@raycast/utils";
+import { environment, LaunchType, LocalStorage } from "@raycast/api";
 
-let linearClient: LinearClient | null = null;
+import { refreshQuickCommandSubtitles } from "../helpers/refreshQuickSubtitles";
+
+import { ensureToken, fetchViewerIdentity, getServiceForProviderId, linear } from "./oauth";
+import {
+  EntryRef,
+  entryKey,
+  getActiveEntry,
+  migrateIfNeeded,
+  reconcileEntries,
+  setActiveEntry,
+  WorkspaceEntry,
+  WorkspaceRegistry,
+} from "./workspaces";
+
+const clientsByProviderId = new Map<string, LinearClient>();
+const tokensByProviderId = new Map<string, string>();
+let activeProviderId: string | null = null;
+
+export type WorkspaceSnapshot = {
+  registry: WorkspaceRegistry;
+  activeEntry: WorkspaceEntry | null;
+  // Entry keys whose client holds no token — "Needs re-authentication" must surface in
+  // ordinary command UI too, not only in Manage Workspaces (§4.2 View-bootstrap reconciliation).
+  needsReauth: string[];
+};
+
+let lastBootstrap: WorkspaceSnapshot | null = null;
+
+// Render-time access to the launch-resolved workspace state (set by bootstrapWorkspaceAuth,
+// which the withWorkspaceAuth wrapper awaits before anything renders or executes).
+export function getWorkspaceSnapshot(): WorkspaceSnapshot | null {
+  return lastBootstrap;
+}
 
 type GraphQLResult<Data> = { data?: Data; errors?: Array<{ message?: string }> };
 
+// Upstream (41baddf044): surface the first GraphQL error message instead of the SDK's
+// generic failure. Installed on every per-workspace client by makeClient.
 async function makeGraphQLRequest<Data, Variables extends Record<string, unknown>>(
   url: string,
   options: RequestInit,
@@ -37,37 +70,241 @@ async function makeGraphQLRequest<Data, Variables extends Record<string, unknown
   );
 }
 
-export const linear = OAuthService.linear({
-  scope: "read write",
-  onAuthorize({ token }) {
-    linearClient = new LinearClient({
-      accessToken: token,
-      headers: {
-        "public-file-urls-expire-in": "60",
-        "linear-raycast-extension-name": environment.extensionName,
-      },
+export function makeClient(accessToken: string): LinearClient {
+  const client = new LinearClient({
+    accessToken,
+    headers: {
+      "public-file-urls-expire-in": "60",
+      "linear-raycast-extension-name": environment.extensionName,
+    },
+  });
+  const graphQLClient = client.client as unknown as {
+    url: string;
+    options: RequestInit;
+    rawRequest: LinearGraphQLClient["rawRequest"];
+  };
+  graphQLClient.rawRequest = ((query, variables, requestHeaders) =>
+    makeGraphQLRequest(
+      graphQLClient.url,
+      graphQLClient.options,
+      query,
+      variables,
+      requestHeaders,
+    )) as LinearGraphQLClient["rawRequest"];
+  return client;
+}
+
+function isBackgroundLaunch(): boolean {
+  return environment.launchType === LaunchType.Background;
+}
+
+function serviceForEntry(entry: WorkspaceEntry) {
+  return getServiceForProviderId(
+    entry.providerId,
+    `Connect to ${entry.orgName} (${entry.userEmail})`,
+    `Linear — ${entry.orgName}`,
+  );
+}
+
+// Interactive grants bind to whatever account/workspace is active at linear.app (spike S3),
+// so any token MINTED interactively into an entry-keyed slot must be identity-verified
+// before use — otherwise workspace X's token silently lands under entry Y (a D10
+// violation: every "Y" query would really hit X). Slot 0 is NOT exempt: once migration
+// has bound an identity to the "linear" entry, a fully revoked authorization re-granted
+// while another workspace is active at linear.app could corrupt it the same way —
+// verification is one API call and only runs on actual mints.
+export async function ensureEntryToken(entry: WorkspaceEntry, options: { interactive: boolean }): Promise<string> {
+  const service = serviceForEntry(entry);
+  const existing = await service.client.getTokens();
+  const hadUsableToken = Boolean(existing?.accessToken && !existing.isExpired());
+  const token = await ensureToken(service, options);
+  const possiblyMinted = options.interactive && !hadUsableToken;
+  if (possiblyMinted && token !== existing?.accessToken) {
+    const identity = await fetchViewerIdentity(token);
+    if (identity.orgId !== entry.orgId || identity.userId !== entry.userId) {
+      await service.client.removeTokens();
+      throw new Error(
+        `Linear granted access for ${identity.orgName} (${identity.userEmail}), not ` +
+          `${entry.orgName} (${entry.userEmail}). Switch to that account and workspace at ` +
+          `linear.app (top-left switcher), then try again — or use Add Workspace to connect it.`,
+      );
+    }
+  }
+  return token;
+}
+
+// D11 follow-up: constructing a labeled OAuthService is pure in-process object creation —
+// it never reaches Raycast, so the Settings account-row label only has a chance to update
+// the next time a token is actually WRITTEN through that labeled client. This does a single
+// benign re-write of slot 0's existing token set through the labeled client, once, so the
+// row has a shot at picking up the "Linear — <org>" label. Guarded by a LocalStorage flag so
+// it only ever runs once; a failure here must never affect bootstrap.
+const SLOT0_RELABEL_KEY = "slot0-relabelled-v1";
+
+async function relabelSlot0Once(entry: WorkspaceEntry): Promise<void> {
+  if (entry.providerId !== "linear") return; // only slot 0 needs this touch
+  if (isBackgroundLaunch()) return; // foreground only
+  try {
+    if (await LocalStorage.getItem<string>(SLOT0_RELABEL_KEY)) return;
+    const labeled = getServiceForProviderId("linear", undefined, `Linear — ${entry.orgName}`);
+    const tokens = await labeled.client.getTokens();
+    if (!tokens?.accessToken) return; // nothing to re-write; do NOT set the flag
+    // setTokens re-stamps updatedAt to now, so pass the REMAINING lifetime (same math as
+    // completeAddFromStaging), not the original duration. Omit expiresIn entirely when the
+    // stored set lacks it — defaulting would make a non-expiring token look expiring.
+    const elapsedSeconds = Math.floor((Date.now() - tokens.updatedAt.getTime()) / 1000);
+    await labeled.client.setTokens({
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+      idToken: tokens.idToken,
+      scope: tokens.scope,
+      ...(tokens.expiresIn !== undefined ? { expiresIn: Math.max(60, tokens.expiresIn - elapsedSeconds) } : {}),
     });
+    await LocalStorage.setItem(SLOT0_RELABEL_KEY, new Date().toISOString());
+  } catch {
+    // Never break launch for a cosmetic relabel; retry on a later launch.
+  }
+}
 
-    const graphQLClient = linearClient.client as unknown as {
-      url: string;
-      options: RequestInit;
-      rawRequest: LinearGraphQLClient["rawRequest"];
-    };
-    graphQLClient.rawRequest = ((query, variables, requestHeaders) =>
-      makeGraphQLRequest(
-        graphQLClient.url,
-        graphQLClient.options,
-        query,
-        variables,
-        requestHeaders,
-      )) as LinearGraphQLClient["rawRequest"];
-  },
-});
+function cacheClient(providerId: string, token: string): LinearClient {
+  const cached = clientsByProviderId.get(providerId);
+  if (cached && tokensByProviderId.get(providerId) === token) return cached;
+  const client = makeClient(token);
+  clientsByProviderId.set(providerId, client);
+  tokensByProviderId.set(providerId, token);
+  return client;
+}
 
-export function getLinearClient(): { linearClient: LinearClient; graphQLClient: LinearGraphQLClient } {
-  if (!linearClient) {
-    throw new Error("No linear client initialized");
+// Resolve the active workspace ONCE at command launch (design D2); later launches
+// follow whatever the registry says then, but this process stays pinned.
+export async function bootstrapWorkspaceAuth(options?: { interactive?: boolean }): Promise<{
+  token: string;
+  registry: WorkspaceRegistry;
+  activeEntry: WorkspaceEntry | null;
+}> {
+  const interactive = options?.interactive ?? !isBackgroundLaunch();
+  const registry = await migrateIfNeeded({ allowWrite: interactive });
+  const activeEntry = getActiveEntry(registry);
+  // Record the selection BEFORE any token work, so the auth error boundary can name
+  // the workspace that failed (edge case 1) even when the token fetch throws.
+  lastBootstrap = { registry, activeEntry, needsReauth: [] };
+
+  if (!activeEntry) {
+    // Fresh install: drive the slot-0 interactive login (today's exact first-run behavior),
+    // then adopt it on the next foreground bootstrap via migrateIfNeeded.
+    const token = await ensureToken(linear, { interactive });
+    cacheClient("linear", token);
+    activeProviderId = "linear";
+    return { token, registry, activeEntry: null };
   }
 
-  return { linearClient, graphQLClient: linearClient.client };
+  const token = await ensureEntryToken(activeEntry, { interactive });
+  cacheClient(activeEntry.providerId, token);
+  activeProviderId = activeEntry.providerId;
+  // Fire-and-forget, cosmetic only: nothing downstream depends on this completing, and
+  // awaiting it would add a getTokens+setTokens round-trip to every foreground launch
+  // until the one-time flag is set (D-fix, slot-0 relabel touch).
+  void relabelSlot0Once(activeEntry);
+  // View-bootstrap reconciliation (§4.2): entries whose tokens vanished surface as
+  // "Needs re-authentication" in ordinary command UI via the snapshot.
+  const reconciled = await reconcileEntries(registry);
+  lastBootstrap = {
+    registry,
+    activeEntry,
+    needsReauth: reconciled.filter((r) => !r.hasToken).map((r) => entryKey(r.entry)),
+  };
+  return { token, registry, activeEntry };
+}
+
+// P1/P1b/P2 switch semantics (design D2): ensure the target workspace's client BEFORE
+// persisting it as the new global default. Persisting first (the earlier ordering) left
+// a canceled/failed OAuth with the registry default already pointing at the broken
+// workspace — the "no workspace registered" throw would fire only after that write.
+// Look-up is read-only (allowWrite: false); only a successful ensure reaches the write.
+export async function activateWorkspace(ref: EntryRef): Promise<WorkspaceEntry> {
+  const lookupRegistry = await migrateIfNeeded({ allowWrite: false });
+  const lookupEntry = lookupRegistry.workspaces.find((w) => entryKey(w) === entryKey(ref));
+  if (!lookupEntry) throw new Error(`No workspace registered for ${entryKey(ref)}`);
+  await getLinearClientFor(ref, { interactive: true }); // ensures token + caches the client
+
+  const registry = await setActiveEntry(ref);
+  const entry = registry.workspaces.find((w) => entryKey(w) === entryKey(ref));
+  if (!entry) throw new Error(`No workspace registered for ${entryKey(ref)}`);
+  activeProviderId = entry.providerId;
+  lastBootstrap = {
+    registry,
+    activeEntry: entry,
+    // The target just authenticated successfully — drop any stale badge for it.
+    needsReauth: (lastBootstrap?.needsReauth ?? []).filter((key) => key !== entryKey(ref)),
+  };
+  refreshQuickCommandSubtitles(); // fire-and-forget: root-search subtitles pegged to the active workspace are now stale
+  return entry;
+}
+
+// Pinned-flow variant (design D2/D7): swaps THIS process's active client and snapshot
+// WITHOUT persisting a new global default. Used by draft-opened forms whose draft
+// targets a non-default workspace — the form must read AND submit in the draft's
+// workspace while the registry default stays untouched.
+export async function activateWorkspaceInMemory(ref: EntryRef): Promise<WorkspaceEntry> {
+  const registry = await migrateIfNeeded({ allowWrite: false });
+  const entry = registry.workspaces.find((w) => entryKey(w) === entryKey(ref));
+  if (!entry) throw new Error(`No workspace registered for ${entryKey(ref)}`);
+  await getLinearClientFor(ref, { interactive: true });
+  activeProviderId = entry.providerId;
+  lastBootstrap = {
+    registry,
+    activeEntry: entry,
+    needsReauth: (lastBootstrap?.needsReauth ?? []).filter((key) => key !== entryKey(ref)),
+  };
+  return entry;
+}
+
+// Synchronous fast path — signature identical to today's; all 16 src/api/* callers
+// keep working unmodified in this slice.
+export function getLinearClient(): { linearClient: LinearClient; graphQLClient: LinearGraphQLClient } {
+  const client = activeProviderId ? clientsByProviderId.get(activeProviderId) : undefined;
+  if (!client) {
+    throw new Error("No linear client initialized");
+  }
+  return { linearClient: client, graphQLClient: client.client };
+}
+
+// Entry-addressed client access for pinned flows, Manage Workspaces, the menu bar,
+// and AI tools (D10: two entries can share an orgId — the ref carries userId too).
+export async function getLinearClientFor(
+  ref: EntryRef,
+  options?: { interactive?: boolean },
+): Promise<{ linearClient: LinearClient; graphQLClient: LinearGraphQLClient }> {
+  const registry = await migrateIfNeeded({ allowWrite: false });
+  const entry = registry.workspaces.find((w) => entryKey(w) === entryKey(ref));
+  if (!entry) {
+    throw new Error(`No workspace registered for ${entryKey(ref)}`);
+  }
+  // Always re-ensure before reuse: a cached client's token can expire mid-process
+  // (24 h tokens; ensureToken short-circuits fast when the stored token is valid).
+  const interactive = options?.interactive ?? !isBackgroundLaunch();
+  const token = await ensureEntryToken(entry, { interactive });
+  const client = cacheClient(entry.providerId, token);
+  return { linearClient: client, graphQLClient: client.client };
+}
+
+// Explicit-client override for callers that serve more than one workspace in a single
+// process (menu bar, AI tools): falls back to the sync fast path when no client is given.
+export function resolveClient(client?: LinearClient): {
+  linearClient: LinearClient;
+  graphQLClient: LinearGraphQLClient;
+} {
+  if (client) return { linearClient: client, graphQLClient: client.client };
+  return getLinearClient();
+}
+
+// Used by View.tsx's auth error boundary ("Sign in Again"): clear exactly the
+// active entry's tokens so the next bootstrap re-authenticates it.
+export async function clearActiveWorkspaceTokens(): Promise<void> {
+  const registry = await migrateIfNeeded({ allowWrite: false });
+  const activeEntry = getActiveEntry(registry);
+  const service = activeEntry ? serviceForEntry(activeEntry) : linear;
+  await service.client.removeTokens();
+  if (activeProviderId) clientsByProviderId.delete(activeProviderId);
+  activeProviderId = null;
 }

--- a/extensions/linear/src/api/linearClient.ts
+++ b/extensions/linear/src/api/linearClient.ts
@@ -204,7 +204,7 @@ export async function bootstrapWorkspaceAuth(options?: { interactive?: boolean }
   // Fire-and-forget, cosmetic only: nothing downstream depends on this completing, and
   // awaiting it would add a getTokens+setTokens round-trip to every foreground launch
   // until the one-time flag is set (D-fix, slot-0 relabel touch).
-  void relabelSlot0Once(activeEntry);
+  if (options?.interactive !== false) void relabelSlot0Once(activeEntry);
   // View-bootstrap reconciliation (§4.2): entries whose tokens vanished surface as
   // "Needs re-authentication" in ordinary command UI via the snapshot.
   const reconciled = await reconcileEntries(registry);

--- a/extensions/linear/src/api/oauth.ts
+++ b/extensions/linear/src/api/oauth.ts
@@ -79,7 +79,7 @@ export async function refreshNonDestructive(
     });
     if (!response.ok) return { status: "failed" };
     const next = (await response.json()) as { access_token: string; refresh_token?: string; expires_in?: number };
-    await service.client.setTokens(next);
+    await service.client.setTokens({ ...next, refresh_token: next.refresh_token ?? tokens.refreshToken });
     return { status: "ok", accessToken: next.access_token };
   } catch {
     return { status: "failed" };

--- a/extensions/linear/src/api/oauth.ts
+++ b/extensions/linear/src/api/oauth.ts
@@ -1,0 +1,125 @@
+import { OAuth } from "@raycast/api";
+import { OAuthService } from "@raycast/utils";
+
+type AuthBackend = "manual" | "utils";
+// Flip to "utils" once the raycast/utils PR adding providerId/extraParameters ships (design D8).
+export const AUTH_BACKEND: AuthBackend = "manual";
+
+// Copied from @raycast/utils' built-in Linear provider (delete when AUTH_BACKEND becomes "utils"):
+export const LINEAR_PROXY = "https://linear.oauth.raycast.com";
+export const LINEAR_PROXY_CLIENT_ID = "c8ff37b9225c3c9aefd7d66ea0e5b6f1";
+
+// The existing login. Slot 0: providerId "linear", exactly today's service.
+export const linear = OAuthService.linear({ scope: "read write" });
+
+export function workspaceProviderId(orgId: string, userId: string): string {
+  return `linear-ws-${orgId}-${userId}`;
+}
+
+export function makeLinearOAuthService(providerId: string, description: string, providerName = "Linear"): OAuthService {
+  if (AUTH_BACKEND === "utils") {
+    // Requires the raycast/utils PR (Plan 2): providerId + extraParameters options.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return OAuthService.linear({ scope: "read write", providerId, extraParameters: { prompt: "consent" } } as any);
+  }
+  return new OAuthService({
+    client: new OAuth.PKCEClient({
+      redirectMethod: OAuth.RedirectMethod.Web,
+      providerName,
+      providerIcon: "linear-app-icon.png",
+      providerId,
+      description,
+    }),
+    clientId: LINEAR_PROXY_CLIENT_ID,
+    scope: "read write",
+    authorizeUrl: `${LINEAR_PROXY}/authorize`,
+    tokenUrl: `${LINEAR_PROXY}/token`,
+    refreshTokenUrl: `${LINEAR_PROXY}/refresh-token`,
+    // prompt=consent is MANDATORY: without it an already-granted app silently skips
+    // Linear's consent screen, so a second-workspace grant is unreachable (spike S3).
+    extraParameters: { actor: "user", prompt: "consent" },
+  });
+}
+
+export const stagingService = makeLinearOAuthService("linear-staging", "Connect a Linear workspace");
+
+const servicesByProviderId = new Map<string, OAuthService>();
+
+export function getServiceForProviderId(providerId: string, description?: string, providerName?: string): OAuthService {
+  // D11: once slot 0's identity is known, entry-addressed callers pass a providerName
+  // and get a LABELED client (same providerId "linear" → same stored token, spike S1/S2).
+  // Label-less callers (pre-identity paths: migration's token read, fresh-install login)
+  // keep the stock handle.
+  if (providerId === "linear" && !providerName) return linear;
+  if (providerId === "linear-staging") return stagingService;
+  let service = servicesByProviderId.get(providerId);
+  if (!service) {
+    service = makeLinearOAuthService(providerId, description ?? "Connect your Linear account", providerName);
+    servicesByProviderId.set(providerId, service);
+  }
+  return service;
+}
+
+// Background-safe refresh (spike S6). Never deletes tokens: 400, 5xx, and network
+// errors all leave the stored token set untouched, unlike utils' refreshTokens().
+export async function refreshNonDestructive(
+  service: OAuthService,
+): Promise<{ status: "ok"; accessToken: string } | { status: "failed" }> {
+  const tokens = await service.client.getTokens();
+  if (!tokens?.refreshToken) return { status: "failed" };
+  try {
+    const response = await fetch(`${LINEAR_PROXY}/refresh-token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        client_id: LINEAR_PROXY_CLIENT_ID,
+        refresh_token: tokens.refreshToken,
+        grant_type: "refresh_token",
+      }),
+    });
+    if (!response.ok) return { status: "failed" };
+    const next = (await response.json()) as { access_token: string; refresh_token?: string; expires_in?: number };
+    await service.client.setTokens(next);
+    return { status: "ok", accessToken: next.access_token };
+  } catch {
+    return { status: "failed" };
+  }
+}
+
+// Matches Raycast's own background-auth error so existing boundaries
+// (BackgroundAuthBoundary in unread-notifications.tsx) keep working.
+export const BACKGROUND_AUTH_ERROR = "OAuth request creation is not available when command is launched in background";
+
+export async function ensureToken(service: OAuthService, options: { interactive: boolean }): Promise<string> {
+  if (options.interactive) {
+    return service.authorize();
+  }
+  const tokens = await service.client.getTokens();
+  if (tokens?.accessToken && !tokens.isExpired()) return tokens.accessToken;
+  const refreshed = await refreshNonDestructive(service);
+  if (refreshed.status === "ok") return refreshed.accessToken;
+  throw new Error(BACKGROUND_AUTH_ERROR);
+}
+
+export type ViewerIdentity = { userId: string; userEmail: string; orgId: string; orgName: string; urlKey: string };
+
+export async function fetchViewerIdentity(accessToken: string): Promise<ViewerIdentity> {
+  const response = await fetch("https://api.linear.app/graphql", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}` },
+    body: JSON.stringify({ query: "query { viewer { id email organization { id name urlKey } } }" }),
+  });
+  if (!response.ok) throw new Error(`Linear identity query failed: HTTP ${response.status}`);
+  const json = (await response.json()) as {
+    data?: { viewer?: { id: string; email: string; organization: { id: string; name: string; urlKey: string } } };
+  };
+  const viewer = json.data?.viewer;
+  if (!viewer) throw new Error("Linear identity query returned no viewer");
+  return {
+    userId: viewer.id,
+    userEmail: viewer.email,
+    orgId: viewer.organization.id,
+    orgName: viewer.organization.name,
+    urlKey: viewer.organization.urlKey,
+  };
+}

--- a/extensions/linear/src/api/oauth.ts
+++ b/extensions/linear/src/api/oauth.ts
@@ -1,6 +1,8 @@
 import { OAuth } from "@raycast/api";
 import { OAuthService } from "@raycast/utils";
 
+import { traceStagingClient } from "./workspaceAddDiagnostics";
+
 type AuthBackend = "manual" | "utils";
 // Flip to "utils" once the raycast/utils PR adding providerId/extraParameters ships (design D8).
 export const AUTH_BACKEND: AuthBackend = "manual";
@@ -42,6 +44,7 @@ export function makeLinearOAuthService(providerId: string, description: string, 
 }
 
 export const stagingService = makeLinearOAuthService("linear-staging", "Connect a Linear workspace");
+traceStagingClient(stagingService.client);
 
 const servicesByProviderId = new Map<string, OAuthService>();
 

--- a/extensions/linear/src/api/updateIssue.ts
+++ b/extensions/linear/src/api/updateIssue.ts
@@ -1,6 +1,6 @@
-import { Issue } from "@linear/sdk";
+import { Issue, LinearClient } from "@linear/sdk";
 
-import { getLinearClient } from "../api/linearClient";
+import { resolveClient } from "../api/linearClient";
 
 export type UpdateIssuePayload = {
   title: string;
@@ -18,8 +18,8 @@ export type UpdateIssuePayload = {
   parentId?: string;
 };
 
-export async function updateIssue(issueId: Issue["id"], payload: Partial<UpdateIssuePayload>) {
-  const { graphQLClient } = getLinearClient();
+export async function updateIssue(issueId: Issue["id"], payload: Partial<UpdateIssuePayload>, client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
 
   const inputParts: string[] = [];
 

--- a/extensions/linear/src/api/updateNotification.ts
+++ b/extensions/linear/src/api/updateNotification.ts
@@ -1,14 +1,14 @@
-import { Notification } from "@linear/sdk";
+import { LinearClient, Notification } from "@linear/sdk";
 
-import { getLinearClient } from "../api/linearClient";
+import { resolveClient } from "../api/linearClient";
 
 export type UpdateNotificationPayload = {
   id: Notification["id"];
   readAt: Date | null;
 };
 
-export async function updateNotification(payload: UpdateNotificationPayload) {
-  const { graphQLClient } = getLinearClient();
+export async function updateNotification(payload: UpdateNotificationPayload, client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
 
   const { data } = await graphQLClient.rawRequest<
     { notificationUpdate: { success: boolean } },

--- a/extensions/linear/src/api/withWorkspaceAuth.ts
+++ b/extensions/linear/src/api/withWorkspaceAuth.ts
@@ -1,0 +1,17 @@
+import { withAccessToken } from "@raycast/utils";
+
+import { bootstrapWorkspaceAuth } from "./linearClient";
+
+// Reuses the utils wrapper engine (component suspension + async-fn gating) with our
+// bootstrap as the authorizer. The one-token-per-process cache inside withAccessToken
+// is safe here: one process = one launch = one pinned active workspace (design D2);
+// AI tools run one call per process (spike S8). Non-active workspaces NEVER go
+// through this path — they use getLinearClientFor (§4.4).
+const workspaceAuthorizer = {
+  authorize: async () => {
+    const { token } = await bootstrapWorkspaceAuth();
+    return token;
+  },
+};
+
+export const withWorkspaceAuth = withAccessToken(workspaceAuthorizer);

--- a/extensions/linear/src/api/workspaceAddDiagnostics.ts
+++ b/extensions/linear/src/api/workspaceAddDiagnostics.ts
@@ -1,0 +1,37 @@
+import { environment, OAuth } from "@raycast/api";
+
+const build = "workspace-add-recovery-fix";
+let sequence = 0;
+
+// Development logs contain stages and timings only, never credentials or account details.
+export async function traceWorkspaceAdd<T>(stage: string, operation: () => Promise<T>): Promise<T> {
+  if (!environment.isDevelopment) return operation();
+  const step = ++sequence;
+  const startedAt = Date.now();
+  const log = (event: "start" | "success" | "failure") => {
+    console.log(
+      "[linear-workspace-add]",
+      JSON.stringify({ build, processId: process.pid, step, stage, event, elapsedMs: Date.now() - startedAt }),
+    );
+  };
+  log("start");
+  try {
+    const result = await operation();
+    log("success");
+    return result;
+  } catch (error) {
+    log("failure");
+    throw error;
+  }
+}
+
+// OAuthService.authorize combines the native redirect, token exchange, and staging save.
+// Trace the native boundaries too, so a pending browser callback can be distinguished
+// from a failed token exchange without logging the request URL or response body.
+export function traceStagingClient(client: OAuth.PKCEClient): void {
+  if (!environment.isDevelopment) return;
+  const authorize = client.authorize.bind(client);
+  client.authorize = (options) => traceWorkspaceAdd("oauth.browser-callback", () => authorize(options));
+  const setTokens = client.setTokens.bind(client);
+  client.setTokens = (options) => traceWorkspaceAdd("oauth.staging-save", () => setTokens(options));
+}

--- a/extensions/linear/src/api/workspaceAddFlow.ts
+++ b/extensions/linear/src/api/workspaceAddFlow.ts
@@ -1,0 +1,102 @@
+import type { OAuth } from "@raycast/api";
+
+import type { ViewerIdentity } from "./oauth";
+
+export type WorkspaceAddResult = { identity: ViewerIdentity; isNew: boolean } | null;
+
+type Dependencies = {
+  staging: Pick<OAuth.PKCEClient, "getTokens" | "removeTokens">;
+  hasPendingAdd(): Promise<boolean>;
+  markPendingAdd(): Promise<void>;
+  clearPendingAdd(): Promise<void>;
+  authorize(): Promise<string>;
+  identify(accessToken: string): Promise<ViewerIdentity>;
+  verify(accessToken: string): Promise<unknown>;
+  getDestination(identity: ViewerIdentity): Promise<Pick<OAuth.PKCEClient, "setTokens">>;
+  register(identity: ViewerIdentity): Promise<{ isNew: boolean }>;
+  trace<T>(stage: string, operation: () => Promise<T>): Promise<T>;
+};
+
+function isPermanentTokenFailure(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /HTTP (401|403)/.test(message);
+}
+
+export function createWorkspaceAddFlow(dependencies: Dependencies) {
+  const { staging, trace } = dependencies;
+  let adding: Promise<WorkspaceAddResult> | undefined;
+  let recovering: Promise<WorkspaceAddResult> | undefined;
+
+  async function complete(): Promise<WorkspaceAddResult> {
+    const tokens = await trace("staging.read", () => staging.getTokens());
+    if (!tokens?.accessToken) {
+      // The browser grant may still be in progress. Absence of a token does not
+      // prove cancellation, so keep the marker until completion or explicit retry.
+      return null;
+    }
+
+    let identity: ViewerIdentity;
+    try {
+      identity = await trace("identity.fetch", () => dependencies.identify(tokens.accessToken));
+      await trace("identity.verify", () => dependencies.verify(tokens.accessToken));
+    } catch (error) {
+      if (isPermanentTokenFailure(error)) {
+        await trace("staging.reject", () => staging.removeTokens());
+        await dependencies.clearPendingAdd();
+      }
+      throw error;
+    }
+
+    const destination = await dependencies.getDestination(identity);
+    // setTokens restamps updatedAt. Preserve the remaining lifetime during recovery,
+    // and leave tokens without an expiry non-expiring.
+    const elapsedSeconds = Math.floor((Date.now() - tokens.updatedAt.getTime()) / 1000);
+    await trace("destination.save", () =>
+      destination.setTokens({
+        accessToken: tokens.accessToken,
+        refreshToken: tokens.refreshToken,
+        idToken: tokens.idToken,
+        scope: tokens.scope,
+        ...(tokens.expiresIn !== undefined ? { expiresIn: Math.max(60, tokens.expiresIn - elapsedSeconds) } : {}),
+      }),
+    );
+    // Publish only after the credentials are saved. Any save failure leaves the
+    // staging token and marker available for another recovery attempt.
+    const { isNew } = await trace("registry.save", () => dependencies.register(identity));
+    await trace("staging.cleanup", () => staging.removeTokens());
+    await trace("intent.cleanup", dependencies.clearPendingAdd);
+    return { identity, isNew };
+  }
+
+  function add(): Promise<WorkspaceAddResult> {
+    if (adding) return adding;
+    adding = trace("add", async () => {
+      // Finish mount-time recovery before starting a new grant. An explicit Add
+      // action can retry authentication if that recovery failed.
+      if (recovering) await recovering.catch(() => undefined);
+      await trace("staging.reset", () => staging.removeTokens());
+      await trace("intent.save", dependencies.markPendingAdd);
+      await trace("oauth.authorize", dependencies.authorize);
+      return complete();
+    }).finally(() => {
+      adding = undefined;
+    });
+    return adding;
+  }
+
+  function recover(): Promise<WorkspaceAddResult> {
+    // A remounted view joins the existing operation instead of consuming its
+    // staging token or clearing its marker while the browser is still open.
+    if (adding) return adding;
+    if (recovering) return recovering;
+    recovering = trace("recovery", async () => {
+      if (!(await dependencies.hasPendingAdd())) return null;
+      return complete();
+    }).finally(() => {
+      recovering = undefined;
+    });
+    return recovering;
+  }
+
+  return { add, recover };
+}

--- a/extensions/linear/src/api/workspaces.ts
+++ b/extensions/linear/src/api/workspaces.ts
@@ -1,0 +1,196 @@
+import { LocalStorage } from "@raycast/api";
+
+import {
+  ensureToken,
+  fetchViewerIdentity,
+  getServiceForProviderId,
+  linear,
+  workspaceProviderId,
+  ViewerIdentity,
+} from "./oauth";
+
+export type EntryRef = { orgId: string; userId: string };
+
+// D10: the unit of identity is the (workspace, account) PAIR. Two entries may share
+// an orgId (same workspace under two accounts) — never key anything by bare orgId.
+export function entryKey(ref: EntryRef): string {
+  return `${ref.orgId}:${ref.userId}`;
+}
+
+export type WorkspaceEntry = EntryRef & {
+  orgName: string;
+  urlKey: string;
+  userEmail: string;
+  providerId: string;
+};
+
+export type WorkspaceRegistry = {
+  version: 1;
+  updatedAt: string;
+  workspaces: WorkspaceEntry[];
+  active: EntryRef | null;
+};
+
+const REGISTRY_KEY = "workspace-registry";
+// Recovery copy (edge case 9): Raycast has NO API to enumerate stored OAuth providerIds,
+// so a corrupt primary value would otherwise strand every linear-ws-* token unrecoverably.
+// Every write mirrors to the backup; reads fall back to it before giving up.
+const REGISTRY_BACKUP_KEY = "workspace-registry-backup";
+
+function emptyRegistry(): WorkspaceRegistry {
+  return { version: 1, updatedAt: new Date(0).toISOString(), workspaces: [], active: null };
+}
+
+function parseRegistry(raw: string | undefined): WorkspaceRegistry | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as WorkspaceRegistry;
+    if (parsed.version !== 1 || !Array.isArray(parsed.workspaces)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export async function readRegistry(): Promise<WorkspaceRegistry> {
+  const primary = parseRegistry(await LocalStorage.getItem<string>(REGISTRY_KEY));
+  if (primary) return primary;
+  const backup = parseRegistry(await LocalStorage.getItem<string>(REGISTRY_BACKUP_KEY));
+  if (backup) return backup; // corrupt/lost primary healed from the mirror (edge case 9)
+  return emptyRegistry();
+}
+
+// Foreground writers only. The menu-bar process is strictly read-only on the registry (§4.2).
+export async function writeRegistry(
+  mutate: (current: WorkspaceRegistry) => WorkspaceRegistry,
+): Promise<WorkspaceRegistry> {
+  const fresh = await readRegistry(); // re-read immediately before writing: last-write-wins
+  const next = { ...mutate(fresh), version: 1 as const, updatedAt: new Date().toISOString() };
+  const serialized = JSON.stringify(next);
+  await LocalStorage.setItem(REGISTRY_KEY, serialized);
+  await LocalStorage.setItem(REGISTRY_BACKUP_KEY, serialized);
+  return next;
+}
+
+export function getActiveEntry(registry: WorkspaceRegistry): WorkspaceEntry | null {
+  if (registry.active) {
+    const match = registry.workspaces.find((w) => entryKey(w) === entryKey(registry.active as EntryRef));
+    if (match) return match;
+  }
+  return registry.workspaces[0] ?? null;
+}
+
+export async function setActiveEntry(ref: EntryRef): Promise<WorkspaceRegistry> {
+  return writeRegistry((current) => ({ ...current, active: { orgId: ref.orgId, userId: ref.userId } }));
+}
+
+export async function upsertWorkspaceEntry(
+  identity: ViewerIdentity,
+): Promise<{ registry: WorkspaceRegistry; entry: WorkspaceEntry; isNew: boolean }> {
+  const ref: EntryRef = { orgId: identity.orgId, userId: identity.userId };
+  let entry: WorkspaceEntry | undefined;
+  let isNew = false;
+  const registry = await writeRegistry((current) => {
+    const existing = current.workspaces.find((w) => entryKey(w) === entryKey(ref));
+    if (existing) {
+      // Same (org, user): overwrite path — refresh identity fields, same providerId (D10).
+      entry = { ...existing, orgName: identity.orgName, urlKey: identity.urlKey, userEmail: identity.userEmail };
+      return { ...current, workspaces: current.workspaces.map((w) => (entryKey(w) === entryKey(ref) ? entry! : w)) };
+    }
+    // New (org, user) pair — including a same-org-different-user entry (deliberate multi-view, D10).
+    isNew = true;
+    entry = {
+      ...ref,
+      orgName: identity.orgName,
+      urlKey: identity.urlKey,
+      userEmail: identity.userEmail,
+      providerId: workspaceProviderId(identity.orgId, identity.userId),
+    };
+    return {
+      ...current,
+      workspaces: [...current.workspaces, entry],
+      active: current.active ?? ref,
+    };
+  });
+  return { registry, entry: entry!, isNew };
+}
+
+export async function removeWorkspaceEntry(ref: EntryRef): Promise<WorkspaceRegistry> {
+  return writeRegistry((current) => {
+    const remaining = current.workspaces.filter((w) => entryKey(w) !== entryKey(ref));
+    const activeRemoved = current.active !== null && entryKey(current.active) === entryKey(ref);
+    return {
+      ...current,
+      workspaces: remaining,
+      // Logging out the active entry falls back to the first remaining one (edge case 3).
+      active: activeRemoved
+        ? remaining[0]
+          ? { orgId: remaining[0].orgId, userId: remaining[0].userId }
+          : null
+        : current.active,
+    };
+  });
+}
+
+// Entries whose client holds no token render "Needs re-authentication" — never crash,
+// never silently drop (§4.2 reconciliation; built-in sign-out can clear any subset, spike S5).
+export async function reconcileEntries(
+  registry: WorkspaceRegistry,
+): Promise<Array<{ entry: WorkspaceEntry; hasToken: boolean }>> {
+  return Promise.all(
+    registry.workspaces.map(async (entry) => {
+      try {
+        const service = getServiceForProviderId(entry.providerId, undefined, `Linear — ${entry.orgName}`);
+        const tokens = await service.client.getTokens();
+        return { entry, hasToken: Boolean(tokens?.accessToken) };
+      } catch {
+        // "Never crash, never drop" is structural: a failing token read marks the entry
+        // as needing re-auth (conservative) instead of rejecting the whole reconcile.
+        return { entry, hasToken: false };
+      }
+    }),
+  );
+}
+
+// Upgrade path (WS-04): no registry yet + the existing `linear` client holds a token
+// → one viewer.organization call adopts it as workspace #1, active, providerId "linear".
+// allowWrite=false is the background path (menu bar is read-only on the registry, §4.2):
+// it returns the adopted registry in memory without persisting; the next foreground
+// launch persists it.
+export async function migrateIfNeeded(options: { allowWrite: boolean }): Promise<WorkspaceRegistry> {
+  const current = await readRegistry();
+  if (current.workspaces.length > 0) return current;
+
+  const tokens = await linear.client.getTokens();
+  if (!tokens?.accessToken) return current; // fresh install: nothing to adopt
+
+  const accessToken = await ensureToken(linear, { interactive: false }).catch(() => null);
+  if (!accessToken) return current; // expired with no usable refresh: bootstrap will re-auth interactively
+
+  let identity: ViewerIdentity;
+  try {
+    identity = await fetchViewerIdentity(accessToken);
+  } catch {
+    // Offline / API failure during the migration window must NOT break an existing
+    // single-workspace user (slice contract): stay unmigrated — bootstrap's slot-0 path
+    // then serves the stored token exactly as the pre-slice code did; migration retries
+    // on a later launch.
+    return current;
+  }
+  const entry: WorkspaceEntry = {
+    orgId: identity.orgId,
+    userId: identity.userId,
+    orgName: identity.orgName,
+    urlKey: identity.urlKey,
+    userEmail: identity.userEmail,
+    providerId: "linear", // slot 0 keeps its existing storage label
+  };
+  const ref: EntryRef = { orgId: entry.orgId, userId: entry.userId };
+
+  if (!options.allowWrite) {
+    return { version: 1, updatedAt: new Date().toISOString(), workspaces: [entry], active: ref };
+  }
+  return writeRegistry((fresh) =>
+    fresh.workspaces.length > 0 ? fresh : { ...fresh, workspaces: [entry], active: ref },
+  );
+}

--- a/extensions/linear/src/assigned-issues.tsx
+++ b/extensions/linear/src/assigned-issues.tsx
@@ -5,6 +5,12 @@ import { getMyIssuesByView, MyIssuesView } from "./api/getIssues";
 import CreateIssueForm from "./components/CreateIssueForm";
 import StateIssueList from "./components/StateIssueList";
 import View from "./components/View";
+import { useWorkspaces } from "./components/WorkspaceContext";
+import {
+  isWorkspaceDropdownValue,
+  workspaceValueToKey,
+  WorkspaceDropdownSection,
+} from "./components/WorkspaceDropdown";
 import useIssues from "./hooks/useIssues";
 import useMe from "./hooks/useMe";
 import usePriorities from "./hooks/usePriorities";
@@ -32,6 +38,7 @@ const views: { id: MyIssuesView; title: string; icon: Icon; emptyDescription: st
 
 function MyIssues() {
   const [view, setView] = useState<MyIssuesView>("assigned");
+  const { switchWorkspace } = useWorkspaces();
 
   const { issues, isLoadingIssues, mutateList } = useIssues(getMyIssuesByView, [view]);
   const { priorities, isLoadingPriorities } = usePriorities();
@@ -45,7 +52,18 @@ function MyIssues() {
       searchBarPlaceholder="Filter by ID, title, status, assignee or priority"
       filtering={{ keepSectionOrder: true }}
       searchBarAccessory={
-        <List.Dropdown tooltip="Change View" value={view} onChange={(value) => setView(value as MyIssuesView)}>
+        <List.Dropdown
+          tooltip="Change View"
+          value={view}
+          onChange={(value) => {
+            if (isWorkspaceDropdownValue(value)) {
+              switchWorkspace(workspaceValueToKey(value));
+              return;
+            }
+            setView(value as MyIssuesView);
+          }}
+        >
+          <WorkspaceDropdownSection />
           {views.map(({ id, title, icon }) => (
             <List.Dropdown.Item key={id} value={id} title={title} icon={icon} />
           ))}

--- a/extensions/linear/src/components/CreateIssueForm.tsx
+++ b/extensions/linear/src/components/CreateIssueForm.tsx
@@ -37,8 +37,11 @@ import useProjects from "../hooks/useProjects";
 import useStates from "../hooks/useStates";
 import useTeams from "../hooks/useTeams";
 import useUsers from "../hooks/useUsers";
+import { useWorkspaceCachedState } from "../hooks/useWorkspaceCachedState";
 
 import IssueDetail from "./IssueDetail";
+import { useWorkspaces } from "./WorkspaceContext";
+import { WorkspaceFormDropdown } from "./WorkspaceDropdown";
 
 type CreateIssueFormProps = {
   assigneeId?: string;
@@ -55,6 +58,7 @@ type CreateIssueFormProps = {
 };
 
 export type CreateIssueValues = {
+  workspaceKey?: string;
   templateId: string;
   teamId: string;
   title: string;
@@ -107,6 +111,13 @@ function getCopyToastAction(copyToastAction: Preferences.CreateIssue["copyToastA
 export default function CreateIssueForm(props: CreateIssueFormProps) {
   const { push } = useNavigation();
   const { autofocusField, copyToastAction } = getPreferenceValues<Preferences.CreateIssue>();
+  const { showSwitcher } = useWorkspaces();
+
+  // The workspace field lives outside useForm, so focus() cannot target it — the autoFocus
+  // prop does. With <2 entries the field renders null, so the preference must FALL BACK
+  // (to today's behavior) instead of leaving nothing focused.
+  const workspaceAutofocusActive = autofocusField === "workspaceKey" && showSwitcher;
+  const effectiveAutofocusField = autofocusField === "workspaceKey" && !showSwitcher ? undefined : autofocusField;
 
   const [teamQuery, setTeamQuery] = useState<string>("");
   const { teams, org, supportsTeamTypeahead, isLoadingTeams } = useTeams(teamQuery);
@@ -176,8 +187,10 @@ export default function CreateIssueForm(props: CreateIssueFormProps) {
             links: "",
           });
 
-          if (hasMoreThanOneTeam && autofocusField) {
-            focus(autofocusField);
+          if (workspaceAutofocusActive) {
+            // The workspace field already carries autoFocus; focus() cannot target it.
+          } else if (hasMoreThanOneTeam && effectiveAutofocusField) {
+            focus(effectiveAutofocusField);
           } else {
             focus("title");
           }
@@ -257,14 +270,164 @@ export default function CreateIssueForm(props: CreateIssueFormProps) {
     },
   });
 
+  type StoredIssueDefaults = Partial<
+    Pick<CreateIssueValues, "teamId" | "stateId" | "priority" | "assigneeId" | "cycleId" | "projectId" | "milestoneId">
+  >;
+  const [storedDefaults, setStoredDefaults] = useWorkspaceCachedState<StoredIssueDefaults>("create-issue-defaults", {});
+  const restoredRef = useRef(false);
+
+  // Persist selections per workspace (replaces the old Form.Dropdown persistence prop,
+  // §4.5/B6). PER-FIELD READINESS
+  // semantics: a field's current value (INCLUDING an intentional empty like Unassigned /
+  // No Cycle / No Project) is written back only once that field's restore has completed —
+  // dependent option lists load at different times, and their fields are transiently
+  // empty until then; writing before readiness would clobber stored defaults, while
+  // truthy-only merging would make cleared choices resurrect on the next launch.
+  const readyFieldsRef = useRef<Set<keyof StoredIssueDefaults>>(new Set());
+
+  useEffect(() => {
+    if (!restoredRef.current) return;
+    const ready = readyFieldsRef.current;
+    setStoredDefaults({
+      ...storedDefaults,
+      ...(ready.has("teamId") ? { teamId: values.teamId } : {}),
+      ...(ready.has("stateId") ? { stateId: values.stateId } : {}),
+      ...(ready.has("priority") ? { priority: values.priority } : {}),
+      ...(ready.has("assigneeId") ? { assigneeId: values.assigneeId } : {}),
+      ...(ready.has("cycleId") ? { cycleId: values.cycleId } : {}),
+      ...(ready.has("projectId") ? { projectId: values.projectId } : {}),
+      ...(ready.has("milestoneId") ? { milestoneId: values.milestoneId } : {}),
+    });
+    // storedDefaults is deliberately omitted from deps: it's only read here (via the
+    // spread above) to preserve fields not yet ready, and including it would loop this
+    // effect against its own setStoredDefaults call.
+  }, [
+    values.teamId,
+    values.stateId,
+    values.priority,
+    values.assigneeId,
+    values.cycleId,
+    values.projectId,
+    values.milestoneId,
+  ]);
+
+  // Restore once per mount, validated against THIS workspace's data; a draft wins over restore.
+  // Priority is intentionally NOT restored here: setting teamId below triggers the
+  // template-reset effect further down (applyTemplate("") on team change), which would
+  // wipe priority straight back to "" on the very next commit. Priority (and assigneeId)
+  // are instead restored by the effect declared AFTER that reset effect, which re-applies
+  // them once the reset has already happened — see the comment there.
+  useEffect(() => {
+    if (restoredRef.current || isLoadingTeams || !teams) return;
+    restoredRef.current = true;
+    // A draft launch marks NOTHING ready (I4): the persist effect above only writes
+    // fields in readyFieldsRef, so leaving it unset here keeps a draft launch from ever
+    // clobbering the remembered per-workspace defaults. teamId also only restores when
+    // no explicit teamId prop was passed (I5) — pushed forms like SubIssues supply real
+    // context that a stale stored default must not override.
+    if (!props.draftValues) {
+      if (!props.teamId && storedDefaults.teamId && teams.some((team) => team.id === storedDefaults.teamId)) {
+        setValue("teamId", storedDefaults.teamId);
+      }
+      // stateId/assigneeId/cycleId/projectId/milestoneId are validated by their own data
+      // hooks' option lists as they load; setValue only when the id exists there:
+      readyFieldsRef.current.add("teamId");
+    }
+    // Deliberately scoped to [isLoadingTeams, teams]: this restore runs once per mount
+    // (guarded by restoredRef above), so props.draftValues/storedDefaults changing later
+    // must not re-trigger it.
+  }, [isLoadingTeams, teams]);
+
   const execute = !!values.teamId && values.teamId.trim().length > 0;
   const { issueTemplates, isLoadingIssueTemplates } = useIssueTemplates(values.teamId, { execute });
-  const { states } = useStates(values.teamId, { execute });
+  const { states, isLoadingStates } = useStates(values.teamId, { execute });
   const { labels } = useLabels(values.teamId, { execute });
-  const { cycles } = useCycles(values.teamId, { execute });
+  const { cycles, isLoadingCycles } = useCycles(values.teamId, { execute });
   const { issues } = useIssues(getLastCreatedIssues, [], { execute });
-  const { projects } = useProjects(values.teamId, { execute });
-  const { milestones } = useMilestones(values.projectId, { execute: !!values.projectId });
+  const { projects, isLoadingProjects } = useProjects(values.teamId, { execute });
+  const { milestones, isLoadingMilestones } = useMilestones(values.projectId, { execute: !!values.projectId });
+
+  // Team-dependent fields: each restores once its own option list has loaded, validated
+  // against THIS workspace's data (discard-on-restore, §4.5), then marks itself ready
+  // regardless of whether a value applied so the persist effect starts tracking it.
+  useEffect(() => {
+    if (readyFieldsRef.current.has("stateId") || !execute || isLoadingStates) return;
+    // Draft launches mark nothing ready (I4) — see the teamId restore effect above.
+    if (!props.draftValues) {
+      if (storedDefaults.stateId && states?.some((state) => state.id === storedDefaults.stateId)) {
+        setValue("stateId", storedDefaults.stateId);
+      }
+      readyFieldsRef.current.add("stateId");
+    }
+    // Deliberately scoped: guarded by readyFieldsRef.has("stateId") above, so this only
+    // ever acts on the first load of this workspace's state list.
+  }, [execute, isLoadingStates, states]);
+
+  useEffect(() => {
+    if (readyFieldsRef.current.has("assigneeId") || isLoadingUsers) return;
+    // assigneeId only restores when no explicit assigneeId prop was passed (I5) —
+    // assigned-issues.tsx supplies real context that a stale stored default must not override.
+    if (
+      !props.draftValues &&
+      !props.assigneeId &&
+      storedDefaults.assigneeId &&
+      users?.some((user) => user.id === storedDefaults.assigneeId)
+    ) {
+      setValue("assigneeId", storedDefaults.assigneeId);
+    }
+    // Ready-marking for assigneeId is owned by the post-template-reset effect declared
+    // after applyTemplate below (it re-applies assigneeId once a team change's reset has
+    // happened, then marks ready) — this effect only provides an early, best-effort
+    // restore for when the user list resolves before that reset happens.
+  }, [isLoadingUsers, users]);
+
+  useEffect(() => {
+    if (readyFieldsRef.current.has("cycleId") || isLoadingCycles) return;
+    // Draft launches mark nothing ready (I4); cycleId only restores when no explicit
+    // cycleId prop was passed (I5) — SubIssues/active-cycle supply real context that a
+    // stale stored default must not override.
+    if (!props.draftValues) {
+      if (!props.cycleId && storedDefaults.cycleId && cycles?.some((cycle) => cycle.id === storedDefaults.cycleId)) {
+        setValue("cycleId", storedDefaults.cycleId);
+      }
+      readyFieldsRef.current.add("cycleId");
+    }
+    // Deliberately scoped: guarded by readyFieldsRef.has("cycleId") above, so this only
+    // ever acts on the first load of this team's cycle list.
+  }, [isLoadingCycles, cycles]);
+
+  useEffect(() => {
+    if (readyFieldsRef.current.has("projectId") || isLoadingProjects) return;
+    // Draft launches mark nothing ready (I4); projectId only restores when no explicit
+    // projectId prop was passed (I5) — SubIssues/ProjectIssues supply real context that a
+    // stale stored default must not override.
+    if (!props.draftValues) {
+      if (
+        !props.projectId &&
+        storedDefaults.projectId &&
+        projects?.some((project) => project.id === storedDefaults.projectId)
+      ) {
+        setValue("projectId", storedDefaults.projectId);
+      }
+      readyFieldsRef.current.add("projectId");
+    }
+    // Deliberately scoped: guarded by readyFieldsRef.has("projectId") above, so this
+    // only ever acts on the first load of this team's project list.
+  }, [isLoadingProjects, projects]);
+
+  useEffect(() => {
+    if (readyFieldsRef.current.has("milestoneId") || isLoadingMilestones) return;
+    // Draft launches mark nothing ready (I4) — see the teamId restore effect above.
+    // No caller currently passes a milestoneId prop, so no I5 prop-guard is needed here.
+    if (!props.draftValues) {
+      if (storedDefaults.milestoneId && milestones?.some((milestone) => milestone.id === storedDefaults.milestoneId)) {
+        setValue("milestoneId", storedDefaults.milestoneId);
+      }
+      readyFieldsRef.current.add("milestoneId");
+    }
+    // Deliberately scoped: guarded by readyFieldsRef.has("milestoneId") above, so this
+    // only ever acts on the first load of this project's milestone list.
+  }, [isLoadingMilestones, milestones]);
 
   useEffect(() => {
     if (teams?.length === 1) {
@@ -279,6 +442,26 @@ export default function CreateIssueForm(props: CreateIssueFormProps) {
       return;
     }
     applyTemplate("");
+  }, [values.teamId]);
+
+  // Declared after the template effect on purpose: a team change resets the dependent
+  // fields via applyTemplate(""), so the workspace's remembered defaults for the wiped
+  // fields are re-applied here — and only marked ready once this has run.
+  useEffect(() => {
+    if (!restoredRef.current || props.draftValues) return;
+    if (storedDefaults.priority) setValue("priority", storedDefaults.priority);
+    // assigneeId only restores when no explicit assigneeId prop was passed (I5).
+    if (
+      !props.assigneeId &&
+      storedDefaults.assigneeId &&
+      users?.some((user) => user.id === storedDefaults.assigneeId)
+    ) {
+      setValue("assigneeId", storedDefaults.assigneeId);
+    }
+    readyFieldsRef.current.add("priority");
+    readyFieldsRef.current.add("assigneeId");
+    // Deliberate deps: fires when the restored/changed team lands; storedDefaults/users
+    // are read via the render closure.
   }, [values.teamId]);
 
   function applyTemplate(templateId: string) {
@@ -462,11 +645,12 @@ export default function CreateIssueForm(props: CreateIssueFormProps) {
       }
       isLoading={isLoadingTeams || isLoadingUsers || props.isLoading}
     >
+      <WorkspaceFormDropdown autoFocus={workspaceAutofocusActive} />
+
       {(supportsTeamTypeahead || hasMoreThanOneTeam) && (
         <>
           <Form.Dropdown
             title="Team"
-            storeValue
             {...itemProps.teamId}
             {...(supportsTeamTypeahead && {
               onSearchTextChange: setTeamQuery,
@@ -514,7 +698,7 @@ export default function CreateIssueForm(props: CreateIssueFormProps) {
         {...itemProps.description}
       />
 
-      <Form.Dropdown title="Status" storeValue {...itemProps.stateId}>
+      <Form.Dropdown title="Status" {...itemProps.stateId}>
         {hasStates
           ? orderedStates.map((state) => {
               return (
@@ -524,7 +708,7 @@ export default function CreateIssueForm(props: CreateIssueFormProps) {
           : null}
       </Form.Dropdown>
 
-      <Form.Dropdown title="Priority" storeValue {...itemProps.priority}>
+      <Form.Dropdown title="Priority" {...itemProps.priority}>
         {hasPriorities
           ? props.priorities?.map(({ priority, label }) => {
               return (
@@ -541,7 +725,6 @@ export default function CreateIssueForm(props: CreateIssueFormProps) {
 
       <Form.Dropdown
         title="Assignee"
-        storeValue
         {...itemProps.assigneeId}
         {...(supportsUserTypeahead && { onSearchTextChange: setUserQuery, isLoading: isLoadingUsers, throttle: true })}
       >
@@ -586,7 +769,7 @@ export default function CreateIssueForm(props: CreateIssueFormProps) {
       {hasCycles || hasProjects || hasIssues ? <Form.Separator /> : null}
 
       {hasCycles ? (
-        <Form.Dropdown title="Cycle" storeValue {...itemProps.cycleId}>
+        <Form.Dropdown title="Cycle" {...itemProps.cycleId}>
           <Form.Dropdown.Item
             title="No Cycle"
             value=""
@@ -602,7 +785,7 @@ export default function CreateIssueForm(props: CreateIssueFormProps) {
       ) : null}
 
       {hasProjects ? (
-        <Form.Dropdown title="Project" storeValue {...itemProps.projectId}>
+        <Form.Dropdown title="Project" {...itemProps.projectId}>
           <Form.Dropdown.Item
             title="No Project"
             value=""
@@ -623,7 +806,7 @@ export default function CreateIssueForm(props: CreateIssueFormProps) {
       ) : null}
 
       {hasMilestones ? (
-        <Form.Dropdown title="Milestone" storeValue {...itemProps.milestoneId}>
+        <Form.Dropdown title="Milestone" {...itemProps.milestoneId}>
           <Form.Dropdown.Item title="No Milestone" value="" icon={{ source: "linear-icons/no-milestone.svg" }} />
 
           {milestones.map((milestone) => {

--- a/extensions/linear/src/components/CreateMilestoneForm.tsx
+++ b/extensions/linear/src/components/CreateMilestoneForm.tsx
@@ -1,10 +1,12 @@
 import { Action, ActionPanel, Form, Toast, showToast, useNavigation } from "@raycast/api";
 import { useForm, FormValidation } from "@raycast/utils";
+import { useEffect, useRef } from "react";
 
 import { getLinearClient } from "../api/linearClient";
 import { getErrorMessage } from "../helpers/errors";
 import { getProjectIcon } from "../helpers/projects";
 import useProjects from "../hooks/useProjects";
+import { useWorkspaceCachedState } from "../hooks/useWorkspaceCachedState";
 
 export type CreateMilestoneValues = {
   projectId: string;
@@ -19,7 +21,7 @@ export default function CreateMilestoneForm({ projectId }: { projectId?: string 
 
   const { projects, isLoadingProjects } = useProjects();
 
-  const { handleSubmit, itemProps, focus, reset } = useForm<CreateMilestoneValues>({
+  const { handleSubmit, itemProps, values, setValue, focus, reset } = useForm<CreateMilestoneValues>({
     async onSubmit(values) {
       const toast = await showToast({ style: Toast.Style.Animated, title: "Creating Milestone" });
 
@@ -63,6 +65,27 @@ export default function CreateMilestoneForm({ projectId }: { projectId?: string 
     },
   });
 
+  const [storedProject, setStoredProject] = useWorkspaceCachedState<string>("create-milestone-project", "");
+  const restoredRef = useRef(false);
+
+  // Persist the Project selection per workspace (replaces the old Form.Dropdown
+  // persistence prop, §4.5/B6). This dropdown has no "no project" option, so an empty
+  // value is never an intentional choice — only non-empty values are worth remembering.
+  useEffect(() => {
+    if (!restoredRef.current) return;
+    if (values.projectId) setStoredProject(values.projectId);
+  }, [values.projectId]);
+
+  // Restore once per mount, validated against THIS workspace's data; an explicit
+  // projectId prop (e.g. opened from a project's context) wins over the stored default.
+  useEffect(() => {
+    if (restoredRef.current || isLoadingProjects || !projects) return;
+    restoredRef.current = true;
+    if (!projectId && storedProject && projects.some((project) => project.id === storedProject)) {
+      setValue("projectId", storedProject);
+    }
+  }, [isLoadingProjects, projects]);
+
   return (
     <Form
       isLoading={isLoadingProjects}
@@ -72,7 +95,7 @@ export default function CreateMilestoneForm({ projectId }: { projectId?: string 
         </ActionPanel>
       }
     >
-      <Form.Dropdown title="Project" storeValue {...itemProps.projectId}>
+      <Form.Dropdown title="Project" {...itemProps.projectId}>
         {projects?.map((project) => (
           <Form.Dropdown.Item value={project.id} key={project.id} title={project.name} icon={getProjectIcon(project)} />
         ))}

--- a/extensions/linear/src/components/CreateProjectForm.tsx
+++ b/extensions/linear/src/components/CreateProjectForm.tsx
@@ -1,6 +1,6 @@
 import { Action, ActionPanel, Form, Icon, open, Toast, showToast, Keyboard } from "@raycast/api";
 import { useForm, FormValidation } from "@raycast/utils";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { getLinearClient } from "../api/linearClient";
 import { getErrorMessage } from "../helpers/errors";
@@ -11,8 +11,12 @@ import { getUserIcon } from "../helpers/users";
 import useProjectStatuses from "../hooks/useProjectStatuses";
 import useTeams from "../hooks/useTeams";
 import useUsers from "../hooks/useUsers";
+import { useWorkspaceCachedState } from "../hooks/useWorkspaceCachedState";
+
+import { WorkspaceFormDropdown } from "./WorkspaceDropdown";
 
 export type CreateProjectValues = {
+  workspaceKey?: string;
   teamIds: string[];
   name: string;
   description: string;
@@ -23,7 +27,13 @@ export type CreateProjectValues = {
   statusId: string;
 };
 
-export default function CreateProjectForm({ draftValues }: { draftValues?: CreateProjectValues }) {
+export default function CreateProjectForm({
+  draftValues,
+  isLoading,
+}: {
+  draftValues?: CreateProjectValues;
+  isLoading?: boolean;
+}) {
   const { linearClient } = getLinearClient();
 
   const { teams, org, isLoadingTeams } = useTeams();
@@ -33,7 +43,7 @@ export default function CreateProjectForm({ draftValues }: { draftValues?: Creat
   const { users: leads, supportsUserTypeahead, isLoadingUsers: isLoadingLeads } = useUsers(leadQuery);
   const { states, isLoadingStates } = useProjectStatuses();
 
-  const { handleSubmit, itemProps, focus, reset } = useForm<CreateProjectValues>({
+  const { handleSubmit, itemProps, values, setValue, focus, reset } = useForm<CreateProjectValues>({
     async onSubmit(values) {
       const toast = await showToast({ style: Toast.Style.Animated, title: "Creating project" });
 
@@ -100,16 +110,72 @@ export default function CreateProjectForm({ draftValues }: { draftValues?: Creat
     },
   });
 
+  type StoredProjectDefaults = Partial<Pick<CreateProjectValues, "statusId" | "leadId">>;
+  const [storedDefaults, setStoredDefaults] = useWorkspaceCachedState<StoredProjectDefaults>(
+    "create-project-defaults",
+    {},
+  );
+  const restoredRef = useRef(false);
+  // PER-FIELD READINESS, same semantics as CreateIssueForm: a field's value is written
+  // back only once that field's own restore has completed (see that file for the full
+  // rationale).
+  const readyFieldsRef = useRef<Set<keyof StoredProjectDefaults>>(new Set());
+
+  useEffect(() => {
+    if (!restoredRef.current) return;
+    const ready = readyFieldsRef.current;
+    setStoredDefaults({
+      ...storedDefaults,
+      ...(ready.has("statusId") ? { statusId: values.statusId } : {}),
+      ...(ready.has("leadId") ? { leadId: values.leadId } : {}),
+    });
+    // storedDefaults intentionally omitted from deps: it's only read here (via the
+    // spread above) to preserve fields not yet ready, and including it would loop this
+    // effect against its own setStoredDefaults call.
+  }, [values.statusId, values.leadId]);
+
+  // Status and Lead load independently here (no team-dependency chain like
+  // CreateIssueForm), so each restores once its own option list has loaded, validated
+  // against THIS workspace's data (discard-on-restore, §4.5), then marks itself ready
+  // regardless of whether a value applied.
+  useEffect(() => {
+    if (readyFieldsRef.current.has("statusId") || isLoadingStates) return;
+    // Draft launches mark nothing ready (I4): the persist effect above only writes
+    // fields in readyFieldsRef, so leaving it unset here keeps a draft launch from ever
+    // clobbering the remembered per-workspace defaults.
+    if (!draftValues) {
+      if (storedDefaults.statusId && states?.some((status) => status.id === storedDefaults.statusId)) {
+        setValue("statusId", storedDefaults.statusId);
+      }
+      readyFieldsRef.current.add("statusId");
+    }
+    restoredRef.current = true;
+  }, [isLoadingStates, states]);
+
+  useEffect(() => {
+    if (readyFieldsRef.current.has("leadId") || isLoadingLeads) return;
+    // Draft launches mark nothing ready (I4) — see the statusId restore effect above.
+    if (!draftValues) {
+      if (storedDefaults.leadId && leads?.some((user) => user.id === storedDefaults.leadId)) {
+        setValue("leadId", storedDefaults.leadId);
+      }
+      readyFieldsRef.current.add("leadId");
+    }
+    restoredRef.current = true;
+  }, [isLoadingLeads, leads]);
+
   return (
     <Form
       enableDrafts
-      isLoading={isLoadingTeams || isLoadingUsers || isLoadingLeads || isLoadingStates}
+      isLoading={isLoadingTeams || isLoadingUsers || isLoadingLeads || isLoadingStates || isLoading}
       actions={
         <ActionPanel>
           <Action.SubmitForm title="Create Project" onSubmit={handleSubmit} />
         </ActionPanel>
       }
     >
+      <WorkspaceFormDropdown />
+
       <Form.TagPicker title="Team(s)" placeholder="Add team" {...itemProps.teamIds}>
         {teams?.map((team) => (
           <Form.TagPicker.Item key={team.id} value={team.id} title={team.name} icon={getTeamIcon(team, org)} />
@@ -128,7 +194,7 @@ export default function CreateProjectForm({ draftValues }: { draftValues?: Creat
 
       <Form.Separator />
 
-      <Form.Dropdown title="Status" storeValue {...itemProps.statusId}>
+      <Form.Dropdown title="Status" {...itemProps.statusId}>
         {states?.map((status) => (
           <Form.Dropdown.Item
             key={status.id}
@@ -141,7 +207,6 @@ export default function CreateProjectForm({ draftValues }: { draftValues?: Creat
 
       <Form.Dropdown
         title="Lead"
-        storeValue
         {...itemProps.leadId}
         {...(supportsUserTypeahead && { onSearchTextChange: setLeadQuery, throttle: true, isLoading: isLoadingLeads })}
       >

--- a/extensions/linear/src/components/EditIssueForm.tsx
+++ b/extensions/linear/src/components/EditIssueForm.tsx
@@ -296,7 +296,7 @@ export default function EditIssueForm(props: EditIssueFormProps) {
       ) : null}
 
       {hasMilestones ? (
-        <Form.Dropdown title="Milestone" storeValue {...itemProps.milestoneId}>
+        <Form.Dropdown title="Milestone" {...itemProps.milestoneId}>
           <Form.Dropdown.Item title="No Milestone" value="" icon={{ source: "linear-icons/no-milestone.svg" }} />
 
           {milestones.map((milestone) => {

--- a/extensions/linear/src/components/ProjectIssues.tsx
+++ b/extensions/linear/src/components/ProjectIssues.tsx
@@ -1,12 +1,12 @@
 import { IssuePriorityValue, User } from "@linear/sdk";
 import { Action, ActionPanel, List } from "@raycast/api";
-import { useCachedState } from "@raycast/utils";
 import { useMemo } from "react";
 
 import { getProjectIssues } from "../api/getIssues";
 import { getMilestoneIcon } from "../helpers/milestones";
 import useIssues from "../hooks/useIssues";
 import useMilestones from "../hooks/useMilestones";
+import { useWorkspaceCachedState } from "../hooks/useWorkspaceCachedState";
 
 import CreateIssueForm from "./CreateIssueForm";
 import StateIssueList from "./StateIssueList";
@@ -19,8 +19,8 @@ type ProjectIssuesProps = {
 };
 
 export default function ProjectIssues({ projectId, priorities, me }: ProjectIssuesProps) {
-  const { issues, isLoadingIssues, mutateList } = useIssues(getProjectIssues, [projectId]);
-  const [milestone, setMilestone] = useCachedState<string>("");
+  const { issues, isLoadingIssues, mutateList } = useIssues((id: string) => getProjectIssues(id), [projectId]);
+  const [milestone, setMilestone] = useWorkspaceCachedState<string>(`project-milestone-filter-${projectId}`, "");
   const { milestones } = useMilestones(projectId);
 
   const filteredIssues = useMemo(() => {

--- a/extensions/linear/src/components/ProjectList.tsx
+++ b/extensions/linear/src/components/ProjectList.tsx
@@ -7,11 +7,15 @@ import { useInitiatives } from "../hooks/useInitiatives";
 import useMe from "../hooks/useMe";
 import usePriorities from "../hooks/usePriorities";
 import useProjects from "../hooks/useProjects";
+import { useWorkspaceCachedState } from "../hooks/useWorkspaceCachedState";
 
 import Project from "./Project";
+import { useWorkspaces } from "./WorkspaceContext";
+import { isWorkspaceDropdownValue, workspaceValueToKey, WorkspaceDropdownSection } from "./WorkspaceDropdown";
 
 export default function ProjectList() {
-  const [initiativeId, setInitiativeId] = useState<string>("");
+  const { showSwitcher, switchWorkspace } = useWorkspaces();
+  const [storedInitiative, setStoredInitiative] = useWorkspaceCachedState<string>("project-list-initiative", "");
   const [searchText, setSearchText] = useState<string>("");
   const { projects, isLoadingProjects, mutateProjects, pagination } = useProjects(undefined, {
     searchText,
@@ -20,6 +24,8 @@ export default function ProjectList() {
   const { initiatives, isLoadingInitiatives } = useInitiatives();
   const { priorities, isLoadingPriorities } = usePriorities();
   const { me, isLoadingMe } = useMe();
+
+  const initiativeId = (initiatives ?? []).some((i) => i.id === storedInitiative) ? storedInitiative : "";
 
   const filteredProjects = useMemo(() => {
     if (!projects) {
@@ -48,22 +54,35 @@ export default function ProjectList() {
   return (
     <List
       isLoading={isLoadingProjects || isLoadingInitiatives || isLoadingPriorities || isLoadingMe}
-      {...((initiatives ?? []).length > 0
+      {...((initiatives ?? []).length > 0 || showSwitcher
         ? {
             searchBarAccessory: (
-              <List.Dropdown tooltip="Change Initiative" onChange={setInitiativeId} storeValue>
+              <List.Dropdown
+                tooltip="Change Initiative"
+                value={initiativeId}
+                onChange={(value) => {
+                  if (isWorkspaceDropdownValue(value)) {
+                    switchWorkspace(workspaceValueToKey(value));
+                    return;
+                  }
+                  if (value !== initiativeId) setStoredInitiative(value);
+                }}
+              >
+                <WorkspaceDropdownSection />
                 <List.Dropdown.Item value="" title="All Projects" />
 
-                <List.Dropdown.Section title="Initiatives">
-                  {initiatives?.map((initiative) => (
-                    <List.Dropdown.Item
-                      key={initiative.id}
-                      value={initiative.id}
-                      title={initiative.name}
-                      icon={getInitiativeIcon(initiative)}
-                    />
-                  ))}
-                </List.Dropdown.Section>
+                {(initiatives ?? []).length > 0 && (
+                  <List.Dropdown.Section title="Initiatives">
+                    {initiatives?.map((initiative) => (
+                      <List.Dropdown.Item
+                        key={initiative.id}
+                        value={initiative.id}
+                        title={initiative.name}
+                        icon={getInitiativeIcon(initiative)}
+                      />
+                    ))}
+                  </List.Dropdown.Section>
+                )}
               </List.Dropdown>
             ),
           }

--- a/extensions/linear/src/components/View.tsx
+++ b/extensions/linear/src/components/View.tsx
@@ -1,9 +1,11 @@
 import { Action, ActionPanel, Detail } from "@raycast/api";
-import { withAccessToken } from "@raycast/utils";
 import React, { useEffect } from "react";
 
-import { linear } from "../api/linearClient";
+import { bootstrapWorkspaceAuth, clearActiveWorkspaceTokens, getWorkspaceSnapshot } from "../api/linearClient";
+import { withWorkspaceAuth } from "../api/withWorkspaceAuth";
 import { checkLinearApp } from "../helpers/isLinearInstalled";
+
+import { WorkspaceProvider } from "./WorkspaceContext";
 
 /**
  * Makes sure that we have a authenticated linear client available in the children
@@ -13,7 +15,7 @@ function View({ children }: { children: React.ReactNode }) {
     checkLinearApp();
   }, []);
 
-  return children;
+  return <WorkspaceProvider>{children}</WorkspaceProvider>;
 }
 
 interface AuthErrorBoundaryState {
@@ -49,18 +51,26 @@ class AuthErrorBoundary extends React.Component<{ children: React.ReactNode }, A
     // and let everything else surface normally.
     if (!isAuthError) throw error;
 
+    const failedWorkspaceName = getWorkspaceSnapshot()?.activeEntry?.orgName;
+
     return (
       <Detail
-        markdown={`# Sign In Failed\n\nFailed to authenticate with Linear:\n\`\`\`\n${error.message}\n\`\`\`\n\nThis can happen when the network is unreliable or the authorization code has expired. Please try signing in again.`}
+        markdown={`# Sign In Failed${failedWorkspaceName ? ` — ${failedWorkspaceName}` : ""}\n\nFailed to authenticate with Linear:\n\`\`\`\n${error.message}\n\`\`\`\n\nThis can happen when the network is unreliable or the authorization code has expired. Please try signing in again.`}
         actions={
           <ActionPanel>
             <Action
               title="Sign in Again"
               onAction={async () => {
-                await linear.client.removeTokens();
-                this.setState({ error: null });
+                await clearActiveWorkspaceTokens();
+                try {
+                  await bootstrapWorkspaceAuth(); // fresh interactive flow, identity-verified (ensureEntryToken)
+                  this.setState({ error: null });
+                } catch (error) {
+                  this.setState({ error: error instanceof Error ? error : new Error(String(error)) });
+                }
               }}
             />
+            <Action.Open title="Manage Workspaces" target="raycast://extensions/linear/linear/manage-workspaces" />
           </ActionPanel>
         }
       />
@@ -68,7 +78,7 @@ class AuthErrorBoundary extends React.Component<{ children: React.ReactNode }, A
   }
 }
 
-const AuthenticatedView = withAccessToken(linear)(View);
+const AuthenticatedView = withWorkspaceAuth(View);
 
 export default function ViewWithErrorBoundary({ children }: { children: React.ReactNode }) {
   return (

--- a/extensions/linear/src/components/WorkspaceContext.tsx
+++ b/extensions/linear/src/components/WorkspaceContext.tsx
@@ -1,0 +1,110 @@
+import { showToast, Toast } from "@raycast/api";
+import { createContext, ReactNode, useContext, useMemo, useState } from "react";
+
+import { activateWorkspace, activateWorkspaceInMemory, getWorkspaceSnapshot } from "../api/linearClient";
+import { entryKey, WorkspaceEntry } from "../api/workspaces";
+
+type WorkspaceContextValue = {
+  entries: WorkspaceEntry[];
+  activeEntry: WorkspaceEntry | null;
+  workspaceKey: string;
+  showSwitcher: boolean;
+  // Entry keys currently lacking tokens (from the bootstrap snapshot, §4.2) — dropdowns
+  // badge these rows so a dead workspace is visible from ordinary command UI.
+  needsReauth: string[];
+  switchWorkspace: (key: string) => Promise<void>;
+  // Pins THIS process to a workspace without persisting a new global default (D2/D7).
+  pinWorkspace: (key: string) => Promise<void>;
+};
+
+const WorkspaceContext = createContext<WorkspaceContextValue | null>(null);
+
+export function WorkspaceProvider({ children }: { children: ReactNode }) {
+  const snapshot = getWorkspaceSnapshot();
+  const [activeEntry, setActiveEntryState] = useState<WorkspaceEntry | null>(snapshot?.activeEntry ?? null);
+  const entries = snapshot?.registry.workspaces ?? [];
+
+  const value = useMemo<WorkspaceContextValue>(() => {
+    const workspaceKey = activeEntry ? entryKey(activeEntry) : "single";
+    return {
+      entries,
+      activeEntry,
+      workspaceKey,
+      showSwitcher: entries.length >= 2, // invisible below 2 entries (spec §5)
+      needsReauth: snapshot?.needsReauth ?? [],
+      async switchWorkspace(key: string) {
+        // S9 guard: controlled dropdowns still report their current value on mount;
+        // a no-op selection must never trigger a switch.
+        if (!activeEntry || key === entryKey(activeEntry)) return;
+        const target = entries.find((w) => entryKey(w) === key);
+        if (!target) return;
+        try {
+          const entry = await activateWorkspace({ orgId: target.orgId, userId: target.userId });
+          setActiveEntryState(entry);
+        } catch (error) {
+          await showToast({
+            style: Toast.Style.Failure,
+            title: `Could not switch to ${target.orgName}`,
+            message: error instanceof Error ? error.message : String(error),
+          });
+        }
+      },
+      async pinWorkspace(key: string) {
+        if (!activeEntry || key === entryKey(activeEntry)) return;
+        const target = entries.find((w) => entryKey(w) === key);
+        if (!target) return;
+        const entry = await activateWorkspaceInMemory({ orgId: target.orgId, userId: target.userId });
+        setActiveEntryState(entry); // context + remount boundary follow; registry default untouched
+      },
+    };
+    // Deliberate deps: entries identity is tracked via the joined key string, not the
+    // array reference (the snapshot array is re-derived each render).
+  }, [activeEntry, entries.map(entryKey).join("|")]);
+
+  // Remount boundary (§4.5): the whole command subtree remounts on switch, so
+  // keepPreviousData caches and pushed detail views (WS-30) can never render the
+  // previous workspace's data under the new selection.
+  return (
+    <WorkspaceContext.Provider value={value}>
+      <WorkspaceBoundary>{children}</WorkspaceBoundary>
+    </WorkspaceContext.Provider>
+  );
+}
+
+function WorkspaceBoundary({ children }: { children: ReactNode }) {
+  const { workspaceKey } = useWorkspaces();
+  return <ItemWithKey key={workspaceKey}>{children}</ItemWithKey>;
+}
+
+function ItemWithKey({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}
+
+async function noSwitchHere() {
+  // Pushed views are pinned to their launch workspace (design D2); switching only
+  // happens at command roots where the provider's remount boundary exists.
+}
+
+// CRITICAL: Raycast's useNavigation().push / Action.Push mounts the target in a FRESH
+// React tree — ancestor contexts do NOT reach pushed views (see the in-repo precedent:
+// extensions/bitwarden re-provides its contexts around every pushed component). Since
+// the 20 data hooks and useWorkspaceCachedState all call useWorkspaces(), throwing
+// outside the provider would crash every pushed screen (IssueDetail, ProjectIssues,
+// pushed CreateIssueForm, …) — even for single-workspace users. Outside the provider we
+// therefore fall back to the module-level snapshot (same process, so it is always set
+// by the time anything renders); switching stays provider-only.
+export function useWorkspaces(): WorkspaceContextValue {
+  const ctx = useContext(WorkspaceContext);
+  if (ctx) return ctx;
+  const snapshot = getWorkspaceSnapshot();
+  const activeEntry = snapshot?.activeEntry ?? null;
+  return {
+    entries: snapshot?.registry.workspaces ?? [],
+    activeEntry,
+    workspaceKey: activeEntry ? entryKey(activeEntry) : "single",
+    showSwitcher: false, // pushed views never render a switcher — they are pinned flows
+    needsReauth: snapshot?.needsReauth ?? [],
+    switchWorkspace: noSwitchHere,
+    pinWorkspace: noSwitchHere,
+  };
+}

--- a/extensions/linear/src/components/WorkspaceDropdown.tsx
+++ b/extensions/linear/src/components/WorkspaceDropdown.tsx
@@ -1,0 +1,98 @@
+import { Form, Image, List } from "@raycast/api";
+
+import { entryKey, WorkspaceEntry } from "../api/workspaces";
+
+import { useWorkspaces } from "./WorkspaceContext";
+
+function entryTitle(entry: WorkspaceEntry, entries: WorkspaceEntry[], needsReauth: string[]): string {
+  // Two entries can share an orgName/orgId across accounts (D10) — disambiguate with the email.
+  const duplicated = entries.filter((w) => w.orgId === entry.orgId).length > 1;
+  const base = duplicated ? `${entry.orgName} (${entry.userEmail})` : entry.orgName;
+  // §4.2: a token-less entry is visible as needing re-auth from ordinary command UI too.
+  return needsReauth.includes(entryKey(entry)) ? `${base} — needs re-authentication` : base;
+}
+
+const workspaceIcon: Image.ImageLike = "linear-app-icon.png";
+
+// P1: sole searchBarAccessory for list commands with a free search bar.
+export function WorkspaceListDropdown() {
+  const { entries, activeEntry, showSwitcher, needsReauth, switchWorkspace } = useWorkspaces();
+  if (!showSwitcher || !activeEntry) return null;
+  return (
+    <List.Dropdown tooltip="Change Workspace (⌘P)" value={entryKey(activeEntry)} onChange={switchWorkspace}>
+      {entries.map((w) => (
+        <List.Dropdown.Item
+          key={entryKey(w)}
+          value={entryKey(w)}
+          title={entryTitle(w, entries, needsReauth)}
+          icon={workspaceIcon}
+        />
+      ))}
+    </List.Dropdown>
+  );
+}
+
+// P1b: prepended section inside an EXISTING dropdown; values namespaced "ws:" so they
+// can never collide with the host dropdown's own values (DocumentList precedent).
+export const WORKSPACE_VALUE_PREFIX = "ws:";
+
+export function isWorkspaceDropdownValue(value: string): boolean {
+  return value.startsWith(WORKSPACE_VALUE_PREFIX);
+}
+
+export function workspaceValueToKey(value: string): string {
+  return value.slice(WORKSPACE_VALUE_PREFIX.length);
+}
+
+export function WorkspaceDropdownSection() {
+  const { entries, activeEntry, showSwitcher, needsReauth } = useWorkspaces();
+  if (!showSwitcher) return null;
+  return (
+    <List.Dropdown.Section title="Workspace">
+      {entries.map((w) => {
+        // S9-safe: selecting the current row still routes through switchWorkspace, which
+        // no-ops when the key already matches the active entry.
+        const isCurrent = activeEntry !== null && entryKey(w) === entryKey(activeEntry);
+        return (
+          <List.Dropdown.Item
+            key={`${WORKSPACE_VALUE_PREFIX}${entryKey(w)}`}
+            value={`${WORKSPACE_VALUE_PREFIX}${entryKey(w)}`}
+            title={
+              isCurrent
+                ? `✓ ${entryTitle(w, entries, needsReauth)} — current`
+                : `Switch to ${entryTitle(w, entries, needsReauth)}`
+            }
+            icon={workspaceIcon}
+          />
+        );
+      })}
+    </List.Dropdown.Section>
+  );
+}
+
+// P2: first form field, above Team. Changing it sets the global default and the form
+// resets downstream fields (the remount boundary in WorkspaceProvider does the reset).
+// The item id is "workspaceKey" so Raycast drafts capture the value under
+// draftValues.workspaceKey (D7) — the field is controlled from context, not useForm.
+export function WorkspaceFormDropdown(props: { autoFocus?: boolean }) {
+  const { entries, activeEntry, showSwitcher, needsReauth, switchWorkspace } = useWorkspaces();
+  if (!showSwitcher || !activeEntry) return null;
+  return (
+    <Form.Dropdown
+      id="workspaceKey"
+      title="Workspace"
+      value={entryKey(activeEntry)}
+      onChange={switchWorkspace}
+      autoFocus={props.autoFocus}
+    >
+      {entries.map((w) => (
+        <Form.Dropdown.Item
+          key={entryKey(w)}
+          value={entryKey(w)}
+          title={entryTitle(w, entries, needsReauth)}
+          icon={workspaceIcon}
+        />
+      ))}
+    </Form.Dropdown>
+  );
+}

--- a/extensions/linear/src/components/docs/DocumentList.tsx
+++ b/extensions/linear/src/components/docs/DocumentList.tsx
@@ -7,7 +7,10 @@ import { getProjectIcon } from "../../helpers/projects";
 import { useDocuments } from "../../hooks/useDocuments";
 import { useInitiatives } from "../../hooks/useInitiatives";
 import useProjects from "../../hooks/useProjects";
+import { useWorkspaceCachedState } from "../../hooks/useWorkspaceCachedState";
 import { DocumentEntity } from "../../tools/get-documents";
+import { useWorkspaces } from "../WorkspaceContext";
+import { isWorkspaceDropdownValue, workspaceValueToKey, WorkspaceDropdownSection } from "../WorkspaceDropdown";
 
 import { Document } from "./Document";
 
@@ -17,10 +20,33 @@ type DocumentListProps = {
 
 export function DocumentList({ project }: DocumentListProps) {
   const [query, setQuery] = useState<string>("");
-  const [entity, setEntity] = useState<DocumentEntity>({ projectId: "" });
+  const { showSwitcher, switchWorkspace } = useWorkspaces();
+  const [storedEntity, setStoredEntity] = useWorkspaceCachedState<string>("document-list-entity", "");
 
   const { projects, isLoadingProjects } = useProjects();
   const { initiatives, isLoadingInitiatives } = useInitiatives();
+
+  // Restore validation: the stored value is used only if its id still exists in the
+  // loaded initiatives/projects — otherwise "" (All Documents). A pushed "Project
+  // Documents" view (`project` set) never reads persisted state — it stays pinned to
+  // its launch project, the dropdown isn't even rendered for it.
+  const validatedEntityValue = useMemo(() => {
+    if (project) return "";
+    if (storedEntity.startsWith("initiative:")) {
+      const id = storedEntity.replace("initiative:", "");
+      return (initiatives ?? []).some((initiative) => initiative.id === id) ? storedEntity : "";
+    }
+    if (storedEntity.startsWith("project:")) {
+      const id = storedEntity.replace("project:", "");
+      return (projects ?? []).some((p) => p.id === id) ? storedEntity : "";
+    }
+    return "";
+  }, [project, storedEntity, initiatives, projects]);
+
+  const entity: DocumentEntity = validatedEntityValue.startsWith("initiative:")
+    ? { initiativeId: validatedEntityValue.replace("initiative:", "") }
+    : { projectId: validatedEntityValue.replace("project:", "") };
+
   const { docs, isLoadingDocs, supportsDocTypeahead, mutateDocs } = useDocuments(query, entity);
 
   const filteredDocs = useMemo(() => {
@@ -50,19 +76,21 @@ export function DocumentList({ project }: DocumentListProps) {
     <List
       isLoading={isLoadingProjects || isLoadingDocs || isLoadingInitiatives}
       navigationTitle={project ? `${project.name} Documents` : undefined}
-      {...(!project && ((projects ?? []).length > 0 || (initiatives ?? []).length > 0)
+      {...(!project && ((projects ?? []).length > 0 || (initiatives ?? []).length > 0 || showSwitcher)
         ? {
             searchBarAccessory: (
               <List.Dropdown
                 tooltip="Change Entity"
+                value={validatedEntityValue}
                 onChange={(newValue) => {
-                  const entity: DocumentEntity = newValue.startsWith("initiative:")
-                    ? { initiativeId: newValue.replace("initiative:", "") }
-                    : { projectId: newValue.replace("project:", "") };
-                  setEntity(entity);
+                  if (isWorkspaceDropdownValue(newValue)) {
+                    switchWorkspace(workspaceValueToKey(newValue));
+                    return;
+                  }
+                  if (newValue !== validatedEntityValue) setStoredEntity(newValue);
                 }}
-                storeValue
               >
+                <WorkspaceDropdownSection />
                 <List.Dropdown.Item value="" title="All Documents" />
 
                 {(initiatives ?? []).length > 0 && (

--- a/extensions/linear/src/create-issue-for-myself-in-workspace.ts
+++ b/extensions/linear/src/create-issue-for-myself-in-workspace.ts
@@ -1,0 +1,41 @@
+import { getPreferenceValues, Toast, showToast } from "@raycast/api";
+
+import { withWorkspaceAuth } from "./api/withWorkspaceAuth";
+import { createIssueForMyself } from "./helpers/createIssueForMyself";
+import { resolveWorkspaceArgument, updateWorkspaceChoicesSubtitle } from "./helpers/workspaceArgument";
+
+const command = async (props: {
+  arguments: Arguments.CreateIssueForMyselfInWorkspace;
+  launchContext?: { refreshSubtitle?: boolean };
+}) => {
+  await updateWorkspaceChoicesSubtitle(); // awaited: the no-view process exits when the command resolves — a fire-and-forget write would be killed
+
+  if (props.launchContext?.refreshSubtitle) {
+    return; // background refresh launch — subtitle updated above, do nothing else
+  }
+
+  if (!props.arguments.workspace?.trim()) {
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "Workspace required",
+      message: "Name the target workspace (URL key, email, or unique name prefix).",
+    });
+    return;
+  }
+
+  const resolved = await resolveWorkspaceArgument(props.arguments.workspace);
+  if (!resolved.ok) {
+    await showToast({ style: Toast.Style.Failure, title: "Workspace not matched", message: resolved.message });
+    return;
+  }
+
+  const preferences = getPreferenceValues<Preferences.CreateIssueForMyselfInWorkspace>();
+
+  await createIssueForMyself(
+    { title: props.arguments.title, description: props.arguments.description },
+    preferences,
+    resolved.client,
+  );
+};
+
+export default withWorkspaceAuth(command);

--- a/extensions/linear/src/create-issue-for-myself.ts
+++ b/extensions/linear/src/create-issue-for-myself.ts
@@ -1,99 +1,26 @@
-import { Clipboard, closeMainWindow, getPreferenceValues, open, Toast, showToast, Keyboard } from "@raycast/api";
-import { withAccessToken } from "@raycast/utils";
+import { getPreferenceValues } from "@raycast/api";
 
-import { getTeams } from "./api/getTeams";
-import { getLinearClient, linear } from "./api/linearClient";
+import { withWorkspaceAuth } from "./api/withWorkspaceAuth";
+import { createIssueForMyself } from "./helpers/createIssueForMyself";
+import { updateActiveWorkspaceSubtitle } from "./helpers/workspaceArgument";
 
-const command = async (props: { arguments: Arguments.CreateIssueForMyself }) => {
-  const toast = await showToast({ style: Toast.Style.Animated, title: "Creating issue" });
+const command = async (props: {
+  arguments: Arguments.CreateIssueForMyself;
+  launchContext?: { refreshSubtitle?: boolean };
+}) => {
+  await updateActiveWorkspaceSubtitle(); // awaited: the no-view process exits when the command resolves — a fire-and-forget write would be killed
 
-  try {
-    const { linearClient } = getLinearClient();
-
-    const preferences = getPreferenceValues<Preferences.CreateIssueForMyself>();
-
-    if (preferences.shouldCloseMainWindow) {
-      await closeMainWindow();
-    }
-
-    const viewer = await linearClient.viewer;
-    const { teams } = await getTeams();
-
-    let teamId: string | undefined;
-
-    if (preferences.preferredTeamKey) {
-      const team = teams.find((t) => t.key === preferences.preferredTeamKey);
-      if (team) {
-        teamId = team.id;
-      }
-    }
-
-    if (!teamId) {
-      teamId = teams[0].id;
-    }
-
-    if (!teamId) {
-      throw Error("No team found");
-    }
-
-    let stateId: string | undefined;
-
-    if (preferences.preferredStatusName) {
-      const states = await linearClient.workflowStates({
-        filter: {
-          team: { id: { eq: teamId } },
-          name: { eq: preferences.preferredStatusName },
-        },
-      });
-
-      const state = states.nodes[0];
-
-      if (!state) {
-        throw Error(`Status "${preferences.preferredStatusName}" not found`);
-      }
-
-      stateId = state.id;
-    }
-
-    const payload = await linearClient.createIssue({
-      teamId: teamId,
-      title: props.arguments.title,
-      description: props.arguments.description,
-      assigneeId: viewer.id,
-      stateId: stateId,
-    });
-
-    const issue = await payload.issue;
-    if (!payload.success || !issue) {
-      throw Error("Something went wrong");
-    }
-
-    toast.style = Toast.Style.Success;
-    toast.title = `Created issue • ${issue.identifier}`;
-    toast.primaryAction = {
-      title: "Open Issue",
-      shortcut: Keyboard.Shortcut.Common.OpenWith,
-      onAction: async () => {
-        await open(issue.url);
-        await toast.hide();
-      },
-    };
-
-    toast.secondaryAction = {
-      title: "Copy Issue ID",
-      shortcut: Keyboard.Shortcut.Common.Copy,
-      onAction: () => Clipboard.copy(issue.identifier),
-    };
-  } catch (e) {
-    toast.style = Toast.Style.Failure;
-    toast.title = "Failed creating issue";
-    toast.message = e instanceof Error ? e.message : String(e);
-    toast.primaryAction = {
-      title: "Copy Error Log",
-      shortcut: Keyboard.Shortcut.Common.Copy,
-      onAction: () => Clipboard.copy(e instanceof Error ? (e.stack ?? e.message) : String(e)),
-    };
+  if (props.launchContext?.refreshSubtitle) {
+    return; // background refresh launch — subtitle updated above, do nothing else
   }
+
+  const preferences = getPreferenceValues<Preferences.CreateIssueForMyself>();
+
+  await createIssueForMyself(
+    { title: props.arguments.title, description: props.arguments.description },
+    preferences,
+    undefined,
+  );
 };
 
-export default withAccessToken(linear)(command);
+export default withWorkspaceAuth(command);

--- a/extensions/linear/src/create-issue.tsx
+++ b/extensions/linear/src/create-issue.tsx
@@ -1,15 +1,70 @@
+import { showToast, Toast } from "@raycast/api";
+import { useEffect, useState } from "react";
+
+import { entryKey } from "./api/workspaces";
 import CreateIssueForm, { CreateIssueValues } from "./components/CreateIssueForm";
 import View from "./components/View";
+import { useWorkspaces } from "./components/WorkspaceContext";
 import useMe from "./hooks/useMe";
 import usePriorities from "./hooks/usePriorities";
 
+// Module-scoped, not component state: the component sits inside the provider's
+// key={workspaceKey} remount boundary, so a user changing the Workspace field in a
+// draft-opened form remounts Form and would re-run a []-deps effect, re-pinning the
+// workspace back and showing a now-false "draft from another workspace" toast (I1).
+// Module state survives that remount and dies only with the process — draft pinning is
+// a launch-time decision, so "once per launch" is the correct scope, not "once per mount".
+let draftPinHandled = false;
+
 function Form({ draftValues }: { draftValues?: CreateIssueValues }) {
+  const { entries, activeEntry, pinWorkspace } = useWorkspaces();
+  const draftKey = draftValues?.workspaceKey;
+  const draftEntry = draftKey ? entries.find((w) => entryKey(w) === draftKey) : undefined;
+  const needsPin = Boolean(draftEntry && activeEntry && draftKey !== entryKey(activeEntry));
+  const [pinned, setPinned] = useState(!needsPin || draftPinHandled); // draftPinHandled: the launch-time pin already ran; later boundary remounts must not re-gate rendering
+
+  useEffect(() => {
+    if (draftPinHandled) return;
+    draftPinHandled = true;
+    (async () => {
+      if (needsPin && draftEntry) {
+        // Pin THIS process to the draft's workspace: field, hooks, and submission all
+        // target it; the global default stays untouched (D7 — field only, with a toast).
+        try {
+          await pinWorkspace(draftKey!);
+          await showToast({
+            style: Toast.Style.Success,
+            title: "Draft from another workspace",
+            message: `This draft targets ${draftEntry.orgName}; your default workspace is unchanged.`,
+          });
+        } catch (error) {
+          await showToast({
+            style: Toast.Style.Failure,
+            title: `Could not switch to ${draftEntry.orgName}`,
+            message: `Using ${activeEntry?.orgName ?? "the active workspace"} instead: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          });
+        }
+        setPinned(true);
+      } else if (draftKey && !draftEntry) {
+        // Removed workspace (edge case 7): fall back to the active one, keep other values.
+        await showToast({
+          style: Toast.Style.Failure,
+          title: "Draft's workspace is no longer connected",
+          message: `Using ${activeEntry?.orgName ?? "the active workspace"} instead.`,
+        });
+      }
+    })();
+    // Runs once on mount by design (draft pinning is a launch-time decision).
+  }, []);
+
   const { priorities, isLoadingPriorities } = usePriorities();
   const { me, isLoadingMe } = useMe();
 
   return (
     <CreateIssueForm
-      isLoading={isLoadingPriorities || isLoadingMe}
+      isLoading={isLoadingPriorities || isLoadingMe || !pinned}
       priorities={priorities}
       me={me}
       enableDrafts

--- a/extensions/linear/src/create-project.tsx
+++ b/extensions/linear/src/create-project.tsx
@@ -1,10 +1,69 @@
+import { showToast, Toast } from "@raycast/api";
+import { useEffect, useState } from "react";
+
+import { entryKey } from "./api/workspaces";
 import CreateProjectForm, { CreateProjectValues } from "./components/CreateProjectForm";
 import View from "./components/View";
+import { useWorkspaces } from "./components/WorkspaceContext";
+
+// Module-scoped, not component state: the component sits inside the provider's
+// key={workspaceKey} remount boundary, so a user changing the Workspace field in a
+// draft-opened form remounts Form and would re-run a []-deps effect, re-pinning the
+// workspace back and showing a now-false "draft from another workspace" toast (I1).
+// Module state survives that remount and dies only with the process — draft pinning is
+// a launch-time decision, so "once per launch" is the correct scope, not "once per mount".
+let draftPinHandled = false;
+
+function Form({ draftValues }: { draftValues?: CreateProjectValues }) {
+  const { entries, activeEntry, pinWorkspace } = useWorkspaces();
+  const draftKey = draftValues?.workspaceKey;
+  const draftEntry = draftKey ? entries.find((w) => entryKey(w) === draftKey) : undefined;
+  const needsPin = Boolean(draftEntry && activeEntry && draftKey !== entryKey(activeEntry));
+  const [pinned, setPinned] = useState(!needsPin || draftPinHandled); // draftPinHandled: the launch-time pin already ran; later boundary remounts must not re-gate rendering
+
+  useEffect(() => {
+    if (draftPinHandled) return;
+    draftPinHandled = true;
+    (async () => {
+      if (needsPin && draftEntry) {
+        // Pin THIS process to the draft's workspace: field, hooks, and submission all
+        // target it; the global default stays untouched (D7 — field only, with a toast).
+        try {
+          await pinWorkspace(draftKey!);
+          await showToast({
+            style: Toast.Style.Success,
+            title: "Draft from another workspace",
+            message: `This draft targets ${draftEntry.orgName}; your default workspace is unchanged.`,
+          });
+        } catch (error) {
+          await showToast({
+            style: Toast.Style.Failure,
+            title: `Could not switch to ${draftEntry.orgName}`,
+            message: `Using ${activeEntry?.orgName ?? "the active workspace"} instead: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          });
+        }
+        setPinned(true);
+      } else if (draftKey && !draftEntry) {
+        // Removed workspace (edge case 7): fall back to the active one, keep other values.
+        await showToast({
+          style: Toast.Style.Failure,
+          title: "Draft's workspace is no longer connected",
+          message: `Using ${activeEntry?.orgName ?? "the active workspace"} instead.`,
+        });
+      }
+    })();
+    // Runs once on mount by design (draft pinning is a launch-time decision).
+  }, []);
+
+  return <CreateProjectForm isLoading={!pinned} draftValues={draftValues} />;
+}
 
 export default function Command({ draftValues }: { draftValues?: CreateProjectValues }) {
   return (
     <View>
-      <CreateProjectForm draftValues={draftValues} />
+      <Form draftValues={draftValues} />
     </View>
   );
 }

--- a/extensions/linear/src/created-issues.tsx
+++ b/extensions/linear/src/created-issues.tsx
@@ -4,6 +4,7 @@ import { getCreatedIssues } from "./api/getIssues";
 import CreateIssueForm from "./components/CreateIssueForm";
 import StateIssueList from "./components/StateIssueList";
 import View from "./components/View";
+import { WorkspaceListDropdown } from "./components/WorkspaceDropdown";
 import useIssues from "./hooks/useIssues";
 import useMe from "./hooks/useMe";
 import usePriorities from "./hooks/usePriorities";
@@ -18,6 +19,7 @@ function CreatedIssues() {
       isLoading={isLoadingIssues || isLoadingPriorities || isLoadingMe}
       searchBarPlaceholder="Filter by ID, title, status, assignee or priority"
       filtering={{ keepSectionOrder: true }}
+      searchBarAccessory={<WorkspaceListDropdown />}
     >
       <List.EmptyView
         title="No issues"

--- a/extensions/linear/src/favorites.tsx
+++ b/extensions/linear/src/favorites.tsx
@@ -6,6 +6,8 @@ import { ComponentProps, ReactElement } from "react";
 import { getFavorites } from "./api/favorites";
 import OpenInLinear from "./components/OpenInLinear";
 import View from "./components/View";
+import { useWorkspaces } from "./components/WorkspaceContext";
+import { WorkspaceListDropdown } from "./components/WorkspaceDropdown";
 import { formatCycle } from "./helpers/cycles";
 import { getIcon } from "./helpers/icons";
 import { getInitiativeIcon } from "./helpers/initiatives";
@@ -15,7 +17,14 @@ import { getUserIcon } from "./helpers/users";
 import { CustomViewIssues } from "./search-custom-views";
 
 function Favorites() {
-  const { data, isLoading } = useCachedPromise(getFavorites);
+  const { workspaceKey } = useWorkspaces();
+  const { data, isLoading } = useCachedPromise(
+    (key: string) => {
+      void key;
+      return getFavorites();
+    },
+    [workspaceKey],
+  );
 
   const favorites = data?.favorites ?? [];
   const urlKey = data?.organization?.urlKey;
@@ -23,7 +32,7 @@ function Favorites() {
   const baseLinearUrl = `https://linear.app/${urlKey}`;
 
   return (
-    <List isLoading={isLoading}>
+    <List isLoading={isLoading} searchBarAccessory={<WorkspaceListDropdown />}>
       {favorites.map(
         ({ id, type, customView, cycle, document, issue, label, project, initiative, user, updatedAt }) => {
           let props: Pick<List.Item.Props, "icon" | "title"> | null = null;

--- a/extensions/linear/src/helpers/createIssueForMyself.ts
+++ b/extensions/linear/src/helpers/createIssueForMyself.ts
@@ -31,11 +31,11 @@ export async function createIssueForMyself(
     }
 
     if (!teamId) {
-      teamId = teams[0].id;
-    }
-
-    if (!teamId) {
-      throw Error("No team found");
+      const [firstTeam] = teams;
+      if (!firstTeam) {
+        throw Error("No team found");
+      }
+      teamId = firstTeam.id;
     }
 
     let stateId: string | undefined;

--- a/extensions/linear/src/helpers/createIssueForMyself.ts
+++ b/extensions/linear/src/helpers/createIssueForMyself.ts
@@ -1,0 +1,99 @@
+import { LinearClient } from "@linear/sdk";
+import { Clipboard, closeMainWindow, open, Toast, showToast, Keyboard } from "@raycast/api";
+
+import { getTeams } from "../api/getTeams";
+import { getLinearClient } from "../api/linearClient";
+
+export async function createIssueForMyself(
+  args: { title: string; description?: string },
+  preferences: { preferredTeamKey?: string; preferredStatusName?: string; shouldCloseMainWindow: boolean },
+  client?: LinearClient,
+): Promise<void> {
+  const toast = await showToast({ style: Toast.Style.Animated, title: "Creating issue" });
+
+  try {
+    const linearClient = client ?? getLinearClient().linearClient;
+
+    if (preferences.shouldCloseMainWindow) {
+      await closeMainWindow();
+    }
+
+    const viewer = await linearClient.viewer;
+    const { teams } = await getTeams(undefined, client);
+
+    let teamId: string | undefined;
+
+    if (preferences.preferredTeamKey) {
+      const team = teams.find((t) => t.key === preferences.preferredTeamKey);
+      if (team) {
+        teamId = team.id;
+      }
+    }
+
+    if (!teamId) {
+      teamId = teams[0].id;
+    }
+
+    if (!teamId) {
+      throw Error("No team found");
+    }
+
+    let stateId: string | undefined;
+
+    if (preferences.preferredStatusName) {
+      const states = await linearClient.workflowStates({
+        filter: {
+          team: { id: { eq: teamId } },
+          name: { eq: preferences.preferredStatusName },
+        },
+      });
+
+      const state = states.nodes[0];
+
+      if (!state) {
+        throw Error(`Status "${preferences.preferredStatusName}" not found`);
+      }
+
+      stateId = state.id;
+    }
+
+    const payload = await linearClient.createIssue({
+      teamId: teamId,
+      title: args.title,
+      description: args.description,
+      assigneeId: viewer.id,
+      stateId: stateId,
+    });
+
+    const issue = await payload.issue;
+    if (!payload.success || !issue) {
+      throw Error("Something went wrong");
+    }
+
+    toast.style = Toast.Style.Success;
+    toast.title = `Created issue • ${issue.identifier}`;
+    toast.primaryAction = {
+      title: "Open Issue",
+      shortcut: Keyboard.Shortcut.Common.OpenWith,
+      onAction: async () => {
+        await open(issue.url);
+        await toast.hide();
+      },
+    };
+
+    toast.secondaryAction = {
+      title: "Copy Issue ID",
+      shortcut: Keyboard.Shortcut.Common.Copy,
+      onAction: () => Clipboard.copy(issue.identifier),
+    };
+  } catch (e) {
+    toast.style = Toast.Style.Failure;
+    toast.title = "Failed creating issue";
+    toast.message = e instanceof Error ? e.message : String(e);
+    toast.primaryAction = {
+      title: "Copy Error Log",
+      shortcut: Keyboard.Shortcut.Common.Copy,
+      onAction: () => Clipboard.copy(e instanceof Error ? (e.stack ?? e.message) : String(e)),
+    };
+  }
+}

--- a/extensions/linear/src/helpers/refreshQuickSubtitles.ts
+++ b/extensions/linear/src/helpers/refreshQuickSubtitles.ts
@@ -1,0 +1,20 @@
+import { launchCommand, LaunchType } from "@raycast/api";
+
+// updateCommandMetadata only updates the CURRENT command, so subtitle freshness after a
+// workspace change requires each quick command to briefly run itself: a background
+// launch with refreshSubtitle context makes it update its subtitle and exit. Failures
+// are swallowed — subtitle freshness is cosmetic and background launches can be
+// unavailable (e.g. command disabled).
+const QUICK_COMMANDS: Array<{ name: string; arguments: Record<string, string> }> = [
+  { name: "create-issue-for-myself", arguments: { title: "" } },
+  { name: "create-issue-for-myself-in-workspace", arguments: { workspace: "", title: "" } },
+  { name: "quick-add-comment-to-issue", arguments: { comment: "", issueId: "" } },
+];
+
+export function refreshQuickCommandSubtitles(): void {
+  for (const { name, arguments: args } of QUICK_COMMANDS) {
+    launchCommand({ name, type: LaunchType.Background, arguments: args, context: { refreshSubtitle: true } }).catch(
+      () => {},
+    );
+  }
+}

--- a/extensions/linear/src/helpers/workspaceArgument.ts
+++ b/extensions/linear/src/helpers/workspaceArgument.ts
@@ -1,0 +1,99 @@
+import { LinearClient } from "@linear/sdk";
+import { updateCommandMetadata } from "@raycast/api";
+
+import { getLinearClientFor } from "../api/linearClient";
+import { entryKey, getActiveEntry, migrateIfNeeded, WorkspaceEntry } from "../api/workspaces";
+
+// P3 matching: exact urlKey, else exact account email, else unique orgName prefix, else unique email prefix.
+// A match is a ONE-SHOT override — it never writes the registry (design D2).
+export async function resolveWorkspaceArgument(
+  argument: string | undefined,
+): Promise<
+  { ok: true; entry: WorkspaceEntry | null; client: LinearClient | undefined } | { ok: false; message: string }
+> {
+  const query = argument?.trim();
+  if (!query) return { ok: true, entry: null, client: undefined }; // no arg → active workspace via sync fast path
+
+  const registry = await migrateIfNeeded({ allowWrite: false });
+  const lower = query.toLowerCase();
+  const workspaces = registry.workspaces;
+  // D10: two entries can share BOTH urlKey and orgName (same org under two accounts),
+  // so the account email is a first-class matcher, not just display text.
+  const byUrlKey = workspaces.filter((w) => w.urlKey.toLowerCase() === lower);
+  const byEmail = workspaces.filter((w) => w.userEmail.toLowerCase() === lower);
+  const byNamePrefix = workspaces.filter((w) => w.orgName.toLowerCase().startsWith(lower));
+  const byEmailPrefix = workspaces.filter((w) => w.userEmail.toLowerCase().startsWith(lower));
+  const candidates =
+    byUrlKey.length === 1
+      ? byUrlKey
+      : byEmail.length === 1
+        ? byEmail
+        : byNamePrefix.length === 1
+          ? byNamePrefix
+          : byEmailPrefix.length === 1
+            ? byEmailPrefix
+            : byUrlKey.length > 0
+              ? byUrlKey
+              : byEmail.length > 0
+                ? byEmail // one account in several orgs: list them as ambiguous
+                : byNamePrefix.length > 0
+                  ? byNamePrefix
+                  : byEmailPrefix.length > 0
+                    ? byEmailPrefix
+                    : [];
+
+  if (candidates.length === 0) {
+    const names = workspaces.map((w) => `${w.orgName} (${w.urlKey}, ${w.userEmail})`).join(", ");
+    return { ok: false, message: `No workspace matches "${query}". Connected: ${names || "none"}` };
+  }
+  if (candidates.length > 1) {
+    const names = candidates.map((w) => `${w.orgName} (${w.userEmail})`).join(", ");
+    return { ok: false, message: `"${query}" is ambiguous: ${names}. Use the account email to pick one.` };
+  }
+  const entry = candidates[0];
+  const { linearClient } = await getLinearClientFor(
+    { orgId: entry.orgId, userId: entry.userId },
+    { interactive: true },
+  );
+  return { ok: true, entry, client: linearClient };
+}
+
+// Root-search subtitle for the command pegged to the active workspace: shows
+// which workspace it will create in. Hidden entirely for single-workspace
+// users (updateCommandMetadata clears it).
+export async function updateActiveWorkspaceSubtitle(): Promise<void> {
+  try {
+    const registry = await migrateIfNeeded({ allowWrite: false });
+    if (registry.workspaces.length < 2) {
+      await updateCommandMetadata({ subtitle: null });
+      return;
+    }
+    const active = getActiveEntry(registry);
+    await updateCommandMetadata({
+      subtitle: active ? `Linear — will create in ${active.orgName}` : null,
+    });
+  } catch {
+    // Subtitle is cosmetic — never let it affect the command.
+  }
+}
+
+// Root-search subtitle for the quick commands that take a `workspace`
+// argument: shows the active workspace plus the alternatives the user can
+// type. Hidden entirely for single-workspace users (updateCommandMetadata
+// clears it).
+export async function updateWorkspaceChoicesSubtitle(): Promise<void> {
+  try {
+    const registry = await migrateIfNeeded({ allowWrite: false });
+    if (registry.workspaces.length < 2) {
+      await updateCommandMetadata({ subtitle: null });
+      return;
+    }
+    const active = getActiveEntry(registry);
+    const others = registry.workspaces.filter((w) => !active || entryKey(w) !== entryKey(active)).map((w) => w.orgName);
+    await updateCommandMetadata({
+      subtitle: active ? `Linear Workspace - Default: ${active.orgName}, others: ${others.join(", ")}` : null,
+    });
+  } catch {
+    // Subtitle is cosmetic — never let it affect the command.
+  }
+}

--- a/extensions/linear/src/hooks/useAllWorkspaceNotifications.ts
+++ b/extensions/linear/src/hooks/useAllWorkspaceNotifications.ts
@@ -1,0 +1,48 @@
+import { useCachedPromise } from "@raycast/utils";
+
+import { getNotifications, NotificationResult } from "../api/getNotifications";
+import { getLinearClientFor } from "../api/linearClient";
+import { migrateIfNeeded, WorkspaceEntry } from "../api/workspaces";
+
+// No client on the row: useCachedPromise JSON-serializes this result to Raycast's
+// UNENCRYPTED cache. A LinearClient instance carries its bearer token in an
+// Authorization header — persisting it here would write the token to disk, and a
+// rehydrated cache row would carry a method-less plain object anyway. Actions resolve
+// the client on demand via getLinearClientFor (see unread-notifications.tsx).
+export type WorkspaceNotificationRow = {
+  entry: WorkspaceEntry;
+  status: "ok" | "needs-reauth";
+  urlKey: string;
+  notifications: NotificationResult[];
+};
+
+// Menu-bar data source (P4): strictly read-only on the registry; per-entry clients;
+// background-safe token access only (never authorize(), §4.3). One row per ENTRY —
+// two entries can share an orgId (D10), so grouping is by entryKey.
+export default function useAllWorkspaceNotifications() {
+  const { data, isLoading, mutate } = useCachedPromise(async (): Promise<WorkspaceNotificationRow[]> => {
+    const registry = await migrateIfNeeded({ allowWrite: false });
+    return Promise.all(
+      registry.workspaces.map(async (entry): Promise<WorkspaceNotificationRow> => {
+        try {
+          const { linearClient } = await getLinearClientFor(
+            { orgId: entry.orgId, userId: entry.userId },
+            { interactive: false },
+          );
+          const { notifications, urlKey } = await getNotifications(linearClient);
+          return {
+            entry,
+            status: "ok",
+            urlKey: urlKey ?? entry.urlKey,
+            notifications: notifications ?? [],
+          };
+        } catch {
+          // Expired-with-no-refresh, revoked, or transient failure: render the
+          // re-auth row; NEVER log the workspace out from the menu bar (S6/S7, T13).
+          return { entry, status: "needs-reauth", urlKey: entry.urlKey, notifications: [] };
+        }
+      }),
+    );
+  }, []);
+  return { rows: data ?? [], isLoading, mutate };
+}

--- a/extensions/linear/src/hooks/useAllWorkspaceNotifications.ts
+++ b/extensions/linear/src/hooks/useAllWorkspaceNotifications.ts
@@ -5,7 +5,7 @@ import { getNotifications, NotificationResult } from "../api/getNotifications";
 import { getLinearClientFor } from "../api/linearClient";
 import { migrateIfNeeded, WorkspaceEntry } from "../api/workspaces";
 
-// No client on the row: useCachedPromise JSON-serializes this result to Raycast's
+// No client on the row: useCachedState JSON-serializes this result to Raycast's
 // UNENCRYPTED cache. A LinearClient instance carries its bearer token in an
 // Authorization header — persisting it here would write the token to disk, and a
 // rehydrated cache row would carry a method-less plain object anyway. Actions resolve

--- a/extensions/linear/src/hooks/useAllWorkspaceNotifications.ts
+++ b/extensions/linear/src/hooks/useAllWorkspaceNotifications.ts
@@ -1,4 +1,5 @@
-import { useCachedPromise } from "@raycast/utils";
+import { Cache } from "@raycast/api";
+import { useCachedState, usePromise } from "@raycast/utils";
 
 import { getNotifications, NotificationResult } from "../api/getNotifications";
 import { getLinearClientFor } from "../api/linearClient";
@@ -16,33 +17,52 @@ export type WorkspaceNotificationRow = {
   notifications: NotificationResult[];
 };
 
+// Named namespace so Manage Workspaces can drop cached rows the moment a workspace is
+// removed (Greptile review on PR #30314): useCachedPromise's namespace is a hash of its
+// fetcher and cannot be addressed from another command.
+export const NOTIFICATIONS_CACHE_NAMESPACE = "linear-workspace-notifications";
+const ROWS_KEY = "rows";
+
+export function clearWorkspaceNotificationsCache(): void {
+  new Cache({ namespace: NOTIFICATIONS_CACHE_NAMESPACE }).clear();
+}
+
 // Menu-bar data source (P4): strictly read-only on the registry; per-entry clients;
 // background-safe token access only (never authorize(), §4.3). One row per ENTRY —
 // two entries can share an orgId (D10), so grouping is by entryKey.
 export default function useAllWorkspaceNotifications() {
-  const { data, isLoading, mutate } = useCachedPromise(async (): Promise<WorkspaceNotificationRow[]> => {
-    const registry = await migrateIfNeeded({ allowWrite: false });
-    return Promise.all(
-      registry.workspaces.map(async (entry): Promise<WorkspaceNotificationRow> => {
-        try {
-          const { linearClient } = await getLinearClientFor(
-            { orgId: entry.orgId, userId: entry.userId },
-            { interactive: false },
-          );
-          const { notifications, urlKey } = await getNotifications(linearClient);
-          return {
-            entry,
-            status: "ok",
-            urlKey: urlKey ?? entry.urlKey,
-            notifications: notifications ?? [],
-          };
-        } catch {
-          // Expired-with-no-refresh, revoked, or transient failure: render the
-          // re-auth row; NEVER log the workspace out from the menu bar (S6/S7, T13).
-          return { entry, status: "needs-reauth", urlKey: entry.urlKey, notifications: [] };
-        }
-      }),
-    );
-  }, []);
-  return { rows: data ?? [], isLoading, mutate };
+  const [cachedRows, setCachedRows] = useCachedState<WorkspaceNotificationRow[]>(ROWS_KEY, [], {
+    cacheNamespace: NOTIFICATIONS_CACHE_NAMESPACE,
+  });
+  const { data, isLoading, mutate } = usePromise(
+    async (): Promise<WorkspaceNotificationRow[]> => {
+      const registry = await migrateIfNeeded({ allowWrite: false });
+      return Promise.all(
+        registry.workspaces.map(async (entry): Promise<WorkspaceNotificationRow> => {
+          try {
+            const { linearClient } = await getLinearClientFor(
+              { orgId: entry.orgId, userId: entry.userId },
+              { interactive: false },
+            );
+            const { notifications, urlKey } = await getNotifications(linearClient);
+            return {
+              entry,
+              status: "ok",
+              urlKey: urlKey ?? entry.urlKey,
+              notifications: notifications ?? [],
+            };
+          } catch {
+            // Expired-with-no-refresh, revoked, or transient failure: render the
+            // re-auth row; NEVER log the workspace out from the menu bar (S6/S7, T13).
+            return { entry, status: "needs-reauth", urlKey: entry.urlKey, notifications: [] };
+          }
+        }),
+      );
+    },
+    [],
+    { onData: setCachedRows },
+  );
+  // Live data first: usePromise's mutate(..., { optimisticUpdate }) writes to `data`, not to
+  // the cached copy, so returning `data ?? cachedRows` keeps optimistic updates visible.
+  return { rows: data ?? cachedRows, isLoading, mutate };
 }

--- a/extensions/linear/src/hooks/useCustomViews.ts
+++ b/extensions/linear/src/hooks/useCustomViews.ts
@@ -2,17 +2,30 @@ import { useCachedPromise } from "@raycast/utils";
 
 import { getCustomViews, getCustomViewIssues, CustomViewResult } from "../api/getCustomViews";
 import { IssueResult } from "../api/getIssues";
+import { useWorkspaces } from "../components/WorkspaceContext";
 
 export function useCustomViews() {
-  const { data, error, isLoading } = useCachedPromise(getCustomViews);
+  const { workspaceKey } = useWorkspaces();
+  const { data, error, isLoading } = useCachedPromise(
+    (key: string) => {
+      void key;
+      return getCustomViews();
+    },
+    [workspaceKey],
+  );
 
   return { customViews: data, customViewsError: error, isLoadingCustomViews: isLoading };
 }
 
 export function useCustomViewIssues(viewId: string) {
-  const { data, error, isLoading, mutate } = useCachedPromise(getCustomViewIssues, [viewId], {
-    execute: !!viewId,
-  });
+  const { workspaceKey } = useWorkspaces();
+  const { data, error, isLoading, mutate } = useCachedPromise(
+    (key: string, viewId: string) => getCustomViewIssues(viewId),
+    [workspaceKey, viewId],
+    {
+      execute: !!viewId,
+    },
+  );
 
   return {
     issues: data,

--- a/extensions/linear/src/hooks/useCycles.ts
+++ b/extensions/linear/src/hooks/useCycles.ts
@@ -1,18 +1,20 @@
 import { useCachedPromise } from "@raycast/utils";
 
 import { getLinearClient } from "../api/linearClient";
+import { useWorkspaces } from "../components/WorkspaceContext";
 
 export default function useCycles(teamId?: string, config?: { execute?: boolean }) {
   const { linearClient } = getLinearClient();
+  const { workspaceKey } = useWorkspaces();
 
   const { data, error, isLoading } = useCachedPromise(
-    async (teamId: string | undefined) => {
+    async (key: string, teamId: string | undefined) => {
       const cycles = await linearClient.cycles({ filter: { team: { id: { eq: teamId } } } });
 
       // The cycles seem to be ordered from the furthest cycle to the closest cycle
       return cycles.nodes.sort((a, b) => a.number - b.number);
     },
-    [teamId],
+    [workspaceKey, teamId],
     { execute: config?.execute !== false && !!teamId },
   );
 

--- a/extensions/linear/src/hooks/useDocuments.ts
+++ b/extensions/linear/src/hooks/useDocuments.ts
@@ -1,13 +1,19 @@
 import { useCachedPromise } from "@raycast/utils";
 
+import { useWorkspaces } from "../components/WorkspaceContext";
 import { getDocumentContent } from "../tools/get-document-content";
 import { DocumentEntity, getDocuments } from "../tools/get-documents";
 
 export function useDocuments(query: string = "", entity: DocumentEntity = { projectId: "" }) {
-  const { data, error, isLoading, mutate } = useCachedPromise(getDocuments, [query, entity], {
-    failureToastOptions: { title: "Failed to load documents" },
-    keepPreviousData: true,
-  });
+  const { workspaceKey } = useWorkspaces();
+  const { data, error, isLoading, mutate } = useCachedPromise(
+    (key: string, query: string, entity: DocumentEntity) => getDocuments(query, entity),
+    [workspaceKey, query, entity],
+    {
+      failureToastOptions: { title: "Failed to load documents" },
+      keepPreviousData: true,
+    },
+  );
 
   return {
     docs: data?.docs,
@@ -19,9 +25,14 @@ export function useDocuments(query: string = "", entity: DocumentEntity = { proj
 }
 
 export function useDocumentContent(documentId: string) {
-  const { data, error, isLoading, mutate } = useCachedPromise(getDocumentContent, [documentId], {
-    failureToastOptions: { title: "Failed to load document content" },
-  });
+  const { workspaceKey } = useWorkspaces();
+  const { data, error, isLoading, mutate } = useCachedPromise(
+    (key: string, documentId: string) => getDocumentContent(documentId),
+    [workspaceKey, documentId],
+    {
+      failureToastOptions: { title: "Failed to load document content" },
+    },
+  );
 
   return {
     doc: data,

--- a/extensions/linear/src/hooks/useInitiatives.ts
+++ b/extensions/linear/src/hooks/useInitiatives.ts
@@ -1,12 +1,21 @@
 import { useCachedPromise } from "@raycast/utils";
 
+import { useWorkspaces } from "../components/WorkspaceContext";
 import { getInitiatives } from "../tools/get-initiatives";
 
 export function useInitiatives() {
-  const { data, error, isLoading, mutate } = useCachedPromise(getInitiatives, [], {
-    failureToastOptions: { title: "Failed to load initiatives" },
-    keepPreviousData: true,
-  });
+  const { workspaceKey } = useWorkspaces();
+  const { data, error, isLoading, mutate } = useCachedPromise(
+    (key: string) => {
+      void key;
+      return getInitiatives();
+    },
+    [workspaceKey],
+    {
+      failureToastOptions: { title: "Failed to load initiatives" },
+      keepPreviousData: true,
+    },
+  );
 
   return {
     initiatives: data,

--- a/extensions/linear/src/hooks/useIssueComments.ts
+++ b/extensions/linear/src/hooks/useIssueComments.ts
@@ -2,9 +2,14 @@ import { Issue } from "@linear/sdk";
 import { useCachedPromise } from "@raycast/utils";
 
 import { getComments } from "../api/getIssues";
+import { useWorkspaces } from "../components/WorkspaceContext";
 
 export default function useIssueComments(issueId: Issue["id"]) {
-  const { data, error, isLoading, mutate } = useCachedPromise(getComments, [issueId]);
+  const { workspaceKey } = useWorkspaces();
+  const { data, error, isLoading, mutate } = useCachedPromise(
+    (key: string, issueId: Issue["id"]) => getComments(issueId),
+    [workspaceKey, issueId],
+  );
 
   return { comments: data, commentsError: error, isLoadingComments: isLoading, mutateComments: mutate };
 }

--- a/extensions/linear/src/hooks/useIssueDetail.ts
+++ b/extensions/linear/src/hooks/useIssueDetail.ts
@@ -1,16 +1,22 @@
 import { useCachedPromise } from "@raycast/utils";
 
 import { getIssueDetail, IssueResult, IssueDetailResult } from "../api/getIssues";
+import { useWorkspaces } from "../components/WorkspaceContext";
 
 export default function useIssueDetail(existingIssue: IssueResult) {
   const issueId = existingIssue.id;
+  const { workspaceKey } = useWorkspaces();
 
-  const { data, error, isLoading, mutate } = useCachedPromise(getIssueDetail, [issueId], {
-    initialData: {
-      ...existingIssue,
-      description: "",
-    } as IssueDetailResult,
-  });
+  const { data, error, isLoading, mutate } = useCachedPromise(
+    (key: string, issueId: string) => getIssueDetail(issueId),
+    [workspaceKey, issueId],
+    {
+      initialData: {
+        ...existingIssue,
+        description: "",
+      } as IssueDetailResult,
+    },
+  );
 
   return { issue: data, issueError: error, isLoadingIssue: isLoading, mutateDetail: mutate };
 }

--- a/extensions/linear/src/hooks/useIssueTemplates.ts
+++ b/extensions/linear/src/hooks/useIssueTemplates.ts
@@ -1,11 +1,17 @@
 import { useCachedPromise } from "@raycast/utils";
 
 import { getIssueTemplates } from "../api/getIssueTemplates";
+import { useWorkspaces } from "../components/WorkspaceContext";
 
 export default function useIssueTemplates(teamId?: string, config?: { execute?: boolean }) {
-  const { data, error, isLoading } = useCachedPromise(getIssueTemplates, [teamId], {
-    execute: config?.execute !== false && !!teamId,
-  });
+  const { workspaceKey } = useWorkspaces();
+  const { data, error, isLoading } = useCachedPromise(
+    (key: string, teamId?: string) => getIssueTemplates(teamId),
+    [workspaceKey, teamId],
+    {
+      execute: config?.execute !== false && !!teamId,
+    },
+  );
 
   return { issueTemplates: data, issueTemplatesError: error, isLoadingIssueTemplates: (!data && !error) || isLoading };
 }

--- a/extensions/linear/src/hooks/useIssues.ts
+++ b/extensions/linear/src/hooks/useIssues.ts
@@ -1,13 +1,19 @@
 import { useCachedPromise } from "@raycast/utils";
 
 import { IssueResult } from "../api/getIssues";
+import { useWorkspaces } from "../components/WorkspaceContext";
 
 export default function useIssues<T>(
   fetcher: (...args: T[]) => Promise<IssueResult[] | undefined>,
   args: T[] = [],
   config?: { execute?: boolean; keepPreviousData?: boolean },
 ) {
-  const { data, error, isLoading, mutate } = useCachedPromise(fetcher, args, config);
+  const { workspaceKey } = useWorkspaces();
+  const { data, error, isLoading, mutate } = useCachedPromise(
+    (key: string, ...rest: T[]) => fetcher(...rest),
+    [workspaceKey, ...args],
+    config,
+  );
 
   return { issues: data, issuesError: error, isLoadingIssues: isLoading, mutateList: mutate };
 }

--- a/extensions/linear/src/hooks/useLabels.ts
+++ b/extensions/linear/src/hooks/useLabels.ts
@@ -1,11 +1,17 @@
 import { useCachedPromise } from "@raycast/utils";
 
 import { getLabels } from "../api/getLabels";
+import { useWorkspaces } from "../components/WorkspaceContext";
 
 export default function useLabels(teamId?: string, config?: { execute?: boolean }) {
-  const { data, error, isLoading } = useCachedPromise(getLabels, [teamId], {
-    execute: config?.execute !== false && !!teamId,
-  });
+  const { workspaceKey } = useWorkspaces();
+  const { data, error, isLoading } = useCachedPromise(
+    (key: string, teamId?: string) => getLabels(teamId),
+    [workspaceKey, teamId],
+    {
+      execute: config?.execute !== false && !!teamId,
+    },
+  );
 
   return { labels: data, labelsError: error, isLoadingLabels: (!data && !error) || isLoading };
 }

--- a/extensions/linear/src/hooks/useMe.ts
+++ b/extensions/linear/src/hooks/useMe.ts
@@ -1,10 +1,18 @@
 import { useCachedPromise } from "@raycast/utils";
 
 import { getLinearClient } from "../api/linearClient";
+import { useWorkspaces } from "../components/WorkspaceContext";
 
 export default function useMe() {
   const { linearClient } = getLinearClient();
-  const { data, error, isLoading } = useCachedPromise(() => linearClient.viewer);
+  const { workspaceKey } = useWorkspaces();
+  const { data, error, isLoading } = useCachedPromise(
+    (key: string) => {
+      void key;
+      return linearClient.viewer;
+    },
+    [workspaceKey],
+  );
 
   return { me: data, meError: error, isLoadingMe: (!data && !error) || isLoading };
 }

--- a/extensions/linear/src/hooks/useMilestones.ts
+++ b/extensions/linear/src/hooks/useMilestones.ts
@@ -1,11 +1,17 @@
 import { useCachedPromise } from "@raycast/utils";
 
 import { getMilestones } from "../api/getMilestones";
+import { useWorkspaces } from "../components/WorkspaceContext";
 
 export default function useMilestones(projectId?: string, config?: { execute?: boolean }) {
-  const { data, error, isLoading, mutate } = useCachedPromise(getMilestones, [projectId], {
-    execute: config?.execute !== false,
-  });
+  const { workspaceKey } = useWorkspaces();
+  const { data, error, isLoading, mutate } = useCachedPromise(
+    (key: string, projectId?: string) => getMilestones(projectId),
+    [workspaceKey, projectId],
+    {
+      execute: config?.execute !== false,
+    },
+  );
 
   return {
     milestones: data,

--- a/extensions/linear/src/hooks/useNotifications.ts
+++ b/extensions/linear/src/hooks/useNotifications.ts
@@ -2,9 +2,17 @@ import { useCachedPromise } from "@raycast/utils";
 import { chain } from "lodash";
 
 import { getNotifications } from "../api/getNotifications";
+import { useWorkspaces } from "../components/WorkspaceContext";
 
 export default function useNotifications() {
-  const { data, error, isLoading, mutate } = useCachedPromise(getNotifications);
+  const { workspaceKey } = useWorkspaces();
+  const { data, error, isLoading, mutate } = useCachedPromise(
+    (key: string) => {
+      void key;
+      return getNotifications();
+    },
+    [workspaceKey],
+  );
 
   const { notifications, urlKey } = data || {};
 

--- a/extensions/linear/src/hooks/usePriorities.ts
+++ b/extensions/linear/src/hooks/usePriorities.ts
@@ -1,11 +1,20 @@
 import { useCachedPromise } from "@raycast/utils";
 
 import { getLinearClient } from "../api/linearClient";
+import { useWorkspaces } from "../components/WorkspaceContext";
 
 export default function usePriorities() {
   const { linearClient } = getLinearClient();
+  const { workspaceKey } = useWorkspaces();
 
-  const { data, error, isLoading } = useCachedPromise(() => linearClient.issuePriorityValues, [], { initialData: [] });
+  const { data, error, isLoading } = useCachedPromise(
+    (key: string) => {
+      void key;
+      return linearClient.issuePriorityValues;
+    },
+    [workspaceKey],
+    { initialData: [] },
+  );
 
   return { priorities: data, prioritiesError: error, isLoadingPriorities: (!data && !error) || isLoading };
 }

--- a/extensions/linear/src/hooks/useProjectStatuses.ts
+++ b/extensions/linear/src/hooks/useProjectStatuses.ts
@@ -1,13 +1,19 @@
 import { useCachedPromise } from "@raycast/utils";
 
 import { getLinearClient } from "../api/linearClient";
+import { useWorkspaces } from "../components/WorkspaceContext";
 
 export default function useProjectStatuses() {
   const { linearClient } = getLinearClient();
-  const { data: states, isLoading: isLoadingStates } = useCachedPromise(async () => {
-    const states = await linearClient.projectStatuses();
-    return states.nodes.sort((a, b) => a.position - b.position);
-  });
+  const { workspaceKey } = useWorkspaces();
+  const { data: states, isLoading: isLoadingStates } = useCachedPromise(
+    async (key: string) => {
+      void key;
+      const states = await linearClient.projectStatuses();
+      return states.nodes.sort((a, b) => a.position - b.position);
+    },
+    [workspaceKey],
+  );
 
   return { states, isLoadingStates };
 }

--- a/extensions/linear/src/hooks/useProjectUpdates.ts
+++ b/extensions/linear/src/hooks/useProjectUpdates.ts
@@ -1,9 +1,14 @@
 import { useCachedPromise } from "@raycast/utils";
 
 import { getProjectUpdates } from "../api/getProjects";
+import { useWorkspaces } from "../components/WorkspaceContext";
 
 export default function useProjectUpdates(projectId: string) {
-  const { data, error, isLoading, mutate } = useCachedPromise(getProjectUpdates, [projectId]);
+  const { workspaceKey } = useWorkspaces();
+  const { data, error, isLoading, mutate } = useCachedPromise(
+    (key: string, projectId: string) => getProjectUpdates(projectId),
+    [workspaceKey, projectId],
+  );
 
   return { updates: data, updatesError: error, isLoadingUpdates: isLoading, mutateUpdates: mutate };
 }

--- a/extensions/linear/src/hooks/useProjects.ts
+++ b/extensions/linear/src/hooks/useProjects.ts
@@ -2,20 +2,22 @@ import { useCachedPromise } from "@raycast/utils";
 import type { PaginationOptions } from "@raycast/utils/dist/types";
 
 import { getProjects, type ProjectResult } from "../api/getProjects";
+import { useWorkspaces } from "../components/WorkspaceContext";
 
 export default function useProjects(
   teamId?: string,
   config?: { execute?: boolean; searchText?: string; pageSize?: number },
 ) {
+  const { workspaceKey } = useWorkspaces();
   const { data, error, isLoading, mutate, pagination } = useCachedPromise(
-    (teamId?: string, searchText?: string) => (pagination: PaginationOptions<ProjectResult[]>) =>
+    (key: string, teamId?: string, searchText?: string) => (pagination: PaginationOptions<ProjectResult[]>) =>
       getProjects({
         teamId,
         searchText,
         after: pagination.cursor,
         first: config?.pageSize,
       }),
-    [teamId, config?.searchText],
+    [workspaceKey, teamId, config?.searchText],
     {
       execute: config?.execute !== false,
       keepPreviousData: true,

--- a/extensions/linear/src/hooks/useSearchIssues.ts
+++ b/extensions/linear/src/hooks/useSearchIssues.ts
@@ -2,10 +2,12 @@ import { useCachedPromise } from "@raycast/utils";
 import { UseCachedPromiseReturnType } from "@raycast/utils/dist/types";
 
 import { IssueResult, getLastUpdatedIssues, searchIssues } from "../api/getIssues";
+import { useWorkspaces } from "../components/WorkspaceContext";
 
 export default function useSearchIssues(query: string) {
+  const { workspaceKey } = useWorkspaces();
   return useCachedPromise(
-    (query: string) =>
+    (key: string, query: string) =>
       async ({ cursor }) => {
         if (!query) {
           const { issues, pageInfo } = await getLastUpdatedIssues(cursor);
@@ -15,6 +17,6 @@ export default function useSearchIssues(query: string) {
         const { issues, pageInfo } = await searchIssues(query, cursor);
         return { data: issues ?? [], hasMore: pageInfo?.hasNextPage, cursor: pageInfo?.endCursor };
       },
-    [query],
+    [workspaceKey, query],
   ) as UseCachedPromiseReturnType<IssueResult[], undefined>;
 }

--- a/extensions/linear/src/hooks/useStates.ts
+++ b/extensions/linear/src/hooks/useStates.ts
@@ -1,20 +1,22 @@
 import { useCachedPromise } from "@raycast/utils";
 
 import { getLinearClient } from "../api/linearClient";
+import { useWorkspaces } from "../components/WorkspaceContext";
 
 export default function useStates(teamId?: string, config?: { execute?: boolean }) {
   const { linearClient } = getLinearClient();
+  const { workspaceKey } = useWorkspaces();
 
   const {
     data: states,
     error: statesError,
     isLoading: isLoadingStates,
   } = useCachedPromise(
-    async (teamId: string | undefined) => {
+    async (key: string, teamId: string | undefined) => {
       const states = await linearClient.workflowStates({ filter: { team: { id: { eq: teamId } } } });
       return states.nodes.sort((a, b) => a.position - b.position);
     },
-    [teamId],
+    [workspaceKey, teamId],
     {
       initialData: [],
       execute: config?.execute !== false,

--- a/extensions/linear/src/hooks/useTeams.ts
+++ b/extensions/linear/src/hooks/useTeams.ts
@@ -1,9 +1,14 @@
 import { useCachedPromise } from "@raycast/utils";
 
 import { getTeams } from "../api/getTeams";
+import { useWorkspaces } from "../components/WorkspaceContext";
 
 export default function useTeams(query: string = "") {
-  const { data, error, isLoading } = useCachedPromise(getTeams, [query]);
+  const { workspaceKey } = useWorkspaces();
+  const { data, error, isLoading } = useCachedPromise(
+    (key: string, query: string) => getTeams(query),
+    [workspaceKey, query],
+  );
 
   return {
     teams: data?.teams,

--- a/extensions/linear/src/hooks/useUsers.ts
+++ b/extensions/linear/src/hooks/useUsers.ts
@@ -1,18 +1,20 @@
 import { useCachedPromise } from "@raycast/utils";
 
 import { getLinearClient } from "../api/linearClient";
+import { useWorkspaces } from "../components/WorkspaceContext";
 
 export default function useUsers(query: string = "") {
   const { linearClient } = getLinearClient();
+  const { workspaceKey } = useWorkspaces();
 
   const { data, error, isLoading } = useCachedPromise(
-    async (contains: string) => {
+    async (key: string, contains: string) => {
       const users = await linearClient.users(
         contains.trim().length > 0 ? { filter: { name: { containsIgnoreCase: contains } } } : undefined,
       );
       return { users: users?.nodes ?? [], hasMoreUsers: !!users?.pageInfo?.hasNextPage };
     },
-    [query],
+    [workspaceKey, query],
     { initialData: [] },
   );
 

--- a/extensions/linear/src/hooks/useWorkspaceCachedState.ts
+++ b/extensions/linear/src/hooks/useWorkspaceCachedState.ts
@@ -1,0 +1,11 @@
+import { useCachedState } from "@raycast/utils";
+
+import { useWorkspaces } from "../components/WorkspaceContext";
+
+// Workspace-scoped persisted UI state (§4.5): key gains the ENTRY key (D10), so two
+// entries — even two views of the same org under different accounts — never share state.
+export function useWorkspaceCachedState<T>(baseKey: string, defaultValue: T): [T, (value: T) => void] {
+  const { workspaceKey } = useWorkspaces();
+  const [value, setValue] = useCachedState<T>(`${baseKey}-${workspaceKey}`, defaultValue);
+  return [value, setValue];
+}

--- a/extensions/linear/src/manage-workspaces.tsx
+++ b/extensions/linear/src/manage-workspaces.tsx
@@ -1,0 +1,359 @@
+import {
+  Action,
+  ActionPanel,
+  Alert,
+  Color,
+  confirmAlert,
+  Icon,
+  List,
+  LocalStorage,
+  showToast,
+  Toast,
+} from "@raycast/api";
+import { useCallback, useEffect, useState } from "react";
+
+import { ensureEntryToken, makeClient } from "./api/linearClient";
+import { fetchViewerIdentity, getServiceForProviderId, stagingService, ViewerIdentity } from "./api/oauth";
+import {
+  entryKey,
+  EntryRef,
+  getActiveEntry,
+  migrateIfNeeded,
+  readRegistry,
+  reconcileEntries,
+  removeWorkspaceEntry,
+  setActiveEntry,
+  upsertWorkspaceEntry,
+  WorkspaceEntry,
+  WorkspaceRegistry,
+} from "./api/workspaces";
+import { refreshQuickCommandSubtitles } from "./helpers/refreshQuickSubtitles";
+
+type Row = { entry: WorkspaceEntry; hasToken: boolean };
+
+// Written when addWorkspace starts an interactive grant, cleared once completeAddFromStaging
+// reaches a definitive outcome for that token (success or a proven-bad token) — see fix F-3.
+// Gates the MOUNT-TIME recovery call so a stray staging token can't be replayed as an
+// implicit "add" on every open of Manage Workspaces.
+const ADD_IN_FLIGHT_KEY = "staging-add-in-flight";
+
+// fetchViewerIdentity's error messages embed the HTTP status ("HTTP 401"). A 401/403 means
+// the staging token itself was rejected (permanent); anything else (network failure, 5xx) is
+// treated as transient so a stranded-but-still-good token survives to be retried.
+function isPermanentTokenFailure(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /HTTP (401|403)/.test(message);
+}
+
+async function revokeAtLinear(accessToken: string): Promise<boolean> {
+  try {
+    const response = await fetch("https://api.linear.app/oauth/revoke", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+export default function ManageWorkspaces() {
+  const [isLoading, setIsLoading] = useState(true);
+  const [registry, setRegistry] = useState<WorkspaceRegistry | null>(null);
+  const [rows, setRows] = useState<Row[]>([]);
+
+  const reload = useCallback(async () => {
+    setIsLoading(true);
+    const fresh = await migrateIfNeeded({ allowWrite: true });
+    setRegistry(fresh);
+    setRows(await reconcileEntries(fresh));
+    setIsLoading(false);
+  }, []);
+
+  // Finish an interrupted add: registry write from an authorized staging token (§4.1 step 5).
+  // Ordering fix (F-2): the token is VERIFIED before anything is written to the registry —
+  // the original order wrote the entry first and verified after, so a failure between those
+  // two steps left a token-less entry behind that a stray staging token would keep resurrecting
+  // on every subsequent mount.
+  const completeAddFromStaging = useCallback(async () => {
+    const stagingTokens = await stagingService.client.getTokens();
+    if (!stagingTokens?.accessToken) {
+      // Nothing staged — clear a stale in-flight marker from a crash before any grant landed.
+      await LocalStorage.removeItem(ADD_IN_FLIGHT_KEY);
+      return false;
+    }
+
+    let identity: ViewerIdentity;
+    try {
+      identity = await fetchViewerIdentity(stagingTokens.accessToken);
+      // Second, SDK-path verification of the same token before it is ever written anywhere.
+      await makeClient(stagingTokens.accessToken).viewer;
+    } catch (error) {
+      if (isPermanentTokenFailure(error)) {
+        // The token itself is rejected (permanent failure) — clear it so a dead token
+        // doesn't keep silently failing on every future mount.
+        await stagingService.client.removeTokens();
+        await LocalStorage.removeItem(ADD_IN_FLIGHT_KEY);
+      }
+      // A transient failure (network, 5xx) leaves staging untouched so recovery can retry.
+      throw error;
+    }
+
+    const { entry, isNew } = await upsertWorkspaceEntry(identity);
+    const destination = getServiceForProviderId(entry.providerId, undefined, `Linear — ${entry.orgName}`);
+    // setTokens re-stamps updatedAt to NOW, so pass the REMAINING lifetime, not the
+    // original duration — crash recovery can run hours after the grant, and copying the
+    // full duration would make isExpired() lag the server's fixed expiry. Omit expiresIn
+    // entirely when the stored set lacks it (do not default it — that would make a
+    // non-expiring token look expiring).
+    const elapsedSeconds = Math.floor((Date.now() - stagingTokens.updatedAt.getTime()) / 1000);
+    try {
+      await destination.client.setTokens({
+        accessToken: stagingTokens.accessToken,
+        refreshToken: stagingTokens.refreshToken,
+        idToken: stagingTokens.idToken,
+        scope: stagingTokens.scope,
+        ...(stagingTokens.expiresIn !== undefined
+          ? { expiresIn: Math.max(60, stagingTokens.expiresIn - elapsedSeconds) }
+          : {}),
+      });
+    } finally {
+      // The identity is verified and the entry is written by this point — the staging
+      // token must not linger regardless of whether setTokens itself succeeded.
+      await stagingService.client.removeTokens();
+      await LocalStorage.removeItem(ADD_IN_FLIGHT_KEY);
+    }
+    await showToast({
+      style: Toast.Style.Success,
+      title: isNew ? `Added ${identity.orgName}` : `Re-authenticated ${identity.orgName}`,
+      message: identity.userEmail,
+    });
+    refreshQuickCommandSubtitles(); // fire-and-forget: workspace membership changed, subtitles listing "others" are now stale
+    return true;
+  }, []);
+
+  useEffect(() => {
+    (async () => {
+      // Crash/cancel recovery on mount: only resume an add the user actually started (F-3) —
+      // a stray staging token must never be replayed as an implicit "add" on every mount.
+      try {
+        const addInFlight = await LocalStorage.getItem<string>(ADD_IN_FLIGHT_KEY);
+        if (addInFlight) {
+          await completeAddFromStaging();
+        }
+      } catch {
+        // Leave staging for the next attempt; never crash the management surface.
+      }
+      await reload();
+    })();
+  }, [completeAddFromStaging, reload]);
+
+  async function addWorkspace() {
+    const proceed = await confirmAlert({
+      title: "Add a Linear Workspace",
+      // S3: there is NO workspace picker on Linear's consent page — the grant binds to
+      // whichever workspace is active at linear.app. The user steers it there first.
+      message:
+        "First, in your browser, go to linear.app and switch to the workspace you want to add (top-left workspace switcher). Then continue — Linear will ask you to approve access for that workspace.",
+      primaryAction: { title: "Continue to Linear" },
+    });
+    if (!proceed) return;
+    try {
+      await stagingService.client.removeTokens(); // clear any prior abort (§4.1 step 1)
+      // Mark that an add is genuinely in flight, so a crash before this completes still lets
+      // mount-time recovery resume it (F-3) — cleared inside completeAddFromStaging once the
+      // token is proven good or proven bad.
+      await LocalStorage.setItem(ADD_IN_FLIGHT_KEY, "1");
+      await stagingService.authorize(); // interactive; prompt=consent forces the consent screen
+      await completeAddFromStaging();
+      await reload();
+    } catch (error) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Adding workspace failed",
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  async function reauthenticate(entry: WorkspaceEntry) {
+    try {
+      const service = getServiceForProviderId(entry.providerId, undefined, `Linear — ${entry.orgName}`);
+      await service.client.removeTokens();
+      // ensureEntryToken (NOT plain authorize): the grant follows the account/workspace
+      // active at linear.app (S3), so the minted token's (orgId, userId) is verified
+      // against THIS entry and rejected with a corrective message on mismatch (D10).
+      await ensureEntryToken(entry, { interactive: true });
+      await showToast({ style: Toast.Style.Success, title: `Re-authenticated ${entry.orgName}` });
+      await reload();
+    } catch (error) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Re-authentication failed",
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  async function logOut(entry: WorkspaceEntry, options: { revoke: boolean }) {
+    const confirmed = await confirmAlert({
+      title: options.revoke ? `Log Out and Revoke ${entry.orgName}?` : `Log Out of ${entry.orgName}?`,
+      message: options.revoke
+        ? // S7 blast radius, disclosed verbatim: authorization-scoped + eventually consistent
+          // (observed: ~10 s clean case, 8–12 min worst case).
+          "Revoking at Linear invalidates every Raycast token for this account and workspace — including the primary Linear login if it uses the same account and workspace — and can take from seconds up to ~12 minutes to land. A workspace re-added during that window may be logged out again when the revocation lands."
+        : "Removes this workspace's login from Raycast. The authorization at Linear stays (remove it at linear.app under Security & access if you want); its current access token expires on its own within 24 hours.",
+      primaryAction: {
+        title: options.revoke ? "Log Out and Revoke" : "Log Out",
+        style: Alert.ActionStyle.Destructive,
+      },
+    });
+    if (!confirmed) return;
+    const ref: EntryRef = { orgId: entry.orgId, userId: entry.userId };
+    // Named-step tracker: logOut had no error handling at all, so a throw anywhere in this
+    // sequence (e.g. removeTokens or the registry write) silently left the entry behind,
+    // reporting "removed" via Settings while Manage Workspaces still showed it needing
+    // re-authentication. Every await below updates `step` first so a failure toast can say
+    // which part of the log-out actually failed.
+    let step = "removing the local login";
+    try {
+      const service = getServiceForProviderId(entry.providerId, undefined, `Linear — ${entry.orgName}`);
+      let revoked = false;
+      if (options.revoke) {
+        step = "revoking access at Linear";
+        const tokens = await service.client.getTokens();
+        if (tokens?.accessToken) revoked = await revokeAtLinear(tokens.accessToken);
+      }
+      step = "removing the stored token";
+      await service.client.removeTokens(); // default: local deletion (S7)
+      step = "removing the workspace from the list";
+      await removeWorkspaceEntry(ref);
+      let after = await readRegistry();
+      if (after.workspaces.some((w) => entryKey(w) === entryKey(ref))) {
+        // Removal did not persist — retry once before treating it as a hard failure.
+        await removeWorkspaceEntry(ref);
+        after = await readRegistry();
+        if (after.workspaces.some((w) => entryKey(w) === entryKey(ref))) {
+          throw new Error(`Removing ${entry.orgName} from the workspace list did not persist.`);
+        }
+      }
+      step = "refreshing the workspace list";
+      const fresh = await migrateIfNeeded({ allowWrite: true });
+      const nextActive = getActiveEntry(fresh);
+      await showToast({
+        style: Toast.Style.Success,
+        title: options.revoke
+          ? revoked
+            ? `Removed from Raycast; revocation requested at Linear`
+            : `Removed from Raycast (revoke request failed)`
+          : `Logged out of ${entry.orgName}`,
+        message: nextActive ? `Active workspace: ${nextActive.orgName}` : undefined,
+      });
+      refreshQuickCommandSubtitles(); // fire-and-forget: workspace membership changed, subtitles listing "others" are now stale
+      await reload();
+    } catch (error) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: `Logging out of ${entry.orgName} failed while ${step}`,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  async function logOutAll() {
+    const confirmed = await confirmAlert({
+      title: "Log Out of All Workspaces?",
+      message:
+        "Removes every workspace login from Raycast (tokens are deleted locally; each access token expires at Linear on its own within 24 hours).",
+      primaryAction: { title: "Log Out of All", style: Alert.ActionStyle.Destructive },
+    });
+    if (!confirmed) return;
+    for (const row of rows) {
+      const service = getServiceForProviderId(row.entry.providerId, undefined, `Linear — ${row.entry.orgName}`);
+      await service.client.removeTokens();
+      await removeWorkspaceEntry({ orgId: row.entry.orgId, userId: row.entry.userId });
+    }
+    await showToast({ style: Toast.Style.Success, title: "Logged out of all workspaces" });
+    refreshQuickCommandSubtitles(); // fire-and-forget: workspace membership changed, subtitles listing "others" are now stale
+    await reload();
+  }
+
+  const activeEntry = registry ? getActiveEntry(registry) : null;
+
+  return (
+    <List isLoading={isLoading} searchBarPlaceholder="Filter workspaces">
+      <List.EmptyView
+        title="No Workspaces Connected"
+        description="Add a Linear workspace to get started."
+        actions={
+          <ActionPanel>
+            <Action title="Add Workspace" icon={Icon.Plus} onAction={addWorkspace} />
+          </ActionPanel>
+        }
+      />
+      {rows.map(({ entry, hasToken }) => {
+        const isActive = activeEntry !== null && entryKey(activeEntry) === entryKey(entry);
+        const ref: EntryRef = { orgId: entry.orgId, userId: entry.userId };
+        return (
+          <List.Item
+            key={entryKey(entry)}
+            icon={Icon.PersonCircle}
+            title={entry.orgName}
+            subtitle={entry.userEmail}
+            accessories={
+              hasToken
+                ? isActive
+                  ? [{ tag: { value: "Active", color: Color.Green } }]
+                  : []
+                : [{ tag: { value: "Needs re-authentication", color: Color.Orange } }]
+            }
+            actions={
+              <ActionPanel>
+                {hasToken && !isActive ? (
+                  <Action
+                    title="Set Active"
+                    icon={Icon.CheckCircle}
+                    onAction={async () => {
+                      await setActiveEntry(ref);
+                      refreshQuickCommandSubtitles(); // fire-and-forget: the active workspace changed, subtitles pegged to it are now stale
+                      await reload();
+                    }}
+                  />
+                ) : null}
+                {!hasToken ? (
+                  <Action title="Re-Authenticate" icon={Icon.Key} onAction={() => reauthenticate(entry)} />
+                ) : null}
+                <Action
+                  title="Add Workspace"
+                  icon={Icon.Plus}
+                  shortcut={{ modifiers: ["cmd"], key: "n" }}
+                  onAction={addWorkspace}
+                />
+                <Action
+                  title="Log out of This Workspace"
+                  icon={Icon.Logout}
+                  style={Action.Style.Destructive}
+                  shortcut={{ modifiers: ["ctrl"], key: "x" }}
+                  onAction={() => logOut(entry, { revoke: false })}
+                />
+                <Action
+                  title="Log out and Revoke at Linear"
+                  icon={Icon.ExclamationMark}
+                  style={Action.Style.Destructive}
+                  onAction={() => logOut(entry, { revoke: true })}
+                />
+                <Action
+                  title="Log out of All Workspaces"
+                  icon={Icon.XMarkCircle}
+                  style={Action.Style.Destructive}
+                  shortcut={{ modifiers: ["ctrl", "shift"], key: "x" }}
+                  onAction={logOutAll}
+                />
+              </ActionPanel>
+            }
+          />
+        );
+      })}
+    </List>
+  );
+}

--- a/extensions/linear/src/manage-workspaces.tsx
+++ b/extensions/linear/src/manage-workspaces.tsx
@@ -28,6 +28,7 @@ import {
   WorkspaceRegistry,
 } from "./api/workspaces";
 import { refreshQuickCommandSubtitles } from "./helpers/refreshQuickSubtitles";
+import { clearWorkspaceNotificationsCache } from "./hooks/useAllWorkspaceNotifications";
 
 type Row = { entry: WorkspaceEntry; hasToken: boolean };
 
@@ -228,6 +229,7 @@ export default function ManageWorkspaces() {
       await service.client.removeTokens(); // default: local deletion (S7)
       step = "removing the workspace from the list";
       await removeWorkspaceEntry(ref);
+      clearWorkspaceNotificationsCache(); // drop this entry's cached notification rows now, not at the next 15-min refresh
       let after = await readRegistry();
       if (after.workspaces.some((w) => entryKey(w) === entryKey(ref))) {
         // Removal did not persist — retry once before treating it as a hard failure.
@@ -280,6 +282,7 @@ export default function ManageWorkspaces() {
         failed.push(`${row.entry.orgName} (${step}: ${error instanceof Error ? error.message : String(error)})`);
       }
     }
+    clearWorkspaceNotificationsCache(); // drop this entry's cached notification rows now, not at the next 15-min refresh
     if (failed.length === 0) {
       await showToast({ style: Toast.Style.Success, title: "Logged out of all workspaces" });
     } else {

--- a/extensions/linear/src/manage-workspaces.tsx
+++ b/extensions/linear/src/manage-workspaces.tsx
@@ -282,7 +282,7 @@ export default function ManageWorkspaces() {
         failed.push(`${row.entry.orgName} (${step}: ${error instanceof Error ? error.message : String(error)})`);
       }
     }
-    clearWorkspaceNotificationsCache(); // drop this entry's cached notification rows now, not at the next 15-min refresh
+    clearWorkspaceNotificationsCache(); // drop every workspace's cached notification rows now, not at the next 15-min refresh
     if (failed.length === 0) {
       await showToast({ style: Toast.Style.Success, title: "Logged out of all workspaces" });
     } else {

--- a/extensions/linear/src/manage-workspaces.tsx
+++ b/extensions/linear/src/manage-workspaces.tsx
@@ -268,12 +268,27 @@ export default function ManageWorkspaces() {
       primaryAction: { title: "Log Out of All", style: Alert.ActionStyle.Destructive },
     });
     if (!confirmed) return;
+    const failed: string[] = [];
     for (const row of rows) {
-      const service = getServiceForProviderId(row.entry.providerId, undefined, `Linear — ${row.entry.orgName}`);
-      await service.client.removeTokens();
-      await removeWorkspaceEntry({ orgId: row.entry.orgId, userId: row.entry.userId });
+      let step = "removing the stored token";
+      try {
+        const service = getServiceForProviderId(row.entry.providerId, undefined, `Linear — ${row.entry.orgName}`);
+        await service.client.removeTokens();
+        step = "removing the workspace from the list";
+        await removeWorkspaceEntry({ orgId: row.entry.orgId, userId: row.entry.userId });
+      } catch (error) {
+        failed.push(`${row.entry.orgName} (${step}: ${error instanceof Error ? error.message : String(error)})`);
+      }
     }
-    await showToast({ style: Toast.Style.Success, title: "Logged out of all workspaces" });
+    if (failed.length === 0) {
+      await showToast({ style: Toast.Style.Success, title: "Logged out of all workspaces" });
+    } else {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: `Logged out of ${rows.length - failed.length} of ${rows.length} workspaces`,
+        message: `Failed: ${failed.join("; ")}`,
+      });
+    }
     refreshQuickCommandSubtitles(); // fire-and-forget: workspace membership changed, subtitles listing "others" are now stale
     await reload();
   }

--- a/extensions/linear/src/manage-workspaces.tsx
+++ b/extensions/linear/src/manage-workspaces.tsx
@@ -13,7 +13,9 @@ import {
 import { useCallback, useEffect, useState } from "react";
 
 import { ensureEntryToken, makeClient } from "./api/linearClient";
-import { fetchViewerIdentity, getServiceForProviderId, stagingService, ViewerIdentity } from "./api/oauth";
+import { fetchViewerIdentity, getServiceForProviderId, stagingService, workspaceProviderId } from "./api/oauth";
+import { traceWorkspaceAdd } from "./api/workspaceAddDiagnostics";
+import { createWorkspaceAddFlow } from "./api/workspaceAddFlow";
 import {
   entryKey,
   EntryRef,
@@ -32,19 +34,26 @@ import { clearWorkspaceNotificationsCache } from "./hooks/useAllWorkspaceNotific
 
 type Row = { entry: WorkspaceEntry; hasToken: boolean };
 
-// Written when addWorkspace starts an interactive grant, cleared once completeAddFromStaging
-// reaches a definitive outcome for that token (success or a proven-bad token) — see fix F-3.
-// Gates the MOUNT-TIME recovery call so a stray staging token can't be replayed as an
-// implicit "add" on every open of Manage Workspaces.
+// The flow lives outside the component so a remounted view can join an active add.
 const ADD_IN_FLIGHT_KEY = "staging-add-in-flight";
-
-// fetchViewerIdentity's error messages embed the HTTP status ("HTTP 401"). A 401/403 means
-// the staging token itself was rejected (permanent); anything else (network failure, 5xx) is
-// treated as transient so a stranded-but-still-good token survives to be retried.
-function isPermanentTokenFailure(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return /HTTP (401|403)/.test(message);
-}
+const workspaceAdd = createWorkspaceAddFlow({
+  staging: stagingService.client,
+  hasPendingAdd: async () => Boolean(await LocalStorage.getItem<string>(ADD_IN_FLIGHT_KEY)),
+  markPendingAdd: () => LocalStorage.setItem(ADD_IN_FLIGHT_KEY, "1"),
+  clearPendingAdd: () => LocalStorage.removeItem(ADD_IN_FLIGHT_KEY),
+  authorize: () => stagingService.authorize(),
+  identify: fetchViewerIdentity,
+  verify: async (accessToken) => makeClient(accessToken).viewer,
+  getDestination: async (identity) => {
+    const registry = await readRegistry();
+    const existing = registry.workspaces.find((entry) => entryKey(entry) === entryKey(identity));
+    // An adopted first workspace keeps its original "linear" storage slot.
+    const providerId = existing?.providerId ?? workspaceProviderId(identity.orgId, identity.userId);
+    return getServiceForProviderId(providerId, undefined, `Linear — ${identity.orgName}`).client;
+  },
+  register: upsertWorkspaceEntry,
+  trace: traceWorkspaceAdd,
+});
 
 async function revokeAtLinear(accessToken: string): Promise<boolean> {
   try {
@@ -71,83 +80,17 @@ export default function ManageWorkspaces() {
     setIsLoading(false);
   }, []);
 
-  // Finish an interrupted add: registry write from an authorized staging token (§4.1 step 5).
-  // Ordering fix (F-2): the token is VERIFIED before anything is written to the registry —
-  // the original order wrote the entry first and verified after, so a failure between those
-  // two steps left a token-less entry behind that a stray staging token would keep resurrecting
-  // on every subsequent mount.
-  const completeAddFromStaging = useCallback(async () => {
-    const stagingTokens = await stagingService.client.getTokens();
-    if (!stagingTokens?.accessToken) {
-      // Nothing staged — clear a stale in-flight marker from a crash before any grant landed.
-      await LocalStorage.removeItem(ADD_IN_FLIGHT_KEY);
-      return false;
-    }
-
-    let identity: ViewerIdentity;
-    try {
-      identity = await fetchViewerIdentity(stagingTokens.accessToken);
-      // Second, SDK-path verification of the same token before it is ever written anywhere.
-      await makeClient(stagingTokens.accessToken).viewer;
-    } catch (error) {
-      if (isPermanentTokenFailure(error)) {
-        // The token itself is rejected (permanent failure) — clear it so a dead token
-        // doesn't keep silently failing on every future mount.
-        await stagingService.client.removeTokens();
-        await LocalStorage.removeItem(ADD_IN_FLIGHT_KEY);
-      }
-      // A transient failure (network, 5xx) leaves staging untouched so recovery can retry.
-      throw error;
-    }
-
-    const { entry, isNew } = await upsertWorkspaceEntry(identity);
-    const destination = getServiceForProviderId(entry.providerId, undefined, `Linear — ${entry.orgName}`);
-    // setTokens re-stamps updatedAt to NOW, so pass the REMAINING lifetime, not the
-    // original duration — crash recovery can run hours after the grant, and copying the
-    // full duration would make isExpired() lag the server's fixed expiry. Omit expiresIn
-    // entirely when the stored set lacks it (do not default it — that would make a
-    // non-expiring token look expiring).
-    const elapsedSeconds = Math.floor((Date.now() - stagingTokens.updatedAt.getTime()) / 1000);
-    try {
-      await destination.client.setTokens({
-        accessToken: stagingTokens.accessToken,
-        refreshToken: stagingTokens.refreshToken,
-        idToken: stagingTokens.idToken,
-        scope: stagingTokens.scope,
-        ...(stagingTokens.expiresIn !== undefined
-          ? { expiresIn: Math.max(60, stagingTokens.expiresIn - elapsedSeconds) }
-          : {}),
-      });
-    } finally {
-      // The identity is verified and the entry is written by this point — the staging
-      // token must not linger regardless of whether setTokens itself succeeded.
-      await stagingService.client.removeTokens();
-      await LocalStorage.removeItem(ADD_IN_FLIGHT_KEY);
-    }
-    await showToast({
-      style: Toast.Style.Success,
-      title: isNew ? `Added ${identity.orgName}` : `Re-authenticated ${identity.orgName}`,
-      message: identity.userEmail,
-    });
-    refreshQuickCommandSubtitles(); // fire-and-forget: workspace membership changed, subtitles listing "others" are now stale
-    return true;
-  }, []);
-
   useEffect(() => {
     (async () => {
-      // Crash/cancel recovery on mount: only resume an add the user actually started (F-3) —
-      // a stray staging token must never be replayed as an implicit "add" on every mount.
       try {
-        const addInFlight = await LocalStorage.getItem<string>(ADD_IN_FLIGHT_KEY);
-        if (addInFlight) {
-          await completeAddFromStaging();
-        }
+        const recovered = await workspaceAdd.recover();
+        if (recovered) refreshQuickCommandSubtitles();
       } catch {
-        // Leave staging for the next attempt; never crash the management surface.
+        // The flow logs the failing stage in development and preserves recovery state.
       }
       await reload();
     })();
-  }, [completeAddFromStaging, reload]);
+  }, [reload]);
 
   async function addWorkspace() {
     const proceed = await confirmAlert({
@@ -160,14 +103,16 @@ export default function ManageWorkspaces() {
     });
     if (!proceed) return;
     try {
-      await stagingService.client.removeTokens(); // clear any prior abort (§4.1 step 1)
-      // Mark that an add is genuinely in flight, so a crash before this completes still lets
-      // mount-time recovery resume it (F-3) — cleared inside completeAddFromStaging once the
-      // token is proven good or proven bad.
-      await LocalStorage.setItem(ADD_IN_FLIGHT_KEY, "1");
-      await stagingService.authorize(); // interactive; prompt=consent forces the consent screen
-      await completeAddFromStaging();
-      await reload();
+      const added = await workspaceAdd.add();
+      if (added) {
+        await showToast({
+          style: Toast.Style.Success,
+          title: added.isNew ? `Added ${added.identity.orgName}` : `Re-authenticated ${added.identity.orgName}`,
+          message: added.identity.userEmail,
+        });
+        refreshQuickCommandSubtitles();
+      }
+      await traceWorkspaceAdd("ui.reload", reload);
     } catch (error) {
       await showToast({
         style: Toast.Style.Failure,

--- a/extensions/linear/src/notifications.tsx
+++ b/extensions/linear/src/notifications.tsx
@@ -7,6 +7,7 @@ import { updateNotification } from "./api/updateNotification";
 import IssueDetail from "./components/IssueDetail";
 import OpenInLinear from "./components/OpenInLinear";
 import View from "./components/View";
+import { WorkspaceListDropdown } from "./components/WorkspaceDropdown";
 import { getBotIcon } from "./helpers/bots";
 import { getErrorMessage } from "./helpers/errors";
 import { getNotificationIcon, getNotificationURL } from "./helpers/notifications";
@@ -14,6 +15,18 @@ import { getUserIcon } from "./helpers/users";
 import useMe from "./hooks/useMe";
 import useNotifications from "./hooks/useNotifications";
 import usePriorities from "./hooks/usePriorities";
+
+// The dev-build install may not have "Unread Notifications" (a menu-bar command) activated,
+// which makes launchCommand reject with "must be activated before it can be run in the
+// background". That refresh is best-effort — it must never turn a completed mutation
+// (mark as read/unread, mark all as read) into a reported failure (todoist precedent:
+// extensions/todoist/src/helpers/menu-bar.ts).
+function refreshUnreadNotificationsMenuBar() {
+  return launchCommand({ name: "unread-notifications", type: LaunchType.Background }).catch(() => {
+    // The menu-bar command may not be activated; a failed refresh must not report the
+    // completed mutation as a failure.
+  });
+}
 
 function Notifications() {
   const {
@@ -74,7 +87,7 @@ function Notifications() {
       });
 
       await showToast({ style: Toast.Style.Success, title: "Marked as read" });
-      await launchCommand({ name: "unread-notifications", type: LaunchType.Background });
+      await refreshUnreadNotificationsMenuBar();
     } catch (error) {
       showToast({
         style: Toast.Style.Failure,
@@ -115,7 +128,7 @@ function Notifications() {
       });
 
       await showToast({ style: Toast.Style.Success, title: "Marked as unread" });
-      await launchCommand({ name: "unread-notifications", type: LaunchType.Background });
+      await refreshUnreadNotificationsMenuBar();
     } catch (error) {
       showToast({
         style: Toast.Style.Failure,
@@ -203,7 +216,7 @@ function Notifications() {
       );
 
       await showToast({ style: Toast.Style.Success, title: "Marked all as read" });
-      await launchCommand({ name: "unread-notifications", type: LaunchType.Background });
+      await refreshUnreadNotificationsMenuBar();
     } catch (error) {
       showToast({
         style: Toast.Style.Failure,
@@ -214,7 +227,10 @@ function Notifications() {
   }
 
   return (
-    <List isLoading={isLoadingNotifications || isLoadingPriorities || isLoadingMe}>
+    <List
+      isLoading={isLoadingNotifications || isLoadingPriorities || isLoadingMe}
+      searchBarAccessory={<WorkspaceListDropdown />}
+    >
       <List.EmptyView title="Inbox" description="You don't have any notifications." />
 
       {sections.map(({ title, notifications }) => {

--- a/extensions/linear/src/quick-add-comment-to-issue.ts
+++ b/extensions/linear/src/quick-add-comment-to-issue.ts
@@ -8,11 +8,21 @@ import {
   showHUD,
   Keyboard,
 } from "@raycast/api";
-import { withAccessToken } from "@raycast/utils";
 
-import { getLinearClient, linear } from "./api/linearClient";
+import { getLinearClient } from "./api/linearClient";
+import { withWorkspaceAuth } from "./api/withWorkspaceAuth";
+import { resolveWorkspaceArgument, updateWorkspaceChoicesSubtitle } from "./helpers/workspaceArgument";
 
-const command = async (props: { arguments: Arguments.QuickAddCommentToIssue }) => {
+const command = async (props: {
+  arguments: Arguments.QuickAddCommentToIssue;
+  launchContext?: { refreshSubtitle?: boolean };
+}) => {
+  await updateWorkspaceChoicesSubtitle(); // awaited: the no-view process exits when the command resolves — a fire-and-forget write would be killed
+
+  if (props.launchContext?.refreshSubtitle) {
+    return; // background refresh launch — subtitle updated above, do nothing else
+  }
+
   const { issueId, comment } = props.arguments;
 
   const toast = await showToast({
@@ -20,10 +30,18 @@ const command = async (props: { arguments: Arguments.QuickAddCommentToIssue }) =
     title: `Adding comment to ${issueId}`,
   });
 
+  const resolved = await resolveWorkspaceArgument(props.arguments.workspace);
+  if (!resolved.ok) {
+    toast.style = Toast.Style.Failure;
+    toast.title = "Workspace not matched";
+    toast.message = resolved.message;
+    return;
+  }
+
   const preferences = getPreferenceValues<Preferences.QuickAddCommentToIssue>();
 
   try {
-    const { linearClient } = getLinearClient();
+    const linearClient = resolved.client ?? getLinearClient().linearClient;
 
     if (preferences.shouldCloseMainWindow) {
       await closeMainWindow();
@@ -75,4 +93,4 @@ const command = async (props: { arguments: Arguments.QuickAddCommentToIssue }) =
   }
 };
 
-export default withAccessToken(linear)(command);
+export default withWorkspaceAuth(command);

--- a/extensions/linear/src/search-custom-views.tsx
+++ b/extensions/linear/src/search-custom-views.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 
 import IssueListItem from "./components/IssueListItem";
 import View from "./components/View";
+import { WorkspaceListDropdown } from "./components/WorkspaceDropdown";
 import { getIcon } from "./helpers/icons";
 import { useCustomViews, useCustomViewIssues } from "./hooks/useCustomViews";
 import useMe from "./hooks/useMe";
@@ -50,7 +51,11 @@ function CustomViewList() {
   }, [customViewsError]);
 
   return (
-    <List isLoading={isLoadingCustomViews} searchBarPlaceholder="Search custom views">
+    <List
+      isLoading={isLoadingCustomViews}
+      searchBarPlaceholder="Search custom views"
+      searchBarAccessory={<WorkspaceListDropdown />}
+    >
       {customViews?.map((view) => {
         const accessories: List.Item.Accessory[] = [];
 

--- a/extensions/linear/src/search-issues.tsx
+++ b/extensions/linear/src/search-issues.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 
 import IssueListItem from "./components/IssueListItem";
 import View from "./components/View";
+import { WorkspaceListDropdown } from "./components/WorkspaceDropdown";
 import useMe from "./hooks/useMe";
 import usePriorities from "./hooks/usePriorities";
 import useSearchIssues from "./hooks/useSearchIssues";
@@ -24,6 +25,7 @@ function SearchIssues() {
       throttle
       searchBarPlaceholder="Globally search issues across projects"
       pagination={pagination}
+      searchBarAccessory={<WorkspaceListDropdown />}
     >
       <List.Section title="Updated Recently" subtitle={numberOfIssues}>
         {data?.map((issue) => (

--- a/extensions/linear/src/tools/add-label.ts
+++ b/extensions/linear/src/tools/add-label.ts
@@ -1,6 +1,6 @@
-import { withAccessToken } from "@raycast/utils";
+import { resolveClient } from "../api/linearClient";
 
-import { getLinearClient, linear } from "../api/linearClient";
+import { describeToolWorkspace, resolveToolClient, withToolAuth } from "./resolveToolWorkspace";
 
 type Input = {
   /** The ID of the issue to add the label to. Format is a combination of a team key and a unique number, like `ENG-123` */
@@ -8,10 +8,14 @@ type Input = {
 
   /** The ID of the label to add to the issue. Never use title as ID: you have to use `get-labels` tool to get the actual ID from the list of labels */
   labelId: string;
+
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 };
 
-export default withAccessToken(linear)(async ({ issueId, labelId }: Input) => {
-  const { linearClient } = getLinearClient();
+export default withToolAuth(async ({ issueId, labelId, workspaceId }: Input) => {
+  const client = await resolveToolClient(workspaceId);
+  const { linearClient } = resolveClient(client);
   const issue = await linearClient.issue(issueId);
   const currentLabelIds = issue.labelIds || [];
   const result = await linearClient.updateIssue(issueId, {
@@ -25,13 +29,16 @@ export default withAccessToken(linear)(async ({ issueId, labelId }: Input) => {
   return result.issue;
 });
 
-export const confirmation = withAccessToken(linear)(async ({ issueId, labelId }: Input) => {
-  const { linearClient } = getLinearClient();
+export const confirmation = withToolAuth(async ({ issueId, labelId, workspaceId }: Input) => {
+  const workspaceName = await describeToolWorkspace(workspaceId);
+  const client = await resolveToolClient(workspaceId);
+  const { linearClient } = resolveClient(client);
   const label = await linearClient.issueLabel(labelId);
   const issue = await linearClient.issue(issueId);
 
   return {
     info: [
+      ...(workspaceName ? [{ name: "Workspace", value: workspaceName }] : []),
       { name: "Issue", value: issue.title },
       { name: "Label", value: label.name },
     ],

--- a/extensions/linear/src/tools/create-attachment.ts
+++ b/extensions/linear/src/tools/create-attachment.ts
@@ -1,9 +1,7 @@
-import { withAccessToken } from "@raycast/utils";
-
 import { uploadFile } from "../api/attachments";
-import { linear } from "../api/linearClient";
 
 import { client, resolveIssue } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 type Input = {
   issue: string;
@@ -11,9 +9,11 @@ type Input = {
   filePath: string;
   title?: string;
   subtitle?: string;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 };
 
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   const issue = await resolveIssue(input.issue);
   const file = await uploadFile(input.filePath);
   const result = await client().createAttachment({

--- a/extensions/linear/src/tools/create-comment.ts
+++ b/extensions/linear/src/tools/create-comment.ts
@@ -1,11 +1,10 @@
 import path from "path";
 
-import { withAccessToken } from "@raycast/utils";
-
 import { appendFileAttachments } from "../api/attachments";
-import { getLinearClient, linear } from "../api/linearClient";
+import { resolveClient } from "../api/linearClient";
 
 import { serializeComment } from "./commentUtils";
+import { describeToolWorkspace, resolveToolClient, withToolAuth } from "./resolveToolWorkspace";
 
 type Input = {
   /** The ID of the issue to associate the comment with. Format is a combination of a team key and a unique number, like `ENG-123` */
@@ -22,11 +21,15 @@ type Input = {
 
   /** A list of absolute local file paths to upload and append to the comment */
   attachmentPaths?: string[];
+
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 };
 
-export default withAccessToken(linear)(async (inputs: Input) => {
-  const { linearClient } = getLinearClient();
-  const body = await appendFileAttachments(inputs.body, inputs.attachmentPaths);
+export default withToolAuth(async (inputs: Input) => {
+  const client = await resolveToolClient(inputs.workspaceId);
+  const { linearClient } = resolveClient(client);
+  const body = await appendFileAttachments(inputs.body, inputs.attachmentPaths, client);
   const result = await linearClient.createComment({
     issueId: inputs.issueId,
     parentId: inputs.parentId,
@@ -41,34 +44,33 @@ export default withAccessToken(linear)(async (inputs: Input) => {
   return serializeComment(await result.comment);
 });
 
-export const confirmation = withAccessToken(linear)(async ({
-  issueId,
-  parentId,
-  projectUpdateId,
-  body,
-  attachmentPaths,
-}: Input) => {
-  const { linearClient } = getLinearClient();
+export const confirmation = withToolAuth(
+  async ({ issueId, parentId, projectUpdateId, body, attachmentPaths, workspaceId }: Input) => {
+    const workspaceName = await describeToolWorkspace(workspaceId);
+    const client = await resolveToolClient(workspaceId);
+    const { linearClient } = resolveClient(client);
 
-  let title: string = "";
+    let title: string = "";
 
-  if (issueId) {
-    const issue = await linearClient.issue(issueId);
-    title = issue.title;
-  } else if (parentId) {
-    const parentComment = await linearClient.comment({ id: parentId });
-    title = parentComment.body;
-  } else if (projectUpdateId) {
-    title = "Project Update";
-  }
+    if (issueId) {
+      const issue = await linearClient.issue(issueId);
+      title = issue.title;
+    } else if (parentId) {
+      const parentComment = await linearClient.comment({ id: parentId });
+      title = parentComment.body;
+    } else if (projectUpdateId) {
+      title = "Project Update";
+    }
 
-  return {
-    info: [
-      { name: "Title", value: title },
-      { name: "Comment", value: body },
-      ...(attachmentPaths?.length
-        ? [{ name: "Attachments", value: attachmentPaths.map((filePath) => path.basename(filePath)).join(", ") }]
-        : []),
-    ],
-  };
-});
+    return {
+      info: [
+        ...(workspaceName ? [{ name: "Workspace", value: workspaceName }] : []),
+        { name: "Title", value: title },
+        { name: "Comment", value: body },
+        ...(attachmentPaths?.length
+          ? [{ name: "Attachments", value: attachmentPaths.map((filePath) => path.basename(filePath)).join(", ") }]
+          : []),
+      ],
+    };
+  },
+);

--- a/extensions/linear/src/tools/create-document.ts
+++ b/extensions/linear/src/tools/create-document.ts
@@ -1,6 +1,6 @@
-import { withAccessToken } from "@raycast/utils";
+import { resolveClient } from "../api/linearClient";
 
-import { getLinearClient, linear } from "../api/linearClient";
+import { describeToolWorkspace, resolveToolClient, withToolAuth } from "./resolveToolWorkspace";
 
 type Input = {
   /** The content of the document/PRD as a Markdown string */
@@ -11,10 +11,14 @@ type Input = {
 
   /** The ID of the project the document/PRD belongs to */
   projectId: string;
+
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 };
 
-export default withAccessToken(linear)(async (inputs: Input) => {
-  const { linearClient } = getLinearClient();
+export default withToolAuth(async ({ workspaceId, ...inputs }: Input) => {
+  const client = await resolveToolClient(workspaceId);
+  const { linearClient } = resolveClient(client);
   const result = await linearClient.createDocument(inputs);
 
   if (!result.success) {
@@ -24,13 +28,16 @@ export default withAccessToken(linear)(async (inputs: Input) => {
   return result.document;
 });
 
-export const confirmation = withAccessToken(linear)(async ({ title, projectId }: Input) => {
-  const { linearClient } = getLinearClient();
+export const confirmation = withToolAuth(async ({ title, projectId, workspaceId }: Input) => {
+  const workspaceName = await describeToolWorkspace(workspaceId);
+  const client = await resolveToolClient(workspaceId);
+  const { linearClient } = resolveClient(client);
 
   const project = await linearClient.project(projectId);
 
   return {
     info: [
+      ...(workspaceName ? [{ name: "Workspace", value: workspaceName }] : []),
       { name: "Title", value: title },
       { name: "Project", value: project.name },
     ],

--- a/extensions/linear/src/tools/create-initiative-label.ts
+++ b/extensions/linear/src/tools/create-initiative-label.ts
@@ -1,11 +1,16 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { client, resolveInitiativeLabel } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
-type Input = { name: string; description?: string; color?: string; parent?: string; isGroup?: boolean };
-export default withAccessToken(linear)(async (input: Input) => {
+type Input = {
+  name: string;
+  description?: string;
+  color?: string;
+  parent?: string;
+  isGroup?: boolean;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
+export default withToolAuth(async (input: Input) => {
   const parentId = input.parent ? (await resolveInitiativeLabel(input.parent)).id : undefined;
   const result = await client().createInitiativeLabel({
     name: input.name,

--- a/extensions/linear/src/tools/create-issue-label.ts
+++ b/extensions/linear/src/tools/create-issue-label.ts
@@ -1,8 +1,5 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { client, resolveIssueLabel } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 type Input = {
   name: string;
@@ -11,8 +8,10 @@ type Input = {
   teamId?: string;
   parent?: string;
   isGroup?: boolean;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 };
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   const parentId = input.parent ? (await resolveIssueLabel(input.parent)).id : undefined;
   const result = await client().createIssueLabel({
     name: input.name,

--- a/extensions/linear/src/tools/create-issue.ts
+++ b/extensions/linear/src/tools/create-issue.ts
@@ -1,9 +1,7 @@
-import { withAccessToken } from "@raycast/utils";
-
 import { createIssue, CreateIssuePayload } from "../api/createIssue";
-import { linear } from "../api/linearClient";
 
 import { formatConfirmation } from "./formatConfirmation";
+import { describeToolWorkspace, resolveToolClient, withToolAuth } from "./resolveToolWorkspace";
 
 type Input = {
   /** The priority of the issue (0-4, where 0 is no priority and 4 is urgent) */
@@ -45,9 +43,13 @@ type Input = {
 
   /** The estimate of the issue using a 0-5 scale */
   estimate?: number;
+
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 };
 
-export default withAccessToken(linear)(async (inputs: Input) => {
+export default withToolAuth(async (inputs: Input) => {
+  const client = await resolveToolClient(inputs.workspaceId);
   const payload: CreateIssuePayload = {
     teamId: inputs.teamId,
     title: inputs.title,
@@ -61,19 +63,26 @@ export default withAccessToken(linear)(async (inputs: Input) => {
     priority: inputs.priority || 0,
   };
 
-  return createIssue(payload);
+  return createIssue(payload, client);
 });
 
-export const confirmation = withAccessToken(linear)(async (inputs: Input) => {
-  const { title, ...fields } = inputs;
+export const confirmation = withToolAuth(async (inputs: Input) => {
+  const workspaceName = await describeToolWorkspace(inputs.workspaceId);
+  const client = await resolveToolClient(inputs.workspaceId);
+  const { title, workspaceId, ...fields } = inputs;
+  void workspaceId; // destructured only to exclude it from `fields`
   const details = await Promise.all(
     Object.keys(fields).map((key) => {
       const name = key as keyof typeof fields;
-      return formatConfirmation({ name, value: fields[name] });
+      return formatConfirmation({ name, value: fields[name], client });
     }),
   );
 
   return {
-    info: [formatConfirmation({ name: "Title", value: title }), ...details],
+    info: [
+      ...(workspaceName ? [{ name: "Workspace", value: workspaceName }] : []),
+      formatConfirmation({ name: "Title", value: title, client }),
+      ...details,
+    ],
   };
 });

--- a/extensions/linear/src/tools/create-project-update.ts
+++ b/extensions/linear/src/tools/create-project-update.ts
@@ -1,6 +1,6 @@
-import { withAccessToken } from "@raycast/utils";
+import { resolveClient } from "../api/linearClient";
 
-import { getLinearClient, linear } from "../api/linearClient";
+import { describeToolWorkspace, resolveToolClient, withToolAuth } from "./resolveToolWorkspace";
 
 type Input = {
   /** The ID of the project to create an update for. Use the 'get-projects' tool to get the project ID. */
@@ -11,10 +11,14 @@ type Input = {
 
   /** The health status of the project */
   health: "onTrack" | "atRisk" | "offTrack";
+
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 };
 
-export default withAccessToken(linear)(async (inputs: Input) => {
-  const { linearClient } = getLinearClient();
+export default withToolAuth(async ({ workspaceId, ...inputs }: Input) => {
+  const client = await resolveToolClient(workspaceId);
+  const { linearClient } = resolveClient(client);
   // @ts-expect-error the enum is correct
   const result = await linearClient.createProjectUpdate(inputs);
 
@@ -25,12 +29,17 @@ export default withAccessToken(linear)(async (inputs: Input) => {
   return result.projectUpdate;
 });
 
-export const confirmation = withAccessToken(linear)(async ({ projectId }: Input) => {
-  const { linearClient } = getLinearClient();
+export const confirmation = withToolAuth(async ({ projectId, workspaceId }: Input) => {
+  const workspaceName = await describeToolWorkspace(workspaceId);
+  const client = await resolveToolClient(workspaceId);
+  const { linearClient } = resolveClient(client);
 
   const project = await linearClient.project(projectId);
 
   return {
-    info: [{ name: "Project", value: project.name }],
+    info: [
+      ...(workspaceName ? [{ name: "Workspace", value: workspaceName }] : []),
+      { name: "Project", value: project.name },
+    ],
   };
 });

--- a/extensions/linear/src/tools/delete-attachment.ts
+++ b/extensions/linear/src/tools/delete-attachment.ts
@@ -1,11 +1,12 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { client } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
-type Input = { id: string };
-export default withAccessToken(linear)(async ({ id }: Input) => {
+type Input = {
+  id: string;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
+export default withToolAuth(async ({ id }: Input) => {
   const result = await client().deleteAttachment(id);
   return { success: result.success };
 });

--- a/extensions/linear/src/tools/delete-comment.ts
+++ b/extensions/linear/src/tools/delete-comment.ts
@@ -1,7 +1,8 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { client } from "./linearUtils";
-type Input = { /** Comment ID */ id: string };
-export default withAccessToken(linear)(async ({ id }: Input) => client().deleteComment(id));
+import { withToolAuth } from "./resolveToolWorkspace";
+type Input = {
+  /** Comment ID */ id: string;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
+export default withToolAuth(async ({ id }: Input) => client().deleteComment(id));

--- a/extensions/linear/src/tools/delete-issue.ts
+++ b/extensions/linear/src/tools/delete-issue.ts
@@ -1,15 +1,14 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { client, resolveIssue } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 type Input = {
   /** Issue ID or identifier (e.g. LIN-123). */
   id: string;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 };
 
-export default withAccessToken(linear)(async ({ id }: Input) => {
+export default withToolAuth(async ({ id }: Input) => {
   const issue = await resolveIssue(id);
   const result = await client().deleteIssue(issue.id);
 
@@ -24,7 +23,7 @@ export default withAccessToken(linear)(async ({ id }: Input) => {
   };
 });
 
-export const confirmation = withAccessToken(linear)(async ({ id }: Input) => {
+export const confirmation = withToolAuth(async ({ id }: Input) => {
   const issue = await resolveIssue(id);
 
   return {

--- a/extensions/linear/src/tools/delete-status-update.ts
+++ b/extensions/linear/src/tools/delete-status-update.ts
@@ -1,12 +1,14 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { client } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
-type Input = { type: "project" | "initiative"; id: string };
+type Input = {
+  type: "project" | "initiative";
+  id: string;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
 
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   const result =
     input.type === "project"
       ? await client().archiveProjectUpdate(input.id)

--- a/extensions/linear/src/tools/filter-issues.ts
+++ b/extensions/linear/src/tools/filter-issues.ts
@@ -1,9 +1,7 @@
-import { withAccessToken } from "@raycast/utils";
-
 import { filterIssues } from "../api/getIssues";
-import { linear } from "../api/linearClient";
 
 import { collect, CursorPageInput } from "./linearUtils";
+import { resolveToolClient, withToolAuth } from "./resolveToolWorkspace";
 
 interface Input extends CursorPageInput {
   /** Max results (default 50, max 250) */ limit?: number;
@@ -132,11 +130,14 @@ interface Input extends CursorPageInput {
   * IMPORTANT: When user asks about my issues (assigned to me, my issues, etc), always filter by assignee.
   */
   filter: string;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 }
 
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
+  const client = await resolveToolClient(input.workspaceId);
   return collect(async ({ first, after }) => {
-    const result = await filterIssues(input.filter, after, first);
+    const result = await filterIssues(input.filter, after, first, client);
     return {
       nodes: result.issues ?? [],
       pageInfo: result.pageInfo ?? { hasNextPage: false },

--- a/extensions/linear/src/tools/formatConfirmation.ts
+++ b/extensions/linear/src/tools/formatConfirmation.ts
@@ -1,13 +1,17 @@
-import { getLinearClient } from "../api/linearClient";
+import { LinearClient } from "@linear/sdk";
+
+import { resolveClient } from "../api/linearClient";
 
 export function formatConfirmation({
   name,
   value,
+  client,
 }: {
   name: string;
   value: undefined | null | number | string | string[];
+  client?: LinearClient;
 }) {
-  const { linearClient } = getLinearClient();
+  const { linearClient } = resolveClient(client);
 
   const formatters = {
     assigneeId: async (assigneeId: string) => {

--- a/extensions/linear/src/tools/full-text-search-issues.ts
+++ b/extensions/linear/src/tools/full-text-search-issues.ts
@@ -1,20 +1,21 @@
-import { withAccessToken } from "@raycast/utils";
-
 import { searchIssues } from "../api/getIssues";
-import { linear } from "../api/linearClient";
 
 import { collect, CursorPageInput } from "./linearUtils";
+import { resolveToolClient, withToolAuth } from "./resolveToolWorkspace";
 
 interface Input extends CursorPageInput {
   /** Max results (default 50, max 250) */ limit?: number;
   /** Next page cursor */ cursor?: string;
   /** The query to search for. Only use plain text: it doesn't support any operators */
   query: string;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 }
 
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
+  const client = await resolveToolClient(input.workspaceId);
   return collect(async ({ first, after }) => {
-    const result = await searchIssues(input.query, after, first);
+    const result = await searchIssues(input.query, after, first, client);
     return {
       nodes: result.issues ?? [],
       pageInfo: result.pageInfo ?? { hasNextPage: false },

--- a/extensions/linear/src/tools/get-agent-skill.ts
+++ b/extensions/linear/src/tools/get-agent-skill.ts
@@ -1,8 +1,9 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { client } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
-type Input = { /** Agent skill ID */ id: string };
-export default withAccessToken(linear)(async ({ id }: Input) => client().agentSkill(id));
+type Input = {
+  /** Agent skill ID */ id: string;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
+export default withToolAuth(async ({ id }: Input) => client().agentSkill(id));

--- a/extensions/linear/src/tools/get-attachment.ts
+++ b/extensions/linear/src/tools/get-attachment.ts
@@ -1,8 +1,9 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { client } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
-type Input = { id: string };
-export default withAccessToken(linear)(async ({ id }: Input) => client().attachment(id));
+type Input = {
+  id: string;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
+export default withToolAuth(async ({ id }: Input) => client().attachment(id));

--- a/extensions/linear/src/tools/get-current-user.ts
+++ b/extensions/linear/src/tools/get-current-user.ts
@@ -1,9 +1,15 @@
-import { withAccessToken } from "@raycast/utils";
+import { resolveClient } from "../api/linearClient";
 
-import { getLinearClient, linear } from "../api/linearClient";
+import { resolveToolClient, withToolAuth } from "./resolveToolWorkspace";
 
-export default withAccessToken(linear)(async () => {
-  const { linearClient } = getLinearClient();
+type Input = {
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
+
+export default withToolAuth(async ({ workspaceId }: Input) => {
+  const client = await resolveToolClient(workspaceId);
+  const { linearClient } = resolveClient(client);
 
   const user = await linearClient.client.rawRequest(`
     query {

--- a/extensions/linear/src/tools/get-document-content.ts
+++ b/extensions/linear/src/tools/get-document-content.ts
@@ -1,9 +1,9 @@
-import { Document } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
+import { Document, LinearClient } from "@linear/sdk";
 
-import { getLinearClient, linear } from "../api/linearClient";
+import { resolveClient } from "../api/linearClient";
 
 import { DocumentResult } from "./get-documents";
+import { resolveToolClient, withToolAuth } from "./resolveToolWorkspace";
 
 export type DocumentWithContent = Pick<Document, "content"> & DocumentResult;
 
@@ -35,8 +35,8 @@ const docFragment = `
   }
 `;
 
-export async function getDocumentContent(documentId: string) {
-  const { graphQLClient } = getLinearClient();
+export async function getDocumentContent(documentId: string, client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
 
   const { data } = await graphQLClient.rawRequest<
     { documents: { nodes: DocumentWithContent[] } },
@@ -58,9 +58,15 @@ export async function getDocumentContent(documentId: string) {
   return data?.documents.nodes?.[0];
 }
 
-export default withAccessToken(linear)(async (inputs: {
+type Input = {
   /** The ID of the document/PRD to fetch */
   documentId: string;
-}) => {
-  return await getDocumentContent(inputs.documentId);
+
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
+
+export default withToolAuth(async (inputs: Input) => {
+  const client = await resolveToolClient(inputs.workspaceId);
+  return await getDocumentContent(inputs.documentId, client);
 });

--- a/extensions/linear/src/tools/get-document.ts
+++ b/extensions/linear/src/tools/get-document.ts
@@ -1,9 +1,10 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { resolveDocument } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
-type Input = { /** Document ID or slug */ id: string };
+type Input = {
+  /** Document ID or slug */ id: string;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
 
-export default withAccessToken(linear)(async ({ id }: Input) => resolveDocument(id));
+export default withToolAuth(async ({ id }: Input) => resolveDocument(id));

--- a/extensions/linear/src/tools/get-documents.ts
+++ b/extensions/linear/src/tools/get-documents.ts
@@ -1,8 +1,9 @@
-import { Document, Initiative, Project, User } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
+import { Document, Initiative, LinearClient, Project, User } from "@linear/sdk";
 import { sortBy } from "lodash";
 
-import { getLinearClient, linear } from "../api/linearClient";
+import { resolveClient } from "../api/linearClient";
+
+import { resolveToolClient, withToolAuth } from "./resolveToolWorkspace";
 
 export type DocumentResult = Pick<
   Document,
@@ -49,8 +50,12 @@ const docFragment = `
 
 export type DocumentEntity = { projectId: string } | { initiativeId: string };
 
-export async function getDocuments(query: string = "", entity: DocumentEntity = { projectId: "" }) {
-  const { graphQLClient } = getLinearClient();
+export async function getDocuments(
+  query: string = "",
+  entity: DocumentEntity = { projectId: "" },
+  client?: LinearClient,
+) {
+  const { graphQLClient } = resolveClient(client);
 
   const searchProject = "projectId" in entity && entity.projectId.length > 0;
   const searchInitiative = "initiativeId" in entity && entity.initiativeId.length > 0;
@@ -86,19 +91,25 @@ export async function getDocuments(query: string = "", entity: DocumentEntity = 
   return { docs, hasMoreDocs };
 }
 
-export default withAccessToken(linear)(async (inputs: {
+type Input = {
   /** Search query to filter documents */
   query?: string;
   /** Restrict the documents/PRDs returned to a specific initiative */
   initiativeId?: string;
   /** Restrict the documents/PRDs returned to a specific project */
   projectId?: string;
-}) => {
+
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
+
+export default withToolAuth(async (inputs: Input) => {
+  const client = await resolveToolClient(inputs.workspaceId);
   let entity: DocumentEntity = { projectId: "" };
   if (inputs.projectId) {
     entity = { projectId: inputs.projectId };
   } else if (inputs.initiativeId) {
     entity = { initiativeId: inputs.initiativeId };
   }
-  return (await getDocuments(inputs.query || undefined, entity)).docs;
+  return (await getDocuments(inputs.query || undefined, entity, client)).docs;
 });

--- a/extensions/linear/src/tools/get-initiative.ts
+++ b/extensions/linear/src/tools/get-initiative.ts
@@ -1,13 +1,16 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { defaultInitiativeFields, InitiativeField, serializeInitiative } from "./initiativeUtils";
 import { resolveInitiative } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
-type Input = { query: string; includeProjects?: boolean; includeSubInitiatives?: boolean };
+type Input = {
+  query: string;
+  includeProjects?: boolean;
+  includeSubInitiatives?: boolean;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
 
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   const initiative = await resolveInitiative(input.query);
   const fields: InitiativeField[] = [
     ...defaultInitiativeFields,

--- a/extensions/linear/src/tools/get-initiatives.ts
+++ b/extensions/linear/src/tools/get-initiatives.ts
@@ -1,8 +1,9 @@
-import { Initiative, Project } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
+import { Initiative, LinearClient, Project } from "@linear/sdk";
 import { sortBy } from "lodash";
 
-import { getLinearClient, linear } from "../api/linearClient";
+import { resolveClient } from "../api/linearClient";
+
+import { resolveToolClient, withToolAuth } from "./resolveToolWorkspace";
 
 export type InitiativeResult = Pick<Initiative, "id" | "name" | "color" | "icon" | "sortOrder" | "description"> & {
   projects?: { nodes: Pick<Project, "id">[] };
@@ -24,8 +25,8 @@ const initiativeFragment = `
   }
 `;
 
-export async function getInitiatives() {
-  const { graphQLClient } = getLinearClient();
+export async function getInitiatives(client?: LinearClient) {
+  const { graphQLClient } = resolveClient(client);
   const { data } = await graphQLClient.rawRequest<InitiativeList, Record<string, unknown>>(
     `
       query {
@@ -41,6 +42,12 @@ export async function getInitiatives() {
   return sortBy(data?.initiatives.nodes ?? [], (i) => i.sortOrder ?? Infinity);
 }
 
-export default withAccessToken(linear)(async () => {
-  return await getInitiatives();
+type Input = {
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
+
+export default withToolAuth(async ({ workspaceId }: Input) => {
+  const client = await resolveToolClient(workspaceId);
+  return await getInitiatives(client);
 });

--- a/extensions/linear/src/tools/get-issue-states.ts
+++ b/extensions/linear/src/tools/get-issue-states.ts
@@ -1,40 +1,48 @@
 import { WorkflowState } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
 
-import { getLinearClient, linear } from "../api/linearClient";
+import { resolveClient } from "../api/linearClient";
+
+import { resolveToolClient, withToolAuth } from "./resolveToolWorkspace";
 
 export type StatusResult = Pick<WorkflowState, "id" | "name" | "description" | "position" | "type">;
 
-export default withAccessToken(linear)(async ({
-  teamId,
-}: {
-  /** The ID of the team to fetch the statuses for. Do not ask user to specify team if there is only one in the list */
-  teamId: string;
-}) => {
-  const { linearClient } = getLinearClient();
+export default withToolAuth(
+  async ({
+    teamId,
+    workspaceId,
+  }: {
+    /** The ID of the team to fetch the statuses for. Do not ask user to specify team if there is only one in the list */
+    teamId: string;
 
-  const allStates: StatusResult[] = [];
-  let hasNextPage = true;
-  let endCursor = null;
+    /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+    workspaceId?: string;
+  }) => {
+    const client = await resolveToolClient(workspaceId);
+    const { linearClient } = resolveClient(client);
 
-  while (hasNextPage) {
-    const states = await linearClient.workflowStates({
-      filter: { team: { id: { eq: teamId } } },
-      after: endCursor,
-      first: 100,
-    });
-    allStates.push(
-      ...states.nodes.map((state) => ({
-        id: state.id,
-        name: state.name,
-        description: state.description,
-        position: state.position,
-        type: state.type,
-      })),
-    );
-    hasNextPage = states.pageInfo.hasNextPage;
-    endCursor = states.pageInfo.endCursor;
-  }
+    const allStates: StatusResult[] = [];
+    let hasNextPage = true;
+    let endCursor = null;
 
-  return allStates;
-});
+    while (hasNextPage) {
+      const states = await linearClient.workflowStates({
+        filter: { team: { id: { eq: teamId } } },
+        after: endCursor,
+        first: 100,
+      });
+      allStates.push(
+        ...states.nodes.map((state) => ({
+          id: state.id,
+          name: state.name,
+          description: state.description,
+          position: state.position,
+          type: state.type,
+        })),
+      );
+      hasNextPage = states.pageInfo.hasNextPage;
+      endCursor = states.pageInfo.endCursor;
+    }
+
+    return allStates;
+  },
+);

--- a/extensions/linear/src/tools/get-issue-status.ts
+++ b/extensions/linear/src/tools/get-issue-status.ts
@@ -1,12 +1,15 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { resolveWorkflowState } from "./issueUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
-type Input = { id: string; name: string; team: string };
+type Input = {
+  id: string;
+  name: string;
+  team: string;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
 
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   const status = await resolveWorkflowState(input.id, input.team);
   if (status.name.toLowerCase() !== input.name.toLowerCase()) {
     throw new Error(`Status ${input.id} is named "${status.name}", not "${input.name}".`);

--- a/extensions/linear/src/tools/get-issue.ts
+++ b/extensions/linear/src/tools/get-issue.ts
@@ -1,18 +1,17 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { serializeIssue } from "./issueUtils";
 import { resolveIssue } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 type Input = {
   id: string;
   includeRelations?: boolean;
   includeCustomerNeeds?: boolean;
   includeReleases?: boolean;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 };
 
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   const issue = await resolveIssue(input.id);
   return {
     ...(await serializeIssue(issue)),

--- a/extensions/linear/src/tools/get-labels.ts
+++ b/extensions/linear/src/tools/get-labels.ts
@@ -1,12 +1,19 @@
 import { IssueLabel } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
 
-import { getLinearClient, linear } from "../api/linearClient";
+import { resolveClient } from "../api/linearClient";
+
+import { resolveToolClient, withToolAuth } from "./resolveToolWorkspace";
 
 export type LabelResult = Pick<IssueLabel, "id" | "description" | "name">;
 
-export default withAccessToken(linear)(async () => {
-  const { linearClient } = getLinearClient();
+type Input = {
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
+
+export default withToolAuth(async ({ workspaceId }: Input) => {
+  const client = await resolveToolClient(workspaceId);
+  const { linearClient } = resolveClient(client);
 
   const allLabels: LabelResult[] = [];
   let hasNextPage = true;

--- a/extensions/linear/src/tools/get-members.ts
+++ b/extensions/linear/src/tools/get-members.ts
@@ -1,12 +1,19 @@
 import { User } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
 
-import { getLinearClient, linear } from "../api/linearClient";
+import { resolveClient } from "../api/linearClient";
+
+import { resolveToolClient, withToolAuth } from "./resolveToolWorkspace";
 
 export type MemberResult = Pick<User, "id" | "description" | "displayName" | "email" | "isMe" | "name" | "url">;
 
-export default withAccessToken(linear)(async () => {
-  const { linearClient } = getLinearClient();
+type Input = {
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
+
+export default withToolAuth(async ({ workspaceId }: Input) => {
+  const client = await resolveToolClient(workspaceId);
+  const { linearClient } = resolveClient(client);
 
   const allMembers: MemberResult[] = [];
   let hasNextPage = true;

--- a/extensions/linear/src/tools/get-milestone.ts
+++ b/extensions/linear/src/tools/get-milestone.ts
@@ -1,7 +1,9 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { resolveMilestone } from "./linearUtils";
-type Input = { project: string; query: string };
-export default withAccessToken(linear)(async ({ project, query }: Input) => resolveMilestone(project, query));
+import { withToolAuth } from "./resolveToolWorkspace";
+type Input = {
+  project: string;
+  query: string;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
+export default withToolAuth(async ({ project, query }: Input) => resolveMilestone(project, query));

--- a/extensions/linear/src/tools/get-notifications.ts
+++ b/extensions/linear/src/tools/get-notifications.ts
@@ -1,10 +1,15 @@
-import { withAccessToken } from "@raycast/utils";
-
 import { getNotifications } from "../api/getNotifications";
-import { linear } from "../api/linearClient";
 
-export default withAccessToken(linear)(async () => {
-  const { notifications } = await getNotifications();
+import { resolveToolClient, withToolAuth } from "./resolveToolWorkspace";
+
+type Input = {
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
+
+export default withToolAuth(async ({ workspaceId }: Input) => {
+  const client = await resolveToolClient(workspaceId);
+  const { notifications } = await getNotifications(client);
 
   return notifications;
 });

--- a/extensions/linear/src/tools/get-project-statuses.ts
+++ b/extensions/linear/src/tools/get-project-statuses.ts
@@ -1,9 +1,15 @@
-import { withAccessToken } from "@raycast/utils";
+import { resolveClient } from "../api/linearClient";
 
-import { getLinearClient, linear } from "../api/linearClient";
+import { resolveToolClient, withToolAuth } from "./resolveToolWorkspace";
 
-export default withAccessToken(linear)(async () => {
-  const { linearClient } = getLinearClient();
+type Input = {
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
+
+export default withToolAuth(async ({ workspaceId }: Input) => {
+  const client = await resolveToolClient(workspaceId);
+  const { linearClient } = resolveClient(client);
 
   const statuses = [];
   const projectStatuses = await linearClient.projectStatuses();

--- a/extensions/linear/src/tools/get-project-updates.ts
+++ b/extensions/linear/src/tools/get-project-updates.ts
@@ -1,42 +1,50 @@
 import { ProjectUpdate } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
 
-import { getLinearClient, linear } from "../api/linearClient";
+import { resolveClient } from "../api/linearClient";
+
+import { resolveToolClient, withToolAuth } from "./resolveToolWorkspace";
 
 export type ProjectUpdateResult = Pick<ProjectUpdate, "id" | "health" | "body" | "updatedAt" | "url">;
 
-export default withAccessToken(linear)(async ({
-  projectId,
-}: {
-  /** The ID of the project to fetch the updates for. Use the 'get-projects' tool to get the project ID. */
-  projectId: string;
-}) => {
-  const { linearClient } = getLinearClient();
+export default withToolAuth(
+  async ({
+    projectId,
+    workspaceId,
+  }: {
+    /** The ID of the project to fetch the updates for. Use the 'get-projects' tool to get the project ID. */
+    projectId: string;
 
-  const allUpdates: ProjectUpdateResult[] = [];
-  let hasNextPage = true;
-  let endCursor = null;
+    /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+    workspaceId?: string;
+  }) => {
+    const client = await resolveToolClient(workspaceId);
+    const { linearClient } = resolveClient(client);
 
-  while (hasNextPage) {
-    const projectUpdates = await linearClient.projectUpdates({
-      filter: {
-        project: { id: { eq: projectId } },
-      },
-      after: endCursor,
-      first: 100, // Fetch 100 updates at a time
-    });
-    allUpdates.push(
-      ...projectUpdates.nodes.map((update) => ({
-        id: update.id,
-        health: update.health,
-        body: update.body,
-        updatedAt: update.updatedAt,
-        url: update.url,
-      })),
-    );
-    hasNextPage = projectUpdates.pageInfo.hasNextPage;
-    endCursor = projectUpdates.pageInfo.endCursor;
-  }
+    const allUpdates: ProjectUpdateResult[] = [];
+    let hasNextPage = true;
+    let endCursor = null;
 
-  return allUpdates;
-});
+    while (hasNextPage) {
+      const projectUpdates = await linearClient.projectUpdates({
+        filter: {
+          project: { id: { eq: projectId } },
+        },
+        after: endCursor,
+        first: 100, // Fetch 100 updates at a time
+      });
+      allUpdates.push(
+        ...projectUpdates.nodes.map((update) => ({
+          id: update.id,
+          health: update.health,
+          body: update.body,
+          updatedAt: update.updatedAt,
+          url: update.url,
+        })),
+      );
+      hasNextPage = projectUpdates.pageInfo.hasNextPage;
+      endCursor = projectUpdates.pageInfo.endCursor;
+    }
+
+    return allUpdates;
+  },
+);

--- a/extensions/linear/src/tools/get-project.ts
+++ b/extensions/linear/src/tools/get-project.ts
@@ -1,10 +1,14 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { resolveProject } from "./linearUtils";
-type Input = { query: string; includeMilestones?: boolean; includeMembers?: boolean; includeResources?: boolean };
-export default withAccessToken(linear)(async (input: Input) => {
+import { withToolAuth } from "./resolveToolWorkspace";
+type Input = {
+  query: string;
+  includeMilestones?: boolean;
+  includeMembers?: boolean;
+  includeResources?: boolean;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
+export default withToolAuth(async (input: Input) => {
   const project = await resolveProject(input.query);
   return {
     ...project,

--- a/extensions/linear/src/tools/get-projects.ts
+++ b/extensions/linear/src/tools/get-projects.ts
@@ -1,15 +1,22 @@
 import { Project } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
 
-import { getLinearClient, linear } from "../api/linearClient";
+import { resolveClient } from "../api/linearClient";
+
+import { resolveToolClient, withToolAuth } from "./resolveToolWorkspace";
 
 export type ProjectResult = Pick<
   Project,
   "id" | "description" | "name" | "content" | "progress" | "targetDate" | "startDate"
 >;
 
-export default withAccessToken(linear)(async () => {
-  const { linearClient } = getLinearClient();
+type Input = {
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
+
+export default withToolAuth(async ({ workspaceId }: Input) => {
+  const client = await resolveToolClient(workspaceId);
+  const { linearClient } = resolveClient(client);
 
   const allProjects: ProjectResult[] = [];
   let hasNextPage = true;

--- a/extensions/linear/src/tools/get-release-note.ts
+++ b/extensions/linear/src/tools/get-release-note.ts
@@ -1,10 +1,12 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { resolveReleaseNote } from "./linearUtils";
-type Input = { id: string; includeReleases?: boolean };
-export default withAccessToken(linear)(async ({ id, includeReleases }: Input) => {
+import { withToolAuth } from "./resolveToolWorkspace";
+type Input = {
+  id: string;
+  includeReleases?: boolean;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
+export default withToolAuth(async ({ id, includeReleases }: Input) => {
   const note = await resolveReleaseNote(id);
   return {
     ...note,

--- a/extensions/linear/src/tools/get-release.ts
+++ b/extensions/linear/src/tools/get-release.ts
@@ -1,10 +1,12 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { resolveRelease } from "./linearUtils";
-type Input = { id: string; includeReleaseNotes?: boolean };
-export default withAccessToken(linear)(async ({ id, includeReleaseNotes }: Input) => {
+import { withToolAuth } from "./resolveToolWorkspace";
+type Input = {
+  id: string;
+  includeReleaseNotes?: boolean;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
+export default withToolAuth(async ({ id, includeReleaseNotes }: Input) => {
   const release = await resolveRelease(id);
   return { ...release, releaseNotes: includeReleaseNotes ? release.releaseNotes : undefined };
 });

--- a/extensions/linear/src/tools/get-status-updates.ts
+++ b/extensions/linear/src/tools/get-status-updates.ts
@@ -1,9 +1,7 @@
 import { LinearClient, PaginationOrderBy } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
 
 import { afterDate, client, collect, PageInput, resolveInitiative, resolveProject, resolveUser } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 type ProjectUpdateFilter = NonNullable<Parameters<LinearClient["projectUpdates"]>[0]>["filter"];
 type InitiativeUpdateFilter = NonNullable<Parameters<LinearClient["initiativeUpdates"]>[0]>["filter"];
@@ -20,9 +18,11 @@ interface Input extends PageInput {
   createdAt?: string;
   updatedAt?: string;
   includeArchived?: boolean;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 }
 
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   if (input.id)
     return input.type === "project" ? client().projectUpdate(input.id) : client().initiativeUpdate(input.id);
   const project = input.project ? await resolveProject(input.project) : undefined;

--- a/extensions/linear/src/tools/get-team.ts
+++ b/extensions/linear/src/tools/get-team.ts
@@ -1,7 +1,8 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { resolveTeam } from "./linearUtils";
-type Input = { /** Team UUID, key, or name */ query: string };
-export default withAccessToken(linear)(async ({ query }: Input) => resolveTeam(query));
+import { withToolAuth } from "./resolveToolWorkspace";
+type Input = {
+  /** Team UUID, key, or name */ query: string;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
+export default withToolAuth(async ({ query }: Input) => resolveTeam(query));

--- a/extensions/linear/src/tools/get-teams.ts
+++ b/extensions/linear/src/tools/get-teams.ts
@@ -1,11 +1,17 @@
 import { Team } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
 
 import { getTeams } from "../api/getTeams";
-import { linear } from "../api/linearClient";
+
+import { resolveToolClient, withToolAuth } from "./resolveToolWorkspace";
 
 export type TeamResult = Pick<Team, "id" | "name" | "key" | "icon" | "color">;
 
-export default withAccessToken(linear)(async () => {
-  return getTeams();
+type Input = {
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
+
+export default withToolAuth(async ({ workspaceId }: Input) => {
+  const client = await resolveToolClient(workspaceId);
+  return getTeams(undefined, client);
 });

--- a/extensions/linear/src/tools/get-user.ts
+++ b/extensions/linear/src/tools/get-user.ts
@@ -1,7 +1,8 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { resolveUser } from "./linearUtils";
-type Input = { /** User ID, name, email, or "me" */ query: string };
-export default withAccessToken(linear)(async ({ query }: Input) => resolveUser(query));
+import { withToolAuth } from "./resolveToolWorkspace";
+type Input = {
+  /** User ID, name, email, or "me" */ query: string;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
+export default withToolAuth(async ({ query }: Input) => resolveUser(query));

--- a/extensions/linear/src/tools/get-workspace.ts
+++ b/extensions/linear/src/tools/get-workspace.ts
@@ -1,6 +1,11 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { client } from "./linearUtils";
-export default withAccessToken(linear)(async () => client().organization);
+import { withToolAuth } from "./resolveToolWorkspace";
+
+type Input = {
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export default withToolAuth(async (_input: Input) => client().organization);
+/* eslint-enable @typescript-eslint/no-unused-vars */

--- a/extensions/linear/src/tools/get-workspaces.ts
+++ b/extensions/linear/src/tools/get-workspaces.ts
@@ -1,0 +1,15 @@
+import { entryKey, getActiveEntry, migrateIfNeeded } from "../api/workspaces";
+
+// Registry-only read: works even when a workspace's token is dead, and never
+// triggers an OAuth flow — so it is deliberately NOT wrapped in withWorkspaceAuth.
+export default async function () {
+  const registry = await migrateIfNeeded({ allowWrite: false });
+  const active = getActiveEntry(registry);
+  return registry.workspaces.map((w) => ({
+    workspaceId: entryKey(w),
+    name: w.orgName,
+    urlKey: w.urlKey,
+    userEmail: w.userEmail,
+    isActive: active !== null && entryKey(w) === entryKey(active),
+  }));
+}

--- a/extensions/linear/src/tools/list-agent-skills.ts
+++ b/extensions/linear/src/tools/list-agent-skills.ts
@@ -1,11 +1,14 @@
 import { PaginationOrderBy } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
 
 import { client, collect, PageInput } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
-export default withAccessToken(linear)(async (input: PageInput) => {
+interface Input extends PageInput {
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+}
+
+export default withToolAuth(async (input: Input) => {
   return collect(
     ({ first, after }) =>
       client().agentSkills({

--- a/extensions/linear/src/tools/list-comments.ts
+++ b/extensions/linear/src/tools/list-comments.ts
@@ -1,7 +1,4 @@
 import { LinearClient, PaginationOrderBy } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
 
 import { serializeComment } from "./commentUtils";
 import {
@@ -14,6 +11,7 @@ import {
   resolveProject,
   tryGet,
 } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 interface Input extends PageInput {
   /** Max results (default 50, max 250) */ limit?: number;
@@ -26,11 +24,13 @@ interface Input extends PageInput {
   /** Milestone UUID. Provide exactly one parent. */ milestoneId?: string;
   /** Status update UUID. Provide exactly one parent. */ statusUpdateId?: string;
   /** Status update type */ statusUpdateType?: "project" | "initiative";
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 }
 
 type CommentFilter = NonNullable<Parameters<LinearClient["comments"]>[0]>["filter"];
 
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   if (input.statusUpdateType && !input.statusUpdateId) {
     throw new Error("statusUpdateType requires statusUpdateId.");
   }

--- a/extensions/linear/src/tools/list-cycles.ts
+++ b/extensions/linear/src/tools/list-cycles.ts
@@ -1,17 +1,16 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { client, collectFiltered, CursorPageInput } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 interface Input extends CursorPageInput {
   /** Max results (default 50, max 250) */ limit?: number;
   /** Next page cursor */ cursor?: string;
   /** Team ID */ teamId: string;
   /** Filter the team's cycles */ type?: "current" | "previous" | "next";
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 }
 
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   const team = await client().team(input.teamId);
   return collectFiltered(
     ({ first, after }) => team.cycles({ first, after }),

--- a/extensions/linear/src/tools/list-documents.ts
+++ b/extensions/linear/src/tools/list-documents.ts
@@ -1,7 +1,4 @@
 import { LinearClient, PaginationOrderBy } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
 
 import {
   afterDate,
@@ -14,6 +11,7 @@ import {
   resolveTeam,
   resolveUser,
 } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 type DocumentFilter = NonNullable<Parameters<LinearClient["documents"]>[0]>["filter"];
 type Field =
@@ -43,10 +41,12 @@ interface Input extends PageInput {
   updatedAt?: string;
   includeArchived?: boolean;
   fields?: Field[];
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 }
 const defaultFields = ["id", "title", "url", "createdAt", "updatedAt", "archivedAt"] as const;
 
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   const project = input.projectId ? await resolveProject(input.projectId) : undefined;
   const initiative = input.initiativeId ? await resolveInitiative(input.initiativeId) : undefined;
   const team = input.teamId ? await resolveTeam(input.teamId) : undefined;

--- a/extensions/linear/src/tools/list-initiative-labels.ts
+++ b/extensions/linear/src/tools/list-initiative-labels.ts
@@ -1,17 +1,17 @@
 import { PaginationOrderBy } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
 
 import { client, collectFiltered, PageInput } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 interface Input extends PageInput {
   /** Max results (default 50, max 250) */ limit?: number;
   /** Next page cursor */ cursor?: string;
   /** Sort: createdAt | updatedAt */ orderBy?: "createdAt" | "updatedAt";
   name?: string;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 }
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   const name = input.name?.toLowerCase();
   return collectFiltered(
     ({ first, after }) =>

--- a/extensions/linear/src/tools/list-initiatives.ts
+++ b/extensions/linear/src/tools/list-initiatives.ts
@@ -1,7 +1,4 @@
 import { LinearClient, PaginationOrderBy } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
 
 import { InitiativeField, initiativeStatus, serializeInitiative } from "./initiativeUtils";
 import {
@@ -14,6 +11,7 @@ import {
   resolveTeam,
   resolveUser,
 } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 type InitiativeFilter = NonNullable<Parameters<LinearClient["initiatives"]>[0]>["filter"];
 
@@ -33,9 +31,11 @@ interface Input extends PageInput {
   includeProjects?: boolean;
   includeSubInitiatives?: boolean;
   fields?: InitiativeField[];
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 }
 
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   const owner = input.owner ? await resolveUser(input.owner) : undefined;
   const team = input.leadTeam ? await resolveTeam(input.leadTeam) : undefined;
   const parent = input.parentInitiative ? await resolveInitiative(input.parentInitiative) : undefined;

--- a/extensions/linear/src/tools/list-issue-labels.ts
+++ b/extensions/linear/src/tools/list-issue-labels.ts
@@ -1,9 +1,7 @@
 import { PaginationOrderBy } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
 
 import { client, collectFiltered, PageInput, resolveTeam } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 interface Input extends PageInput {
   /** Max results (default 50, max 250) */ limit?: number;
@@ -11,8 +9,10 @@ interface Input extends PageInput {
   /** Sort: createdAt | updatedAt */ orderBy?: "createdAt" | "updatedAt";
   name?: string;
   team?: string;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 }
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   const teamId = input.team ? (await resolveTeam(input.team)).id : undefined;
   const name = input.name?.toLowerCase();
   return collectFiltered(

--- a/extensions/linear/src/tools/list-issue-statuses.ts
+++ b/extensions/linear/src/tools/list-issue-statuses.ts
@@ -1,16 +1,15 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { collect, CursorPageInput, resolveTeam } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 interface Input extends CursorPageInput {
   /** Max results (default 50, max 250) */ limit?: number;
   /** Next page cursor */ cursor?: string;
   team: string;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 }
 
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   const team = await resolveTeam(input.team);
   return collect(({ first, after }) => team.states({ first, after }), input);
 });

--- a/extensions/linear/src/tools/list-issues.ts
+++ b/extensions/linear/src/tools/list-issues.ts
@@ -1,7 +1,4 @@
 import { LinearClient, PaginationOrderBy } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
 
 import { IssueField, resolveWorkflowState, serializeIssue } from "./issueUtils";
 import {
@@ -17,6 +14,7 @@ import {
   resolveTeam,
   resolveUser,
 } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 type IssueFilter = NonNullable<Parameters<LinearClient["issues"]>[0]>["filter"];
 
@@ -40,9 +38,11 @@ interface Input extends PageInput {
   createdAt?: string;
   updatedAt?: string;
   includeArchived?: boolean;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 }
 
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   const team = input.team ? await resolveTeam(input.team) : undefined;
   const state = input.state ? await resolveState(input.state, team?.id) : undefined;
   const cycle = input.cycle ? await resolveCycle(input.cycle, team?.id) : undefined;

--- a/extensions/linear/src/tools/list-milestones.ts
+++ b/extensions/linear/src/tools/list-milestones.ts
@@ -1,16 +1,15 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { collect, CursorPageInput, resolveProject } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 interface Input extends CursorPageInput {
   /** Max results (default 50, max 250) */ limit?: number;
   /** Next page cursor */ cursor?: string;
   project: string;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 }
 
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   const project = await resolveProject(input.project);
   return collect(({ first, after }) => project.projectMilestones({ first, after }), input);
 });

--- a/extensions/linear/src/tools/list-project-labels.ts
+++ b/extensions/linear/src/tools/list-project-labels.ts
@@ -1,17 +1,17 @@
 import { PaginationOrderBy } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
 
 import { client, collectFiltered, PageInput } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 interface Input extends PageInput {
   /** Max results (default 50, max 250) */ limit?: number;
   /** Next page cursor */ cursor?: string;
   /** Sort: createdAt | updatedAt */ orderBy?: "createdAt" | "updatedAt";
   name?: string;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 }
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   const name = input.name?.toLowerCase();
   return collectFiltered(
     ({ first, after }) =>

--- a/extensions/linear/src/tools/list-projects.ts
+++ b/extensions/linear/src/tools/list-projects.ts
@@ -1,7 +1,4 @@
 import { LinearClient, PaginationOrderBy } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
 
 import {
   afterDate,
@@ -14,6 +11,7 @@ import {
   resolveTeam,
   resolveUser,
 } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 type ProjectFilter = NonNullable<Parameters<LinearClient["projects"]>[0]>["filter"];
 type Field =
@@ -56,10 +54,12 @@ interface Input extends PageInput {
   includeMembers?: boolean;
   includeArchived?: boolean;
   fields?: Field[];
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 }
 const defaultFields: Field[] = ["id", "name", "summary", "description", "url", "priority", "createdAt", "updatedAt"];
 
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   const initiative = input.initiative ? await resolveInitiative(input.initiative) : undefined;
   const team = input.team ? await resolveTeam(input.team) : undefined;
   const member = input.member ? await resolveUser(input.member) : undefined;

--- a/extensions/linear/src/tools/list-release-notes.ts
+++ b/extensions/linear/src/tools/list-release-notes.ts
@@ -1,9 +1,7 @@
 import { LinearClient, PaginationOrderBy } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
 
 import { afterDate, client, collect, PageInput, resolveRelease, resolveReleasePipeline } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 type ReleaseNoteFilter = NonNullable<Parameters<LinearClient["releaseNotes"]>[0]>["filter"];
 
@@ -19,9 +17,11 @@ interface Input extends PageInput {
   createdAt?: string;
   updatedAt?: string;
   includeArchived?: boolean;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 }
 
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   const pipeline = input.pipeline ? await resolveReleasePipeline(input.pipeline) : undefined;
   const release = input.release ? await resolveRelease(input.release) : undefined;
   const createdAfter = afterDate(input.createdAt);

--- a/extensions/linear/src/tools/list-release-pipelines.ts
+++ b/extensions/linear/src/tools/list-release-pipelines.ts
@@ -1,9 +1,7 @@
 import { LinearClient, PaginationOrderBy, ReleasePipelineType } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
 
 import { afterDate, client, collect, PageInput, resolveTeam } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 type ReleasePipelineFilter = NonNullable<Parameters<LinearClient["releasePipelines"]>[0]>["filter"];
 
@@ -20,9 +18,11 @@ interface Input extends PageInput {
   createdAt?: string;
   updatedAt?: string;
   includeArchived?: boolean;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 }
 
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   const team = input.team ? await resolveTeam(input.team) : undefined;
   const createdAfter = afterDate(input.createdAt);
   const updatedAfter = afterDate(input.updatedAt);

--- a/extensions/linear/src/tools/list-releases.ts
+++ b/extensions/linear/src/tools/list-releases.ts
@@ -1,9 +1,7 @@
 import { LinearClient, PaginationOrderBy, ReleaseStageType } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
 
 import { afterDate, client, collect, PageInput, resolveReleasePipeline } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 type ReleaseFilter = NonNullable<Parameters<LinearClient["releases"]>[0]>["filter"];
 
@@ -21,9 +19,11 @@ interface Input extends PageInput {
   createdAt?: string;
   updatedAt?: string;
   includeArchived?: boolean;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 }
 
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   const pipeline = input.pipeline ? await resolveReleasePipeline(input.pipeline) : undefined;
   const createdAfter = afterDate(input.createdAt);
   const updatedAfter = afterDate(input.updatedAt);

--- a/extensions/linear/src/tools/list-teams.ts
+++ b/extensions/linear/src/tools/list-teams.ts
@@ -1,9 +1,7 @@
 import { PaginationOrderBy } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
 
 import { client, collectFiltered, PageInput } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 interface Input extends PageInput {
   /** Max results (default 50, max 250) */ limit?: number;
@@ -11,8 +9,10 @@ interface Input extends PageInput {
   /** Sort: createdAt | updatedAt */ orderBy?: "createdAt" | "updatedAt";
   /** Search team name or key */ query?: string;
   /** Include archived teams */ includeArchived?: boolean;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 }
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   const query = input.query?.toLowerCase();
   return collectFiltered(
     ({ first, after }) =>

--- a/extensions/linear/src/tools/list-users.ts
+++ b/extensions/linear/src/tools/list-users.ts
@@ -1,9 +1,7 @@
 import { PaginationOrderBy } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
 
 import { client, collectFiltered, PageInput, resolveTeam } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 interface Input extends PageInput {
   /** Max results (default 50, max 250) */ limit?: number;
@@ -11,8 +9,10 @@ interface Input extends PageInput {
   /** Sort: createdAt | updatedAt */ orderBy?: "createdAt" | "updatedAt";
   /** Filter by name or email */ query?: string;
   /** Team name or ID */ team?: string;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 }
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   const team = input.team ? await resolveTeam(input.team) : undefined;
   const query = input.query?.toLowerCase();
   return collectFiltered(

--- a/extensions/linear/src/tools/remove-label.ts
+++ b/extensions/linear/src/tools/remove-label.ts
@@ -1,7 +1,8 @@
 import { Action } from "@raycast/api";
-import { withAccessToken } from "@raycast/utils";
 
-import { getLinearClient, linear } from "../api/linearClient";
+import { resolveClient } from "../api/linearClient";
+
+import { describeToolWorkspace, resolveToolClient, withToolAuth } from "./resolveToolWorkspace";
 
 type Input = {
   /** The ID of the issue to add the label to. Format is a combination of a team key and a unique number, like `ENG-123` */
@@ -9,10 +10,14 @@ type Input = {
 
   /** The ID of the label to add to the issue. Never use title as ID: you have to use `get-labels` tool to get the actual ID from the list of labels */
   labelId: string;
+
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 };
 
-export default withAccessToken(linear)(async ({ issueId, labelId }: Input) => {
-  const { linearClient } = getLinearClient();
+export default withToolAuth(async ({ issueId, labelId, workspaceId }: Input) => {
+  const client = await resolveToolClient(workspaceId);
+  const { linearClient } = resolveClient(client);
   const issue = await linearClient.issue(issueId);
   const currentLabelIds = issue.labelIds || [];
   const updatedLabelIds = currentLabelIds.filter((id) => id !== labelId);
@@ -27,8 +32,10 @@ export default withAccessToken(linear)(async ({ issueId, labelId }: Input) => {
   return result.issue;
 });
 
-export const confirmation = withAccessToken(linear)(async ({ issueId, labelId }: Input) => {
-  const { linearClient } = getLinearClient();
+export const confirmation = withToolAuth(async ({ issueId, labelId, workspaceId }: Input) => {
+  const workspaceName = await describeToolWorkspace(workspaceId);
+  const client = await resolveToolClient(workspaceId);
+  const { linearClient } = resolveClient(client);
 
   const label = await linearClient.issueLabel(labelId);
   const issue = await linearClient.issue(issueId);
@@ -36,6 +43,7 @@ export const confirmation = withAccessToken(linear)(async ({ issueId, labelId }:
   return {
     style: Action.Style.Destructive,
     info: [
+      ...(workspaceName ? [{ name: "Workspace", value: workspaceName }] : []),
       { name: "Issue", value: issue.title },
       { name: "Label", value: label.name },
     ],

--- a/extensions/linear/src/tools/resolveToolWorkspace.ts
+++ b/extensions/linear/src/tools/resolveToolWorkspace.ts
@@ -1,6 +1,6 @@
 import { LinearClient } from "@linear/sdk";
 
-import { bootstrapWorkspaceAuth, getLinearClientFor } from "../api/linearClient";
+import { activateToolWorkspace, bootstrapWorkspaceAuth, getLinearClientFor } from "../api/linearClient";
 import { entryKey, getActiveEntry, migrateIfNeeded } from "../api/workspaces";
 
 function parseWorkspaceId(workspaceId: string): { orgId: string; userId: string } {
@@ -28,6 +28,24 @@ export function withToolAuth<T extends { workspaceId?: string }, R>(
       if (!inputs?.workspaceId) {
         throw new Error(
           "No authenticated Linear workspace is available. Ask the user to open the Manage Workspaces command in Raycast to sign in (or re-authenticate), or pass a workspaceId from get-workspaces to act in another workspace.",
+        );
+      }
+    }
+    if (inputs?.workspaceId) {
+      // Route the whole process at the target (D6/S8) so tools that reach the client through
+      // the sync fast path (linearUtils.client(), resolve* helpers) act in that workspace too.
+      const ref = parseWorkspaceId(inputs.workspaceId);
+      const registry = await migrateIfNeeded({ allowWrite: false });
+      if (!registry.workspaces.some((w) => entryKey(w) === inputs.workspaceId)) {
+        throw new Error(
+          `No connected workspace matches workspaceId "${inputs.workspaceId}". Call get-workspaces again and use one of its returned values.`,
+        );
+      }
+      try {
+        await activateToolWorkspace(ref);
+      } catch {
+        throw new Error(
+          `The workspace for "${inputs.workspaceId}" needs re-authentication. Ask the user to open the Manage Workspaces command in Raycast.`,
         );
       }
     }

--- a/extensions/linear/src/tools/resolveToolWorkspace.ts
+++ b/extensions/linear/src/tools/resolveToolWorkspace.ts
@@ -16,8 +16,8 @@ function parseWorkspaceId(workspaceId: string): { orgId: string; userId: string 
 // AI-tool wrapper (replaces withWorkspaceAuth for tools — §4.3: AI tools NEVER trigger
 // an OAuth browser flow). Bootstraps the active workspace non-interactively so the sync
 // fast path serves workspaceId-less calls; when the call names its target explicitly,
-// a dead ACTIVE workspace must not block it (resolveToolClient resolves the target
-// independently), so bootstrap failure is tolerated in that case.
+// withToolAuth activates it itself (see the activation block below), so a dead ACTIVE
+// workspace must not block it — bootstrap failure is tolerated in that case.
 export function withToolAuth<T extends { workspaceId?: string }, R>(
   fn: (inputs: T) => Promise<R>,
 ): (inputs: T) => Promise<R> {

--- a/extensions/linear/src/tools/resolveToolWorkspace.ts
+++ b/extensions/linear/src/tools/resolveToolWorkspace.ts
@@ -1,0 +1,69 @@
+import { LinearClient } from "@linear/sdk";
+
+import { bootstrapWorkspaceAuth, getLinearClientFor } from "../api/linearClient";
+import { entryKey, getActiveEntry, migrateIfNeeded } from "../api/workspaces";
+
+function parseWorkspaceId(workspaceId: string): { orgId: string; userId: string } {
+  const separator = workspaceId.indexOf(":");
+  if (separator <= 0 || separator === workspaceId.length - 1) {
+    throw new Error(
+      `Invalid workspaceId "${workspaceId}". Use a workspaceId value returned by the get-workspaces tool.`,
+    );
+  }
+  return { orgId: workspaceId.slice(0, separator), userId: workspaceId.slice(separator + 1) };
+}
+
+// AI-tool wrapper (replaces withWorkspaceAuth for tools — §4.3: AI tools NEVER trigger
+// an OAuth browser flow). Bootstraps the active workspace non-interactively so the sync
+// fast path serves workspaceId-less calls; when the call names its target explicitly,
+// a dead ACTIVE workspace must not block it (resolveToolClient resolves the target
+// independently), so bootstrap failure is tolerated in that case.
+export function withToolAuth<T extends { workspaceId?: string }, R>(
+  fn: (inputs: T) => Promise<R>,
+): (inputs: T) => Promise<R> {
+  return async (inputs: T) => {
+    try {
+      await bootstrapWorkspaceAuth({ interactive: false });
+    } catch {
+      if (!inputs?.workspaceId) {
+        throw new Error(
+          "No authenticated Linear workspace is available. Ask the user to open the Manage Workspaces command in Raycast to sign in (or re-authenticate), or pass a workspaceId from get-workspaces to act in another workspace.",
+        );
+      }
+    }
+    // Defensive: previously zero-arg tools now destructure inputs; guarantee an object.
+    return fn(inputs ?? ({} as T));
+  };
+}
+
+// Per-call workspace routing (D6/S8): every AI tool call is a fresh process, so the
+// workspaceId input is the ONLY way to route a call. Absent → active workspace.
+export async function resolveToolClient(workspaceId?: string): Promise<LinearClient | undefined> {
+  if (!workspaceId) return undefined;
+  const ref = parseWorkspaceId(workspaceId);
+  const registry = await migrateIfNeeded({ allowWrite: false });
+  if (!registry.workspaces.some((w) => entryKey(w) === workspaceId)) {
+    // Unknown/stale id is a ROUTING error, not an auth error — tell the model to re-list.
+    throw new Error(
+      `No connected workspace matches workspaceId "${workspaceId}". Call get-workspaces again and use one of its returned values.`,
+    );
+  }
+  try {
+    // interactive: false — AI tools never open a browser flow (§4.3).
+    const { linearClient } = await getLinearClientFor(ref, { interactive: false });
+    return linearClient;
+  } catch {
+    throw new Error(
+      `The workspace for "${workspaceId}" needs re-authentication. Ask the user to open the Manage Workspaces command in Raycast.`,
+    );
+  }
+}
+
+export async function describeToolWorkspace(workspaceId?: string): Promise<string | undefined> {
+  const registry = await migrateIfNeeded({ allowWrite: false });
+  if (!workspaceId && registry.workspaces.length < 2) return undefined; // single workspace: keep confirmations unchanged (T1)
+  const target = workspaceId ? registry.workspaces.find((w) => entryKey(w) === workspaceId) : getActiveEntry(registry);
+  if (!target) return workspaceId; // unknown id: show it verbatim so the user can spot the problem
+  const duplicated = registry.workspaces.filter((w) => w.orgId === target.orgId).length > 1;
+  return duplicated ? `${target.orgName} (${target.userEmail})` : target.orgName;
+}

--- a/extensions/linear/src/tools/save-comment.ts
+++ b/extensions/linear/src/tools/save-comment.ts
@@ -1,7 +1,3 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { serializeComment } from "./commentUtils";
 import {
   client,
@@ -12,6 +8,7 @@ import {
   resolveProject,
   tryGet,
 } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 interface Input {
   body: string;
@@ -24,9 +21,11 @@ interface Input {
   milestoneId?: string;
   statusUpdateId?: string;
   statusUpdateType?: "project" | "initiative";
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 }
 
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   const linearClient = client();
 
   if ((input.id || input.parentId) && input.statusUpdateType) {

--- a/extensions/linear/src/tools/save-document.ts
+++ b/extensions/linear/src/tools/save-document.ts
@@ -1,7 +1,3 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import {
   applyPatch,
   client,
@@ -13,6 +9,7 @@ import {
   resolveProject,
   resolveTeam,
 } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 type Input = {
   id?: string;
@@ -35,9 +32,11 @@ type Input = {
   team?: string;
   icon?: string;
   color?: string;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 };
 
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   if (input.content !== undefined && input.patch) throw new Error("Pass content or patch, not both.");
   const parentCount = [input.project, input.issue, input.initiative, input.cycle, input.team && !input.cycle].filter(
     Boolean,

--- a/extensions/linear/src/tools/save-initiative.ts
+++ b/extensions/linear/src/tools/save-initiative.ts
@@ -1,9 +1,6 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { addParentInitiatives, initiativeInput, InitiativeUpdateInput, serializeInitiative } from "./initiativeUtils";
 import { applyPatch, client, ContentPatch, resolveInitiative } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 type Input = {
   id?: string;
@@ -31,9 +28,11 @@ type Input = {
   leadTeam?: string;
   parentInitiatives?: string[];
   labels?: string[];
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 };
 
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   const existing = input.id ? await resolveInitiative(input.id) : undefined;
   if (!existing && !input.name) throw new Error("name is required when creating an initiative.");
   if (input.description !== undefined && input.patch) throw new Error("Pass description or patch, not both.");

--- a/extensions/linear/src/tools/save-issue.ts
+++ b/extensions/linear/src/tools/save-issue.ts
@@ -1,9 +1,6 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { issueInput, IssueUpdateInput, serializeIssue, setIssueRelations, setIssueReleases } from "./issueUtils";
 import { applyPatch, client, ContentPatch, resolveIssue } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 type Input = {
   id?: string;
@@ -54,9 +51,11 @@ type Input = {
   removeBlocks?: string[];
   removeBlockedBy?: string[];
   removeRelatedTo?: string[];
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 };
 
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   if (input.description !== undefined && input.patch) throw new Error("Pass description or patch, not both.");
   const existing = input.id ? await resolveIssue(input.id) : undefined;
   if (!existing && (!input.title || !input.team))

--- a/extensions/linear/src/tools/save-milestone.ts
+++ b/extensions/linear/src/tools/save-milestone.ts
@@ -1,10 +1,15 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { client, resolveMilestone, resolveProject } from "./linearUtils";
-type Input = { project: string; id?: string; name?: string; description?: string; targetDate?: string };
-export default withAccessToken(linear)(async (input: Input) => {
+import { withToolAuth } from "./resolveToolWorkspace";
+type Input = {
+  project: string;
+  id?: string;
+  name?: string;
+  description?: string;
+  targetDate?: string;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
+};
+export default withToolAuth(async (input: Input) => {
   const project = await resolveProject(input.project);
   if (input.id) {
     const milestone = await resolveMilestone(project.id, input.id);

--- a/extensions/linear/src/tools/save-project.ts
+++ b/extensions/linear/src/tools/save-project.ts
@@ -1,7 +1,4 @@
 import { DateResolutionType } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
 
 import {
   applyPatch,
@@ -14,6 +11,7 @@ import {
   resolveTeam,
   resolveUser,
 } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 type Input = {
   id?: string;
   name?: string;
@@ -47,11 +45,13 @@ type Input = {
   removeInitiatives?: string[];
   setInitiatives?: string[];
   links?: { url: string; title: string }[];
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 };
 async function ids(values: string[] | undefined, resolve: (value: string) => Promise<{ id: string }>) {
   return values ? Promise.all(values.map(async (value) => (await resolve(value)).id)) : undefined;
 }
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   if (input.description !== undefined && input.patch) throw new Error("Pass description or patch, not both.");
   if (input.setTeams && (input.addTeams || input.removeTeams))
     throw new Error("setTeams cannot be combined with addTeams or removeTeams.");

--- a/extensions/linear/src/tools/save-release-note.ts
+++ b/extensions/linear/src/tools/save-release-note.ts
@@ -1,7 +1,3 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import {
   applyPatch,
   client,
@@ -10,6 +6,7 @@ import {
   resolveReleaseNote,
   resolveReleasePipeline,
 } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 type Input = {
   id?: string;
   pipeline?: string;
@@ -28,6 +25,8 @@ type Input = {
   releases?: string[];
   rangeFromRelease?: string;
   rangeToRelease?: string;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 };
 async function releaseFields(input: Input) {
   return {
@@ -38,7 +37,7 @@ async function releaseFields(input: Input) {
     rangeToReleaseId: input.rangeToRelease ? (await resolveRelease(input.rangeToRelease)).id : undefined,
   };
 }
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   if (input.id) {
     if (input.content !== undefined && input.patch) throw new Error("Pass content or patch, not both.");
     const note = await resolveReleaseNote(input.id);

--- a/extensions/linear/src/tools/save-release.ts
+++ b/extensions/linear/src/tools/save-release.ts
@@ -1,8 +1,5 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
-
 import { client, resolveRelease, resolveReleasePipeline } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 function date(value?: string): Date | null | undefined {
   return value === "null" ? null : value === undefined ? undefined : new Date(value);
@@ -29,6 +26,8 @@ type Input = {
   /** Completed timestamp, or the literal string "null" to remove it. */
   completedAt?: string;
   commitSha?: string;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 };
 async function resolveStage(pipelineId: string, query?: string) {
   if (!query) return undefined;
@@ -40,7 +39,7 @@ async function resolveStage(pipelineId: string, query?: string) {
   if (!stage) throw new Error(`No release stage found for "${query}".`);
   return stage.id;
 }
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   if (input.id) {
     const release = await resolveRelease(input.id);
     if (input.pipeline) {

--- a/extensions/linear/src/tools/save-status-update.ts
+++ b/extensions/linear/src/tools/save-status-update.ts
@@ -1,9 +1,7 @@
 import { InitiativeUpdateHealthType, ProjectUpdateHealthType } from "@linear/sdk";
-import { withAccessToken } from "@raycast/utils";
-
-import { linear } from "../api/linearClient";
 
 import { client, resolveInitiative, resolveProject } from "./linearUtils";
+import { withToolAuth } from "./resolveToolWorkspace";
 
 type Input = {
   type: "project" | "initiative";
@@ -13,9 +11,11 @@ type Input = {
   body?: string;
   health?: "onTrack" | "atRisk" | "offTrack";
   isDiffHidden?: boolean;
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 };
 
-export default withAccessToken(linear)(async (input: Input) => {
+export default withToolAuth(async (input: Input) => {
   if (input.id) {
     const result =
       input.type === "project"

--- a/extensions/linear/src/tools/update-comment.ts
+++ b/extensions/linear/src/tools/update-comment.ts
@@ -1,11 +1,10 @@
 import path from "path";
 
-import { withAccessToken } from "@raycast/utils";
-
 import { appendFileAttachments } from "../api/attachments";
-import { getLinearClient, linear } from "../api/linearClient";
+import { resolveClient } from "../api/linearClient";
 
 import { serializeComment } from "./commentUtils";
+import { describeToolWorkspace, resolveToolClient, withToolAuth } from "./resolveToolWorkspace";
 
 type Input = {
   /** The comment content in markdown format */
@@ -16,11 +15,15 @@ type Input = {
 
   /** The ID of the comment to update */
   id: string;
+
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 };
 
-export default withAccessToken(linear)(async (inputs: Input) => {
-  const { linearClient } = getLinearClient();
-  const body = await appendFileAttachments(inputs.body, inputs.attachmentPaths);
+export default withToolAuth(async (inputs: Input) => {
+  const client = await resolveToolClient(inputs.workspaceId);
+  const { linearClient } = resolveClient(client);
+  const body = await appendFileAttachments(inputs.body, inputs.attachmentPaths, client);
   const result = await linearClient.updateComment(inputs.id, { body });
 
   if (!result.success || !result.comment) {
@@ -29,14 +32,17 @@ export default withAccessToken(linear)(async (inputs: Input) => {
   return serializeComment(await result.comment);
 });
 
-export const confirmation = withAccessToken(linear)(async ({ id, body, attachmentPaths }: Input) => {
-  const { linearClient } = getLinearClient();
+export const confirmation = withToolAuth(async ({ id, body, attachmentPaths, workspaceId }: Input) => {
+  const workspaceName = await describeToolWorkspace(workspaceId);
+  const client = await resolveToolClient(workspaceId);
+  const { linearClient } = resolveClient(client);
 
   const comment = await linearClient.comment({ id });
 
   return {
     message: `Are you sure you want to update the [comment](${comment.url})?`,
     info: [
+      ...(workspaceName ? [{ name: "Workspace", value: workspaceName }] : []),
       { name: "Comment", value: body },
       ...(attachmentPaths?.length
         ? [{ name: "Attachments", value: attachmentPaths.map((filePath) => path.basename(filePath)).join(", ") }]

--- a/extensions/linear/src/tools/update-document.ts
+++ b/extensions/linear/src/tools/update-document.ts
@@ -1,6 +1,6 @@
-import { withAccessToken } from "@raycast/utils";
+import { resolveClient } from "../api/linearClient";
 
-import { getLinearClient, linear } from "../api/linearClient";
+import { describeToolWorkspace, resolveToolClient, withToolAuth } from "./resolveToolWorkspace";
 
 type Input = {
   /** The ID of the document/PRD to update */
@@ -14,10 +14,14 @@ type Input = {
 
   /** The ID of the project the document/PRD belongs to */
   projectId?: string;
+
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 };
 
-export default withAccessToken(linear)(async (inputs: Input) => {
-  const { linearClient } = getLinearClient();
+export default withToolAuth(async (inputs: Input) => {
+  const client = await resolveToolClient(inputs.workspaceId);
+  const { linearClient } = resolveClient(client);
   const result = await linearClient.updateDocument(inputs.documentId, {
     content: inputs.content,
     projectId: inputs.projectId,
@@ -31,13 +35,18 @@ export default withAccessToken(linear)(async (inputs: Input) => {
   return result.document;
 });
 
-export const confirmation = withAccessToken(linear)(async ({ documentId }: Input) => {
-  const { linearClient } = getLinearClient();
+export const confirmation = withToolAuth(async ({ documentId, workspaceId }: Input) => {
+  const workspaceName = await describeToolWorkspace(workspaceId);
+  const client = await resolveToolClient(workspaceId);
+  const { linearClient } = resolveClient(client);
 
   const document = await linearClient.document(documentId);
 
   return {
     message: `Are you sure you want to update the [document](${document.url})?`,
-    info: [{ name: "Title", value: document.title }],
+    info: [
+      ...(workspaceName ? [{ name: "Workspace", value: workspaceName }] : []),
+      { name: "Title", value: document.title },
+    ],
   };
 });

--- a/extensions/linear/src/tools/update-issue.ts
+++ b/extensions/linear/src/tools/update-issue.ts
@@ -1,9 +1,8 @@
-import { withAccessToken } from "@raycast/utils";
-
-import { getLinearClient, linear } from "../api/linearClient";
+import { resolveClient } from "../api/linearClient";
 import { updateIssue } from "../api/updateIssue";
 
 import { formatConfirmation } from "./formatConfirmation";
+import { describeToolWorkspace, resolveToolClient, withToolAuth } from "./resolveToolWorkspace";
 
 type Input = {
   /**
@@ -45,11 +44,16 @@ type Input = {
 
   /** A detailed description of the issue */
   description?: string;
+
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 };
 
-export default withAccessToken(linear)(async (inputs: Input) => {
-  const { issueId, ...update } = inputs;
-  const result = await updateIssue(issueId, update);
+export default withToolAuth(async (inputs: Input) => {
+  const client = await resolveToolClient(inputs.workspaceId);
+  const { issueId, workspaceId, ...update } = inputs;
+  void workspaceId; // destructured only to exclude it from `update`
+  const result = await updateIssue(issueId, update, client);
 
   if (!result.success) {
     throw new Error("Failed to update issue");
@@ -58,21 +62,28 @@ export default withAccessToken(linear)(async (inputs: Input) => {
   return result;
 });
 
-export const confirmation = withAccessToken(linear)(async (inputs: Input) => {
-  const { issueId, ...fieldsToUpdate } = inputs;
-  const { linearClient } = getLinearClient();
+export const confirmation = withToolAuth(async (inputs: Input) => {
+  const workspaceName = await describeToolWorkspace(inputs.workspaceId);
+  const client = await resolveToolClient(inputs.workspaceId);
+  const { issueId, workspaceId, ...fieldsToUpdate } = inputs;
+  void workspaceId; // destructured only to exclude it from `fieldsToUpdate`
+  const { linearClient } = resolveClient(client);
 
   const issue = await linearClient.issue(issueId);
 
   const details = await Promise.all(
     Object.keys(fieldsToUpdate).map((key) => {
       const name = key as keyof typeof fieldsToUpdate;
-      return formatConfirmation({ name, value: fieldsToUpdate[name] });
+      return formatConfirmation({ name, value: fieldsToUpdate[name], client });
     }),
   );
 
   return {
     message: `Are you sure you want to update the [issue](${issue.url})?`,
-    info: [{ name: "Issue", value: issue.title }, ...details],
+    info: [
+      ...(workspaceName ? [{ name: "Workspace", value: workspaceName }] : []),
+      { name: "Issue", value: issue.title },
+      ...details,
+    ],
   };
 });

--- a/extensions/linear/src/tools/update-project-milestone.ts
+++ b/extensions/linear/src/tools/update-project-milestone.ts
@@ -1,6 +1,6 @@
-import { withAccessToken } from "@raycast/utils";
+import { resolveClient } from "../api/linearClient";
 
-import { getLinearClient, linear } from "../api/linearClient";
+import { describeToolWorkspace, resolveToolClient, withToolAuth } from "./resolveToolWorkspace";
 
 type Input = {
   /** The ID of the project update to modify. */
@@ -14,10 +14,14 @@ type Input = {
 
   /** The new target date of the milestone in ISO date format (e.g., '2023-12-31') */
   targetDate?: string;
+
+  /** The workspace to act in: a workspaceId value returned by the get-workspaces tool. Omit to use the active workspace. */
+  workspaceId?: string;
 };
 
-export default withAccessToken(linear)(async ({ milestoneId, ...inputs }: Input) => {
-  const { linearClient } = getLinearClient();
+export default withToolAuth(async ({ milestoneId, workspaceId, ...inputs }: Input) => {
+  const client = await resolveToolClient(workspaceId);
+  const { linearClient } = resolveClient(client);
   const result = await linearClient.updateProjectMilestone(milestoneId, inputs);
 
   if (!result.success) {
@@ -27,12 +31,17 @@ export default withAccessToken(linear)(async ({ milestoneId, ...inputs }: Input)
   return JSON.stringify(result.projectMilestone);
 });
 
-export const confirmation = withAccessToken(linear)(async ({ milestoneId }: Input) => {
-  const { linearClient } = getLinearClient();
+export const confirmation = withToolAuth(async ({ milestoneId, workspaceId }: Input) => {
+  const workspaceName = await describeToolWorkspace(workspaceId);
+  const client = await resolveToolClient(workspaceId);
+  const { linearClient } = resolveClient(client);
 
   const milestone = await linearClient.projectMilestone(milestoneId);
 
   return {
-    info: [{ name: "Name", value: milestone.name }],
+    info: [
+      ...(workspaceName ? [{ name: "Workspace", value: workspaceName }] : []),
+      { name: "Name", value: milestone.name },
+    ],
   };
 });

--- a/extensions/linear/src/unread-notifications.tsx
+++ b/extensions/linear/src/unread-notifications.tsx
@@ -13,143 +13,156 @@ import {
 import React from "react";
 
 import { NotificationResult } from "./api/getNotifications";
+import { getLinearClientFor } from "./api/linearClient";
 import { updateNotification } from "./api/updateNotification";
-import View from "./components/View";
+import { entryKey } from "./api/workspaces";
 import { getNotificationMenuBarTitle, getNotificationURL } from "./helpers/notifications";
 import { getUserIcon } from "./helpers/users";
-import useNotifications from "./hooks/useNotifications";
+import useAllWorkspaceNotifications, { WorkspaceNotificationRow } from "./hooks/useAllWorkspaceNotifications";
 
 const preferences = getPreferenceValues<Preferences.UnreadNotifications>();
 
 function UnreadNotifications() {
-  const { isLoadingNotifications, unreadNotifications, urlKey, mutateNotifications } = useNotifications();
+  const { rows, isLoading, mutate } = useAllWorkspaceNotifications();
 
-  async function markNotificationAsRead(notification: NotificationResult) {
-    await mutateNotifications(updateNotification({ id: notification.id, readAt: new Date() }), {
-      optimisticUpdate(data) {
-        if (!data) {
-          return data;
-        }
-        return {
-          ...data,
-          notifications: data?.notifications?.map((x) => (x.id === notification.id ? { ...x, readAt: new Date() } : x)),
-        };
-      },
-      shouldRevalidateAfter: true,
-    });
-  }
+  const unreadOf = (row: WorkspaceNotificationRow) =>
+    row.notifications.filter((n) => !n.readAt && (!n.snoozedUntilAt || n.snoozedUntilAt < new Date()));
 
-  async function openNotification(notification: NotificationResult) {
-    const applications = await getApplications();
-    const linearApp = applications.find((app) => app.bundleId === "com.linear");
-    const url = getNotificationURL(notification);
-    if (url) {
-      await open(url, linearApp);
-    } else {
-      await openInbox();
-    }
-    await markNotificationAsRead(notification);
-  }
-
-  async function openInbox() {
-    const applications = await getApplications();
-    const linearApp = applications.find((app) => app.bundleId === "com.linear");
-    await open(`https://linear.app/${urlKey}/inbox`, linearApp);
-  }
-
-  async function markAllAsRead() {
-    if (unreadNotifications.length === 0) {
-      return;
-    }
-
-    const readAt = new Date();
-
-    await mutateNotifications(
-      Promise.all(unreadNotifications.map((notification) => updateNotification({ id: notification.id, readAt }))),
-      {
-        optimisticUpdate(data) {
-          if (!data) {
-            return data;
-          }
-          return {
-            ...data,
-            notifications: data?.notifications?.map((x) => (x.readAt ? x : { ...x, readAt })),
-          };
-        },
-        shouldRevalidateAfter: true,
-      },
-    );
-  }
+  const totalUnread = rows.flatMap(unreadOf); // count sums reachable entries only (P4)
 
   const truncate = (text: string, maxLength: number) => {
     const ellipsis = text.length > maxLength ? "…" : "";
     return text.substring(0, maxLength).trim() + ellipsis;
   };
 
-  if (!preferences.alwaysShow && !isLoadingNotifications && unreadNotifications && unreadNotifications.length === 0) {
-    return null;
+  async function markAsRead(row: WorkspaceNotificationRow, notification: NotificationResult) {
+    if (row.status !== "ok") return;
+    try {
+      // Resolved at ACTION TIME, never stored on the row (C1): a cached client would
+      // serialize its bearer token to Raycast's unencrypted cache.
+      const { linearClient } = await getLinearClientFor(
+        { orgId: row.entry.orgId, userId: row.entry.userId },
+        { interactive: false },
+      );
+      await updateNotification({ id: notification.id, readAt: new Date() }, linearClient); // that section's client — never the global one
+    } catch {
+      // Background client resolution failed (expired/revoked token, transient network
+      // error). No toast — this is an unattended menu-bar context — but silently no-op'ing
+      // would hide the failure entirely; refresh instead so the row surfaces as
+      // "needs re-authentication" (or clears itself on a transient blip).
+    } finally {
+      await mutate();
+    }
   }
+
+  async function markAllAsRead(row: WorkspaceNotificationRow) {
+    if (row.status !== "ok") return;
+    const readAt = new Date();
+    try {
+      const { linearClient } = await getLinearClientFor(
+        { orgId: row.entry.orgId, userId: row.entry.userId },
+        { interactive: false },
+      );
+      await Promise.all(unreadOf(row).map((n) => updateNotification({ id: n.id, readAt }, linearClient)));
+    } catch {
+      // See markAsRead: refresh on failure instead of silently no-op'ing.
+    } finally {
+      await mutate();
+    }
+  }
+
+  async function openInbox(row: WorkspaceNotificationRow) {
+    const applications = await getApplications();
+    const linearApp = applications.find((app) => app.bundleId === "com.linear");
+    await open(`https://linear.app/${row.urlKey}/inbox`, linearApp);
+  }
+
+  async function openNotification(row: WorkspaceNotificationRow, notification: NotificationResult) {
+    const applications = await getApplications();
+    const linearApp = applications.find((app) => app.bundleId === "com.linear");
+    // WS-31: the notification's own workspace URL — API-provided absolute url first,
+    // inbox fallback built from the ROW's urlKey, never the active workspace's.
+    const url = getNotificationURL(notification);
+    await open(url ?? `https://linear.app/${row.urlKey}/inbox`, linearApp);
+    await markAsRead(row, notification);
+  }
+
+  if (!preferences.alwaysShow && !isLoading && totalUnread.length === 0) return null;
+
+  const multi = rows.length >= 2;
 
   return (
     <MenuBarExtra
-      title={getNotificationMenuBarTitle(unreadNotifications)}
+      title={getNotificationMenuBarTitle(totalUnread)}
       icon={{ source: { dark: "dark/linear.svg", light: "light/linear.svg" } }}
-      isLoading={isLoadingNotifications}
+      isLoading={isLoading}
     >
-      <MenuBarExtra.Section>
-        <MenuBarExtra.Item
-          title="Open Inbox"
-          icon="linear-app-icon.png"
-          shortcut={Keyboard.Shortcut.Common.Open}
-          onAction={openInbox}
-        />
-        {unreadNotifications.length > 0 ? (
-          <MenuBarExtra.Item
-            title="Mark All as Read"
-            icon={Icon.CheckCircle}
-            shortcut={{
-              macOS: { modifiers: ["cmd", "shift"], key: "u" },
-              Windows: { modifiers: ["ctrl", "shift"], key: "u" },
-            }}
-            onAction={markAllAsRead}
-          />
-        ) : null}
-      </MenuBarExtra.Section>
-
-      <MenuBarExtra.Section>
-        <MenuBarExtra.Item
-          title={unreadNotifications.length !== 0 ? "Unread Notifications" : "No Unread Notifications"}
-        />
-
-        {unreadNotifications.map((notification) => {
-          // Use Linear API's title and subtitle fields for consistent notification display
-          const title = truncate(notification.subtitle, 30);
-          const icon = notification.actor ? getUserIcon(notification.actor) : "linear-app-icon.png";
-          const subtitle = truncate(notification.title, 20);
-          const tooltip = `${notification.subtitle}: ${notification.title}`;
-
-          return (
-            <MenuBarExtra.Item
-              key={notification.id}
-              icon={icon}
-              title={title}
-              subtitle={subtitle}
-              tooltip={tooltip}
-              onAction={() => openNotification(notification)}
-              alternate={
-                <MenuBarExtra.Item
-                  icon={icon}
-                  title={title}
-                  subtitle="Mark as Read"
-                  tooltip={tooltip}
-                  onAction={() => markNotificationAsRead(notification)}
-                />
+      {rows.map((row) => (
+        <MenuBarExtra.Section
+          key={entryKey(row.entry)}
+          {...(multi
+            ? {
+                title:
+                  row.entry.orgName +
+                  (rows.filter((r) => r.entry.orgId === row.entry.orgId).length > 1 ? ` (${row.entry.userEmail})` : ""),
               }
+            : {})}
+        >
+          {row.status === "needs-reauth" ? (
+            <MenuBarExtra.Item
+              title={`Re-authenticate ${row.entry.orgName}`}
+              icon={Icon.Key}
+              onAction={() => launchCommand({ name: "manage-workspaces", type: LaunchType.UserInitiated })}
             />
-          );
-        })}
-      </MenuBarExtra.Section>
+          ) : (
+            <>
+              <MenuBarExtra.Item
+                title="Open Inbox"
+                icon="linear-app-icon.png"
+                shortcut={Keyboard.Shortcut.Common.Open}
+                onAction={() => openInbox(row)}
+              />
+              {unreadOf(row).length > 0 ? (
+                <MenuBarExtra.Item
+                  title="Mark All as Read"
+                  icon={Icon.CheckCircle}
+                  shortcut={{
+                    macOS: { modifiers: ["cmd", "shift"], key: "u" },
+                    Windows: { modifiers: ["ctrl", "shift"], key: "u" },
+                  }}
+                  onAction={() => markAllAsRead(row)}
+                />
+              ) : null}
+              {unreadOf(row).map((notification) => {
+                const title = truncate(notification.subtitle, 30);
+                const icon = notification.actor ? getUserIcon(notification.actor) : "linear-app-icon.png";
+                const subtitle = truncate(notification.title, 20);
+                const tooltip = `${notification.subtitle}: ${notification.title}`;
 
+                return (
+                  <MenuBarExtra.Item
+                    key={notification.id}
+                    icon={icon}
+                    title={title}
+                    subtitle={subtitle}
+                    tooltip={tooltip}
+                    onAction={() => openNotification(row, notification)}
+                    alternate={
+                      <MenuBarExtra.Item
+                        icon={icon}
+                        title={title}
+                        subtitle="Mark as Read"
+                        tooltip={tooltip}
+                        onAction={() => markAsRead(row, notification)}
+                      />
+                    }
+                  />
+                );
+              })}
+            </>
+          )}
+        </MenuBarExtra.Section>
+      ))}
       <MenuBarExtra.Section>
         <MenuBarExtra.Item
           icon={Icon.Eye}
@@ -203,9 +216,7 @@ class BackgroundAuthBoundary extends React.Component<{ children: React.ReactNode
 export default function Command() {
   return (
     <BackgroundAuthBoundary>
-      <View>
-        <UnreadNotifications />
-      </View>
+      <UnreadNotifications />
     </BackgroundAuthBoundary>
   );
 }

--- a/extensions/linear/src/unread-notifications.tsx
+++ b/extensions/linear/src/unread-notifications.tsx
@@ -10,6 +10,7 @@ import {
   openExtensionPreferences,
   Keyboard,
 } from "@raycast/api";
+import { countBy } from "lodash";
 import React from "react";
 
 import { NotificationResult } from "./api/getNotifications";
@@ -90,6 +91,7 @@ function UnreadNotifications() {
   if (!preferences.alwaysShow && !isLoading && totalUnread.length === 0) return null;
 
   const multi = rows.length >= 2;
+  const entriesPerOrg = countBy(rows, (row) => row.entry.orgId);
 
   return (
     <MenuBarExtra
@@ -102,9 +104,7 @@ function UnreadNotifications() {
           key={entryKey(row.entry)}
           {...(multi
             ? {
-                title:
-                  row.entry.orgName +
-                  (rows.filter((r) => r.entry.orgId === row.entry.orgId).length > 1 ? ` (${row.entry.userEmail})` : ""),
+                title: row.entry.orgName + (entriesPerOrg[row.entry.orgId] > 1 ? ` (${row.entry.userEmail})` : ""),
               }
             : {})}
         >

--- a/extensions/linear/tests/workspaceAddFlow.test.mts
+++ b/extensions/linear/tests/workspaceAddFlow.test.mts
@@ -1,0 +1,231 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { OAuth } from "@raycast/api";
+
+import { createWorkspaceAddFlow } from "../src/api/workspaceAddFlow.ts";
+
+type Dependencies = Parameters<typeof createWorkspaceAddFlow>[0];
+type Identity = Awaited<ReturnType<Dependencies["identify"]>>;
+type Tokens = NonNullable<Awaited<ReturnType<Dependencies["staging"]["getTokens"]>>>;
+
+const identity: Identity = {
+  orgId: "workspace-b",
+  userId: "account-b",
+  orgName: "Workspace B",
+  userEmail: "account@example.invalid",
+  urlKey: "workspace-b",
+};
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => (resolve = done));
+  return { promise, resolve };
+}
+
+function fixture() {
+  const grant: Tokens = {
+    accessToken: "fake-access-token",
+    refreshToken: "fake-refresh-token",
+    idToken: "fake-id-token",
+    scope: "read write",
+    expiresIn: 3600,
+    updatedAt: new Date(),
+    isExpired: () => false,
+  };
+  const state = {
+    staged: undefined as Tokens | undefined,
+    destination: undefined as OAuth.TokenSetOptions | undefined,
+    registered: false,
+    publishedWithoutCredentials: false,
+    pending: false,
+    authorizeCalls: 0,
+    destinationWrites: 0,
+    identityCalls: 0,
+    failStage: "",
+    authorizationGate: undefined as ReturnType<typeof deferred> | undefined,
+    recoveryGate: undefined as ReturnType<typeof deferred> | undefined,
+  };
+  const fail = (stage: string) => {
+    if (state.failStage === stage) throw new Error(`Injected ${stage} failure`);
+  };
+  const dependencies: Dependencies = {
+    staging: {
+      getTokens: async () => state.staged,
+      removeTokens: async () => {
+        fail("cleanup");
+        state.staged = undefined;
+      },
+    },
+    hasPendingAdd: async () => {
+      if (state.recoveryGate) await state.recoveryGate.promise;
+      return state.pending;
+    },
+    markPendingAdd: async () => {
+      state.pending = true;
+    },
+    clearPendingAdd: async () => {
+      state.pending = false;
+    },
+    authorize: async () => {
+      state.authorizeCalls++;
+      if (state.authorizationGate) await state.authorizationGate.promise;
+      state.staged = grant;
+      return grant.accessToken;
+    },
+    identify: async () => {
+      state.identityCalls++;
+      fail("identity");
+      if (state.failStage === "permanent") throw new Error("Linear identity query failed: HTTP 401");
+      return identity;
+    },
+    verify: async () => {
+      fail("verification");
+    },
+    getDestination: async () => ({
+      setTokens: async (tokens) => {
+        state.destinationWrites++;
+        fail("destination");
+        assert.ok("accessToken" in tokens);
+        state.destination = tokens;
+      },
+    }),
+    register: async () => {
+      fail("registry");
+      state.publishedWithoutCredentials ||= !state.destination;
+      const isNew = !state.registered;
+      state.registered = true;
+      return { isNew };
+    },
+    trace: async (_stage, operation) => operation(),
+  };
+  return { state, grant, flow: createWorkspaceAddFlow(dependencies) };
+}
+
+test("a workspace becomes visible only after its credentials are saved", async () => {
+  const { state, flow } = fixture();
+  assert.deepEqual(await flow.add(), { identity, isNew: true });
+  assert.equal(state.publishedWithoutCredentials, false);
+  assert.equal(state.registered, true);
+  assert.equal(state.pending, false);
+  assert.equal(state.staged, undefined);
+  assert.equal(state.destination?.accessToken, "fake-access-token");
+  assert.equal(state.destination?.refreshToken, "fake-refresh-token");
+  assert.equal(state.destination?.idToken, "fake-id-token");
+});
+
+test("a failed credential save preserves recovery and publishes no workspace", async () => {
+  const { state, flow } = fixture();
+  state.failStage = "destination";
+  await assert.rejects(flow.add(), /Injected destination failure/);
+  assert.equal(state.registered, false);
+  assert.equal(state.pending, true);
+  assert.ok(state.staged);
+  state.failStage = "";
+  assert.deepEqual(await flow.recover(), { identity, isNew: true });
+  assert.equal(state.registered, true);
+  assert.equal(state.authorizeCalls, 1);
+});
+
+test("a failed registry write preserves credentials and retries without another browser grant", async () => {
+  const { state, flow } = fixture();
+  state.failStage = "registry";
+  await assert.rejects(flow.add(), /Injected registry failure/);
+  assert.ok(state.destination);
+  assert.ok(state.staged);
+  assert.equal(state.pending, true);
+  state.failStage = "";
+  await flow.recover();
+  assert.equal(state.registered, true);
+  assert.equal(state.authorizeCalls, 1);
+});
+
+for (const stage of ["identity", "verification"]) {
+  test(`a transient ${stage} failure can be recovered on reopening`, async () => {
+    const { state, flow } = fixture();
+    state.failStage = stage;
+    await assert.rejects(flow.add(), new RegExp(`Injected ${stage} failure`));
+    assert.equal(state.registered, false);
+    assert.equal(state.pending, true);
+    assert.ok(state.staged);
+    state.failStage = "";
+    await flow.recover();
+    assert.equal(state.registered, true);
+  });
+}
+
+test("a rejected credential is discarded rather than retried on every open", async () => {
+  const { state, flow } = fixture();
+  state.failStage = "permanent";
+  await assert.rejects(flow.add(), /HTTP 401/);
+  assert.equal(state.staged, undefined);
+  assert.equal(state.pending, false);
+  assert.equal(state.registered, false);
+});
+
+test("an empty staging slot does not cancel an unfinished authorization", async () => {
+  const { state, grant, flow } = fixture();
+  state.pending = true;
+  assert.equal(await flow.recover(), null);
+  assert.equal(state.pending, true);
+  state.staged = grant;
+  assert.deepEqual(await flow.recover(), { identity, isNew: true });
+});
+
+test("a stray staging credential without an add marker is never registered", async () => {
+  const { state, grant, flow } = fixture();
+  state.staged = grant;
+  assert.equal(await flow.recover(), null);
+  assert.equal(state.registered, false);
+  assert.equal(state.identityCalls, 0);
+});
+
+test("recovery during a live authorization waits for the same operation", async () => {
+  const { state, flow } = fixture();
+  state.authorizationGate = deferred();
+  const adding = flow.add();
+  await new Promise((resolve) => setImmediate(resolve));
+  const recovering = flow.recover();
+  state.authorizationGate.resolve();
+  const [added, recovered] = await Promise.all([adding, recovering]);
+  assert.deepEqual(recovered, added);
+  assert.equal(state.authorizeCalls, 1);
+  assert.equal(state.destinationWrites, 1);
+});
+
+test("repeated Add actions share one authorization", async () => {
+  const { state, flow } = fixture();
+  state.authorizationGate = deferred();
+  const first = flow.add();
+  const second = flow.add();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(state.authorizeCalls, 1);
+  state.authorizationGate.resolve();
+  assert.deepEqual(await first, await second);
+  assert.equal(state.destinationWrites, 1);
+});
+
+test("an Add action during initial recovery starts after recovery finishes", async () => {
+  const { state, flow } = fixture();
+  state.recoveryGate = deferred();
+  const recovering = flow.recover();
+  const adding = flow.add();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(state.authorizeCalls, 0);
+  state.recoveryGate.resolve();
+  await recovering;
+  assert.deepEqual(await adding, { identity, isNew: true });
+  assert.equal(state.authorizeCalls, 1);
+});
+
+test("token copying preserves the remaining lifetime and optional expiry", async () => {
+  const { state, grant, flow } = fixture();
+  state.pending = true;
+  state.staged = { ...grant, updatedAt: new Date(Date.now() - 120_000) };
+  await flow.recover();
+  assert.ok(state.destination?.expiresIn && state.destination.expiresIn <= 3480);
+  state.pending = true;
+  state.staged = { ...grant, expiresIn: undefined };
+  await flow.recover();
+  assert.equal(Object.hasOwn(state.destination!, "expiresIn"), false);
+});


### PR DESCRIPTION

## Description

Adds multi-workspace support to the Linear extension: connect any number of workspaces
(including the same workspace under two accounts), switch via a consistent pattern on
every surface (list dropdowns, a form field, a dedicated Create Issue for Myself in
Workspace quick command plus a one-shot `workspace` argument on Quick Add Comment), a
new Manage Workspaces command, an aggregated menu bar, and workspace-routable AI tools
with a new `get-workspaces` tool. The quick commands surface their target via a live
root-search subtitle (hidden for single-workspace users).

Single-workspace users see no behavior change: every switcher is invisible until a
second workspace is connected, and an existing login is adopted silently (no re-auth).
The only visible additions are the new Manage Workspaces and Create Issue for Myself
in Workspace commands and an optional `workspace` argument on Quick Add Comment.

Closes #24297. Supersedes the PAT-based approach in #25646 — this stays entirely on
Raycast's OAuth proxy and token storage.

## Approach

- One OAuth token-storage slot per (workspace, account) pair via per-entry providerIds
  (`linear-ws-<orgId>-<userId>`); the existing `linear` slot is adopted unchanged.
- raycast/utils#80 adds `providerId`/`extraParameters` to `OAuthService.linear()`; until
  it ships in a release, a small factory (`src/api/oauth.ts`, `AUTH_BACKEND` switch)
  constructs the service manually with the same proxy + clientId — the copied constants
  are temporary by design and deleted when the utils option lands.
- Adding a workspace uses `prompt=consent` (without it Linear silently skips consent for
  an already-granted app). Linear's consent page has no workspace picker — the grant
  follows the active workspace at linear.app, so the add flow instructs the user to
  switch there first (verified empirically).
- Background contexts (menu bar) never trigger OAuth flows and use a non-destructive
  token refresh, so a transient network failure can never log a workspace out.
- Removing a workspace deletes the local token only; Linear-side revocation is opt-in
  (revocation is authorization-scoped and eventually consistent, so an unconditional
  revoke could affect the primary login).
- AI tools take a per-call `workspaceId` (each tool call runs in a fresh process, so
  per-call routing is the only reliable design); confirmations resolve the same client
  as executions and display the target workspace.

## Testing notes & known limitations

- The extension declares macOS and Windows support; this change was fully tested on
  macOS only (no Windows hardware available to the author) — flagging for reviewers.
- Manually verified on macOS across the full design test matrix (two workspaces,
  including the same workspace under two accounts): silent adoption on upgrade, add /
  switch / re-authenticate / log out flows, per-workspace remembered form defaults,
  cross-workspace drafts (draft pins its workspace; the global default is untouched),
  menu-bar aggregation with per-workspace re-auth rows, and AI-tool workspace routing.
- `workspaceId` on AI tools is optional by design (absent → active workspace). If the
  model never calls `get-workspaces` and the user switches the default between a
  confirmation and its execution, routing follows the default; mitigations are the AI
  instructions, a Workspace row on every mutating confirmation, and routing evals.
- Workspace targeting on the quick commands is a text argument (Raycast argument
  dropdowns require a static list; workspaces are per-user runtime data). It matches
  URL key, account email, or a unique name prefix, and never changes the default
  workspace; Create Issue for Myself is deliberately pegged to the active workspace,
  with the dedicated in-Workspace command for explicit targeting.
- Pre-existing and deliberately untouched: `create-project-update.ts` and
  `get-initiatives.ts` exist undeclared in `tools[]`; team switch clears the Create
  Issue title via the template-reset effect (upstream behavior, kept for parity).
- Raycast Settings' extension login-row list does not live-refresh (platform behavior);
  Manage Workspaces is the primary management surface and labels each login row
  (`providerName: "Linear — <org>"`).
- One narrow known issue kept small on purpose: permanent-vs-transient classification of
  a failed staged-add verification matches on error text ("HTTP 401/403") — an SDK-path
  auth failure in a rare race is treated as transient (retried) rather than permanent.

## Screencast

<attach the Manage Workspaces add/switch screencast>
