### PR TITLE
Add explicit OBS output commands

### DIFF
--- a/extensions/obs-control/CHANGELOG.md
+++ b/extensions/obs-control/CHANGELOG.md
@@ -1,5 +1,12 @@
 # OBS Control Changelog
 
+## [New Commands] - 2026-08-18
+
+- Added explicit start and stop commands for recording, streaming, virtual camera, and replay buffer
+- Added explicit pause and resume recording commands
+- Added an optional scene name argument to Set Scene for automation
+- Launch OBS Studio automatically before connecting when it is installed but not running
+
 ## [New Command] - 2025-01-24
 
 Added Toggle Replay Buffer command

--- a/extensions/obs-control/package.json
+++ b/extensions/obs-control/package.json
@@ -19,13 +19,35 @@
       "title": "Set Scene",
       "subtitle": "OBS Control",
       "description": "Set Current Scene",
-      "mode": "view"
+      "mode": "view",
+      "arguments": [
+        {
+          "name": "sceneName",
+          "placeholder": "Scene Name",
+          "type": "text",
+          "required": false
+        }
+      ]
     },
     {
       "name": "toggle-stream",
       "title": "Toggle Stream",
       "subtitle": "OBS Control",
       "description": "Toggle Stream",
+      "mode": "no-view"
+    },
+    {
+      "name": "start-stream",
+      "title": "Start Stream",
+      "subtitle": "OBS Control",
+      "description": "Start Stream",
+      "mode": "no-view"
+    },
+    {
+      "name": "stop-stream",
+      "title": "Stop Stream",
+      "subtitle": "OBS Control",
+      "description": "Stop OBS Stream",
       "mode": "no-view"
     },
     {
@@ -36,6 +58,20 @@
       "mode": "no-view"
     },
     {
+      "name": "start-virtual-cam",
+      "title": "Start Virtual Camera",
+      "subtitle": "OBS Control",
+      "description": "Start Virtual Camera",
+      "mode": "no-view"
+    },
+    {
+      "name": "stop-virtual-cam",
+      "title": "Stop Virtual Camera",
+      "subtitle": "OBS Control",
+      "description": "Stop Virtual Camera",
+      "mode": "no-view"
+    },
+    {
       "name": "toggle-recording",
       "title": "Toggle Recording",
       "subtitle": "OBS Control",
@@ -43,10 +79,38 @@
       "mode": "no-view"
     },
     {
+      "name": "start-recording",
+      "title": "Start Recording",
+      "subtitle": "OBS Control",
+      "description": "Start Recording",
+      "mode": "no-view"
+    },
+    {
+      "name": "stop-recording",
+      "title": "Stop Recording",
+      "subtitle": "OBS Control",
+      "description": "Stop Recording",
+      "mode": "no-view"
+    },
+    {
       "name": "toggle-pause-recording",
       "title": "Toggle Pause Recording",
       "subtitle": "OBS Control",
       "description": "Toggle Pause Recording",
+      "mode": "no-view"
+    },
+    {
+      "name": "pause-recording",
+      "title": "Pause Recording",
+      "subtitle": "OBS Control",
+      "description": "Pause Recording",
+      "mode": "no-view"
+    },
+    {
+      "name": "resume-recording",
+      "title": "Resume Recording",
+      "subtitle": "OBS Control",
+      "description": "Resume Recording",
       "mode": "no-view"
     },
     {
@@ -68,6 +132,20 @@
       "title": "Toggle Replay Buffer",
       "subtitle": "OBS Control",
       "description": "Toggle Replay Buffer",
+      "mode": "no-view"
+    },
+    {
+      "name": "start-replay-buffer",
+      "title": "Start Replay Buffer",
+      "subtitle": "OBS Control",
+      "description": "Start Replay Buffer",
+      "mode": "no-view"
+    },
+    {
+      "name": "stop-replay-buffer",
+      "title": "Stop Replay Buffer",
+      "subtitle": "OBS Control",
+      "description": "Stop Replay Buffer",
       "mode": "no-view"
     }
   ],

--- a/extensions/obs-control/src/lib/obs.ts
+++ b/extensions/obs-control/src/lib/obs.ts
@@ -1,14 +1,20 @@
 import OBSWebSocket from "obs-websocket-js";
 import type { OBSRequestTypes } from "obs-websocket-js";
 import { getPreferenceValues } from "@raycast/api";
