### PR TITLE
[feat]: Added hide menu bar item action

### DIFF
--- a/extensions/coffee/CHANGELOG.md
+++ b/extensions/coffee/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Coffee Changelog
 
+## [Enhancement] - {PR_MERGE_DATE}
+
+- Added a "Hide Menu Bar Item" action to the menu bar dropdown so the icon can be hidden in one click.
+- Re-running the "Caffeinate Status Menu Bar" command from Raycast brings the icon back.
+
 ## [Enhancement] - 2026-08-14
 
 - Added an "instant on" feature: when the new *Start caffeination when Raycast starts* preference is enabled, Coffee automatically keeps your Mac awake (indefinitely) shortly after Raycast launches. Manual decaffeination persists until the next Raycast restart.

--- a/extensions/coffee/README.md
+++ b/extensions/coffee/README.md
@@ -77,6 +77,8 @@ Get the current state of caffeination.
 
 Get the status of current caffeination in your menu bar.
 
+To quickly remove the icon from your menu bar, select **Hide Menu Bar Item** in the dropdown. Re-run the *Caffeinate Status Menu Bar* command from Raycast to show it again.
+
 ### 8. **Auto-Caffeinate on Launch**
 
 Optionally have Coffee start caffeinating your Mac (indefinitely) automatically whenever Raycast launches. Enable the **Start caffeination when Raycast starts** toggle under the **Launch** section in the extension's preferences.

