### PR TITLE
Update linear extension

### DIFF
--- a/extensions/linear/CHANGELOG.md
+++ b/extensions/linear/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Copy as Prompt] - {PR_MERGE_DATE}
 
-- Add a "Copy as Prompt" action to issue copy actions, matching Linear's native action of the same name. Copies the issue as a structured prompt for coding agents, including its description, team, labels, project, and parent or sub-issues. The shortcut is `Cmd/Ctrl + Shift + P`, since `Cmd/Ctrl + Alt + P` is already taken by `Set Priority`.
+- Add a "Copy as Prompt" action to issue copy actions, matching Linear's native action of the same name. Copies the issue as a structured prompt for coding agents, including its description, team, labels, project, and parent or sub-issues.
 
 ## [My Issues Sub Views] - 2026-07-30
 

--- a/extensions/linear/CHANGELOG.md
+++ b/extensions/linear/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Linear Changelog
 
-## [Copy as Prompt] - {PR_MERGE_DATE}
+## [Copy as Prompt] - 2026-08-19
 
 - Add a "Copy as Prompt" action to issue copy actions, matching Linear's native action of the same name. Copies the issue as a structured prompt for coding agents, including its description, team, labels, project, and parent or sub-issues.
 

--- a/extensions/linear/CHANGELOG.md
+++ b/extensions/linear/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Linear Changelog
 
+## [Copy as Prompt] - {PR_MERGE_DATE}
+
+- Add a "Copy as Prompt" action to issue copy actions, matching Linear's native action of the same name. Copies the issue as a structured prompt for coding agents, including its description, team, labels, project, and parent or sub-issues. The shortcut is `Cmd/Ctrl + Shift + P`, since `Cmd/Ctrl + Alt + P` is already taken by `Set Priority`.
+
 ## [My Issues Sub Views] - 2026-07-30
 
 - Add a dropdown to the "My Issues" command to switch between the Assigned, Created, and Subscribed sub views, matching the Linear app. Assigned stays the default.

--- a/extensions/linear/package.json
+++ b/extensions/linear/package.json
@@ -19,7 +19,8 @@
     "xmok",
     "0xdhrv",
     "erikjs",
