### PR TITLE
[Apple Reminders] Display subtasks nested under their parent reminder

### DIFF
--- a/extensions/apple-reminders/CHANGELOG.md
+++ b/extensions/apple-reminders/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Apple Reminders Changelog
 
+## [Display subtasks nested under their parent reminder] - {PR_MERGE_DATE}
+
+- Subtasks are now displayed indented under their parent reminder in the "My Reminders" command. Since EventKit doesn't expose subtask relationships, they are read from the local Reminders database, which requires granting Raycast Full Disk Access. Without it, reminders are displayed as a flat list, as before.
+
 ## [Fix natural-language due dates] - 2026-08-19
 
 - Restore relative due-date parsing in Create Reminder for `1h`, `1 hour`, `3 hours`, `in 10 minutes`, `3:45 pm`, `3 days`, and `1 year`.

--- a/extensions/apple-reminders/README.md
+++ b/extensions/apple-reminders/README.md
@@ -90,6 +90,10 @@ The AI will set:
 
 You can disable this behavior by toggling on the "Don't use the AI" preference for the "Quick Add Reminder" command. The intelligent date and time parsing will still work, but not the other fields.
 
+## Subtasks
+
+Subtasks are displayed indented under their parent reminder in the "My Reminders" command. Apple's EventKit framework doesn't expose subtask relationships, so they are read from the local Reminders database. This requires granting Raycast Full Disk Access in `System Settings → Privacy & Security → Full Disk Access`. Without it, reminders are displayed as a flat list.
+
 ## Troubleshooting
 
 > I can't see any reminders and get a `Failed to fetch latest data` error.

