### PR TITLE
Fix Obsidian plugin checks for inaccessible config files

### DIFF
--- a/extensions/obsidian/CHANGELOG.md
+++ b/extensions/obsidian/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Obsidian Changelog
 
+## [Fix Plugin Configuration Permission Errors] - 2026-08-19
+
+- Prevent plugin checks from crashing when Obsidian configuration files cannot be read
+
 ## [Fix AI searchNote OOM on oversized Markdown] - 2026-08-15
 
 - Skip Markdown files larger than 1 MiB during full-content search instead of reading them into the 100 MB extension heap

--- a/extensions/obsidian/CHANGELOG.md
+++ b/extensions/obsidian/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Obsidian Changelog
 
-## [Fix Plugin Configuration Permission Errors] - 2026-08-19
+## [Fix Plugin Configuration Permission Errors] - {PR_MERGE_DATE}
 
 - Prevent plugin checks from crashing when Obsidian configuration files cannot be read
 

--- a/extensions/obsidian/CHANGELOG.md
+++ b/extensions/obsidian/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Obsidian Changelog
 
-## [Fix Plugin Configuration Permission Errors] - {PR_MERGE_DATE}
+## [Fix Plugin Configuration Permission Errors] - 2026-08-19
 
 - Prevent plugin checks from crashing when Obsidian configuration files cannot be read
 

--- a/extensions/obsidian/package.json
+++ b/extensions/obsidian/package.json
@@ -25,7 +25,8 @@
     "byheaven",
     "tofrankie",
     "alexi.build",
