### PR TITLE
Fix caffeination schedule activation

### DIFF
--- a/extensions/coffee/CHANGELOG.md
+++ b/extensions/coffee/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Coffee Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-08-20
 
 - Fixed future caffeination schedules not activating automatically and ensured they stop at the configured end time.
 

--- a/extensions/coffee/CHANGELOG.md
+++ b/extensions/coffee/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Coffee Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Fixed future caffeination schedules not activating automatically.
+- Kept the schedule dashboard status in sync while it remains open.
+- Ensured schedules started inside an active time range stop at the configured end time.
+- Improved the guidance shown when schedule times are missing.
+
 ## [Enhancement] - 2026-08-14
 
 - Added an "instant on" feature: when the new *Start caffeination when Raycast starts* preference is enabled, Coffee automatically keeps your Mac awake (indefinitely) shortly after Raycast launches. Manual decaffeination persists until the next Raycast restart.

--- a/extensions/coffee/CHANGELOG.md
+++ b/extensions/coffee/CHANGELOG.md
@@ -2,10 +2,7 @@
 
 ## [Fix] - {PR_MERGE_DATE}
 
-- Fixed future caffeination schedules not activating automatically.
-- Kept the schedule dashboard status in sync while it remains open.
-- Ensured schedules started inside an active time range stop at the configured end time.
-- Improved the guidance shown when schedule times are missing.
+- Fixed future caffeination schedules not activating automatically and ensured they stop at the configured end time.
 
 ## [Enhancement] - 2026-08-14
 

--- a/extensions/coffee/package.json
+++ b/extensions/coffee/package.json
@@ -17,7 +17,8 @@
     "alexi.build",
     "mbuvarp",
     "frederik_obe",
