### PR TITLE
Update AirBuddy extension: fix scripting setting location, add Product Hunt badge

### DIFF
--- a/extensions/airbuddy/CHANGELOG.md
+++ b/extensions/airbuddy/CHANGELOG.md
@@ -1,8 +1,8 @@
 # AirBuddy
 
-## [Docs: fix scripting setting location, add Product Hunt badge] - {PR_MERGE_DATE}
+## [Fix scripting setting location, add Product Hunt badge] - {PR_MERGE_DATE}
 
-- Correct the setup docs: "Enable Apple Script for automation" is under Settings → General → Security, not Advanced.
+- Correct the scripting setting location (docs and the runtime error view): "Enable Apple Script for automation" is under Settings → General → Security, not Advanced.
 - Add the Product Hunt badge for AirBuddy 3.
 
 ## [Initial Release] - 2026-08-18

--- a/extensions/airbuddy/CHANGELOG.md
+++ b/extensions/airbuddy/CHANGELOG.md
@@ -1,3 +1,8 @@
 # AirBuddy
 
+## [Docs: fix scripting setting location, add Product Hunt badge] - {PR_MERGE_DATE}
+
+- Correct the setup docs: "Enable Apple Script for automation" is under Settings → General → Security, not Advanced.
+- Add the Product Hunt badge for AirBuddy 3.
+
 ## [Initial Release] - 2026-08-18

--- a/extensions/airbuddy/CHANGELOG.md
+++ b/extensions/airbuddy/CHANGELOG.md
@@ -1,6 +1,6 @@
 # AirBuddy
 
-## [Fix scripting setting location, add Product Hunt badge] - {PR_MERGE_DATE}
+## [Fix scripting setting location, add Product Hunt badge] - 2026-08-19
 
 - Correct the scripting setting location (docs and the runtime error view): "Enable Apple Script for automation" is under Settings → General → Security, not Advanced.
 - Add the Product Hunt badge for AirBuddy 3.

--- a/extensions/airbuddy/README.md
+++ b/extensions/airbuddy/README.md
@@ -14,7 +14,7 @@ default, and the extension will show you which one is missing.
 
 ### 1. Enable scripting in AirBuddy
 
-AirBuddy → Settings → Advanced → Security → turn on **"Enable Apple Script for automation."**
+AirBuddy → Settings → General → Security → turn on **"Enable Apple Script for automation."**
 
 ### 2. Allow Raycast to control AirBuddy
 
@@ -62,6 +62,8 @@ reports that immediately instead of waiting out a timeout.
 **AirBuddy** is by [Gui Rambo](https://www.rambo.codes/). This extension is an unofficial companion to it and
 is not affiliated with or endorsed by AirBuddy. The extension icon is AirBuddy's own app icon, used to
 identify the app this extension controls.
+
+<a href="https://www.producthunt.com/products/airbuddy-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-airbuddy-3-4" target="_blank" rel="noopener noreferrer"><img alt="AirBuddy 3 - Easily manage devices and switch them between Macs | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1223171&amp;theme=neutral&amp;t=1787080026411"></a>
 
 **Device icons are [SF Symbols](https://developer.apple.com/sf-symbols/)**, provided by Apple and used
 under the [SF Symbols license](https://developer.apple.com/fonts/).

--- a/extensions/airbuddy/src/components/error-views.tsx
+++ b/extensions/airbuddy/src/components/error-views.tsx
@@ -47,7 +47,7 @@ export function ErrorView({ error, onRetry }: { error: Error; onRetry: () => voi
       <List.EmptyView
         icon={Icon.Lock}
         title="Turn on Scripting in AirBuddy"
-        description="AirBuddy Settings → Advanced → Security → “Enable Apple Script for automation”"
+        description="AirBuddy Settings → General → Security → “Enable Apple Script for automation”"
         actions={
           <ActionPanel>
             <Action


### PR DESCRIPTION
## Description

Small docs-only follow-up to the AirBuddy extension (now live), coinciding with AirBuddy 3.0 going public.

- **Fix:** the "Enable Apple Script for automation" toggle lives under **Settings → General → Security**, not Advanced. Corrected the setup instructions.
- **Add:** the Product Hunt embed for AirBuddy 3.

No code or manifest changes — README only.