### PR TITLE
[Google Lens] Upload images directly to Lens

### DIFF
--- a/extensions/google-lens/CHANGELOG.md
+++ b/extensions/google-lens/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Google Lens Changelog
 
+## [Fix] - 2026-08-20
+
+- Upload images directly to Google Lens instead of relying on a third-party server.
+
 ## [Maintenance] - 2026-04-15
 
 - Update the API base URL to avoid DNS issues.

--- a/extensions/google-lens/package.json
+++ b/extensions/google-lens/package.json
@@ -19,7 +19,7 @@
           "type": "checkbox",
           "required": false,
           "title": "Upload Image Alert",
-          "description": "Turn off the upload alert when uploading an image to Google Lens",
+          "description": "Turn off the alert before sending an image directly to Google Lens",
           "default": false
         }
       ]

--- a/extensions/google-lens/src/constants.ts
+++ b/extensions/google-lens/src/constants.ts
@@ -1,3 +1,3 @@
-export const API_BASE_URL = "https://google-lens.yencheng.dev";
-export const UPLOAD_ENDPOINT = `${API_BASE_URL}/upload-image`;
+export const GOOGLE_LENS_UPLOAD_ENDPOINT = "https://lens.google.com/v3/upload";
+export const MAX_FILE_SIZE_BYTES = 20 * 1024 * 1024;
 export const ACCEPTED_TYPES = ["png", "jpeg", "jpg", "gif", "webp"];

--- a/extensions/google-lens/src/search-image-with-google-lens.ts
+++ b/extensions/google-lens/src/search-image-with-google-lens.ts
@@ -17,8 +17,7 @@ import { existsSync } from "fs";
 import { readFile, unlink } from "fs/promises";
 import FormData from "form-data";
 import fetch from "node-fetch";
-import { API_BASE_URL, UPLOAD_ENDPOINT, ACCEPTED_TYPES } from "./constants";
-import { UploadResponse } from "./types";
+import { ACCEPTED_TYPES, GOOGLE_LENS_UPLOAD_ENDPOINT, MAX_FILE_SIZE_BYTES } from "./constants";
 
 const exec = promisify(execCb);
 
@@ -35,9 +34,9 @@ export default async () => {
   if (!turnOffUploadAlert) {
     if (
       !(await confirmAlert({
-        title: "Are you sure upload image?",
+        title: "Upload image to Google Lens?",
         message:
-          "The image will be uploaded to a third-party server maintained by the extension author to generate a public URL for Google Lens. Please avoid uploading sensitive content. (You can disable this warning in preferences)",
+          "The image will be sent directly to Google Lens for processing. Please avoid uploading sensitive content. (You can disable this warning in preferences)",
       }))
     ) {
       return;
@@ -115,34 +114,41 @@ export default async () => {
     }
 
     const buffer = await readFile(filePath);
+    if (buffer.length > MAX_FILE_SIZE_BYTES) {
+      throw new Error("Image exceeds the 20 MB Google Lens upload limit");
+    }
+
     const form = new FormData();
     const separator = platform() === "win32" ? "\\" : "/";
-    form.append("image", buffer, {
+    form.append("encoded_image", buffer, {
       filename: filePath.split(separator).pop(),
-      contentType: `image/${fileExtension}`,
+      contentType: `image/${fileExtension === "jpg" ? "jpeg" : fileExtension}`,
     });
 
-    const res = await fetch(UPLOAD_ENDPOINT, {
+    const uploadUrl = new URL(GOOGLE_LENS_UPLOAD_ENDPOINT);
+    uploadUrl.searchParams.set("ep", "cntpubb");
+    uploadUrl.searchParams.set("st", Date.now().toString());
+
+    const response = await fetch(uploadUrl, {
       method: "POST",
       body: form,
       headers: form.getHeaders(),
     });
 
-    if (res.ok) {
-      const result = (await res.json()) as UploadResponse;
-      if (result.filename) {
-        const imageUrl = `${API_BASE_URL}/image/${result.filename}`;
-        await showToast({
-          style: Toast.Style.Success,
-          title: "Opening Google Lens...",
-        });
-        await open(`https://lens.google.com/uploadbyurl?url=${encodeURIComponent(imageUrl)}`);
-      } else {
-        throw new Error("Search failed");
-      }
-    } else {
-      throw new Error("Search failed");
+    if (!response.ok) {
+      throw new Error(`Google Lens upload failed (${response.status} ${response.statusText})`);
     }
+
+    const resultUrl = new URL(response.url);
+    if (resultUrl.protocol !== "https:" || resultUrl.hostname !== "lens.google.com") {
+      throw new Error("Google Lens returned an unexpected result URL");
+    }
+
+    await showToast({
+      style: Toast.Style.Success,
+      title: "Opening Google Lens...",
+    });
+    await open(resultUrl.toString());
   } catch (error) {
     showFailureToast(error, { title: usedScreenshot ? "Screenshot search failed" : "Image search failed" });
   } finally {

--- a/extensions/google-lens/src/types.ts
+++ b/extensions/google-lens/src/types.ts
@@ -1,5 +1,0 @@
-export interface UploadResponse {
-  filename?: string;
-  message?: string;
-  error?: string;
-}


### PR DESCRIPTION
## Summary

I was not able to reproduce the reported error locally. However, the existing flow depends on a third-party upload server before opening the image in Google Lens, making that service the most likely failure point.

This PR replaces that flow with a direct multipart upload to the Google Lens v3 upload endpoint using the encoded_image field used by Chromium.

It also:

- Enforces the 20 MB Google Lens upload limit.
- Validates the returned HTTPS Lens URL before opening it.
- Includes the HTTP status in upload errors.
- Updates the privacy warning to reflect that images are sent directly to Google Lens.
- Removes the obsolete third-party upload response type.

## Testing

- npm run lint
- npm run build
- git diff --check

All checks pass locally. I was not able to reproduce the original failure or manually verify every screenshot, Finder, and Windows flow.

Fixes #30375