-    "alexi.build"
+    "alexi.build",
+    "samuelkraft"
   ],
   "pastContributors": [
     "mathieudutour",

--- a/extensions/linear/src/api/getIssues.ts
+++ b/extensions/linear/src/api/getIssues.ts
@@ -2,6 +2,7 @@ import {
   Comment,
   Cycle,
   Issue,
+  IssueLabel,
   IssueRelation,
   Project,
   ProjectMilestone,
@@ -446,6 +447,67 @@ export async function getSubIssues(issueId: string) {
   }
 
   return data.issue.children.nodes;
+}
+
+export type IssuePromptRelative = Pick<Issue, "id" | "identifier" | "title" | "description">;
+
+export type IssuePromptResult = Pick<Issue, "identifier" | "title" | "branchName" | "description"> & {
+  team?: Pick<Team, "name">;
+  labels: { nodes: Pick<IssueLabel, "name">[] };
+  project?: Pick<Project, "name" | "description">;
+  parent?: IssuePromptRelative;
+  children: { nodes: IssuePromptRelative[] };
+};
+
+/** Fetches exactly the fields Linear's "Copy as prompt" renders, and nothing else. */
+export async function getIssuePromptData(issueId: string) {
+  const { graphQLClient } = getLinearClient();
+
+  const { data } = await graphQLClient.rawRequest<{ issue: IssuePromptResult }, Record<string, unknown>>(
+    `
+      query($issueId: String!) {
+        issue(id: $issueId) {
+          identifier
+          title
+          branchName
+          description
+          team {
+            name
+          }
+          labels {
+            nodes {
+              name
+            }
+          }
+          project {
+            name
+            description
+          }
+          parent {
+            id
+            identifier
+            title
+            description
+          }
+          children {
+            nodes {
+              id
+              identifier
+              title
+              description
+            }
+          }
+        }
+      }
+    `,
+    { issueId },
+  );
+
+  if (!data) {
+    throw new Error("Cannot find the Linear issue");
+  }
+
+  return data.issue;
 }
 
 export type CommentResult = Pick<Comment, "id" | "body" | "createdAt" | "url"> & {

--- a/extensions/linear/src/api/getIssues.ts
+++ b/extensions/linear/src/api/getIssues.ts
@@ -459,7 +459,6 @@ export type IssuePromptResult = Pick<Issue, "identifier" | "title" | "branchName
   children: { nodes: IssuePromptRelative[] };
 };
 
-/** Fetches exactly the fields Linear's "Copy as prompt" renders, and nothing else. */
 export async function getIssuePromptData(issueId: string) {
   const { graphQLClient } = getLinearClient();
 

--- a/extensions/linear/src/components/IssueActions/CopyToClipboardSection.tsx
+++ b/extensions/linear/src/components/IssueActions/CopyToClipboardSection.tsx
@@ -32,12 +32,9 @@ export default function CopyToClipboardSection({ issue }: { issue: IssueResult }
   const { issueCustomCopyAction } = getPreferenceValues<Preferences>();
 
   async function copyIssueAsPrompt() {
-    // Unlike the other copy actions this one waits on a request, so show that it's working.
     const toast = await showToast({ style: Toast.Style.Animated, title: "Copying prompt" });
 
     try {
-      // The prompt needs the description plus the issue's hierarchy, none of which the
-      // list and detail queries carry, so it always gets its own fetch.
       await Clipboard.copy(getIssuePrompt(await getIssuePromptData(issue.id)));
       toast.style = Toast.Style.Success;
       toast.title = "Copied prompt to clipboard";
@@ -92,15 +89,6 @@ export default function CopyToClipboardSection({ issue }: { issue: IssueResult }
         title="Copy Git Branch Name"
         shortcut={Keyboard.Shortcut.Common.CopyName}
       />
-      <Action
-        icon={Icon.Clipboard}
-        title="Copy as Prompt"
-        onAction={copyIssueAsPrompt}
-        shortcut={{
-          macOS: { modifiers: ["cmd", "shift"], key: "p" },
-          Windows: { modifiers: ["ctrl", "shift"], key: "p" },
-        }}
-      />
       {issueCustomCopyAction && issueCustomCopyAction !== "" ? (
         <Action.CopyToClipboard
           content={issueCustomCopyAction?.replace(/\{(.*?)\}/g, (substring, variable) => {
@@ -114,6 +102,15 @@ export default function CopyToClipboardSection({ issue }: { issue: IssueResult }
           }}
         />
       ) : null}
+      <Action
+        icon={Icon.Clipboard}
+        title="Copy as Prompt"
+        onAction={copyIssueAsPrompt}
+        shortcut={{
+          macOS: { modifiers: ["cmd", "opt", "shift"], key: "p" },
+          Windows: { modifiers: ["ctrl", "alt", "shift"], key: "p" },
+        }}
+      />
     </ActionPanel.Section>
   );
 }

--- a/extensions/linear/src/components/IssueActions/CopyToClipboardSection.tsx
+++ b/extensions/linear/src/components/IssueActions/CopyToClipboardSection.tsx
@@ -1,6 +1,8 @@
-import { ActionPanel, Action, getPreferenceValues, Keyboard } from "@raycast/api";
+import { ActionPanel, Action, Clipboard, getPreferenceValues, Icon, Keyboard, showToast, Toast } from "@raycast/api";
 
-import { IssueResult } from "../../api/getIssues";
+import { getIssuePromptData, IssueResult } from "../../api/getIssues";
+import { getErrorMessage } from "../../helpers/errors";
+import { getIssuePrompt } from "../../helpers/prompts";
 
 type ISSUE_KEY = "title" | "identifier" | "url" | "branchName";
 
@@ -28,6 +30,23 @@ function getTitleLink(issue: IssueResult) {
 
 export default function CopyToClipboardSection({ issue }: { issue: IssueResult }) {
   const { issueCustomCopyAction } = getPreferenceValues<Preferences>();
+
+  async function copyIssueAsPrompt() {
+    // Unlike the other copy actions this one waits on a request, so show that it's working.
+    const toast = await showToast({ style: Toast.Style.Animated, title: "Copying prompt" });
+
+    try {
+      // The prompt needs the description plus the issue's hierarchy, none of which the
+      // list and detail queries carry, so it always gets its own fetch.
+      await Clipboard.copy(getIssuePrompt(await getIssuePromptData(issue.id)));
+      toast.style = Toast.Style.Success;
+      toast.title = "Copied prompt to clipboard";
+    } catch (error) {
+      toast.style = Toast.Style.Failure;
+      toast.title = "Failed copying prompt";
+      toast.message = getErrorMessage(error);
+    }
+  }
 
   return (
     <ActionPanel.Section>
@@ -72,6 +91,15 @@ export default function CopyToClipboardSection({ issue }: { issue: IssueResult }
         content={issue.branchName}
         title="Copy Git Branch Name"
         shortcut={Keyboard.Shortcut.Common.CopyName}
+      />
+      <Action
+        icon={Icon.Clipboard}
+        title="Copy as Prompt"
+        onAction={copyIssueAsPrompt}
+        shortcut={{
+          macOS: { modifiers: ["cmd", "shift"], key: "p" },
+          Windows: { modifiers: ["ctrl", "shift"], key: "p" },
+        }}
       />
       {issueCustomCopyAction && issueCustomCopyAction !== "" ? (
         <Action.CopyToClipboard

--- a/extensions/linear/src/helpers/prompts.ts
+++ b/extensions/linear/src/helpers/prompts.ts
@@ -1,0 +1,90 @@
+import { IssuePromptRelative, IssuePromptResult } from "../api/getIssues";
+
+/**
+ * Mirrors Linear's "Copy as prompt" action. Linear renders the identifier, branch name, title,
+ * description, team, labels, project and the issue's immediate hierarchy - state, priority,
+ * assignee and milestone are deliberately left out, and tags for empty values are omitted
+ * rather than emitted blank.
+ */
+export function getIssuePrompt(issue: IssuePromptResult) {
+  const lines = [`Work on Linear issue ${issue.identifier}:`, ""];
+
+  const branchName = getSuggestedBranchName(issue.branchName);
+  if (branchName) {
+    lines.push(`Suggested branch name: ${branchName}`, "");
+  }
+
+  lines.push(`<issue identifier="${escapeAttribute(issue.identifier)}">`);
+  lines.push(`<title>${issue.title}</title>`);
+  lines.push(...getDescriptionLines(issue.description));
+
+  if (issue.team?.name) {
+    lines.push(`<team name="${escapeAttribute(issue.team.name)}"/>`);
+  }
+
+  issue.labels?.nodes?.forEach((label) => {
+    lines.push(`<label>${label.name}</label>`);
+  });
+
+  if (issue.project?.name) {
+    const name = escapeAttribute(issue.project.name);
+    lines.push(
+      issue.project.description
+        ? `<project name="${name}">${issue.project.description}</project>`
+        : `<project name="${name}"/>`,
+    );
+  }
+
+  if (issue.parent) {
+    lines.push(...getRelativeLines("parent-issue", issue.parent));
+  }
+
+  const children = issue.children?.nodes ?? [];
+  if (children.length > 0) {
+    lines.push("<sub-issues>");
+    children.forEach((child) => lines.push(...getRelativeLines("sub-issue", child)));
+    lines.push("</sub-issues>");
+  }
+
+  lines.push("</issue>");
+
+  return lines.join("\n");
+}
+
+/** The parent and each sub-issue are rendered as a trimmed-down issue carrying its UUID. */
+function getRelativeLines(tag: "parent-issue" | "sub-issue", issue: IssuePromptRelative) {
+  return [
+    `<${tag} identifier="${escapeAttribute(issue.identifier)}">`,
+    `<id>${issue.id}</id>`,
+    `<title>${issue.title}</title>`,
+    ...getDescriptionLines(issue.description),
+    `</${tag}>`,
+  ];
+}
+
+/** Single-line descriptions sit inline, multi-line ones get their own opening and closing lines. */
+function getDescriptionLines(description?: string | null) {
+  if (!description) {
+    return [];
+  }
+
+  return description.includes("\n")
+    ? ["<description>", description, "</description>"]
+    : [`<description>${description}</description>`];
+}
+
+/**
+ * Teams can prefix branch names with the assignee's username (e.g. `samuelkraft/glaze-834-…`),
+ * but the prompt only carries the issue part of the branch.
+ */
+function getSuggestedBranchName(branchName?: string) {
+  if (!branchName) {
+    return branchName;
+  }
+
+  return branchName.slice(branchName.lastIndexOf("/") + 1);
+}
+
+function escapeAttribute(str: string) {
+  return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}

--- a/extensions/linear/src/helpers/prompts.ts
+++ b/extensions/linear/src/helpers/prompts.ts
@@ -1,11 +1,5 @@
 import { IssuePromptRelative, IssuePromptResult } from "../api/getIssues";
 
-/**
- * Mirrors Linear's "Copy as prompt" action. Linear renders the identifier, branch name, title,
- * description, team, labels, project and the issue's immediate hierarchy - state, priority,
- * assignee and milestone are deliberately left out, and tags for empty values are omitted
- * rather than emitted blank.
- */
 export function getIssuePrompt(issue: IssuePromptResult) {
   const lines = [`Work on Linear issue ${issue.identifier}:`, ""];
 
@@ -51,7 +45,6 @@ export function getIssuePrompt(issue: IssuePromptResult) {
   return lines.join("\n");
 }
 
-/** The parent and each sub-issue are rendered as a trimmed-down issue carrying its UUID. */
 function getRelativeLines(tag: "parent-issue" | "sub-issue", issue: IssuePromptRelative) {
   return [
     `<${tag} identifier="${escapeAttribute(issue.identifier)}">`,
@@ -62,7 +55,7 @@ function getRelativeLines(tag: "parent-issue" | "sub-issue", issue: IssuePromptR
   ];
 }
 
-/** Single-line descriptions sit inline, multi-line ones get their own opening and closing lines. */
+// Linear inlines single-line descriptions and puts multi-line ones on their own lines.
 function getDescriptionLines(description?: string | null) {
   if (!description) {
     return [];
@@ -73,10 +66,7 @@ function getDescriptionLines(description?: string | null) {
     : [`<description>${description}</description>`];
 }
 
-/**
- * Teams can prefix branch names with the assignee's username (e.g. `samuelkraft/glaze-834-…`),
- * but the prompt only carries the issue part of the branch.
- */
+// Teams can prefix branch names with the assignee's username, which the prompt leaves out.
 function getSuggestedBranchName(branchName?: string) {
   if (!branchName) {
     return branchName;


### PR DESCRIPTION
## Description

Adds a **Copy as Prompt** action to the issue copy actions, mirroring Linear's own "Copy as prompt" action (⌘⌥P in the Linear app). It copies an issue as a structured prompt ready to paste into a coding agent:

```
Work on Linear issue GLAZE-530:

Suggested branch name: glaze-530-improve-the-blank-slate-empty-state-in-the-agent-composer

<issue identifier="GLAZE-530">
<title>Improve the blank slate / empty state in the agent composer</title>
<description>Reduce the "what do I even type" problem for new users hitting an empty Glaze.</description>
<team name="Glaze"/>
<label>onboarding</label>
<project name="Glaze Public Beta">Prepare Glaze for public beta launch.</project>
<parent-issue identifier="GLAZE-529">
<id>7f7248f5-6e5f-4c2f-904a-e730415964a3</id>
<title>Product readiness — blank slate and prompt-to-first-app</title>
<description>Focus: the first-run experience and the path from an empty state to a first working app.</description>
</parent-issue>
</issue>
```

### Notes for reviewers

**The format is reproduced, not fetched.** Linear composes this prompt client-side in their own app — there is no field or query for it in `@linear/sdk` (v61) or the GraphQL schema. So the renderer lives in `src/helpers/prompts.ts` and was derived by diffing the output of Linear's action across real issues covering: with and without a description, with and without a project, zero/one/two labels, an issue with sub-issues, and an issue with a parent. Two non-obvious behaviours fell out of that:

- Single-line descriptions render inline (`<description>…</description>`), multi-line ones get their own opening and closing lines.
- Nested issues (parent and sub-issues) carry an `<id>` UUID tag that the top-level issue does not.

State, priority, assignee and milestone are excluded even when set — that matches Linear, confirmed against issues that had all of them.

**Why a dedicated query.** Sub-issues and the parent's description are not in the shared `IssueFragment`, and adding them would make every list view pay for data only this action reads. `getIssuePromptData()` fetches exactly the prompt's fields in a single request instead, so `getIssues.ts` is additive only — no existing query or type is modified. The tradeoff is that the fetch happens on keypress, hence the animated toast while it runs.

**Shortcut.** Linear uses ⌘⌥P, but that is already bound to `Set Priority` in this extension (established in the [Set Priority shortcut](https://github.com/raycast/extensions/blob/main/extensions/linear/CHANGELOG.md) release), so this uses ⌘⇧P / `Ctrl Shift P`.

## Screencast

<img width="1872" height="1322" alt="CleanShot 2026-08-19 at 10 47 55@2x" src="https://github.com/user-attachments/assets/ee386638-4315-428b-8296-fd582df11631" />



## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
