### PR TITLE
Update menucloak extension

### DIFF
--- a/extensions/menucloak/CHANGELOG.md
+++ b/extensions/menucloak/CHANGELOG.md
@@ -1,5 +1,11 @@
 # MenuCloak Changelog
 
+## [Google Calendar Setup] - {PR_MERGE_DATE}
+
+- Link directly to the unified MenuCloak 1.9 download.
+- Explain how to connect Google Calendar from the native MenuCloak settings.
+- Clarify that Google credentials and Calendar data never pass through the Raycast extension.
+
 ## [Initial Version] - 2026-08-19
 
 - Set the MenuCloak focus text from Raycast.

--- a/extensions/menucloak/CHANGELOG.md
+++ b/extensions/menucloak/CHANGELOG.md
@@ -1,6 +1,6 @@
 # MenuCloak Changelog
 
-## [Google Calendar Setup] - {PR_MERGE_DATE}
+## [Google Calendar Setup] - 2026-08-20
 
 - Link directly to the unified MenuCloak 1.9 download.
 - Explain how to connect Google Calendar from the native MenuCloak settings.

--- a/extensions/menucloak/README.md
+++ b/extensions/menucloak/README.md
@@ -4,7 +4,13 @@ Control the native MenuCloak app without leaving Raycast.
 
 ## Requirements
 
-[MenuCloak](https://github.com/dans-huang/MenuCloak) must be installed and running on your Mac.
+[MenuCloak 1.9 or newer](https://github.com/dans-huang/MenuCloak/releases/latest) must be installed and running on your Mac. The unified download includes the native app and these five Raycast commands.
+
+## Google Calendar
+
+Google sign-in lives in the native MenuCloak app, not in the Raycast extension. Run **Open MenuCloak Settings**, then click **Connect…** under Google Calendar. Sign-in opens in your default browser and returns directly to MenuCloak.
+
+MenuCloak requests read-only Calendar access and stores the reusable login in macOS Keychain. The Raycast extension never receives your Google credentials or Calendar data; it only sends local `menucloak://` commands to the app.
 
 ## Commands
 
@@ -12,7 +18,7 @@ Control the native MenuCloak app without leaving Raycast.
 - **Toggle MenuCloak** — toggle the cloak with one command or hotkey.
 - **Turn On MenuCloak** — cover application menus.
 - **Turn Off MenuCloak** — reveal application menus.
-- **Open MenuCloak Settings** — open the native settings window.
+- **Open MenuCloak Settings** — edit focus text or connect Google Calendar.
 
 The extension communicates with MenuCloak using its local `menucloak://` URL scheme.
-No account, analytics, or network access is required.
+The extension itself uses no account, analytics, or network access.

--- a/extensions/menucloak/package.json
+++ b/extensions/menucloak/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "menucloak",
   "title": "MenuCloak",
-  "description": "Turn unused application menu space into your current focus",
+  "description": "Control MenuCloak focus, cloak, and Google Calendar settings",
   "icon": "extension-icon.png",
   "categories": [
     "Applications",
@@ -49,7 +49,7 @@
     {
       "name": "open-settings",
       "title": "Open MenuCloak Settings",
-      "description": "Edit focus text and MenuCloak settings",
+      "description": "Edit focus text or connect Google Calendar",
       "mode": "no-view"
     }
   ],

--- a/extensions/menucloak/src/menucloak.ts
+++ b/extensions/menucloak/src/menucloak.ts
@@ -1,7 +1,7 @@
 import { getApplications, open, showHUD, showToast, Toast } from "@raycast/api";
 
 const bundleId = "com.dans.menucloak";
-const projectURL = "https://github.com/dans-huang/MenuCloak";
+const downloadURL = "https://github.com/dans-huang/MenuCloak/releases/latest";
 
 async function isInstalled(): Promise<boolean> {
   const applications = await getApplications();
@@ -13,10 +13,10 @@ export async function runMenuCloakAction(action: string, confirmation: string): 
     await showToast({
       style: Toast.Style.Failure,
       title: "MenuCloak is not installed",
-      message: "Install the native app before using this command.",
+      message: "Install MenuCloak 1.9 or newer to use Raycast and Google Calendar.",
       primaryAction: {
-        title: "View Installation Instructions",
-        onAction: () => open(projectURL),
+        title: "Download MenuCloak",
+        onAction: () => open(downloadURL),
       },
     });
     return;


### PR DESCRIPTION
## Description

MenuCloak 1.9.0 adds Google Calendar sign-in to the native macOS app. This Store update:

- links missing-app users directly to the unified 1.9.0 download
- explains that Google sign-in happens in MenuCloak Settings
- clarifies that the Raycast extension never receives Google credentials or Calendar data
- updates the Open Settings command description for Calendar setup

The native release is live at https://github.com/dans-huang/MenuCloak/releases/tag/v1.9.0. MenuCloak requests read-only Calendar access and stores the reusable login in macOS Keychain. The extension continues to communicate only through local `menucloak://` URLs.

## Screencast

No visual command flow changed; the existing Store screenshot remains current. The update is documentation, command metadata, and the missing-app download action.

## Verification

- `npm run lint`
- `npm run build`
- verified the public MenuCloak 1.9.0 archive contains the Google-enabled universal native app and all five compiled Raycast commands

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
