### PR TITLE
[OpenClaw] Support remote node gateways without a local :18789

### DIFF
--- a/extensions/openclaw/CHANGELOG.md
+++ b/extensions/openclaw/CHANGELOG.md
@@ -1,6 +1,6 @@
 # OpenClaw Changelog
 
-## [Remote gateway / nodes] - {PR_MERGE_DATE}
+## [Remote gateway / nodes] - 2026-08-20
 
 - Read `gateway.remote.token` / `gateway.remote.url` from `~/.openclaw/openclaw.json` when Raycast prefs still have an empty token or the localhost default
 - Token preference is no longer required so node Macs are not blocked on the first-run password field

--- a/extensions/openclaw/CHANGELOG.md
+++ b/extensions/openclaw/CHANGELOG.md
@@ -1,5 +1,12 @@
 # OpenClaw Changelog
 
+## [Remote gateway / nodes] - {PR_MERGE_DATE}
+
+- Read `gateway.remote.token` / `gateway.remote.url` from `~/.openclaw/openclaw.json` when Raycast prefs still have an empty token or the localhost default
+- Token preference is no longer required so node Macs are not blocked on the first-run password field
+- Clearer errors for connection refused, 401, and 404/405 (`chatCompletions` disabled)
+- Docs: do not start a local gateway on node-only Macs; Tailscale HTTPS is the remote path
+
 ## [Initial Release] - 2026-02-23
 
 - Added "Ask OpenClaw" command for quick Q&A

--- a/extensions/openclaw/README.md
+++ b/extensions/openclaw/README.md
@@ -58,8 +58,8 @@ When you first run a command, Raycast will prompt for your API Endpoint and Toke
 
 **Use when:** Raycast and OpenClaw are on the same computer.
 
-| Setting | Value |
-|---------|-------|
+| Setting      | Value                    |
+| ------------ | ------------------------ |
 | API Endpoint | `http://127.0.0.1:18789` |
 
 This is the default - no configuration changes needed on OpenClaw.
@@ -70,13 +70,14 @@ This is the default - no configuration changes needed on OpenClaw.
 
 **Use when:** OpenClaw runs on another computer on your home/office network.
 
-| Setting | Value |
-|---------|-------|
+| Setting      | Value                                |
+| ------------ | ------------------------------------ |
 | API Endpoint | `http://<openclaw-machine-ip>:18789` |
 
 **Setup required on the OpenClaw machine:**
 
 1. Find the machine's local IP:
+
    ```bash
    ipconfig getifaddr en0   # WiFi
    # or
@@ -84,6 +85,7 @@ This is the default - no configuration changes needed on OpenClaw.
    ```
 
 2. Edit `~/.openclaw/openclaw.json` and change the gateway bind setting:
+
    ```json
    {
      "gateway": {
@@ -97,6 +99,7 @@ This is the default - no configuration changes needed on OpenClaw.
 4. Use the local IP as your endpoint, e.g., `http://192.168.1.50:18789`
 
 > **⚠️ Security Warning:** Binding to `0.0.0.0` exposes the gateway to your entire local network. Risks include:
+>
 > - Anyone on the same WiFi can attempt connections
 > - Public WiFi = public exposure
 > - If port forwarding is enabled on your router, it could be internet-accessible
@@ -109,8 +112,8 @@ This is the default - no configuration changes needed on OpenClaw.
 
 **Use when:** You want secure access from anywhere - home, office, mobile, etc.
 
-| Setting | Value |
-|---------|-------|
+| Setting      | Value                                     |
+| ------------ | ----------------------------------------- |
 | API Endpoint | `https://<machine-name>.<tailnet>.ts.net` |
 
 **Setup required on the OpenClaw machine:**