-import { showWebsocketConnectionErrorToast } from "@/lib/utils";
+import { openObsStudio, showWebsocketConnectionErrorToast } from "@/lib/utils";
 
 const values = getPreferenceValues<Preferences>();
 
 export async function getObs() {
   const obs = new OBSWebSocket();
 
-  await obs.connect(values["obs-url"], values["obs-password"]);
+  try {
+    await obs.connect(values["obs-url"], values["obs-password"]);
+  } catch {
+    await openObsStudio();
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+    await obs.connect(values["obs-url"], values["obs-password"]);
+  }
 
   return obs;
 }

--- a/extensions/obs-control/src/lib/output-control.ts
+++ b/extensions/obs-control/src/lib/output-control.ts
@@ -1,0 +1,100 @@
+import type OBSWebSocket from "obs-websocket-js";
+import type { OBSRequestTypes } from "obs-websocket-js";
+import { popToRoot, showHUD } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
+import { getObs } from "@/lib/obs";
+import { appInstalled, appNotInstallAlertDialog, showWebsocketConnectionErrorToast } from "@/lib/utils";
+
+type OutputControlOptions = {
+  label: string;
+  request: keyof OBSRequestTypes;
+  statusRequest: keyof OBSRequestTypes;
+  desiredActive: boolean;
+  activeMessage: string;
+  inactiveMessage: string;
+};
+
+type RecordPauseControlOptions = {
+  request: "PauseRecord" | "ResumeRecord";
+  desiredPaused: boolean;
+  message: string;
+  alreadyMessage: string;
+};
+
+type OutputStatus = {
+  outputActive?: boolean;
+  outputPaused?: boolean;
+};
+
+async function getConnectedObs() {
+  if (!(await appInstalled())) {
+    await appNotInstallAlertDialog();
+    return;
+  }
+
+  let obs: OBSWebSocket;
+  try {
+    obs = await getObs();
+  } catch {
+    await showWebsocketConnectionErrorToast();
+    return;
+  }
+
+  return obs;
+}
+
+export async function controlOutput(options: OutputControlOptions) {
+  const obs = await getConnectedObs();
+  if (!obs) {
+    return;
+  }
+
+  try {
+    const status = (await obs.call(options.statusRequest)) as OutputStatus;
+    const isActive = Boolean(status.outputActive);
+
+    if (isActive === options.desiredActive) {
+      await showHUD(options.desiredActive ? options.activeMessage : options.inactiveMessage);
+      return;
+    }
+
+    await obs.call(options.request);
+    await showHUD(options.desiredActive ? options.activeMessage : options.inactiveMessage);
+  } catch {
+    await showFailureToast(`${options.label} command failed`, {
+      title: "OBS Command Failed",
+    });
+    return popToRoot();
+  }
+}
+
+export async function controlRecordPause(options: RecordPauseControlOptions) {
+  const obs = await getConnectedObs();
+  if (!obs) {
+    return;
+  }
+
+  try {
+    const status = (await obs.call("GetRecordStatus")) as OutputStatus;
+
+    if (!status.outputActive) {
+      await showFailureToast("Recording is not active", {
+        title: "Recording Error",
+      });
+      return popToRoot();
+    }
+
+    if (Boolean(status.outputPaused) === options.desiredPaused) {
+      await showHUD(options.alreadyMessage);
+      return;
+    }
+
+    await obs.call(options.request);
+    await showHUD(options.message);
+  } catch {
+    await showFailureToast("Recording pause command failed", {
+      title: "OBS Command Failed",
+    });
+    return popToRoot();
+  }
+}

--- a/extensions/obs-control/src/lib/utils.ts
+++ b/extensions/obs-control/src/lib/utils.ts
@@ -2,6 +2,12 @@ import type { Alert } from "@raycast/api";
 import { confirmAlert, getApplications, open, popToRoot } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
 