-    "bsradcliffe"
+    "bsradcliffe",
+    "aditi_bhagat"
   ],
   "pastContributors": [
     "Visual-Studio-Coder"

--- a/extensions/coffee/src/addSchedule.tsx
+++ b/extensions/coffee/src/addSchedule.tsx
@@ -142,7 +142,7 @@ export default function Command() {
   };
 
   const handlePauseSchedule = async (schedule: Schedule) => {
-    changeScheduleState("decaffeinate", schedule);
+    await changeScheduleState("decaffeinate", schedule);
     await showToast(
       Toast.Style.Success,
       `Schedule for ${schedule.day.charAt(0).toUpperCase() + schedule.day.slice(1).toLowerCase()} is now paused`,
@@ -159,7 +159,7 @@ export default function Command() {
   };
 
   const handleResumeSchedule = async (schedule: Schedule) => {
-    changeScheduleState("caffeinate", schedule);
+    await changeScheduleState("caffeinate", schedule);
     await showToast(
       Toast.Style.Success,
       `Schedule for ${schedule.day.charAt(0).toUpperCase() + schedule.day.slice(1).toLowerCase()} is now resumed`,

--- a/extensions/coffee/src/addSchedule.tsx
+++ b/extensions/coffee/src/addSchedule.tsx
@@ -22,7 +22,26 @@ import {
   numberToDayString,
 } from "./utils";
 import { extractSchedule } from "./extractSchedule";
-import { checkSchedule } from "./status";
+import { activateScheduleMonitor, checkSchedule, isScheduleMonitorActivated } from "./status";
+
+async function getScheduleMonitorActivationChoice(): Promise<boolean | null> {
+  if (await isScheduleMonitorActivated()) return false;
+
+  const confirmed = await confirmAlert({
+    title: "Enable Automatic Scheduling?",
+    message: "Coffee needs Background Refresh to start schedules at their configured times. This is a one-time setup.",
+    icon: Icon.Clock,
+    primaryAction: {
+      title: "Enable and Continue",
+    },
+    dismissAction: {
+      title: "Cancel",
+      style: Alert.ActionStyle.Cancel,
+    },
+  });
+
+  return confirmed ? true : null;
+}
 
 export default function Command() {
   const [searchText, setSearchText] = useState("");
@@ -38,6 +57,10 @@ export default function Command() {
       if (!parsedSchedule) {
         return;
       }
+
+      const shouldActivateMonitor = await getScheduleMonitorActivationChoice();
+      if (shouldActivateMonitor === null) return;
+
       const { days, from, to } = parsedSchedule;
       const newSchedules = days.map((day) => ({ day, from, to, IsManuallyDecafed: false, IsRunning: false }));
 
@@ -63,9 +86,21 @@ export default function Command() {
 
       await showToast(Toast.Style.Success, "Caffeination schedule set successfully.");
       setSearchText("");
+
+      if (shouldActivateMonitor && !(await activateScheduleMonitor(true))) {
+        await showToast({
+          style: Toast.Style.Failure,
+          title: "Schedule saved, but automatic scheduling is not enabled",
+          message: "Enable Caffeinate Status in Raycast Settings, then run it once.",
+        });
+      }
     } catch (error) {
       console.error("Failed to set schedule:", error);
-      await showToast(Toast.Style.Failure, "Failed to set schedule.");
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Couldn’t save the schedule",
+        message: "Please try again.",
+      });
     }
   };
 
@@ -97,7 +132,11 @@ export default function Command() {
         setSchedules(updatedSchedules);
       } catch (error) {
         console.error("Failed to delete schedule:", error);
-        await showToast(Toast.Style.Failure, "Failed to delete schedule.");
+        await showToast({
+          style: Toast.Style.Failure,
+          title: "Couldn’t delete the schedule",
+          message: "Please try again.",
+        });
       }
     }
   };
@@ -145,7 +184,7 @@ export default function Command() {
       filtering={false}
       actions={
         <ActionPanel>
-          <Action autoFocus title="Set Schedule" icon={Icon.Calendar} onAction={handleSetSchedule} />
+          <Action autoFocus title="Set Caffeination Schedule" icon={Icon.Calendar} onAction={handleSetSchedule} />
         </ActionPanel>
       }
     >
@@ -191,7 +230,6 @@ export default function Command() {
                   icon={Icon.Calendar}
                   actions={
                     <ListActionPanel
-                      searchText={searchText}
                       schedule={schedule}
                       onSetScheduleAction={handleSetSchedule}
                       onDeleteScheduleAction={handleDeleteSchedule}

--- a/extensions/coffee/src/components/ListActionPanel.tsx
+++ b/extensions/coffee/src/components/ListActionPanel.tsx
@@ -2,7 +2,6 @@ import { Action, ActionPanel, Icon, Keyboard } from "@raycast/api";
 import { Schedule } from "../interfaces";
 
 type ActionPanelProps = {
-  searchText: string;
   schedule: Schedule;
   onSetScheduleAction: () => void;
   onDeleteScheduleAction: (schedule: Schedule) => void;
@@ -11,7 +10,6 @@ type ActionPanelProps = {
 };
 
 export function ListActionPanel({
-  searchText,
   schedule,
   onSetScheduleAction,
   onDeleteScheduleAction,
@@ -20,13 +18,7 @@ export function ListActionPanel({
 }: ActionPanelProps) {
   return (
     <ActionPanel>
-      {searchText.length > 0 && <Action title="Set Schedule" icon={Icon.Calendar} onAction={onSetScheduleAction} />}
-      <Action
-        title="Set Caffeination Schedule"
-        icon={Icon.CopyClipboard}
-        shortcut={{ modifiers: ["cmd"], key: "s" }}
-        onAction={() => onSetScheduleAction()}
-      />
+      <Action title="Set Caffeination Schedule" icon={Icon.Calendar} onAction={onSetScheduleAction} />
       <Action
         title="Delete Caffeination Schedule"
         style={Action.Style.Destructive}

--- a/extensions/coffee/src/extractSchedule.ts
+++ b/extensions/coffee/src/extractSchedule.ts
@@ -13,7 +13,11 @@ export async function extractSchedule(text: string): Promise<ParsedSchedule | nu
 
   // Ensure that both fromTime and toTime are present
   if (!times || times.length < 2) {
-    await showToast(Toast.Style.Failure, "Oops! Please specify both 'from' and 'to' times in HH:MM format.");
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "Enter both a start and end time",
+      message: "Example: Monday from 09:00 to 17:00",
+    });
     return null;
   }
 
@@ -25,7 +29,11 @@ export async function extractSchedule(text: string): Promise<ParsedSchedule | nu
   // Handle the "except" case
   if (inputText.includes("except")) {
     if (mentionedDays.length === 0) {
-      await showToast(Toast.Style.Failure, "Oops! Please mention the days to be excluded.");
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Enter the days to exclude",
+        message: "Example: Every day except Saturday and Sunday from 09:00 to 17:00",
+      });
       return null;
     }
     const allDaysExcept = daysOfWeek.filter((day) => !mentionedDays.includes(day));

--- a/extensions/coffee/src/hooks/useLoadStoredSchedules.tsx
+++ b/extensions/coffee/src/hooks/useLoadStoredSchedules.tsx
@@ -1,7 +1,9 @@
 import { LocalStorage } from "@raycast/api";
 import { Schedule } from "../interfaces";
-import { useEffect, useRef } from "react";
-import { parseSchedule } from "../utils";
+import { Dispatch, SetStateAction, useEffect, useRef } from "react";
+import { numberToDayString, parseSchedule } from "../utils";
+
+const SCHEDULE_REFRESH_INTERVAL_MS = 15_000;
 
 const dayOrder: { [key: string]: number } = {
   sunday: 0,
@@ -14,7 +16,7 @@ const dayOrder: { [key: string]: number } = {
 };
 
 export function useLoadStoredSchedules(
-  updateSchedules: (schedules: Schedule[]) => void,
+  updateSchedules: Dispatch<SetStateAction<Schedule[]>>,
   setIsLoading: (isLoading: boolean) => void,
 ) {
   // Use refs to avoid re-running the effect when callbacks change
@@ -32,27 +34,72 @@ export function useLoadStoredSchedules(
     async function loadSchedulesFromLocalStorage() {
       setIsLoadingRef.current(true);
 
-      const allStoredItems = await LocalStorage.allItems();
+      try {
+        const allStoredItems = await LocalStorage.allItems();
 
-      if (!isMounted) return;
+        if (!isMounted) return;
 
-      const schedules: Schedule[] = Object.values(allStoredItems)
-        .map(parseSchedule)
-        .filter((schedule): schedule is Schedule => schedule !== undefined);
-
-      if (schedules.length > 0) {
-        schedules.sort((a, b) => (dayOrder[a.day] ?? -1) - (dayOrder[b.day] ?? -1));
+        const schedules: Schedule[] = Object.values(allStoredItems)
+          .map(parseSchedule)
+          .filter((schedule): schedule is Schedule => schedule !== undefined)
+          .sort(compareSchedulesByDay);
 
         updateSchedulesRef.current(schedules);
+      } finally {
+        if (isMounted) {
+          setIsLoadingRef.current(false);
+        }
       }
+    }
 
-      setIsLoadingRef.current(false);
+    async function refreshTodaysSchedule() {
+      const currentDay = numberToDayString(new Date().getDay()).toLowerCase();
+
+      try {
+        const storedValue = await LocalStorage.getItem(currentDay);
+        if (!isMounted) return;
+
+        const storedSchedule = storedValue === undefined ? undefined : parseSchedule(storedValue);
+
+        updateSchedulesRef.current((currentSchedules) => {
+          const currentSchedule = currentSchedules.find((schedule) => schedule.day === currentDay);
+
+          if (schedulesEqual(currentSchedule, storedSchedule)) {
+            return currentSchedules;
+          }
+
+          return [
+            ...currentSchedules.filter((schedule) => schedule.day !== currentDay),
+            ...(storedSchedule ? [storedSchedule] : []),
+          ].sort(compareSchedulesByDay);
+        });
+      } catch (error) {
+        console.error("Failed to refresh today's caffeination schedule:", error);
+      }
     }
 
     void loadSchedulesFromLocalStorage();
+    const refreshInterval = setInterval(() => void refreshTodaysSchedule(), SCHEDULE_REFRESH_INTERVAL_MS);
 
     return () => {
       isMounted = false;
+      clearInterval(refreshInterval);
     };
   }, []);
+}
+
+function compareSchedulesByDay(a: Schedule, b: Schedule): number {
+  return (dayOrder[a.day] ?? -1) - (dayOrder[b.day] ?? -1);
+}
+
+function schedulesEqual(a: Schedule | undefined, b: Schedule | undefined): boolean {
+  if (a === undefined || b === undefined) return a === b;
+
+  return (
+    a.day === b.day &&
+    a.from === b.from &&
+    a.to === b.to &&
+    a.IsManuallyDecafed === b.IsManuallyDecafed &&
+    a.IsRunning === b.IsRunning
+  );
 }

--- a/extensions/coffee/src/status.ts
+++ b/extensions/coffee/src/status.ts
@@ -141,8 +141,12 @@ export async function maybeAutoCaffeinate(isScheduled?: boolean): Promise<boolea
   return true;
 }
 
-export default async function Command(props: { launchContext?: { returnToSchedule?: boolean } }) {
-  await LocalStorage.setItem(SCHEDULE_MONITOR_LAST_RUN_KEY, Date.now());
+export default async function Command(props: {
+  launchContext?: { returnToSchedule?: boolean; skipScheduleMonitorHeartbeat?: boolean };
+}) {
+  if (!props.launchContext?.skipScheduleMonitorHeartbeat) {
+    await LocalStorage.setItem(SCHEDULE_MONITOR_LAST_RUN_KEY, Date.now());
+  }
 
   const isCaffeinated = isCaffeinateRunning();
   const isScheduled = await checkSchedule();

--- a/extensions/coffee/src/status.ts
+++ b/extensions/coffee/src/status.ts
@@ -1,8 +1,29 @@
-import { getPreferenceValues, LocalStorage, updateCommandMetadata } from "@raycast/api";
+import { getPreferenceValues, launchCommand, LaunchType, LocalStorage, updateCommandMetadata } from "@raycast/api";
 import { execFileSync } from "node:child_process";
 import { Schedule, startCaffeinate, getSchedule, stopCaffeinate, isCaffeinateRunning } from "./utils";
 
 const AUTO_CAFFEINATE_PID_KEY = "autoCaffeinateRaycastPid";
+const SCHEDULE_MONITOR_ACTIVATED_KEY = "scheduleMonitorActivated";
+
+/** Opens the status command once so Raycast activates its recurring background refresh. */
+export async function activateScheduleMonitor(returnToSchedule = false): Promise<boolean> {
+  try {
+    await launchCommand({
+      name: "status",
+      type: LaunchType.UserInitiated,
+      context: { activateScheduleMonitor: true, returnToSchedule },
+    });
+    return true;
+  } catch (error) {
+    console.error("Failed to launch the caffeination schedule monitor:", error);
+    return false;
+  }
+}
+
+export async function isScheduleMonitorActivated(): Promise<boolean> {
+  const value = await LocalStorage.getItem(SCHEDULE_MONITOR_ACTIVATED_KEY);
+  return value === true || value === "true";
+}
 
 /**
  * Returns a session identifier for the currently-running Raycast instance.
@@ -58,8 +79,11 @@ async function handleScheduledCaffeinate(schedule: Schedule): Promise<boolean> {
 
   // If the current time is within scheduled time, start caffeination
   if (isWithinSchedule === true && schedule.IsRunning === false) {
-    const duration = (endHour - startHour) * 3600 + (endMinute - startMinute) * 60;
-    await startCaffeinate({ menubar: true, status: true }, undefined, `-t ${duration}`);
+    const endTime = new Date(currentDate);
+    endTime.setHours(endHour, endMinute, 0, 0);
+    const remainingSeconds = Math.ceil((endTime.getTime() - currentDate.getTime()) / 1000);
+
+    await startCaffeinate({ menubar: true, status: true }, undefined, `-t ${remainingSeconds}`);
     schedule.IsRunning = true;
     await LocalStorage.setItem(schedule.day, JSON.stringify(schedule));
     return true;
@@ -116,7 +140,13 @@ export async function maybeAutoCaffeinate(isScheduled?: boolean): Promise<boolea
   return true;
 }
 
-export default async function Command() {
+export default async function Command(props: {
+  launchContext?: { activateScheduleMonitor?: boolean; returnToSchedule?: boolean };
+}) {
+  if (props.launchContext?.activateScheduleMonitor) {
+    await LocalStorage.setItem(SCHEDULE_MONITOR_ACTIVATED_KEY, "true");
+  }
+
   const isCaffeinated = isCaffeinateRunning();
   const isScheduled = await checkSchedule();
   const autoStarted = await maybeAutoCaffeinate(isScheduled);
@@ -127,5 +157,9 @@ export default async function Command() {
     subtitle = "✔ Caffeinated";
   }
 
-  updateCommandMetadata({ subtitle });
+  await updateCommandMetadata({ subtitle });
+
+  if (props.launchContext?.returnToSchedule) {
+    await launchCommand({ name: "addSchedule", type: LaunchType.UserInitiated });
+  }
 }

--- a/extensions/coffee/src/status.ts
+++ b/extensions/coffee/src/status.ts
@@ -3,7 +3,8 @@ import { execFileSync } from "node:child_process";
 import { Schedule, startCaffeinate, getSchedule, stopCaffeinate, isCaffeinateRunning } from "./utils";
 
 const AUTO_CAFFEINATE_PID_KEY = "autoCaffeinateRaycastPid";
-const SCHEDULE_MONITOR_ACTIVATED_KEY = "scheduleMonitorActivated";
+const SCHEDULE_MONITOR_LAST_RUN_KEY = "scheduleMonitorLastRun";
+const SCHEDULE_MONITOR_STALE_AFTER_MS = 2 * 60 * 1000;
 
 /** Opens the status command once so Raycast activates its recurring background refresh. */
 export async function activateScheduleMonitor(returnToSchedule = false): Promise<boolean> {
@@ -11,7 +12,7 @@ export async function activateScheduleMonitor(returnToSchedule = false): Promise
     await launchCommand({
       name: "status",
       type: LaunchType.UserInitiated,
-      context: { activateScheduleMonitor: true, returnToSchedule },
+      context: { returnToSchedule },
     });
     return true;
   } catch (error) {
@@ -21,8 +22,8 @@ export async function activateScheduleMonitor(returnToSchedule = false): Promise
 }
 
 export async function isScheduleMonitorActivated(): Promise<boolean> {
-  const value = await LocalStorage.getItem(SCHEDULE_MONITOR_ACTIVATED_KEY);
-  return value === true || value === "true";
+  const lastRun = await LocalStorage.getItem<number>(SCHEDULE_MONITOR_LAST_RUN_KEY);
+  return typeof lastRun === "number" && Date.now() - lastRun <= SCHEDULE_MONITOR_STALE_AFTER_MS;
 }
 
 /**
@@ -140,12 +141,8 @@ export async function maybeAutoCaffeinate(isScheduled?: boolean): Promise<boolea
   return true;
 }
 
-export default async function Command(props: {
-  launchContext?: { activateScheduleMonitor?: boolean; returnToSchedule?: boolean };
-}) {
-  if (props.launchContext?.activateScheduleMonitor) {
-    await LocalStorage.setItem(SCHEDULE_MONITOR_ACTIVATED_KEY, "true");
-  }
+export default async function Command(props: { launchContext?: { returnToSchedule?: boolean } }) {
+  await LocalStorage.setItem(SCHEDULE_MONITOR_LAST_RUN_KEY, Date.now());
 
   const isCaffeinated = isCaffeinateRunning();
   const isScheduled = await checkSchedule();

--- a/extensions/coffee/src/utils.ts
+++ b/extensions/coffee/src/utils.ts
@@ -35,11 +35,14 @@ async function update(updates: Updates, caffeinated: boolean) {
     await tryLaunchCommand("index", { caffeinated });
   }
   if (updates.status) {
-    await tryLaunchCommand("status", { caffeinated });
+    await tryLaunchCommand("status", { caffeinated, skipScheduleMonitorHeartbeat: true });
   }
 }
 
-async function tryLaunchCommand(commandName: string, context: { caffeinated: boolean }) {
+async function tryLaunchCommand(
+  commandName: string,
+  context: { caffeinated: boolean; skipScheduleMonitorHeartbeat?: boolean },
+) {
   try {
     await launchCommand({ name: commandName, type: LaunchType.Background, context });
   } catch {


### PR DESCRIPTION
## Description

Fixes future caffeination schedules not starting automatically for new Coffee users.
Fixes : https://github.com/raycast/extensions/issues/30136

### Root cause
Coffee checks a schedule immediately after it is created. This works if the current time is already inside the scheduled range.

For a new Store installation, however, Raycast keeps background refresh for the Caffeinate Status command disabled until that command is opened once. Therefore, if a schedule was created before its start time, nothing checked it again when that time arrived. This could appear to work for existing users who had already activated the status command.

The fix adds a one-time setup prompt that activates background refresh and then returns the user to the schedule dashboard.

### Additional changes
While debugging, another timing bug was found: if Coffee detected a schedule after its start time, it used the schedule’s full duration and could keep caffeination running past the configured end time. It now runs only for the remaining time.

This PR also:
- Refreshes today’s stored schedule every 15 seconds while the dashboard is open, allowing its status to change from `Scheduled` to `Running` without reopening the command.
- Replaces the duplicate and conditional schedule actions with one consistently available Set Caffeination Schedule action. Pressing Enter and selecting the action now follow the same path.
- Improves validation and failure messages.

### Manual testing
  - Created a future schedule and confirmed it activated automatically.
  - Created a schedule during an active range and confirmed it started immediately.
  - Confirmed caffeination stopped at the configured end time.
  - Confirmed the open dashboard changed from Scheduled to Running.
  - Tested enabling and cancelling the first-time setup.
  - Confirmed the setup prompt did not reappear after successful activation.
  - Tested missing-time and invalid-exclusion messages.

## Screencast
NA

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