--- a/extensions/apple-reminders/src/components/ReminderListItem.tsx
+++ b/extensions/apple-reminders/src/components/ReminderListItem.tsx
@@ -96,9 +96,19 @@ export default function ReminderListItem({
 
   return (
     <List.Item
-      icon={reminder.isCompleted ? { source: Icon.CheckCircle, tintColor: Color.Green } : Icon.Circle}
+      icon={
+        reminder.isSubtask
+          ? undefined
+          : reminder.isCompleted
+            ? { source: Icon.CheckCircle, tintColor: Color.Green }
+            : Icon.Circle
+      }
       key={reminder.id}
-      title={reminder.title}
+      title={
+        reminder.isSubtask
+          ? `\u{2800}\u{2800}\u{2800}${reminder.isCompleted ? "\u{2713}" : "\u{25EF}"} ${reminder.title}`
+          : reminder.title
+      }
       subtitle={reminder.notes}
       accessories={accessories}
       keywords={keywords}

--- a/extensions/apple-reminders/src/hooks/useData.ts
+++ b/extensions/apple-reminders/src/hooks/useData.ts
@@ -24,6 +24,7 @@ export type Reminder = {
   list: { id: string; title: string; color: string } | null;
   location?: Location;
   creationDate?: Date;
+  isSubtask?: boolean;
 };
 
 export type List = { id: string; title: string; color: string; isDefault: boolean };

--- a/extensions/apple-reminders/src/hooks/useSubtasks.ts
+++ b/extensions/apple-reminders/src/hooks/useSubtasks.ts
@@ -1,0 +1,68 @@
+import { existsSync, readdirSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+import { executeSQL, useCachedPromise } from "@raycast/utils";
+
+import { Reminder } from "./useData";
+
+// EventKit doesn't expose parent/subtask relationships, so they are read from
+// the Reminders SQLite stores instead. Reading them requires Full Disk Access.
+const storesDirectory = join(homedir(), "Library/Group Containers/group.com.apple.reminders/Container_v1/Stores");
+
+type SubtaskRow = { childId: string; parentId: string };
+
+async function getSubtaskParents(): Promise<Record<string, string>> {
+  const parentIdByChildId: Record<string, string> = {};
+  if (!existsSync(storesDirectory)) return parentIdByChildId;
+
+  const stores = readdirSync(storesDirectory).filter((file) => file.startsWith("Data-") && file.endsWith(".sqlite"));
+
+  for (const store of stores) {
+    try {
+      const rows = await executeSQL<SubtaskRow>(
+        join(storesDirectory, store),
+        `SELECT child.ZCKIDENTIFIER AS childId, parent.ZCKIDENTIFIER AS parentId
+         FROM ZREMCDREMINDER child
+         JOIN ZREMCDREMINDER parent ON child.ZPARENTREMINDER = parent.Z_PK
+         WHERE child.ZCKIDENTIFIER IS NOT NULL AND parent.ZCKIDENTIFIER IS NOT NULL`,
+      );
+
+      for (const row of rows) {
+        parentIdByChildId[row.childId] = row.parentId;
+      }
+    } catch {
+      // The store can't be read (e.g. missing Full Disk Access or a schema
+      // change) — fall back to displaying a flat list.
+    }
+  }
+
+  return parentIdByChildId;
+}
+
+export function useSubtasks() {
+  return useCachedPromise(getSubtaskParents, [], { initialData: {} });
+}
+
+export function nestSubtasks(reminders: Reminder[], parentIdByChildId: Record<string, string>): Reminder[] {
+  const idsInSection = new Set(reminders.map((reminder) => reminder.id));
+  const childrenByParentId = new Map<string, Reminder[]>();
+  const topLevel: Reminder[] = [];
+
+  for (const reminder of reminders) {
+    const parentId = parentIdByChildId[reminder.id];
+    // Only nest under a parent shown in the same section; otherwise keep the
+    // reminder where it is so it doesn't disappear.
+    if (parentId && idsInSection.has(parentId)) {
+      const children = childrenByParentId.get(parentId) ?? [];
+      children.push({ ...reminder, isSubtask: true });
+      childrenByParentId.set(parentId, children);
+    } else {
+      topLevel.push(reminder);
+    }
+  }
+
+  if (childrenByParentId.size === 0) return reminders;
+
+  return topLevel.flatMap((reminder) => [reminder, ...(childrenByParentId.get(reminder.id) ?? [])]);
+}

--- a/extensions/apple-reminders/src/hooks/useSubtasks.ts
+++ b/extensions/apple-reminders/src/hooks/useSubtasks.ts
@@ -64,5 +64,29 @@ export function nestSubtasks(reminders: Reminder[], parentIdByChildId: Record<st
 
   if (childrenByParentId.size === 0) return reminders;
 
-  return topLevel.flatMap((reminder) => [reminder, ...(childrenByParentId.get(reminder.id) ?? [])]);
+  // Emit each top-level reminder followed by its descendants depth-first so
+  // deeper nesting levels are preserved.
+  const nested: Reminder[] = [];
+  const emittedIds = new Set<string>();
+
+  function emit(reminder: Reminder) {
+    if (emittedIds.has(reminder.id)) return;
+    emittedIds.add(reminder.id);
+    nested.push(reminder);
+    for (const child of childrenByParentId.get(reminder.id) ?? []) {
+      emit(child);
+    }
+  }
+
+  for (const reminder of topLevel) {
+    emit(reminder);
+  }
+
+  // Safety net for malformed data (e.g. a parent cycle): never let a reminder
+  // disappear from the list.
+  for (const reminder of reminders) {
+    emit(reminder);
+  }
+
+  return nested;
 }

--- a/extensions/apple-reminders/src/hooks/useViewReminders.ts
+++ b/extensions/apple-reminders/src/hooks/useViewReminders.ts
@@ -8,6 +8,7 @@ import { getCompletedReminders } from "swift:../../swift/AppleReminders";
 import { displayDueDate, getDateString, isFullDay, isOverdue, isToday } from "../helpers";
 
 import { Data, Priority, Reminder } from "./useData";
+import { nestSubtasks, useSubtasks } from "./useSubtasks";
 
 const { useTimeOfDayGrouping } = getPreferenceValues<Preferences.MyReminders>();
 
@@ -233,6 +234,8 @@ export default function useViewReminders(listId: string, { data }: { data?: Data
     false,
   );
 
+  const { data: parentIdByChildId } = useSubtasks();
+
   const { data: completedRemindersData } = useCachedPromise(
     (listId) => getCompletedReminders(listId === "all" ? undefined : listId),
     [listId],
@@ -367,6 +370,7 @@ export default function useViewReminders(listId: string, { data }: { data?: Data
     sections = sections.map((section) => {
       return {
         ...section,
+        reminders: nestSubtasks(section.reminders, parentIdByChildId),
         subtitle: `${section.reminders.length} ${section.reminders.length === 1 ? "reminder" : "reminders"}`,
       };
     });
@@ -378,7 +382,16 @@ export default function useViewReminders(listId: string, { data }: { data?: Data
     };
 
     return { sections, groupByProp };
-  }, [sortedReminders, groupBy, setGroupBy, completedReminders, showCompletedReminders, data, listId]);
+  }, [
+    sortedReminders,
+    groupBy,
+    setGroupBy,
+    completedReminders,
+    showCompletedReminders,
+    data,
+    listId,
+    parentIdByChildId,
+  ]);
 
   const viewProps: ViewProps = {
     groupBy: groupByProp,


### PR DESCRIPTION
## Description

Subtasks are currently displayed as regular, flat reminders in the "My Reminders" command. This PR displays them nested under their parent reminder, similar to the Reminders app (related to #21857).

**How it works:** Apple's EventKit framework doesn't expose parent/subtask relationships, so the parent–child map is read (read-only) from the local Reminders SQLite stores in `~/Library/Group Containers/group.com.apple.reminders/Container_v1/Stores/`, joined to EventKit reminders via `calendarItemIdentifier` = `ZCKIDENTIFIER`, using `executeSQL` from `@raycast/utils`. Within each section, subtasks are moved directly beneath their parent and rendered with an indented circle glyph. A subtask whose parent isn't visible in the same section stays where it is, so it never disappears.

**Graceful fallback:** reading the store requires the user to grant Raycast Full Disk Access. If the store can't be read (no FDA, or Apple changes the private schema), the extension silently falls back to the existing flat list — no errors, no behavior change. The README documents the FDA requirement.

**Scope note:** this is display-only. Creating subtasks isn't included because no public API allows it — EventKit, AppleScript, and Shortcuts all lack a parent/subtask concept, and writing to the CloudKit-synced SQLite store directly would be unsafe. Search/filtering is unaffected (keywords keep the raw title).

## Screencast

_Screenshot to be added in a comment below._

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