--- a/extensions/coffee/src/index.tsx
+++ b/extensions/coffee/src/index.tsx
@@ -92,14 +92,18 @@ export default function Command(props: LaunchProps) {
   const [localCaffeinateStatus, setLocalCaffeinateStatus] = useState<boolean | null>(null);
   const [, setTick] = useState(0);
   const restoreHandledRef = useRef(false);
-  // Start as null (unknown) to avoid a flash when the Cache is cold (e.g. after
-  // a bundle update or dev rebuild) but LocalStorage still holds the hidden flag.
-  // We render nothing until the async LocalStorage read below resolves.
-  const [menuBarHidden, setMenuBarHidden] = useState<boolean | null>(
-    // Fast path: if the Cache already has the flag we can render immediately.
-    // The effect below will still run and sync Cache ↔ LocalStorage as needed.
-    cache.get(HIDE_MENU_BAR_KEY) !== undefined ? cache.get(HIDE_MENU_BAR_KEY) === "true" : null,
-  );
+
+  const [menuBarHidden, setMenuBarHidden] = useState<boolean | null>(() => {
+    const cached = cache.get(HIDE_MENU_BAR_KEY);
+    // Fast-path for the warm-cache visible case — no flicker on background polls.
+    if (cached === "false") return false;
+    // For Background launches, the restore path never runs, so "true" is safe to
+    // use directly — avoids a loading-shell flash every 1-minute poll while hidden.
+    // For UserInitiated launches, defer to null so the useEffect restore path can
+    // run and un-hide the icon when the user re-opens the command from root search.
+    if (cached === "true" && props.launchType === LaunchType.Background) return true;
+    return null;
+  });
 
   const displayCaffeinateStatus = localCaffeinateStatus ?? caffeinateStatus;
 
@@ -111,7 +115,8 @@ export default function Command(props: LaunchProps) {
     if (restoreHandledRef.current) return;
     restoreHandledRef.current = true;
     void (async () => {
-      const stored = (await LocalStorage.getItem(HIDE_MENU_BAR_KEY)) === "true";
+      const rawStored = await LocalStorage.getItem(HIDE_MENU_BAR_KEY);
+      const stored = rawStored === "true";
       if (props.launchType === LaunchType.UserInitiated && stored) {
         cache.remove(HIDE_MENU_BAR_KEY);
         await LocalStorage.removeItem(HIDE_MENU_BAR_KEY);
@@ -189,10 +194,22 @@ export default function Command(props: LaunchProps) {
     await showHUD("Menu bar icon hidden");
   };
 
-  // Render nothing while the hidden state is still being resolved from
-  // LocalStorage (null = unknown). This is the main guard against the
-  // cold-cache flash.
-  if (menuBarHidden === null || menuBarHidden) {
+  // While waiting for the LocalStorage read, render a loading shell instead of
+  // null. Returning null immediately would cause Raycast to terminate the process
+  // before the useEffect restore path has a chance to run. Background polls never
+  // restore the icon, so keep the shell icon-less there — an explicit icon would
+  // flash the hidden Coffee icon while the storage read resolves.
+  if (menuBarHidden === null) {
+    if (props.launchType === LaunchType.Background) {
+      return <MenuBarExtra isLoading={true} />;
+    }
+    return (
+      <MenuBarExtra isLoading={true} icon={{ source: `${preferences.icon}-empty.svg`, tintColor: Color.PrimaryText }} />
+    );
+  }
+
+  // Hidden state is resolved — safely return null now.
+  if (menuBarHidden) {
     return null;
   }
 

--- a/extensions/coffee/src/index.tsx
+++ b/extensions/coffee/src/index.tsx
@@ -1,15 +1,17 @@
 import {
+  Cache,
   Color,
   Icon,
   LaunchProps,
   LaunchType,
+  LocalStorage,
   MenuBarExtra,
   getPreferenceValues,
   launchCommand,
   showHUD,
 } from "@raycast/api";
 import { useExec } from "@raycast/utils";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { formatDuration, startCaffeinate, stopCaffeinate } from "./utils";
 import { maybeAutoCaffeinate } from "./status";
 
@@ -35,6 +37,9 @@ interface CaffeinateInfo {
   totalSeconds: number | null;
   startTime: number | null;
 }
+
+const HIDE_MENU_BAR_KEY = "hideMenuBarItem";
+const cache = new Cache();
 
 const DURATION_PRESETS: { label: string; seconds: number }[] = [
   { label: "10 Minutes", seconds: 10 * 60 },
@@ -86,8 +91,38 @@ export default function Command(props: LaunchProps) {
 
   const [localCaffeinateStatus, setLocalCaffeinateStatus] = useState<boolean | null>(null);
   const [, setTick] = useState(0);
+  const restoreHandledRef = useRef(false);
+  // Start as null (unknown) to avoid a flash when the Cache is cold (e.g. after
+  // a bundle update or dev rebuild) but LocalStorage still holds the hidden flag.
+  // We render nothing until the async LocalStorage read below resolves.
+  const [menuBarHidden, setMenuBarHidden] = useState<boolean | null>(
+    // Fast path: if the Cache already has the flag we can render immediately.
+    // The effect below will still run and sync Cache ↔ LocalStorage as needed.
+    cache.get(HIDE_MENU_BAR_KEY) !== undefined ? cache.get(HIDE_MENU_BAR_KEY) === "true" : null,
+  );
 
   const displayCaffeinateStatus = localCaffeinateStatus ?? caffeinateStatus;
+
+  // LocalStorage is the durable source of truth (it survives bundle updates and
+  // dev rebuilds, which reset the Cache). A hidden icon can only be brought back
+  // from the root search, since the menu bar item itself is not clickable
+  // anymore, so a user-initiated launch while hidden means "show it again".
+  useEffect(() => {
+    if (restoreHandledRef.current) return;
+    restoreHandledRef.current = true;
+    void (async () => {
+      const stored = (await LocalStorage.getItem(HIDE_MENU_BAR_KEY)) === "true";
+      if (props.launchType === LaunchType.UserInitiated && stored) {
+        cache.remove(HIDE_MENU_BAR_KEY);
+        await LocalStorage.removeItem(HIDE_MENU_BAR_KEY);
+        setMenuBarHidden(false);
+        return;
+      }
+      // Always sync the cache and resolve the null (unknown) initial state.
+      cache.set(HIDE_MENU_BAR_KEY, stored ? "true" : "false");
+      setMenuBarHidden(stored);
+    })();
+  }, [props.launchType]);
 
   useEffect(() => {
     setLocalCaffeinateStatus(null);
@@ -147,6 +182,20 @@ export default function Command(props: LaunchProps) {
     }
   };
 
+  const handleHideMenuBarItem = async () => {
+    cache.set(HIDE_MENU_BAR_KEY, "true");
+    void LocalStorage.setItem(HIDE_MENU_BAR_KEY, "true");
+    setMenuBarHidden(true);
+    await showHUD("Menu bar icon hidden");
+  };
+
+  // Render nothing while the hidden state is still being resolved from
+  // LocalStorage (null = unknown). This is the main guard against the
+  // cold-cache flash.
+  if (menuBarHidden === null || menuBarHidden) {
+    return null;
+  }
+
   if (preferences.hidenWhenDecaffeinated && !displayCaffeinateStatus && !isLoading) {
     return null;
   }
@@ -193,6 +242,9 @@ export default function Command(props: LaunchProps) {
                   : () => launchCommand({ name: "caffeinateUntil", type: LaunchType.UserInitiated })
               }
             />
+          </MenuBarExtra.Section>
+          <MenuBarExtra.Section>
+            <MenuBarExtra.Item title="Hide Menu Bar Item" icon={Icon.EyeSlash} onAction={handleHideMenuBarItem} />
           </MenuBarExtra.Section>
         </>
       )}

--- a/extensions/coffee/src/index.tsx
+++ b/extensions/coffee/src/index.tsx
@@ -184,7 +184,7 @@ export default function Command(props: LaunchProps) {
 
   const handleHideMenuBarItem = async () => {
     cache.set(HIDE_MENU_BAR_KEY, "true");
-    void LocalStorage.setItem(HIDE_MENU_BAR_KEY, "true");
+    await LocalStorage.setItem(HIDE_MENU_BAR_KEY, "true");
     setMenuBarHidden(true);
     await showHUD("Menu bar icon hidden");
   };


### PR DESCRIPTION
Fixes #29476 

## Description

Adds a quick, frictionless way to hide the "Caffeinate Status Menu Bar" icon. Previously, hiding it required going to the root search, opening the Actions menu (cmd+k), scrolling to the bottom, and choosing "Deactivate menubar item".

What's new

- One-click hide: the menu bar dropdown now has a Hide Menu Bar Item action (in its own bottom section, with an eye-slash icon). Clicking it hides the icon immediately, no more digging through the action list.
- Easy restore: re-running the Caffeinate Status Menu Bar command from the Raycast root search brings the icon back. This is unambiguous, because a hidden icon can't be clicked, any user-initiated launch while hidden can only come from the root search.
- Hiding is purely visual: the current caffeination state is untouched.


## Screencast

<img width="162" height="320" alt="Screenshot 2026-08-19 at 5 13 41 PM" src="https://github.com/user-attachments/assets/456c7be7-1743-4bc8-8572-d673868cb4f3" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