-    "veilwalker"
+    "veilwalker",
+    "raulkolaric"
   ],
   "license": "MIT",
   "engines": {

--- a/extensions/obsidian/src/obsidian/internal/plugins.ts
+++ b/extensions/obsidian/src/obsidian/internal/plugins.ts
@@ -11,16 +11,22 @@ export interface VaultPluginCheckParams {
   corePlugins?: string[];
 }
 
+export interface VaultPluginCheckResult {
+  vaultsWithPlugin: ObsidianVault[];
+  vaultsWithoutPlugin: ObsidianVault[];
+  cacheable: boolean;
+}
+
 export function readCommunityPlugins(vaultPath: string): string[] | undefined {
   const { configFileName } = getPreferenceValues();
   const path = `${vaultPath}/${configFileName || ".obsidian"}/community-plugins.json`;
+  if (!fs.existsSync(path)) return;
+  const content = fs.readFileSync(path, "utf-8");
   try {
-    if (!fs.existsSync(path)) return;
-    const content = fs.readFileSync(path, "utf-8");
     const plugins: string[] = JSON.parse(content);
     return plugins;
   } catch (error) {
-    logger.error(`Failed to read community-plugins.json for vault ${vaultPath}: ${error}`);
+    logger.error(`Failed to parse community-plugins.json for vault ${vaultPath}: ${error}`);
     return undefined;
   }
 }
@@ -31,34 +37,49 @@ export function readCommunityPlugins(vaultPath: string): string[] | undefined {
 export function readCorePlugins(vaultPath: string): Record<string, boolean> | undefined {
   const { configFileName } = getPreferenceValues();
   const path = `${vaultPath}/${configFileName || ".obsidian"}/core-plugins.json`;
+  if (!fs.existsSync(path)) return;
+  const content = fs.readFileSync(path, "utf-8");
   try {
-    if (!fs.existsSync(path)) return;
-    const content = fs.readFileSync(path, "utf-8");
     const plugins: Record<string, boolean> = JSON.parse(content);
     return plugins;
   } catch (error) {
-    logger.error(`Failed to read core-plugins.json for vault ${vaultPath}: ${error}`);
+    logger.error(`Failed to parse core-plugins.json for vault ${vaultPath}: ${error}`);
     return undefined;
   }
 }
 
-export function vaultPluginCheck(params: VaultPluginCheckParams) {
+export function vaultPluginCheck(params: VaultPluginCheckParams): VaultPluginCheckResult {
   const vaultsWithoutPlugin: ObsidianVault[] = [];
+  let cacheable = true;
   const vaultsWithPlugin = params.vaults.filter((vault: ObsidianVault) => {
     const toCheckCommunityPlugins = params.communityPlugins;
     const toCheckCorePlugins = params.corePlugins;
 
     if (toCheckCommunityPlugins) {
-      const plugins = readCommunityPlugins(vault.path);
-      if (!plugins || !toCheckCommunityPlugins.every((c) => plugins.includes(c))) {
+      let plugins: string[] | undefined;
+      try {
+        plugins = readCommunityPlugins(vault.path);
+      } catch (error) {
+        logger.error(`Failed to read community-plugins.json for vault ${vault.path}: ${error}`);
+        cacheable = false;
+      }
+      const availablePlugins = plugins;
+      if (!availablePlugins || !toCheckCommunityPlugins.every((c) => availablePlugins.includes(c))) {
         vaultsWithoutPlugin.push(vault);
         return false;
       }
     }
 
     if (toCheckCorePlugins) {
-      const plugins = readCorePlugins(vault.path);
-      if (!plugins || !toCheckCorePlugins.every((c) => c in plugins && plugins[c])) {
+      let plugins: Record<string, boolean> | undefined;
+      try {
+        plugins = readCorePlugins(vault.path);
+      } catch (error) {
+        logger.error(`Failed to read core-plugins.json for vault ${vault.path}: ${error}`);
+        cacheable = false;
+      }
+      const availablePlugins = plugins;
+      if (!availablePlugins || !toCheckCorePlugins.every((c) => c in availablePlugins && availablePlugins[c])) {
         vaultsWithoutPlugin.push(vault);
         return false;
       }
@@ -67,5 +88,5 @@ export function vaultPluginCheck(params: VaultPluginCheckParams) {
     return true;
   });
   logger.info(`Vaults with requested plugins: ${vaultsWithPlugin.map((v) => v.name).join(", ")}`);
-  return [vaultsWithPlugin, vaultsWithoutPlugin];
+  return { vaultsWithPlugin, vaultsWithoutPlugin, cacheable };
 }

--- a/extensions/obsidian/src/obsidian/internal/plugins.ts
+++ b/extensions/obsidian/src/obsidian/internal/plugins.ts
@@ -14,13 +14,13 @@ export interface VaultPluginCheckParams {
 export function readCommunityPlugins(vaultPath: string): string[] | undefined {
   const { configFileName } = getPreferenceValues();
   const path = `${vaultPath}/${configFileName || ".obsidian"}/community-plugins.json`;
-  if (!fs.existsSync(path)) return;
-  const content = fs.readFileSync(path, "utf-8");
   try {
+    if (!fs.existsSync(path)) return;
+    const content = fs.readFileSync(path, "utf-8");
     const plugins: string[] = JSON.parse(content);
     return plugins;
   } catch (error) {
-    logger.error(`Failed to parse community-plugins.json for vault ${vaultPath}: ${error}`);
+    logger.error(`Failed to read community-plugins.json for vault ${vaultPath}: ${error}`);
     return undefined;
   }
 }
@@ -31,13 +31,13 @@ export function readCommunityPlugins(vaultPath: string): string[] | undefined {
 export function readCorePlugins(vaultPath: string): Record<string, boolean> | undefined {
   const { configFileName } = getPreferenceValues();
   const path = `${vaultPath}/${configFileName || ".obsidian"}/core-plugins.json`;
-  if (!fs.existsSync(path)) return;
-  const content = fs.readFileSync(path, "utf-8");
   try {
+    if (!fs.existsSync(path)) return;
+    const content = fs.readFileSync(path, "utf-8");
     const plugins: Record<string, boolean> = JSON.parse(content);
     return plugins;
   } catch (error) {
-    logger.error(`Failed to parse core-plugins.json for vault ${vaultPath}: ${error}`);
+    logger.error(`Failed to read core-plugins.json for vault ${vaultPath}: ${error}`);
     return undefined;
   }
 }

--- a/extensions/obsidian/src/tests/plugins.spec.ts
+++ b/extensions/obsidian/src/tests/plugins.spec.ts
@@ -31,6 +31,7 @@ describe("plugins", () => {
     if (tempVaultData) {
       tempVaultData.cleanup();
     }
+    vi.restoreAllMocks();
   });
 
   describe("readCommunityPlugins", () => {
@@ -57,6 +58,16 @@ describe("plugins", () => {
 
       const result = readCommunityPlugins(tempVaultData.vault.path);
       expect(result).toEqual([]);
+    });
+
+    it("should return undefined when community-plugins.json cannot be read", () => {
+      const pluginsPath = path.join(tempVaultData.vault.path, ".obsidian", "community-plugins.json");
+      fs.writeFileSync(pluginsPath, JSON.stringify(["plugin1"]));
+      vi.spyOn(fs, "readFileSync").mockImplementationOnce(() => {
+        throw Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+      });
+
+      expect(readCommunityPlugins(tempVaultData.vault.path)).toBeUndefined();
     });
   });
 
@@ -89,6 +100,16 @@ describe("plugins", () => {
 
       const result = readCorePlugins(tempVaultData.vault.path);
       expect(result).toEqual({});
+    });
+
+    it("should return undefined when core-plugins.json cannot be read", () => {
+      const pluginsPath = path.join(tempVaultData.vault.path, ".obsidian", "core-plugins.json");
+      fs.writeFileSync(pluginsPath, JSON.stringify({ "daily-notes": true }));
+      vi.spyOn(fs, "readFileSync").mockImplementationOnce(() => {
+        throw Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+      });
+
+      expect(readCorePlugins(tempVaultData.vault.path)).toBeUndefined();
     });
   });
 

--- a/extensions/obsidian/src/tests/plugins.spec.ts
+++ b/extensions/obsidian/src/tests/plugins.spec.ts
@@ -59,16 +59,6 @@ describe("plugins", () => {
       const result = readCommunityPlugins(tempVaultData.vault.path);
       expect(result).toEqual([]);
     });
-
-    it("should return undefined when community-plugins.json cannot be read", () => {
-      const pluginsPath = path.join(tempVaultData.vault.path, ".obsidian", "community-plugins.json");
-      fs.writeFileSync(pluginsPath, JSON.stringify(["plugin1"]));
-      vi.spyOn(fs, "readFileSync").mockImplementationOnce(() => {
-        throw Object.assign(new Error("operation not permitted"), { code: "EPERM" });
-      });
-
-      expect(readCommunityPlugins(tempVaultData.vault.path)).toBeUndefined();
-    });
   });
 
   describe("readCorePlugins", () => {
@@ -100,16 +90,6 @@ describe("plugins", () => {
 
       const result = readCorePlugins(tempVaultData.vault.path);
       expect(result).toEqual({});
-    });
-
-    it("should return undefined when core-plugins.json cannot be read", () => {
-      const pluginsPath = path.join(tempVaultData.vault.path, ".obsidian", "core-plugins.json");
-      fs.writeFileSync(pluginsPath, JSON.stringify({ "daily-notes": true }));
-      vi.spyOn(fs, "readFileSync").mockImplementationOnce(() => {
-        throw Object.assign(new Error("operation not permitted"), { code: "EPERM" });
-      });
-
-      expect(readCorePlugins(tempVaultData.vault.path)).toBeUndefined();
     });
   });
 
@@ -147,7 +127,7 @@ describe("plugins", () => {
           communityPlugins: ["plugin1", "plugin2"],
         };
 
-        const [vaultsWithPlugin, vaultsWithoutPlugin] = vaultPluginCheck(params);
+        const { vaultsWithPlugin, vaultsWithoutPlugin } = vaultPluginCheck(params);
 
         expect(vaultsWithPlugin).toHaveLength(1);
         expect(vaultsWithPlugin[0]).toBe(tempVaultData.vault);
@@ -165,7 +145,7 @@ describe("plugins", () => {
           communityPlugins: ["required-plugin"],
         };
 
-        const [vaultsWithPlugin, vaultsWithoutPlugin] = vaultPluginCheck(params);
+        const { vaultsWithPlugin, vaultsWithoutPlugin } = vaultPluginCheck(params);
 
         expect(vaultsWithPlugin).toHaveLength(0);
         expect(vaultsWithoutPlugin).toHaveLength(1);
@@ -177,10 +157,27 @@ describe("plugins", () => {
           communityPlugins: ["plugin1"],
         };
 
-        const [vaultsWithPlugin, vaultsWithoutPlugin] = vaultPluginCheck(params);
+        const { vaultsWithPlugin, vaultsWithoutPlugin } = vaultPluginCheck(params);
 
         expect(vaultsWithPlugin).toHaveLength(0);
         expect(vaultsWithoutPlugin).toHaveLength(1);
+      });
+
+      it("should not cache a failed community plugin configuration read", () => {
+        const pluginsPath = path.join(tempVaultData.vault.path, ".obsidian", "community-plugins.json");
+        fs.writeFileSync(pluginsPath, JSON.stringify(["plugin1"]));
+        vi.spyOn(fs, "readFileSync").mockImplementationOnce(() => {
+          throw Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+        });
+
+        const result = vaultPluginCheck({
+          vaults: [tempVaultData.vault],
+          communityPlugins: ["plugin1"],
+        });
+
+        expect(result.vaultsWithPlugin).toHaveLength(0);
+        expect(result.vaultsWithoutPlugin).toEqual([tempVaultData.vault]);
+        expect(result.cacheable).toBe(false);
       });
     });
 
@@ -208,7 +205,7 @@ describe("plugins", () => {
           corePlugins: ["file-explorer", "search"],
         };
 
-        const [vaultsWithPlugin, vaultsWithoutPlugin] = vaultPluginCheck(params);
+        const { vaultsWithPlugin, vaultsWithoutPlugin } = vaultPluginCheck(params);
 
         expect(vaultsWithPlugin).toHaveLength(1);
         expect(vaultsWithPlugin[0]).toBe(tempVaultData.vault);
@@ -222,7 +219,7 @@ describe("plugins", () => {
           corePlugins: ["file-explorer"],
         };
 
-        const [vaultsWithPlugin, vaultsWithoutPlugin] = vaultPluginCheck(params);
+        const { vaultsWithPlugin, vaultsWithoutPlugin } = vaultPluginCheck(params);
 
         expect(vaultsWithPlugin).toHaveLength(0);
         expect(vaultsWithoutPlugin).toHaveLength(1);
@@ -240,10 +237,27 @@ describe("plugins", () => {
           corePlugins: ["file-explorer", "missing-plugin"],
         };
 
-        const [vaultsWithPlugin, vaultsWithoutPlugin] = vaultPluginCheck(params);
+        const { vaultsWithPlugin, vaultsWithoutPlugin } = vaultPluginCheck(params);
 
         expect(vaultsWithPlugin).toHaveLength(0);
         expect(vaultsWithoutPlugin).toHaveLength(1);
+      });
+
+      it("should not cache a failed core plugin configuration read", () => {
+        const pluginsPath = path.join(tempVaultData.vault.path, ".obsidian", "core-plugins.json");
+        fs.writeFileSync(pluginsPath, JSON.stringify({ "daily-notes": true }));
+        vi.spyOn(fs, "readFileSync").mockImplementationOnce(() => {
+          throw Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+        });
+
+        const result = vaultPluginCheck({
+          vaults: [tempVaultData.vault],
+          corePlugins: ["daily-notes"],
+        });
+
+        expect(result.vaultsWithPlugin).toHaveLength(0);
+        expect(result.vaultsWithoutPlugin).toEqual([tempVaultData.vault]);
+        expect(result.cacheable).toBe(false);
       });
     });
 
@@ -252,10 +266,11 @@ describe("plugins", () => {
         vaults: [tempVaultData.vault],
       };
 
-      const [vaultsWithPlugin, vaultsWithoutPlugin] = vaultPluginCheck(params);
+      const { vaultsWithPlugin, vaultsWithoutPlugin, cacheable } = vaultPluginCheck(params);
 
       expect(vaultsWithPlugin).toEqual([tempVaultData.vault]);
       expect(vaultsWithoutPlugin).toEqual([]);
+      expect(cacheable).toBe(true);
     });
   });
 });