+export async function getObsApplication() {
+  const applications = await getApplications();
+
+  return applications.find((app) => app.bundleId === "com.obsproject.obs-studio");
+}
+
 export const appNotInstallAlertDialog = async () => {
   const options: Alert.Options = {
     title: "OBS Studio is Not Installed",
@@ -24,7 +30,16 @@ export const showWebsocketConnectionErrorToast = async () => {
 };
 
 export async function appInstalled() {
-  const applications = await getApplications();
+  return !!(await getObsApplication());
+}
 
-  return !!applications.find((app) => app.bundleId === "com.obsproject.obs-studio");
+export async function openObsStudio() {
+  const app = await getObsApplication();
+
+  if (app?.path) {
+    await open(app.path);
+    return;
+  }
+
+  await open("obs");
 }

--- a/extensions/obs-control/src/pause-recording.tsx
+++ b/extensions/obs-control/src/pause-recording.tsx
@@ -1,0 +1,10 @@
+import { controlRecordPause } from "@/lib/output-control";
+
+export default async function main() {
+  await controlRecordPause({
+    request: "PauseRecord",
+    desiredPaused: true,
+    message: "Recording paused",
+    alreadyMessage: "Recording already paused",
+  });
+}

--- a/extensions/obs-control/src/resume-recording.tsx
+++ b/extensions/obs-control/src/resume-recording.tsx
@@ -1,0 +1,10 @@
+import { controlRecordPause } from "@/lib/output-control";
+
+export default async function main() {
+  await controlRecordPause({
+    request: "ResumeRecord",
+    desiredPaused: false,
+    message: "Recording resumed",
+    alreadyMessage: "Recording already resumed",
+  });
+}

--- a/extensions/obs-control/src/set-scene.tsx
+++ b/extensions/obs-control/src/set-scene.tsx
@@ -1,25 +1,43 @@
 import type OBSWebSocket from "obs-websocket-js";
+import { useEffect, useRef } from "react";
 import useSWR from "swr";
-import { Action, ActionPanel, Color, Icon, List } from "@raycast/api";
+import type { LaunchProps } from "@raycast/api";
+import { Action, ActionPanel, Color, Icon, List, popToRoot, showHUD } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
 import { getObs } from "@/lib/obs";
 import { showWebsocketConnectionErrorToast } from "@/lib/utils";
 import useIsInstalled from "./hooks/use-is-installed";
 
 let obs: OBSWebSocket;
 
-export default function SetScene() {
+type Scene = {
+  sceneName: string;
+  sceneIndex: number;
+};
+
+type SceneListResponse = {
+  scenes: Scene[];
+  currentProgramSceneName: string;
+};
+
+function findScene(scenes: Scene[], sceneName: string) {
+  const exactMatch = scenes.find((scene) => scene.sceneName === sceneName);
+  if (exactMatch) {
+    return exactMatch;
+  }
+
+  return scenes.find((scene) => scene.sceneName.toLocaleLowerCase() === sceneName.toLocaleLowerCase());
+}
+
+export default function SetScene(props: LaunchProps<{ arguments: { sceneName?: string } }>) {
   const isAppInstalled = useIsInstalled();
+  const didAutoSelectScene = useRef(false);
+  const requestedSceneName = props.arguments.sceneName?.trim();
   const { data, mutate, error } = useSWR(
     () => (isAppInstalled ? "/api/scenes" : null),
     async () => {
       obs = await getObs();
-      return (await obs.call("GetSceneList")) as unknown as {
-        scenes: Array<{
-          sceneName: string;
-          sceneIndex: number;
-        }>;
-        currentProgramSceneName: string;
-      };
+      return (await obs.call("GetSceneList")) as unknown as SceneListResponse;
     },
   );
 
@@ -27,8 +45,41 @@ export default function SetScene() {
     showWebsocketConnectionErrorToast();
   }
 
+  useEffect(() => {
+    if (!data || didAutoSelectScene.current) {
+      return;
+    }
+
+    const scene = requestedSceneName
+      ? findScene(data.scenes, requestedSceneName)
+      : data.scenes.length === 1
+        ? data.scenes[0]
+        : null;
+
+    if (!scene) {
+      if (requestedSceneName) {
+        didAutoSelectScene.current = true;
+        showFailureToast(`Scene "${requestedSceneName}" was not found`, {
+          title: "Scene Not Found",
+        });
+      }
+      return;
+    }
+
+    const selectedScene = scene;
+
+    async function setScene() {
+      didAutoSelectScene.current = true;
+      await obs.call("SetCurrentProgramScene", { sceneName: selectedScene.sceneName });
+      await showHUD(`Switched to ${selectedScene.sceneName}`);
+      popToRoot();
+    }
+
+    setScene();
+  }, [data, requestedSceneName]);
+
   return (
-    <List>
+    <List isLoading={!data && !error}>
       {data?.scenes.map((scene) => {
         const isCurrent = data?.currentProgramSceneName === scene.sceneName;
 

--- a/extensions/obs-control/src/start-recording.tsx
+++ b/extensions/obs-control/src/start-recording.tsx
@@ -1,0 +1,12 @@
+import { controlOutput } from "@/lib/output-control";
+
+export default async function main() {
+  await controlOutput({
+    label: "Recording",
+    request: "StartRecord",
+    statusRequest: "GetRecordStatus",
+    desiredActive: true,
+    activeMessage: "Recording",
+    inactiveMessage: "Recording stopped",
+  });
+}

--- a/extensions/obs-control/src/start-replay-buffer.tsx
+++ b/extensions/obs-control/src/start-replay-buffer.tsx
@@ -1,0 +1,12 @@
+import { controlOutput } from "@/lib/output-control";
+
+export default async function main() {
+  await controlOutput({
+    label: "Replay Buffer",
+    request: "StartReplayBuffer",
+    statusRequest: "GetReplayBufferStatus",
+    desiredActive: true,
+    activeMessage: "Replay buffer started",
+    inactiveMessage: "Replay buffer stopped",
+  });
+}

--- a/extensions/obs-control/src/start-stream.tsx
+++ b/extensions/obs-control/src/start-stream.tsx
@@ -1,0 +1,12 @@
+import { controlOutput } from "@/lib/output-control";
+
+export default async function main() {
+  await controlOutput({
+    label: "Streaming",
+    request: "StartStream",
+    statusRequest: "GetStreamStatus",
+    desiredActive: true,
+    activeMessage: "Streaming",
+    inactiveMessage: "Streaming stopped",
+  });
+}

--- a/extensions/obs-control/src/start-virtual-cam.tsx
+++ b/extensions/obs-control/src/start-virtual-cam.tsx
@@ -1,0 +1,12 @@
+import { controlOutput } from "@/lib/output-control";
+
+export default async function main() {
+  await controlOutput({
+    label: "Virtual Camera",
+    request: "StartVirtualCam",
+    statusRequest: "GetVirtualCamStatus",
+    desiredActive: true,
+    activeMessage: "Virtual Camera started",
+    inactiveMessage: "Virtual Camera stopped",
+  });
+}

--- a/extensions/obs-control/src/stop-recording.tsx
+++ b/extensions/obs-control/src/stop-recording.tsx
@@ -1,0 +1,12 @@
+import { controlOutput } from "@/lib/output-control";
+
+export default async function main() {
+  await controlOutput({
+    label: "Recording",
+    request: "StopRecord",
+    statusRequest: "GetRecordStatus",
+    desiredActive: false,
+    activeMessage: "Recording",
+    inactiveMessage: "Recording stopped",
+  });
+}

--- a/extensions/obs-control/src/stop-replay-buffer.tsx
+++ b/extensions/obs-control/src/stop-replay-buffer.tsx
@@ -1,0 +1,12 @@
+import { controlOutput } from "@/lib/output-control";
+
+export default async function main() {
+  await controlOutput({
+    label: "Replay Buffer",
+    request: "StopReplayBuffer",
+    statusRequest: "GetReplayBufferStatus",
+    desiredActive: false,
+    activeMessage: "Replay buffer started",
+    inactiveMessage: "Replay buffer stopped",
+  });
+}

--- a/extensions/obs-control/src/stop-stream.tsx
+++ b/extensions/obs-control/src/stop-stream.tsx
@@ -1,0 +1,12 @@
+import { controlOutput } from "@/lib/output-control";
+
+export default async function main() {
+  await controlOutput({
+    label: "Streaming",
+    request: "StopStream",
+    statusRequest: "GetStreamStatus",
+    desiredActive: false,
+    activeMessage: "Streaming",
+    inactiveMessage: "Streaming stopped",
+  });
+}

--- a/extensions/obs-control/src/stop-virtual-cam.tsx
+++ b/extensions/obs-control/src/stop-virtual-cam.tsx
@@ -1,0 +1,12 @@
+import { controlOutput } from "@/lib/output-control";
+
+export default async function main() {
+  await controlOutput({
+    label: "Virtual Camera",
+    request: "StopVirtualCam",
+    statusRequest: "GetVirtualCamStatus",
+    desiredActive: false,
+    activeMessage: "Virtual Camera started",
+    inactiveMessage: "Virtual Camera stopped",
+  });
+}


### PR DESCRIPTION
## Summary

Adds explicit Raycast commands for OBS output controls, alongside the existing toggle commands:

- Start/Stop Recording
- Pause/Resume Recording
- Start/Stop Stream
- Start/Stop Virtual Camera
- Start/Stop Replay Buffer

The new commands check the current OBS output state before sending start/stop/pause/resume requests, so they are safe to bind to automation workflows and keyboard shortcuts where an idempotent command is preferable to a toggle.

`Set Scene` now also accepts an optional `sceneName` argument. When supplied, the command switches directly to the matching scene. If no scene name is supplied and OBS only has one scene, it selects that scene automatically. Otherwise, the existing scene picker opens as before.

This also updates OBS connection handling to launch OBS Studio automatically when it is installed but not already reachable over WebSocket, then retries the connection once.

## Validation

- `npm run lint`
- `npm run build`
