### PR TITLE
Add PostEverywhere to Model Context Protocol Registry

### DIFF
--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Model Context Protocol Registry Changelog
 
+## [Add PostEverywhere MCP Server] - {PR_MERGE_DATE}
+
+- Added PostEverywhere (social media publishing to 11 platforms) to the official registry entries
+
 ## [Add Tripsy MCP Server] - 2026-08-19
 
 Add Tripsy to the official registry, enabling AI assistants to create trips and manage flights, stays, activities, expenses, and itinerary details. The remote Streamable HTTP server uses Tripsy OAuth sign-in through an `mcp-remote` bridge.

--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Model Context Protocol Registry Changelog
 
-## [Add PostEverywhere MCP Server] - {PR_MERGE_DATE}
+## [Add PostEverywhere MCP Server] - 2026-08-20
 
 - Added PostEverywhere (social media publishing to 11 platforms) to the official registry entries
 

--- a/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
+++ b/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
@@ -301,6 +301,21 @@ export const OFFICIAL_ENTRIES: RegistryEntry[] = [
     },
   },
   {
+    name: "posteverywhere",
+    title: "PostEverywhere",
+    description:
+      "Social media publishing MCP server. Schedule and post to 11 platforms (Instagram, TikTok, YouTube, LinkedIn, X, Facebook, Threads, Pinterest, Bluesky, Telegram, Discord) with media upload, AI captions, campaigns, and analytics through natural language.",
+    icon: "https://app.posteverywhere.ai/favicon.svg",
+    homepage: "https://developers.posteverywhere.ai/integrations/mcp",
+    configuration: {
+      command: "npx",
+      args: ["-y", "@posteverywhere/mcp"],
+      env: {
+        POSTEVERYWHERE_API_KEY: "<YOUR_API_KEY_HERE>",
+      },
+    },
+  },
+  {
     name: "prisma",
     title: "Prisma",
     description:


### PR DESCRIPTION
## Description

Adds PostEverywhere to OFFICIAL_ENTRIES in the MCP registry extension (we are the vendor). PostEverywhere is a social media publishing MCP server: schedule and post to 11 platforms (Instagram, TikTok, YouTube, LinkedIn, X, Facebook, Threads, Pinterest, Bluesky, Telegram, Discord) with media upload, AI captions, campaigns, and analytics. 33 tools.

- npm: @posteverywhere/mcp (1.7.0), runs via npx with a POSTEVERYWHERE_API_KEY
- Public repo: https://github.com/posteverywhere/mcp
- Also published in the official MCP registry as ai.posteverywhere/mcp
- Docs: https://developers.posteverywhere.ai/integrations/mcp

## Type of change

- [x] New entry in the built-in MCP registry (alphabetical placement, changelog updated)

## Checklist

- [x] Entry follows the existing OFFICIAL_ENTRIES format
- [x] CHANGELOG.md updated with {PR_MERGE_DATE}