--- a/extensions/obsidian/src/utils/hooks.ts
+++ b/extensions/obsidian/src/utils/hooks.ts
@@ -210,12 +210,14 @@ export function useVaultPluginCheck(params: {
     // Cache miss - perform the check
     const result = Vault.checkPlugins(params);
     const resultObject = {
-      vaultsWithPlugin: result[0],
-      vaultsWithoutPlugin: result[1],
+      vaultsWithPlugin: result.vaultsWithPlugin,
+      vaultsWithoutPlugin: result.vaultsWithoutPlugin,
     };
 
-    // Store in cache
-    vaultPluginCheckCache.set(cacheKey, resultObject);
+    // Do not persist transient filesystem failures as plugin absence.
+    if (result.cacheable) {
+      vaultPluginCheckCache.set(cacheKey, resultObject);
+    }
 
     return resultObject;
   }, [params.vaults.map((v) => v.path).join(","), params.communityPlugins?.join(","), params.corePlugins?.join(",")]);


### PR DESCRIPTION
## Description

This PR attempts to address #30308.

The Obsidian plugin readers call `fs.readFileSync` for each vault configuration. When macOS returned `EPERM` for an iCloud-hosted vault, that exception escaped during the shared plugin check and aborted the Daily Note command's render.

The shared plugin check now catches read failures for both `community-plugins.json` and `core-plugins.json`, logs them, and reports the vault as unavailable for the current render instead of crashing. It also marks that result as non-cacheable, so restoring filesystem access can be observed on the next check rather than leaving a transient failure in the process-wide cache. Successful reads, missing files, and malformed configuration keep their previous cache behavior.

The regression tests simulate `EPERM` for both files and verify that those results are not cacheable. I also added `raulkolaric` to the extension's contributor list.

Validation:

- `npm test` — 328 tests passed
- `npm run lint`
- `npm run build`

Fixes #30308

## Screencast

Not included; this is a filesystem error path covered by unit tests.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