@@ -118,19 +121,23 @@ This is the default - no configuration changes needed on OpenClaw.
 1. Install [Tailscale](https://tailscale.com) on both machines and sign in to the same account.
 
 2. On the OpenClaw machine, set up Tailscale serve:
+
    ```bash
    tailscale serve --bg 18789
    ```
 
 3. Get your serve URL:
+
    ```bash
    tailscale serve status
    ```
+
    Output: `https://machine-name.tailca3a37.ts.net`
 
 4. Use that URL as your API Endpoint.
 
 **Benefits:**
+
 - Encrypted connection (HTTPS)
 - Works from anywhere (coffee shop, mobile hotspot, etc.)
 - Only accessible to devices on your Tailscale network
@@ -140,32 +147,39 @@ This is the default - no configuration changes needed on OpenClaw.
 
 #### Connection Method Comparison
 
-| Method | Security | Works Remotely | Setup Complexity | Recommended |
-|--------|----------|----------------|------------------|-------------|
-| Local | High (localhost only) | No | None | ✅ Yes |
-| Local Network | ⚠️ Low (LAN exposure) | No | Low | Only on trusted networks |
-| Tailscale | High (encrypted, private) | Yes | Medium | ✅ Yes - best for remote |
+| Method        | Security                  | Works Remotely | Setup Complexity | Recommended              |
+| ------------- | ------------------------- | -------------- | ---------------- | ------------------------ |
+| Local         | High (localhost only)     | No             | None             | ✅ Yes                   |
+| Local Network | ⚠️ Low (LAN exposure)     | No             | Low              | Only on trusted networks |
+| Tailscale     | High (encrypted, private) | Yes            | Medium           | ✅ Yes - best for remote |
 
 ## Commands
 
 ### Ask OpenClaw
+
 Quick Q&A - type a question, get an answer. Supports passing a question as an argument for automation.
 
 ### Chat with OpenClaw
+
 Full conversation interface with:
+
 - Persistent chat history
 - Multiple conversations
 - Streaming responses
 - Newest messages shown first
 
 ### Ask About Clipboard
+
 Reads your clipboard and lets you ask questions about it. Great for:
+
 - Explaining code snippets
 - Summarizing copied text
 - Translating content
 
 ### Process Selected Text
+
 Select text in any app, then run this command to:
+
 - Explain
 - Summarize
 - Fix Grammar
@@ -182,17 +196,21 @@ Select text in any app, then run this command to:
 ## Troubleshooting
 
 ### "API error: 405 - Method Not Allowed"
+
 The HTTP API endpoint isn't enabled. Add the config shown in Setup step 1.
 
 ### "Failed to connect"
+
 If this Mac is a **node**, `http://127.0.0.1:18789` will fail — nothing should be listening there. Set API Endpoint to the Tailscale HTTPS URL of the gateway (`https://<machine>.<tailnet>.ts.net`). Do not run `openclaw gateway start` on the node.
 
 If OpenClaw is supposed to be local on this Mac:
+
 ```bash
 openclaw gateway status
 ```
 
 ### Token errors
+
 On the gateway host use `gateway.auth.token`. On a node use `gateway.remote.token`.
 
 ## Acknowledgments

--- a/extensions/openclaw/README.md
+++ b/extensions/openclaw/README.md
@@ -1,6 +1,6 @@
 # OpenClaw for Raycast
 
-Chat with your local [OpenClaw](https://github.com/openclaw/openclaw) AI assistant directly from Raycast.
+Chat with your [OpenClaw](https://github.com/openclaw/openclaw) AI assistant from Raycast — on the same Mac as the gateway, or on a node that only talks to a remote gateway.
 
 ## Features
 
@@ -11,8 +11,9 @@ Chat with your local [OpenClaw](https://github.com/openclaw/openclaw) AI assista
 
 ## Requirements
 
-- [OpenClaw](https://github.com/openclaw/openclaw) installed and running locally
-- OpenClaw Gateway with HTTP API enabled
+- [OpenClaw](https://github.com/openclaw/openclaw) installed
+- A reachable OpenClaw **gateway** with the HTTP Chat Completions API enabled
+- This Mac can be the gateway host **or** a node. Do not start a second gateway on node-only Macs.
 
 ## Setup
 
@@ -38,11 +39,16 @@ The gateway will hot-reload the config automatically.
 
 ### 2. Find Your API Token
 
-Your token is in `~/.openclaw/openclaw.json` under `gateway.auth.token`:
+On the **gateway host**, the token is `gateway.auth.token`. On a **node** (`gateway.mode=remote`), use `gateway.remote.token` — it is the same bearer, stored under `remote`.
 
 ```bash
-cat ~/.openclaw/openclaw.json | grep -A 2 '"auth"' | grep token
+# gateway host
+python3 -c 'import json; from pathlib import Path; g=json.loads(Path.home().joinpath(".openclaw/openclaw.json").read_text())["gateway"]; print("auth", bool((g.get("auth") or {}).get("token")))'
+# node
+python3 -c 'import json; from pathlib import Path; g=json.loads(Path.home().joinpath(".openclaw/openclaw.json").read_text())["gateway"]; print("remote", bool((g.get("remote") or {}).get("token")), (g.get("remote") or {}).get("url"))'
 ```
+
+If the token preference is left empty, the extension reads those fields from `~/.openclaw/openclaw.json`. If API Endpoint is still the localhost default and the file has `gateway.remote.url` (`wss://…`), it uses the corresponding `https://` URL.
 
 ### 3. Choose Your Connection Method
 
@@ -179,13 +185,15 @@ Select text in any app, then run this command to:
 The HTTP API endpoint isn't enabled. Add the config shown in Setup step 1.
 
 ### "Failed to connect"
-Make sure OpenClaw gateway is running:
+If this Mac is a **node**, `http://127.0.0.1:18789` will fail — nothing should be listening there. Set API Endpoint to the Tailscale HTTPS URL of the gateway (`https://<machine>.<tailnet>.ts.net`). Do not run `openclaw gateway start` on the node.
+
+If OpenClaw is supposed to be local on this Mac:
 ```bash
 openclaw gateway status
 ```
 
 ### Token errors
-Verify your token matches `gateway.auth.token` in your OpenClaw config.
+On the gateway host use `gateway.auth.token`. On a node use `gateway.remote.token`.
 
 ## Acknowledgments
 

--- a/extensions/openclaw/package.json
+++ b/extensions/openclaw/package.json
@@ -6,7 +6,8 @@
   "icon": "icon.png",
   "author": "leveragedrobot",
   "contributors": [
-    "asaph_kotzin"
+    "asaph_kotzin",
+    "RaviTharuma"
   ],
   "categories": [
     "Productivity",

--- a/extensions/openclaw/package.json
+++ b/extensions/openclaw/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "openclaw",
   "title": "OpenClaw",
-  "description": "Chat with your local OpenClaw AI assistant",
+  "description": "Chat with your OpenClaw AI assistant (local or remote gateway)",
   "icon": "icon.png",
   "author": "leveragedrobot",
   "contributors": [
@@ -71,9 +71,9 @@
     {
       "name": "token",
       "title": "API Token",
-      "description": "Find in ~/.openclaw/openclaw.json under gateway.auth.token",
+      "description": "gateway.auth.token on the gateway host, or gateway.remote.token on a node (~/.openclaw/openclaw.json). Leave empty to use the file.",
       "type": "password",
-      "required": true
+      "required": false
     },
     {
       "name": "agentId",

--- a/extensions/openclaw/src/api.ts
+++ b/extensions/openclaw/src/api.ts
@@ -42,7 +42,9 @@ function trimSlash(url: string): string {
 function isLoopback(endpoint: string): boolean {
   try {
     const hostname = new URL(endpoint).hostname;
-    return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "::1";
+    return (
+      hostname === "127.0.0.1" || hostname === "localhost" || hostname === "::1"
+    );
   } catch {
     return /127\.0\.0\.1|localhost/.test(endpoint);
   }
@@ -63,17 +65,25 @@ function httpEndpointFromRemoteUrl(url: string): string | undefined {
 
 function readOpenClawFileConfig(): FileGatewayConfig {
   try {
-    const raw = readFileSync(join(homedir(), ".openclaw", "openclaw.json"), "utf8");
-    const gateway = (JSON.parse(raw) as { gateway?: Record<string, unknown> }).gateway;
+    const raw = readFileSync(
+      join(homedir(), ".openclaw", "openclaw.json"),
+      "utf8",
+    );
+    const gateway = (JSON.parse(raw) as { gateway?: Record<string, unknown> })
+      .gateway;
     if (!gateway || typeof gateway !== "object") return {};
     const auth = gateway.auth as { token?: string } | undefined;
-    const remote = gateway.remote as { token?: string; url?: string } | undefined;
+    const remote = gateway.remote as
+      | { token?: string; url?: string }
+      | undefined;
     const token =
       (typeof remote?.token === "string" && remote.token.trim()) ||
       (typeof auth?.token === "string" && auth.token.trim()) ||
       undefined;
     const endpoint =
-      (typeof remote?.url === "string" && httpEndpointFromRemoteUrl(remote.url)) || undefined;
+      (typeof remote?.url === "string" &&
+        httpEndpointFromRemoteUrl(remote.url)) ||
+      undefined;
     return { endpoint, token };
   } catch {
     return {};
@@ -91,10 +101,13 @@ export type ResolvedPreferences = Preferences & {
  * fall back to ~/.openclaw/openclaw.json so node/remote Macs work without
  * a second local gateway.
  */
-export function getPreferences<T extends Preferences = Preferences>(): T & ResolvedPreferences {
+export function getPreferences<T extends Preferences = Preferences>(): T &
+  ResolvedPreferences {
   const prefs = getPreferenceValues<T>();
   const file = readOpenClawFileConfig();
-  let endpoint = trimSlash(String(prefs.endpoint ?? "").trim() || LOOPBACK_DEFAULT);
+  let endpoint = trimSlash(
+    String(prefs.endpoint ?? "").trim() || LOOPBACK_DEFAULT,
+  );
   let token = String(prefs.token ?? "").trim();
   const agentId = String(prefs.agentId ?? "").trim() || "main";
 
@@ -119,7 +132,9 @@ function describeHttpError(status: number, body: string): string {
 
 function describeFetchError(error: unknown, endpoint: string): string {
   const msg = error instanceof Error ? error.message : String(error);
-  if (/failed to fetch|ECONNREFUSED|NetworkError|Load failed|network/i.test(msg)) {
+  if (
+    /failed to fetch|ECONNREFUSED|NetworkError|Load failed|network/i.test(msg)
+  ) {
     if (isLoopback(endpoint)) {
       return `Failed to connect to ${endpoint}. If OpenClaw runs on another machine, set API Endpoint to that host's Tailscale HTTPS URL and do not start a local gateway on this Mac.`;
     }

--- a/extensions/openclaw/src/api.ts
+++ b/extensions/openclaw/src/api.ts
@@ -31,6 +31,7 @@ interface StreamDelta {
 interface FileGatewayConfig {
   endpoint?: string;
   token?: string;
+  remoteMode?: boolean;
 }
 
 const LOOPBACK_DEFAULT = "http://127.0.0.1:18789";
@@ -84,7 +85,8 @@ function readOpenClawFileConfig(): FileGatewayConfig {
       (typeof remote?.url === "string" &&
         httpEndpointFromRemoteUrl(remote.url)) ||
       undefined;
-    return { endpoint, token };
+    const remoteMode = gateway.mode === "remote";
+    return { endpoint, token, remoteMode };
   } catch {
     return {};
   }
@@ -115,6 +117,7 @@ export function getPreferences<T extends Preferences = Preferences>(): T &
   if (
     file.endpoint &&
     !isLoopback(file.endpoint) &&
+    file.remoteMode &&
     endpoint === LOOPBACK_DEFAULT
   ) {
     endpoint = file.endpoint;

--- a/extensions/openclaw/src/api.ts
+++ b/extensions/openclaw/src/api.ts
@@ -112,7 +112,11 @@ export function getPreferences<T extends Preferences = Preferences>(): T &
   const agentId = String(prefs.agentId ?? "").trim() || "main";
 
   if (!token && file.token) token = file.token;
-  if (file.endpoint && !isLoopback(file.endpoint) && isLoopback(endpoint)) {
+  if (
+    file.endpoint &&
+    !isLoopback(file.endpoint) &&
+    endpoint === LOOPBACK_DEFAULT
+  ) {
     endpoint = file.endpoint;
   }
 

--- a/extensions/openclaw/src/api.ts
+++ b/extensions/openclaw/src/api.ts
@@ -1,4 +1,7 @@
 import { getPreferenceValues } from "@raycast/api";
+import { homedir } from "os";
+import { join } from "path";
+import { readFileSync } from "fs";
 
 interface Message {
   role: "user" | "assistant";
@@ -25,8 +28,104 @@ interface StreamDelta {
   }[];
 }
 
-export function getPreferences<T extends Preferences = Preferences>() {
-  return getPreferenceValues<T>();
+interface FileGatewayConfig {
+  endpoint?: string;
+  token?: string;
+}
+
+const LOOPBACK_DEFAULT = "http://127.0.0.1:18789";
+
+function trimSlash(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+function isLoopback(endpoint: string): boolean {
+  try {
+    const hostname = new URL(endpoint).hostname;
+    return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "::1";
+  } catch {
+    return /127\.0\.0\.1|localhost/.test(endpoint);
+  }
+}
+
+function httpEndpointFromRemoteUrl(url: string): string | undefined {
+  try {
+    const normalized = url.replace(/^ws/i, "http");
+    const parsed = new URL(normalized);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return trimSlash(`${parsed.protocol}//${parsed.host}`);
+    }
+  } catch {
+    // ignore invalid URLs
+  }
+  return undefined;
+}
+
+function readOpenClawFileConfig(): FileGatewayConfig {
+  try {
+    const raw = readFileSync(join(homedir(), ".openclaw", "openclaw.json"), "utf8");
+    const gateway = (JSON.parse(raw) as { gateway?: Record<string, unknown> }).gateway;
+    if (!gateway || typeof gateway !== "object") return {};
+    const auth = gateway.auth as { token?: string } | undefined;
+    const remote = gateway.remote as { token?: string; url?: string } | undefined;
+    const token =
+      (typeof remote?.token === "string" && remote.token.trim()) ||
+      (typeof auth?.token === "string" && auth.token.trim()) ||
+      undefined;
+    const endpoint =
+      (typeof remote?.url === "string" && httpEndpointFromRemoteUrl(remote.url)) || undefined;
+    return { endpoint, token };
+  } catch {
+    return {};
+  }
+}
+
+export type ResolvedPreferences = Preferences & {
+  endpoint: string;
+  token: string;
+  agentId: string;
+};
+
+/**
+ * Raycast prefs win when set. Empty token / leftover localhost default
+ * fall back to ~/.openclaw/openclaw.json so node/remote Macs work without
+ * a second local gateway.
+ */
+export function getPreferences<T extends Preferences = Preferences>(): T & ResolvedPreferences {
+  const prefs = getPreferenceValues<T>();
+  const file = readOpenClawFileConfig();
+  let endpoint = trimSlash(String(prefs.endpoint ?? "").trim() || LOOPBACK_DEFAULT);
+  let token = String(prefs.token ?? "").trim();
+  const agentId = String(prefs.agentId ?? "").trim() || "main";
+
+  if (!token && file.token) token = file.token;
+  if (file.endpoint && !isLoopback(file.endpoint) && isLoopback(endpoint)) {
+    endpoint = file.endpoint;
+  }
+
+  return { ...prefs, endpoint, token, agentId };
+}
+
+function describeHttpError(status: number, body: string): string {
+  const snippet = body.replace(/\s+/g, " ").slice(0, 180);
+  if (status === 401 || status === 403) {
+    return `API error: ${status} Unauthorized. Check API Token: gateway.auth.token on the gateway host, or gateway.remote.token on a node.`;
+  }
+  if (status === 404 || status === 405) {
+    return `API error: ${status}. Enable gateway.http.endpoints.chatCompletions.enabled on the OpenClaw gateway (not on this Mac if it is only a node).`;
+  }
+  return `API error: ${status} - ${snippet}`;
+}
+
+function describeFetchError(error: unknown, endpoint: string): string {
+  const msg = error instanceof Error ? error.message : String(error);
+  if (/failed to fetch|ECONNREFUSED|NetworkError|Load failed|network/i.test(msg)) {
+    if (isLoopback(endpoint)) {
+      return `Failed to connect to ${endpoint}. If OpenClaw runs on another machine, set API Endpoint to that host's Tailscale HTTPS URL and do not start a local gateway on this Mac.`;
+    }
+    return `Failed to connect to ${endpoint}. Check Tailscale/HTTPS reachability and that chatCompletions is enabled on the gateway.`;
+  }
+  return msg;
 }
 
 export async function sendMessage(
@@ -34,6 +133,11 @@ export async function sendMessage(
   onStream?: (chunk: string) => void,
 ): Promise<string> {
   const prefs = getPreferences();
+  if (!prefs.token) {
+    throw new Error(
+      "Missing API Token. Set it in extension preferences, or in ~/.openclaw/openclaw.json (gateway.auth.token or gateway.remote.token).",
+    );
+  }
   const url = `${prefs.endpoint}/v1/chat/completions`;
   const agentId = prefs.agentId || "main";
 
@@ -44,22 +148,26 @@ export async function sendMessage(
     user: "raycast-extension", // maintains session state across calls
   };
 
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${prefs.token}`,
-    },
-    body: JSON.stringify(body),
-  });
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${prefs.token}`,
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (error) {
+    throw new Error(describeFetchError(error, prefs.endpoint));
+  }
 
   if (!response.ok) {
     const text = await response.text();
-    throw new Error(`API error: ${response.status} - ${text}`);
+    throw new Error(describeHttpError(response.status, text));
   }
 
   if (onStream && response.body) {
-    // Handle streaming response
     const reader = response.body.getReader();
     const decoder = new TextDecoder();
     let fullContent = "";
@@ -98,7 +206,6 @@ export async function sendMessage(
 
     return fullContent;
   } else {
-    // Non-streaming response
     const data = (await response.json()) as ChatCompletionResponse;
     return data.choices[0]?.message?.content || "";
   }
@@ -107,8 +214,6 @@ export async function sendMessage(
 export async function askQuestion(question: string): Promise<string> {
   return sendMessage([{ role: "user", content: question }]);
 }
-
-// Async/background processing types and functions
 
 interface AsyncSubmitResponse {
   ok: boolean;
@@ -121,44 +226,47 @@ export interface AsyncResultResponse {
   error?: string;
 }
 
-/**
- * Fire-and-forget message submission via hooks endpoint.
- * Returns immediately with a runId that can be polled for results.
- */
 export async function submitAsyncMessage(
   messages: Message[],
   conversationId: string,
 ): Promise<string> {
   const prefs = getPreferences();
+  if (!prefs.token) {
+    throw new Error(
+      "Missing API Token. Set it in extension preferences, or in ~/.openclaw/openclaw.json (gateway.auth.token or gateway.remote.token).",
+    );
+  }
   const url = `${prefs.endpoint}/hooks/agent`;
   const agentId = prefs.agentId || "main";
 
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${prefs.token}`,
-    },
-    body: JSON.stringify({
-      model: `openclaw:${agentId}`,
-      messages,
-      sessionKey: `raycast:${conversationId}`,
-      user: "raycast-extension",
-    }),
-  });
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${prefs.token}`,
+      },
+      body: JSON.stringify({
+        model: `openclaw:${agentId}`,
+        messages,
+        sessionKey: `raycast:${conversationId}`,
+        user: "raycast-extension",
+      }),
+    });
+  } catch (error) {
+    throw new Error(describeFetchError(error, prefs.endpoint));
+  }
 
   if (!response.ok) {
     const text = await response.text();
-    throw new Error(`Async submit failed: ${response.status} - ${text}`);
+    throw new Error(describeHttpError(response.status, text));
   }
 
   const data = (await response.json()) as AsyncSubmitResponse;
   return data.runId;
 }
 
-/**
- * Poll for the result of an async message submission.
- */
 export async function pollAsyncResult(
   runId: string,
 ): Promise<AsyncResultResponse> {
@@ -172,7 +280,6 @@ export async function pollAsyncResult(
   });
 
   if (!response.ok) {
-    // Not ready yet or error
     if (response.status === 404) {
       return { status: "pending" };
     }

--- a/extensions/openclaw/src/status.tsx
+++ b/extensions/openclaw/src/status.tsx
@@ -133,19 +133,21 @@ ${
     ? `
 ## Troubleshooting
 
-1. **Check if OpenClaw gateway is running**
+If this Mac is only an OpenClaw **node**, do **not** start a local gateway. Point API Endpoint at the remote Tailscale HTTPS URL and use \`gateway.remote.token\`.
+
+1. **Confirm the HTTP API is enabled on the gateway host**
+   \`\`\`
+   openclaw config get gateway.http.endpoints.chatCompletions.enabled
+   \`\`\`
+
+2. **If OpenClaw is local on this Mac**, check the gateway process
    \`\`\`
    openclaw gateway status
    \`\`\`
 
-2. **Start the gateway if needed**
-   \`\`\`
-   openclaw gateway start
-   \`\`\`
+3. **Verify the endpoint** is \`https://<machine>.<tailnet>.ts.net\` for remote, not \`http://127.0.0.1:18789\` unless a local gateway actually answers.
 
-3. **Verify the endpoint URL** matches your gateway configuration
-
-4. **Check the API token** in extension preferences matches \`~/.openclaw/openclaw.json\`
+4. **Token** is \`gateway.auth.token\` on the gateway host, or \`gateway.remote.token\` on a node.
 `
     : ""
 }


### PR DESCRIPTION
## Description

OpenClaw is often used as a **remote gateway** (Tailscale HTTPS) with Macs as **nodes**. The Store extension still first-runs on `http://127.0.0.1:18789` and `gateway.auth.token` only. On a node that URL has nothing listening, and the token lives at `gateway.remote.token`. Troubleshooting currently tells people to `openclaw gateway start` on the client Mac, which is the wrong fix.

This change:

- Keeps explicit Raycast prefs when the user set them
- If the token is empty, reads `gateway.remote.token` then `gateway.auth.token` from `~/.openclaw/openclaw.json`
- If the endpoint is still the localhost default and the file has `gateway.remote.url` (`wss://…`), uses the matching `https://` host
- Makes the token preference optional so first-run does not block node Macs
- Maps connection refused / 401 / 404 / 405 to that setup
- Updates README and Gateway Status troubleshooting so nodes are not told to start a local gateway

## Screencast

N/A (prefs/docs/error-path change). Happy to add screenshots of Gateway Status against a Tailscale endpoint if useful.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I checked that all existing examples and tests still work
