### PR TITLE
Update tuple extension

### DIFF
--- a/extensions/tuple/CHANGELOG.md
+++ b/extensions/tuple/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Tuple Changelog
 
-## [Smarter Calls and Rooms] - {PR_MERGE_DATE}
+## [Smarter Calls and Rooms] - 2026-08-20
 
 - **Contacts** now show only the call action that person can accept: start when they're online, join when their call has room, and neither when they're offline or the call is full. Favorites, search, and Copy Email still work for everyone.
 - Full calls now say **Call Full** instead of **In a Call**, so it's clear why Join Call isn't available.

--- a/extensions/tuple/CHANGELOG.md
+++ b/extensions/tuple/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Tuple Changelog
 
+## [Smarter Calls and Rooms] - {PR_MERGE_DATE}
+
+- **Contacts** now show only the call action that person can accept: start when they're online, join when their call has room, and neither when they're offline or the call is full. Favorites, search, and Copy Email still work for everyone.
+- Full calls now say **Call Full** instead of **In a Call**, so it's clear why Join Call isn't available.
+- Raycast reports success only after a call connects. Joining a contact or room switches cleanly from your current call.
+- **Join Personal Room** now chooses Tuple's primary room instead of relying on list order, and Search Rooms labels that room explicitly.
+- Ask Raycast AI who is pairing right now to get Tuple's grouped view of active calls.
+- Call failures now use the CLI's typed errors for more accurate guidance, with compatibility fallbacks for older Tuple builds.
+
 ## [New Tuple Integration] - 2026-06-26
 
 - **Calls**: browse contacts with live online/busy status, favorites, and recents; start a call; and run the active call from a menu-bar command — mute/unmute, add a person, copy an AI context prompt, or hang up. Toggle Mute and End Call ship as standalone commands for global hotkeys.

--- a/extensions/tuple/README.md
+++ b/extensions/tuple/README.md
@@ -18,7 +18,10 @@ extension wraps the local `tuple` command-line tool.
 ## Commands
 
 - **Search Contacts** — Browse your contacts with online status, favorites, and recents.
-  Start a call, toggle a favorite, or copy an email.
+  Start a call, toggle a favorite, or copy an email. Everyone stays listed, but the call
+  action matches what Tuple will accept: start a call with someone online, join the call
+  someone's already on while it has room, and neither for someone offline or on a full call.
+  Raycast reports success only after the call connects, and joins switch cleanly from your current call.
 - **Active Call** — A menu-bar command showing your current call. Mute/unmute, start or stop
   transcription, add a person, copy an AI context prompt, or hang up — without leaving the menu bar.
 - **Toggle Mute** — Mute or unmute your microphone in the active call. Bind it to a global
@@ -29,8 +32,9 @@ extension wraps the local `tuple` command-line tool.
   (drafted from the transcript, editable before it’s saved), copy an AI context prompt, export
   it, or delete it.
 - **Search Rooms** — Browse your personal and team rooms, see who’s currently in each, and
-  join one, copy its link, or open it in the browser.
-- **Join Personal Room** — Jump straight into your personal room.
+  join one, copy its link, or open it in the browser. Your primary personal room is identified
+  from the CLI's creation timestamp and shown first.
+- **Join Personal Room** — Jump straight into your primary personal room.
 - **Generate Title & Summary** — Draft a title and summary for your most recent call with AI and save
   them immediately, with no review step (the in-call **Generate Title & Summary…** action is the
   reviewable version). Bind it to a hotkey, or trigger it from a deeplink (pass a `callId` in the launch
@@ -42,7 +46,7 @@ Ask Raycast AI about your calls in **AI Chat** (type `@Tuple`) or the "Ask Tuple
 item — for example, "when did I last talk with Sage?" or "action items from my recent calls".
 The AI uses these read-only tools to answer:
 
-- **List Recent Calls**, **Search Transcripts**, **Read Transcript**, **List Contacts**, **Get Active Call**, **List Rooms**
+- **List Recent Calls**, **Search Transcripts**, **Read Transcript**, **List Contacts**, **List Active Calls**, **Get Active Call**, **List Rooms**
 
 "Summarize with AI" (on any call) and the AI tools use Raycast's built-in AI and require
 **Raycast Pro**. Your transcripts stay within Raycast AI — nothing leaves your machine

--- a/extensions/tuple/package-lock.json
+++ b/extensions/tuple/package-lock.json
@@ -1564,9 +1564,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/extensions/tuple/package.json
+++ b/extensions/tuple/package.json
@@ -54,7 +54,7 @@
     {
       "name": "join-personal-room",
       "title": "Join Personal Room",
-      "description": "Join your most recent personal room.",
+      "description": "Join your primary personal room.",
       "mode": "no-view"
     },
     {
@@ -95,7 +95,12 @@
     {
       "name": "list-contacts",
       "title": "List Contacts",
-      "description": "List Tuple contacts with online status, favorite, and recent flags."
+      "description": "List Tuple contacts with presence, favorites, recency, and the call action currently available."
+    },
+    {
+      "name": "list-active-calls",
+      "title": "List Active Calls",
+      "description": "List ongoing Tuple calls with grouped participants, room, capacity, and joinability."
     },
     {
       "name": "get-active-call",
@@ -105,11 +110,11 @@
     {
       "name": "list-rooms",
       "title": "List Rooms",
-      "description": "List personal and team Tuple rooms and who is currently in each."
+      "description": "List personal and team Tuple rooms, including the primary personal room and current occupants."
     }
   ],
   "ai": {
-    "instructions": "Calls are recorded Tuple pair-programming sessions stored locally. The tools are read-only. To answer questions about what was said, use search-transcripts with a few focused key words or a name (all terms must appear in a segment, so keep queries specific; search again with different terms to broaden). For recency or 'who/when' questions, use list-recent-calls (it accepts a participant filter and includes any saved summary). Resolve a person to their email with list-contacts when needed; contacts carry an online/busy/offline status, so use it for presence questions like 'who is around right now?' (busy means in a call). Rooms are persistent named spaces distinct from calls and can be occupied even when the user isn't on a call — use list-rooms for 'who is in a room?' or 'which rooms are active?'. Use read-transcript only when you need a call's full text. Cite the call (participants and date) in answers.",
+    "instructions": "Calls are recorded Tuple pair-programming sessions stored locally. The tools are read-only. To answer questions about what was said, use search-transcripts with a few focused key words or a name (all terms must appear in a segment, so keep queries specific; search again with different terms to broaden). For recency or 'who/when' questions about recorded calls, use list-recent-calls (it accepts a participant filter and includes any saved summary). Use list-active-calls for who is pairing right now, whether a live call is joinable, or which room it belongs to; it groups participants using Tuple's canonical visibility rules. Resolve an individual to their email or availability with list-contacts. Rooms are persistent named spaces distinct from calls and can be occupied even when the user isn't on a call — use list-rooms for occupancy and primary-room questions. Use read-transcript only when you need a call's full text. Cite the call (participants and date) in answers.",
     "evals": [
       {
         "input": "@tuple am I on a call right now?",
@@ -172,7 +177,8 @@
               "speaker": "Jordan Alvarez",
               "text": "the migration is on track"
             }
-          ]
+          ],
+          "read-transcript": "[10:05:00] Jordan Alvarez: the migration is on track"
         },
         "expected": [
           {
@@ -193,6 +199,8 @@
                 "slug": "tXFZbE",
                 "url": "https://tuple.app/c/tXFZbE",
                 "favorited": false,
+                "primary": false,
+                "createdAt": "2026-06-20T10:00:00Z",
                 "activeCall": false,
                 "occupants": [
                   "Riley Chen"
@@ -205,6 +213,39 @@
           {
             "callsTool": {
               "name": "list-rooms"
+            }
+          }
+        ]
+      },
+      {
+        "input": "@tuple who is pairing right now?",
+        "mocks": {
+          "list-active-calls": [
+            {
+              "id": "call-1",
+              "participants": [
+                {
+                  "name": "Riley Chen",
+                  "email": "riley@example.com"
+                },
+                {
+                  "name": "Jordan Alvarez",
+                  "email": "jordan@example.com"
+                }
+              ],
+              "unknownParticipants": 0,
+              "anonymous": false,
+              "capacity": 4,
+              "joinable": true,
+              "room": null,
+              "current": false
+            }
+          ]
+        },
+        "expected": [
+          {
+            "callsTool": {
+              "name": "list-active-calls"
             }
           }
         ]
@@ -248,7 +289,7 @@
     "publish": "npx @raycast/api@latest publish"
   },
   "overrides": {
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "js-yaml@4": "4.3.1"
   }
 }

--- a/extensions/tuple/src/join-personal-room.ts
+++ b/extensions/tuple/src/join-personal-room.ts
@@ -6,10 +6,12 @@ import { primaryPersonalRoom } from "./lib/types";
 export default async function JoinPersonalRoom() {
   try {
     const personalRooms = await listRooms("--kind", "personal", "--limit", "-1");
-    const room = primaryPersonalRoom(personalRooms) ?? personalRooms[0];
+    const room = primaryPersonalRoom(personalRooms);
 
     if (!room) {
-      await showHUD("No personal room found");
+      await showHUD(
+        personalRooms.length === 0 ? "No personal room found" : "Update Tuple to identify your primary room",
+      );
       return;
     }
 

--- a/extensions/tuple/src/join-personal-room.ts
+++ b/extensions/tuple/src/join-personal-room.ts
@@ -1,13 +1,11 @@
 import { showHUD } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
 import { joinCall, listRooms } from "./lib/tuple";
+import { primaryPersonalRoom } from "./lib/types";
 
 export default async function JoinPersonalRoom() {
   try {
-    // `tuple rooms list --kind personal` returns the user's personal room(s) — almost always
-    // exactly one. The CLI orders rooms by occupied, then favorited, then name, so [0] is the
-    // highest-priority personal room (and, in the common single-room case, the only one).
-    const [room] = await listRooms("--kind", "personal");
+    const room = primaryPersonalRoom(await listRooms("--kind", "personal", "--limit", "-1"));
 
     if (!room) {
       await showHUD("No personal room found");

--- a/extensions/tuple/src/join-personal-room.ts
+++ b/extensions/tuple/src/join-personal-room.ts
@@ -5,7 +5,8 @@ import { primaryPersonalRoom } from "./lib/types";
 
 export default async function JoinPersonalRoom() {
   try {
-    const room = primaryPersonalRoom(await listRooms("--kind", "personal", "--limit", "-1"));
+    const personalRooms = await listRooms("--kind", "personal", "--limit", "-1");
+    const room = primaryPersonalRoom(personalRooms) ?? personalRooms[0];
 
     if (!room) {
       await showHUD("No personal room found");

--- a/extensions/tuple/src/lib/tuple.ts
+++ b/extensions/tuple/src/lib/tuple.ts
@@ -3,7 +3,17 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { promisify } from "node:util";
 import { getPreferenceValues } from "@raycast/api";
-import { CallView, Contact, Room, StoredCall, TranscriptMatch, TupleError, TupleErrorKind } from "./types";
+import {
+  CallView,
+  Contact,
+  OngoingCall,
+  Room,
+  StoredCall,
+  TranscriptMatch,
+  TupleError,
+  TupleErrorKind,
+  TupleErrorPayload,
+} from "./types";
 
 const execFileAsync = promisify(execFile);
 
@@ -57,16 +67,66 @@ export function jsonArgs(...args: string[]): string[] {
 /** Stderr fragments that mean the CLI couldn't reach the Tuple daemon (app not running). */
 const DAEMON_DOWN_SIGNALS = ["tuple.sock", "dial unix", "connection refused", "connect: no such file"];
 
+function fromPayload(payload: TupleErrorPayload): { kind: TupleErrorKind; message: string } | null {
+  const message = payload.error?.trim();
+  switch (payload.kind) {
+    case "contact_offline":
+      return { kind: TupleErrorKind.ContactOffline, message: message || "They’re offline." };
+    case "contact_busy":
+      return { kind: TupleErrorKind.ContactBusy, message: message || "They’re already on a call." };
+    case "invalid_call":
+      return { kind: TupleErrorKind.NotJoinable, message: message || "That call can’t be joined." };
+    case "conflict":
+      return {
+        kind: TupleErrorKind.AlreadyInCall,
+        message: message || "You’re already in a call. Hang up first, then join.",
+      };
+  }
+  // Older structured envelopes had an HTTP status but no stable kind.
+  if (payload.kind) {
+    return null;
+  }
+  switch (payload.error_code) {
+    case 409:
+      return { kind: TupleErrorKind.AlreadyInCall, message: "You’re already in a call. Hang up first, then join." };
+    case 410:
+      return { kind: TupleErrorKind.NoActiveCall, message: "No active call." };
+  }
+  return null;
+}
+
+/**
+ * Parse the JSON error envelope. Current CLIs write it to *stdout* under
+ * `--format json` — stderr stays empty — so the raw exec error carries it
+ * there. Anything that isn't a JSON object with an `error`/`kind` is not an
+ * envelope (an older CLI's prose, or a command run without `--format json`).
+ */
+function parseErrorPayload(stdout: string): TupleErrorPayload | null {
+  const text = stdout.trim();
+  if (!text.startsWith("{")) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(text) as TupleErrorPayload;
+    return typeof parsed?.error === "string" || typeof parsed?.kind === "string" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
 /** Map any thrown exec error to a classified {@link TupleError}. */
 export function classifyError(error: unknown): TupleError {
   if (error instanceof TupleError) {
     return error;
   }
 
-  const err = error as { code?: string | number; message?: string; stderr?: string } | undefined;
+  const err = error as { code?: string | number; message?: string; stdout?: string; stderr?: string } | undefined;
+  const stdout = typeof err?.stdout === "string" ? err.stdout : "";
   const stderr = typeof err?.stderr === "string" ? err.stderr : "";
-  const haystack = `${err?.message ?? ""}\n${stderr}`.toLowerCase();
-  const detail = (stderr || err?.message || "").trim() || undefined;
+  // Commands asking for `--format json` report failures on stdout rather than
+  // stderr, so every signal below has to consider both streams.
+  const haystack = `${err?.message ?? ""}\n${stderr}\n${stdout}`.toLowerCase();
+  const detail = (stderr || stdout || err?.message || "").trim() || undefined;
 
   // Binary missing: spawn ENOENT, or a shell layer reporting "command not found".
   if (err?.code === "ENOENT" || haystack.includes("command not found")) {
@@ -77,9 +137,22 @@ export function classifyError(error: unknown): TupleError {
     );
   }
 
+  const payload = parseErrorPayload(stdout);
+  if (payload) {
+    const classified = fromPayload(payload);
+    if (classified) {
+      return new TupleError(classified.kind, classified.message, detail);
+    }
+  }
+
+  // Prose fallback, retained for CLIs predating the structured envelope.
   // Call-scoped command with no active call. Frequently a normal state (e.g. menu bar).
   if (haystack.includes("not in a call") || haystack.includes("no active call")) {
     return new TupleError(TupleErrorKind.NoActiveCall, "No active call.", detail);
+  }
+
+  if (haystack.includes("not on a joinable call")) {
+    return new TupleError(TupleErrorKind.NotJoinable, "That call can’t be joined.", detail);
   }
 
   // Joining while already in a call: the CLI returns 409 instead of switching you over.
@@ -165,6 +238,11 @@ export async function listContacts(): Promise<Contact[]> {
   return (await runTupleJson<Contact[]>(["contacts", "list"])) ?? [];
 }
 
+/** Ongoing calls, grouped and privacy-normalized by the CLI. */
+export async function listOngoingCalls(): Promise<OngoingCall[]> {
+  return (await runTupleJson<OngoingCall[]>(["call", "list"])) ?? [];
+}
+
 /** List rooms as one flat, kind-tagged array. Extra args (e.g. "--kind", "personal") narrow the result. */
 export async function listRooms(...extraArgs: string[]): Promise<Room[]> {
   return (await runTupleJson<Room[]>(["rooms", "list", ...extraArgs])) ?? [];
@@ -174,59 +252,86 @@ export async function listRooms(...extraArgs: string[]): Promise<Room[]> {
 // Contacts and call participants are addressed by email, which uniquely resolves a person
 // (partial names are ambiguous and the CLI rejects them).
 
-export async function startCall(email: string): Promise<void> {
-  await runTuple(["call", "start", email]);
+/**
+ * Run a mutating command and discard its output. It goes through JSON mode
+ * because that is what makes the CLI emit its `{error, error_code, kind}`
+ * envelope on failure; the reads that need human-readable text
+ * (`transcription show`, `connect --print`) keep calling {@link runTuple}.
+ */
+async function runTupleAction(args: string[]): Promise<void> {
+  await runTuple(jsonArgs(...args));
 }
 
-export async function addToCall(email: string): Promise<void> {
-  await runTuple(["call", "add", email]);
+function isUnsupportedFlag(error: unknown, flag: string): boolean {
+  const classified = classifyError(error);
+  return `${classified.message}\n${classified.detail ?? ""}`.toLowerCase().includes(`unknown flag: ${flag}`);
 }
 
-/** Join a call/room by person name or room URL/slug. */
-export async function joinCall(target: string): Promise<void> {
-  await runTuple(["call", "join", target]);
+async function runTupleActionWithFallback(args: string[], optionalArgs: string[]): Promise<void> {
+  try {
+    await runTupleAction([...args, ...optionalArgs]);
+  } catch (error) {
+    const unsupported = optionalArgs.find((arg) => arg.startsWith("--") && isUnsupportedFlag(error, arg));
+    if (!unsupported) {
+      throw error;
+    }
+    await runTupleAction(args);
+  }
 }
 
-export async function setFavorite(email: string, favorited: boolean): Promise<void> {
-  await runTuple(["contacts", favorited ? "favorite" : "unfavorite", email]);
+export function startCall(email: string): Promise<void> {
+  return runTupleActionWithFallback(["call", "start", email], ["--wait", "--timeout", "12s"]);
+}
+
+export function addToCall(email: string): Promise<void> {
+  return runTupleActionWithFallback(["call", "add", email], ["--wait", "--timeout", "12s"]);
+}
+
+/** Join a call/room by person name or room URL/slug, switching from the current call when needed. */
+export function joinCall(target: string): Promise<void> {
+  return runTupleActionWithFallback(["call", "join", target], ["--switch"]);
+}
+
+export function setFavorite(email: string, favorited: boolean): Promise<void> {
+  return runTupleAction(["contacts", favorited ? "favorite" : "unfavorite", email]);
 }
 
 /** Favorite or unfavorite a room, addressed by its slug (the CLI also accepts the room URL). */
-export async function setRoomFavorite(slug: string, favorited: boolean): Promise<void> {
-  await runTuple(["rooms", favorited ? "favorite" : "unfavorite", slug]);
+export function setRoomFavorite(slug: string, favorited: boolean): Promise<void> {
+  return runTupleAction(["rooms", favorited ? "favorite" : "unfavorite", slug]);
 }
 
-export async function muteCall(): Promise<void> {
-  await runTuple(["call", "mute"]);
+export function muteCall(): Promise<void> {
+  return runTupleAction(["call", "mute"]);
 }
 
-export async function unmuteCall(): Promise<void> {
-  await runTuple(["call", "unmute"]);
+export function unmuteCall(): Promise<void> {
+  return runTupleAction(["call", "unmute"]);
 }
 
-export async function hangUpCall(): Promise<void> {
-  await runTuple(["call", "hang-up"]);
+export function hangUpCall(): Promise<void> {
+  return runTupleAction(["call", "hang-up"]);
 }
 
-export async function startTranscription(): Promise<void> {
-  await runTuple(["transcription", "start"]);
+export function startTranscription(): Promise<void> {
+  return runTupleAction(["transcription", "start"]);
 }
 
-export async function stopTranscription(): Promise<void> {
-  await runTuple(["transcription", "stop"]);
+export function stopTranscription(): Promise<void> {
+  return runTupleAction(["transcription", "stop"]);
 }
 
-export async function setCallTitle(callId: string, title: string): Promise<void> {
-  await runTuple(["transcription", "set-title", callId, title]);
+export function setCallTitle(callId: string, title: string): Promise<void> {
+  return runTupleAction(["transcription", "set-title", callId, title]);
 }
 
-export async function setCallSummary(callId: string, summary: string): Promise<void> {
-  await runTuple(["transcription", "set-summary", callId, summary]);
+export function setCallSummary(callId: string, summary: string): Promise<void> {
+  return runTupleAction(["transcription", "set-summary", callId, summary]);
 }
 
 /** Permanently delete a stored call's transcript. Irreversible — confirm before calling. */
-export async function deleteTranscript(callId: string): Promise<void> {
-  await runTuple(["transcription", "delete", callId]);
+export function deleteTranscript(callId: string): Promise<void> {
+  return runTupleAction(["transcription", "delete", callId]);
 }
 
 /** Export one call (or all, when callId is omitted) to a directory. `transcription export` has no JSON mode. */

--- a/extensions/tuple/src/lib/types.ts
+++ b/extensions/tuple/src/lib/types.ts
@@ -12,12 +12,84 @@ export interface Contact {
   favorited: boolean;
   recent: boolean;
   status: ContactStatus;
+  /** Present for a busy contact: the call they're on. Absent on CLIs predating the contract. */
+  call?: ContactCall | null;
+}
+
+/**
+ * The call a busy contact is on. `joinable` is the CLI's own derivation of the
+ * predicate the engine enforces before letting anyone in, so consumers branch
+ * on it rather than reproducing the participant/capacity arithmetic.
+ */
+export interface ContactCall {
+  id: string;
+  participant_ids: number[];
+  capacity: number;
+  sfu_backed: boolean;
+  personal_room?: { owner: number; auto_join_behavior: string } | null;
+  joinable?: boolean;
+}
+
+/**
+ * Whether a busy contact's call can be joined. `unknown` is the older-CLI case:
+ * builds predating the contract omit `call` entirely, so there is nothing to
+ * judge — the action stays on offer and the CLI rejects it if it must. Treating
+ * unknown as "not joinable" would strip Join Call from every busy contact
+ * against those builds.
+ */
+export type Joinability = "joinable" | "not-joinable" | "unknown";
+
+export function callJoinability(contact: Contact | undefined): Joinability {
+  const call = contact?.call;
+  if (!call) {
+    return "unknown";
+  }
+  if (typeof call.joinable === "boolean") {
+    return call.joinable ? "joinable" : "not-joinable";
+  }
+  // A build that sends the call but not the derived flag: apply the same predicate.
+  if (call.id && Array.isArray(call.participant_ids) && typeof call.capacity === "number") {
+    return call.participant_ids.length < call.capacity ? "joinable" : "not-joinable";
+  }
+  return "unknown";
+}
+
+/**
+ * What a contact's entry should offer. Mirrors the Tuple app's popover: no way
+ * to ring someone offline, and joining only a call that has room. The CLI
+ * enforces the same rules — `call start` at an offline or busy target is
+ * rejected outright — so offering the action anyway would just be a button that
+ * fails. Forcing past the guard is deliberately not on offer, because the app
+ * doesn't offer it either.
+ *
+ * A status that is neither busy nor offline counts as reachable: the daemon
+ * passes presence through verbatim and "available" is a synonym for online.
+ */
+export type ContactCallAction = "start" | "join" | "none";
+
+export function contactCallAction(contact: Contact): ContactCallAction {
+  if (contact.status === "busy") {
+    return callJoinability(contact) === "not-joinable" ? "none" : "join";
+  }
+  return contact.status === "offline" ? "none" : "start";
 }
 
 export interface CallParticipant {
   id: number;
   full_name: string;
   email: string;
+}
+
+/** One grouped live call from `tuple call list`. */
+export interface OngoingCall {
+  id: string;
+  participants: CallParticipant[];
+  unknown_participants: number;
+  anonymous: boolean;
+  capacity: number;
+  joinable: boolean;
+  room: { slug: string; name: string } | null;
+  current: boolean;
 }
 
 /** A stored (recorded) call, from `tuple transcription list`. */
@@ -79,10 +151,24 @@ export interface Room {
   slug: string;
   name: string;
   http_value: string;
+  /** RFC 3339 creation time. Older CLIs omit it. */
+  created_at?: string;
   favorited: boolean;
   members: RoomMember[];
   kind: RoomKind;
   active_call: boolean;
+}
+
+/** The newest-created personal room, matching Tuple's primary-room rule. */
+export function primaryPersonalRoom(rooms: Room[]): Room | undefined {
+  return rooms
+    .filter((room) => room.kind === "personal")
+    .reduce<Room | undefined>((primary, room) => {
+      if (!primary) {
+        return room;
+      }
+      return (room.created_at ?? "") > (primary.created_at ?? "") ? room : primary;
+    }, undefined);
 }
 
 /** One full-text search hit, from `tuple transcription search --format json`. */
@@ -101,14 +187,31 @@ export enum TupleErrorKind {
   NotInstalled = "not_installed",
   /** A call-scoped command ran while no call was active. Often a normal state, not a failure. */
   NoActiveCall = "no_active_call",
-  /** Tried to join a call/room while already in one — the CLI rejects this rather than switching. */
+  /** Tried to join a call/room while already in one without asking the CLI to switch. */
   AlreadyInCall = "already_in_call",
   /** The Tuple app/daemon is not running, so the CLI could not reach it. */
   DaemonDown = "daemon_down",
   /** The transcript store doesn't exist yet — transcription has never run on this machine. */
   TranscriptionUnavailable = "transcription_unavailable",
+  /** `call start` refused: the target is offline. The app offers no start action for them either. */
+  ContactOffline = "contact_offline",
+  /** `call start` refused: the target is already on a call. Join it instead. */
+  ContactBusy = "contact_busy",
+  /** `call join` refused: the target isn't on a call anyone can join. */
+  NotJoinable = "not_joinable",
   /** Anything else — surfaced to the user verbatim. */
   Unknown = "unknown",
+}
+
+/**
+ * The error envelope `--format json` writes to *stdout* (with exit 1) on
+ * current CLIs. `kind` is the daemon's or command's stable identifier;
+ * `error_code` is the HTTP status when the failure came from the daemon.
+ */
+export interface TupleErrorPayload {
+  error?: string;
+  error_code?: number;
+  kind?: string;
 }
 
 export class TupleError extends Error {

--- a/extensions/tuple/src/lib/types.ts
+++ b/extensions/tuple/src/lib/types.ts
@@ -159,16 +159,16 @@ export interface Room {
   active_call: boolean;
 }
 
-/** The newest-created personal room, matching Tuple's primary-room rule. */
+/** The newest-created personal room when the CLI provides enough data to identify it reliably. */
 export function primaryPersonalRoom(rooms: Room[]): Room | undefined {
-  return rooms
-    .filter((room) => room.kind === "personal")
-    .reduce<Room | undefined>((primary, room) => {
-      if (!primary) {
-        return room;
-      }
-      return (room.created_at ?? "") > (primary.created_at ?? "") ? room : primary;
-    }, undefined);
+  const personalRooms = rooms.filter((room) => room.kind === "personal");
+  if (personalRooms.length <= 1) {
+    return personalRooms[0];
+  }
+  if (personalRooms.some((room) => !room.created_at)) {
+    return undefined;
+  }
+  return personalRooms.reduce((primary, room) => (room.created_at! > primary.created_at! ? room : primary));
 }
 
 /** One full-text search hit, from `tuple transcription search --format json`. */

--- a/extensions/tuple/src/search-contacts.tsx
+++ b/extensions/tuple/src/search-contacts.tsx
@@ -3,7 +3,7 @@ import { showFailureToast } from "@raycast/utils";
 import { TupleErrorEmptyView } from "./lib/empty-state";
 import { useTupleJson } from "./lib/hooks";
 import { joinCall, setFavorite, startCall } from "./lib/tuple";
-import { Contact } from "./lib/types";
+import { Contact, ContactCallAction, contactCallAction } from "./lib/types";
 
 export default function SearchContacts() {
   const { data, isLoading, error, revalidate } = useTupleJson<Contact[]>(["contacts", "list"], {
@@ -51,6 +51,7 @@ export default function SearchContacts() {
 }
 
 function ContactItem({ contact, onChange }: { contact: Contact; onChange: () => void }) {
+  const callAction = contactCallAction(contact);
   const accessories: List.Item.Accessory[] = [];
   if (contact.favorited) {
     accessories.push({ icon: "⭐", tooltip: "Favorite" });
@@ -58,7 +59,7 @@ function ContactItem({ contact, onChange }: { contact: Contact; onChange: () => 
   if (contact.recent) {
     accessories.push({ tag: "Recent" });
   }
-  const presence = presenceTag(contact);
+  const presence = presenceTag(contact, callAction);
   accessories.push({ tag: presence });
 
   return (
@@ -70,10 +71,10 @@ function ContactItem({ contact, onChange }: { contact: Contact; onChange: () => 
       accessories={accessories}
       actions={
         <ActionPanel>
-          {contact.status === "busy" ? (
-            // They're already in a call/room, so joining is the only sensible action.
+          {callAction === "join" && (
             <Action title="Join Call" icon={Icon.Phone} onAction={() => joinCallWithFeedback(contact)} />
-          ) : (
+          )}
+          {callAction === "start" && (
             <Action title="Start Call" icon={Icon.Phone} onAction={() => startCallWithFeedback(contact)} />
           )}
           <Action
@@ -134,13 +135,14 @@ function isPresent(contact: Contact): boolean {
   return contact.status === "online" || contact.status === "busy";
 }
 
-/** Status pill: green when online, orange when in a call, muted when offline. */
-function presenceTag(contact: Contact): { value: string; color: Color } {
+function presenceTag(contact: Contact, callAction: ContactCallAction): { value: string; color: Color } {
   switch (contact.status) {
     case "online":
       return { value: "Online", color: Color.Green };
     case "busy":
-      return { value: "In a Call", color: Color.Orange };
+      return callAction === "join"
+        ? { value: "In a Call", color: Color.Orange }
+        : { value: "Call Full", color: Color.SecondaryText };
     default:
       return { value: "Offline", color: Color.SecondaryText };
   }

--- a/extensions/tuple/src/search-rooms.tsx
+++ b/extensions/tuple/src/search-rooms.tsx
@@ -3,7 +3,7 @@ import { showFailureToast } from "@raycast/utils";
 import { TupleErrorEmptyView } from "./lib/empty-state";
 import { useTupleJson } from "./lib/hooks";
 import { joinCall, setRoomFavorite } from "./lib/tuple";
-import { Room } from "./lib/types";
+import { primaryPersonalRoom, Room } from "./lib/types";
 
 export default function SearchRooms() {
   // `tuple rooms list` returns one flat, kind-tagged array, with occupants and the active-room
@@ -14,14 +14,18 @@ export default function SearchRooms() {
   });
 
   const rooms = data ?? [];
-  const personal = sortRooms(rooms.filter((room) => room.kind === "personal"));
+  const primaryRoom = primaryPersonalRoom(rooms);
+  const personal = sortRooms(
+    rooms.filter((room) => room.kind === "personal"),
+    primaryRoom?.slug,
+  );
   const team = sortRooms(rooms.filter((room) => room.kind === "team"));
 
   return (
     <List isLoading={isLoading} searchBarPlaceholder="Search your rooms">
       <List.Section title="Personal">
         {personal.map((room) => (
-          <RoomItem key={room.slug} room={room} onChange={revalidate} />
+          <RoomItem key={room.slug} room={room} primary={room.slug === primaryRoom?.slug} onChange={revalidate} />
         ))}
       </List.Section>
       <List.Section title="Team">
@@ -42,11 +46,14 @@ export default function SearchRooms() {
   );
 }
 
-function RoomItem({ room, onChange }: { room: Room; onChange: () => void }) {
+function RoomItem({ room, primary = false, onChange }: { room: Room; primary?: boolean; onChange: () => void }) {
   const label = roomLabel(room);
   const occupants = room.members.map((member) => member.full_name || member.email || "Someone");
   const accessories: List.Item.Accessory[] = [];
 
+  if (primary) {
+    accessories.push({ tag: "Primary" });
+  }
   if (occupants.length > 0) {
     accessories.push({
       icon: { source: Icon.TwoPeople, tintColor: Color.Green },
@@ -109,8 +116,11 @@ async function toggleFavorite(room: Room, label: string, onChange: () => void) {
 }
 
 /** Occupied rooms first, then favorites, then by name. */
-function sortRooms(rooms: Room[]): Room[] {
+function sortRooms(rooms: Room[], primarySlug?: string): Room[] {
   return [...rooms].sort((a, b) => {
+    if (primarySlug && (a.slug === primarySlug) !== (b.slug === primarySlug)) {
+      return a.slug === primarySlug ? -1 : 1;
+    }
     const aOccupied = a.members.length > 0;
     const bOccupied = b.members.length > 0;
     if (aOccupied !== bOccupied) {

--- a/extensions/tuple/src/tools/list-active-calls.ts
+++ b/extensions/tuple/src/tools/list-active-calls.ts
@@ -1,0 +1,18 @@
+import { listOngoingCalls } from "../lib/tuple";
+
+/** List live Tuple calls using the CLI's canonical grouping and visibility rules. */
+export default async function () {
+  return (await listOngoingCalls()).map((call) => ({
+    id: call.id,
+    participants: call.participants.map((participant) => ({
+      name: participant.full_name,
+      email: participant.email,
+    })),
+    unknownParticipants: call.unknown_participants,
+    anonymous: call.anonymous,
+    capacity: call.capacity,
+    joinable: call.joinable,
+    room: call.room,
+    current: call.current,
+  }));
+}

--- a/extensions/tuple/src/tools/list-contacts.ts
+++ b/extensions/tuple/src/tools/list-contacts.ts
@@ -1,4 +1,5 @@
 import { listContacts } from "../lib/tuple";
+import { contactCallAction } from "../lib/types";
 
 type Input = {
   /** Only include contacts whose name or email contains this text. */
@@ -22,5 +23,6 @@ export default async function (input: Input) {
       favorited: contact.favorited,
       recent: contact.recent,
       kind: contact.kind,
+      callAction: contactCallAction(contact),
     }));
 }

--- a/extensions/tuple/src/tools/list-rooms.ts
+++ b/extensions/tuple/src/tools/list-rooms.ts
@@ -11,11 +11,13 @@ export default async function () {
   // CLI's default count cap applies — an agent answering "which rooms have someone in them?" doesn't
   // need an unbounded dump that floods the model's context on large teams.
   const [rooms, personalRooms] = await Promise.all([listRooms(), listRooms("--kind", "personal", "--limit", "-1")]);
-  const primarySlug = primaryPersonalRoom(personalRooms)?.slug;
+  const primaryRoom = primaryPersonalRoom(personalRooms);
+  const visiblePersonalRooms = rooms.filter((room) => room.kind === "personal");
+  if (primaryRoom && !visiblePersonalRooms.some((room) => room.slug === primaryRoom.slug)) {
+    visiblePersonalRooms.unshift(primaryRoom);
+  }
   return {
-    personal: rooms
-      .filter((room) => room.kind === "personal")
-      .map((room) => describeRoom(room, room.slug === primarySlug)),
+    personal: visiblePersonalRooms.map((room) => describeRoom(room, room.slug === primaryRoom?.slug)),
     team: rooms.filter((room) => room.kind === "team").map((room) => describeRoom(room, false)),
   };
 }

--- a/extensions/tuple/src/tools/list-rooms.ts
+++ b/extensions/tuple/src/tools/list-rooms.ts
@@ -1,5 +1,5 @@
 import { listRooms } from "../lib/tuple";
-import { Room } from "../lib/types";
+import { primaryPersonalRoom, Room } from "../lib/types";
 
 /**
  * List Tuple rooms (personal and team) with who is currently in each. Rooms are persistent named
@@ -10,19 +10,24 @@ export default async function () {
   // `tuple rooms list` returns one flat, kind-tagged array; split it back into personal/team. The
   // CLI's default count cap applies — an agent answering "which rooms have someone in them?" doesn't
   // need an unbounded dump that floods the model's context on large teams.
-  const rooms = await listRooms();
+  const [rooms, personalRooms] = await Promise.all([listRooms(), listRooms("--kind", "personal", "--limit", "-1")]);
+  const primarySlug = primaryPersonalRoom(personalRooms)?.slug;
   return {
-    personal: rooms.filter((room) => room.kind === "personal").map(describeRoom),
-    team: rooms.filter((room) => room.kind === "team").map(describeRoom),
+    personal: rooms
+      .filter((room) => room.kind === "personal")
+      .map((room) => describeRoom(room, room.slug === primarySlug)),
+    team: rooms.filter((room) => room.kind === "team").map((room) => describeRoom(room, false)),
   };
 }
 
-function describeRoom(room: Room) {
+function describeRoom(room: Room, primary: boolean) {
   return {
     name: room.name.trim() || "Personal Room",
     slug: room.slug,
     url: room.http_value,
     favorited: room.favorited,
+    primary,
+    createdAt: room.created_at || undefined,
     // True when the user's current call is in this room — lets an agent answer "which room am I in?".
     activeCall: room.active_call,
     occupants: room.members.map((member) => member.full_name || member.email).filter(Boolean),


### PR DESCRIPTION
## Description

Updates Tuple to use the current bundled CLI contracts throughout the extension:

- Shows only call actions a contact can accept, including a clear Call Full state
- Waits for calls to connect before reporting success and switches cleanly when joining another call or room
- Uses typed CLI error envelopes while retaining compatibility with older Tuple builds
- Identifies and prioritizes the primary personal room from its creation timestamp
- Adds a read-only List Active Calls AI tool backed by the CLI's canonical grouped call view
- Refreshes the affected AI instructions, eval fixtures, documentation, changelog, and dependency security override

Verification:

- `npm run build`
- `npm run lint`
- `npx @raycast/api@latest evals --exit-on-error` (5/5)
- Distribution build loaded successfully through `ray develop`
- Current CLI contracts checked against the production Tuple CLI

## Screencast

Not included: this updates an existing extension's action availability and adds a read-only AI tool rather than adding a new visible command.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
