### PR TITLE
add: telegram forum topics and organized message views

### DIFF
--- a/extensions/telegram/CHANGELOG.md
+++ b/extensions/telegram/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Telegram Changelog
 
+## [Browse Chats, Forum Topics, and Organized Messages] - {PR_MERGE_DATE}
+
+- Browse and search private chats, groups, and pinned conversations with unread counts and recent message previews
+- Navigate searchable topics in Telegram forum groups and read or send messages within individual topics
+- Read chronological, date-grouped message histories with sender avatars, media indicators, compact timestamps, and the newest message focused at the bottom
+- Send text and attachments to chats or topics, with clearer destination context throughout the send flow
+- Extend Raycast AI tools with forum-topic discovery, topic-aware message reading and sending, and improved chat metadata
+
 ## [Add 2-Step Verification Login Support] - 2026-03-26
 
 - Handle Telegram 2FA (`SESSION_PASSWORD_NEEDED`) with a password step

--- a/extensions/telegram/README.md
+++ b/extensions/telegram/README.md
@@ -1,11 +1,14 @@
 # Telegram
 
-A Raycast extension for viewing and sending messages to your Telegram Saved Messages.
+A Raycast extension for browsing Telegram chats and forum topics, reading organized message histories, and sending messages without leaving Raycast.
 
 ## Features
 
-- 📥 **View Saved Messages**: Browse your Telegram saved messages directly in Raycast
-- 📤 **Send to Saved Messages**: Quickly send notes and messages to yourself
+- **Browse chats**: Search private chats, groups, and pinned conversations
+- **Navigate forum topics**: Open searchable topics inside forum-enabled groups
+- **Read organized histories**: Scan sender-first message rows grouped by date, with media and timestamp context
+- **Send messages**: Send text and attachments to chats or specific forum topics
+- **Saved Messages**: Browse and send notes to yourself
 - 🔐 **Secure Authentication**: Uses official Telegram API with session persistence
 
 ## Setup
@@ -56,14 +59,24 @@ Log in to your Telegram account. You'll need to do this once before using the ot
 ### View Saved Messages
 
 Browse your Telegram saved messages in a list view. Features:
+
 - Search through your messages
 - See message timestamps
 - Copy messages to clipboard
 - Refresh the list (⌘ + R)
 
+### Browse Chats
+
+Browse private chats and groups. Forum-enabled groups open into a topic list with unread counts, recent-message previews, and topic search. Open any topic to read or send messages within it.
+
+### Send Message
+
+Choose a private chat, group, or forum topic, then send text and optional file attachments. When opened from a topic history, the destination topic is selected automatically.
+
 ### Send to Saved Messages
 
 Quickly send a message to your Telegram saved messages. Perfect for:
+
 - Saving quick notes
 - Storing links for later
 - Sending reminders to yourself
@@ -88,15 +101,6 @@ Make sure you've entered the correct API ID and API Hash in the extension prefer
 ### "Failed to Load Messages" Error
 
 This usually means your session has expired. Try running the "Authenticate with Telegram" command again.
-
-## Future Features
-
-Coming soon:
-- View all chats
-- Send messages to other users and groups
-- Media support (photos, files)
-- Message search
-- Notifications
 
 ## License
 

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -86,10 +86,31 @@
     {
       "name": "browse-chats",
       "title": "Browse Telegram Chats",
-      "description": "Browse available Telegram chats (private and group). Returns a list of chats with their IDs, titles, types, and last message info. Use this when you need to find a chat to send a message to or when the user asks to see their chats.",
+      "description": "Browse available Telegram chats (private and group). Returns chat IDs, titles, types, forum status, and last message info. Use browse-topics next when isForum is true.",
       "parameters": {
         "type": "object",
         "properties": {}
+      }
+    },
+    {
+      "name": "browse-topics",
+      "title": "Browse Telegram Topics",
+      "description": "Browse or search the topics inside a Telegram forum group. Use browse-chats first to get a forum chatId, then use the returned topic ID with read-messages, analyze-messages, or send-message.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "chatId": {
+            "type": "string",
+            "description": "The forum group chat ID (get this from browse-chats where isForum is true)"
+          },
+          "query": {
+            "type": "string",
+            "description": "Optional topic title search"
+          }
+        },
+        "required": [
+          "chatId"
+        ]
       }
     },
     {
@@ -102,6 +123,10 @@
           "chatId": {
             "type": "string",
             "description": "The chat ID to read messages from (get this from browse-chats tool)"
+          },
+          "topicId": {
+            "type": "number",
+            "description": "Optional forum topic ID (get this from browse-topics tool)"
           },
           "limit": {
             "type": "number",
@@ -123,6 +148,10 @@
           "chatId": {
             "type": "string",
             "description": "The chat ID to send the message to (get this from browse-chats tool)"
+          },
+          "topicId": {
+            "type": "number",
+            "description": "Optional forum topic ID (get this from browse-topics tool)"
           },
           "message": {
             "type": "string",
@@ -149,6 +178,10 @@
           "chatId": {
             "type": "string",
             "description": "The chat ID to analyze messages from (get this from browse-chats tool)"
+          },
+          "topicId": {
+            "type": "number",
+            "description": "Optional forum topic ID (get this from browse-topics tool)"
           },
           "query": {
             "type": "string",
@@ -189,5 +222,8 @@
     "lint": "ray lint",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "contributors": [
+    "alpme"
+  ]
 }

--- a/extensions/telegram/src/browse-chats.tsx
+++ b/extensions/telegram/src/browse-chats.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { List, Icon } from "@raycast/api";
-import { useCachedPromise } from "@raycast/utils";
+import { usePromise } from "@raycast/utils";
 import { getConfig, ensureAuthenticated } from "./utils/auth";
 import { groupChatsByPinned } from "./utils/chat";
 import { getChats } from "./services/telegram-client";
@@ -14,24 +14,18 @@ export default function BrowseChats() {
   const [isShowingDetail, handleToggleDetail] = useDetailToggle(SHOW_DETAIL_KEY);
 
   const {
-    data: chats,
+    data: chats = [],
     isLoading,
     revalidate,
-  } = useCachedPromise(
-    async () => {
-      const authenticated = await ensureAuthenticated();
-      if (!authenticated) {
-        return [];
-      }
+  } = usePromise(async () => {
+    const authenticated = await ensureAuthenticated();
+    if (!authenticated) {
+      return [];
+    }
 
-      const config = getConfig();
-      return await getChats({ config, limit: 100 });
-    },
-    [],
-    {
-      initialData: [],
-    },
-  );
+    const config = getConfig();
+    return await getChats({ config, limit: 100 });
+  }, []);
 
   const filteredChats = chats.filter((chat) => chat.title.toLowerCase().includes(searchText.toLowerCase()));
   const groupedChats = groupChatsByPinned(filteredChats);

--- a/extensions/telegram/src/components/chat-conversation-view.tsx
+++ b/extensions/telegram/src/components/chat-conversation-view.tsx
@@ -1,0 +1,113 @@
+import { Action, ActionPanel, Detail, Icon } from "@raycast/api";
+import { Chat, ChatMessage, ChatTopic } from "../services/telegram-client";
+import { groupMessagesByDate } from "../utils/message";
+import { buildMarkdownWithMedia } from "../utils/markdown";
+import { getMediaDisplayTitle } from "../utils/media";
+import { SendMessageForm } from "./send-message-form";
+import { RefreshAction } from "./actions";
+
+interface ChatConversationViewProps {
+  chat: Chat;
+  topic?: ChatTopic;
+  messages: ChatMessage[];
+  isLoading: boolean;
+  onRefresh: () => void;
+  onShowCompactList: () => void;
+}
+
+function senderName(message: ChatMessage, chat: Chat): string {
+  return message.isOutgoing ? "You" : message.senderName || chat.title;
+}
+
+function messageMarkdown(message: ChatMessage): string {
+  let body = buildMarkdownWithMedia({ text: message.text, media: message.media });
+
+  if (message.media && !["photo", "image"].includes(message.media.type)) {
+    const attachment = message.media.fileName || `${getMediaDisplayTitle(message.media.type)} attachment`;
+    body = body ? `${body}\n\n_📎 ${attachment}_` : `_📎 ${attachment}_`;
+  }
+
+  return body || "_Empty message_";
+}
+
+function quoteMarkdown(markdown: string): string {
+  return markdown
+    .split("\n")
+    .map((line) => `> ${line}`)
+    .join("\n");
+}
+
+function buildConversationMarkdown(messages: ChatMessage[], chat: Chat): string {
+  const lines = [`_${messages.length} recent messages · oldest to newest_`];
+  const groupedMessages = groupMessagesByDate(messages);
+
+  for (const [date, dateMessages] of groupedMessages.entries()) {
+    lines.push(`\n### ${date}`);
+
+    for (const message of dateMessages) {
+      const sender = senderName(message, chat);
+      const time = message.date.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
+      const body = messageMarkdown(message);
+
+      if (message.isOutgoing) {
+        lines.push(`\n> **${sender}** · _${time}_\n>\n${quoteMarkdown(body)}`);
+      } else {
+        lines.push(`\n**${sender}** · _${time}_\n\n${body}`);
+      }
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function buildPlainTranscript(messages: ChatMessage[], chat: Chat): string {
+  return messages
+    .map((message) => {
+      const sender = senderName(message, chat);
+      const timestamp = message.date.toLocaleString();
+      const attachment = message.media
+        ? ` [${message.media.fileName || getMediaDisplayTitle(message.media.type)}]`
+        : "";
+      return `[${timestamp}] ${sender}: ${message.text}${attachment}`;
+    })
+    .join("\n");
+}
+
+export function ChatConversationView({
+  chat,
+  topic,
+  messages,
+  isLoading,
+  onRefresh,
+  onShowCompactList,
+}: ChatConversationViewProps) {
+  const destination = topic ? `${chat.title} · ${topic.title}` : chat.title;
+  const markdown =
+    messages.length > 0
+      ? buildConversationMarkdown(messages, chat)
+      : isLoading
+        ? "# Loading Conversation…"
+        : "# No Messages\n\nThis conversation has no messages yet.";
+
+  return (
+    <Detail
+      isLoading={isLoading}
+      navigationTitle={destination}
+      markdown={markdown}
+      actions={
+        <ActionPanel>
+          <Action.Push
+            icon={Icon.Pencil}
+            title="Send Message"
+            target={<SendMessageForm chat={chat} topic={topic} onSuccess={onRefresh} />}
+          />
+          <Action icon={Icon.List} title="Show Message List" onAction={onShowCompactList} />
+          {messages.length > 0 ? (
+            <Action.CopyToClipboard title="Copy Conversation" content={buildPlainTranscript(messages, chat)} />
+          ) : null}
+          <RefreshAction onRefresh={onRefresh} />
+        </ActionPanel>
+      }
+    />
+  );
+}

--- a/extensions/telegram/src/components/chat-list-item.tsx
+++ b/extensions/telegram/src/components/chat-list-item.tsx
@@ -2,6 +2,7 @@ import { List, ActionPanel, Action, Icon, Color } from "@raycast/api";
 import { Chat } from "../services/telegram-client";
 import { getAvatarIcon } from "../utils/avatar";
 import { ChatMessagesView } from "./chat-messages-view";
+import { ChatTopicsView } from "./chat-topics-view";
 import { ChatListItemDetail } from "./chat-list-item-detail";
 import { SendMessageForm } from "./send-message-form";
 import { ToggleDetailAction, RefreshAction } from "./actions";
@@ -22,6 +23,10 @@ export function ChatListItem({ chat, onRefresh, isShowingDetail, onToggleDetail 
   });
 
   const accessories: List.Item.Accessory[] = [];
+
+  if (chat.isForum) {
+    accessories.push({ icon: Icon.Hashtag, tooltip: "Forum group" });
+  }
 
   if (chat.unreadCount > 0) {
     accessories.push({
@@ -45,10 +50,17 @@ export function ChatListItem({ chat, onRefresh, isShowingDetail, onToggleDetail 
       detail={isShowingDetail ? <ChatListItemDetail chat={chat} /> : undefined}
       actions={
         <ActionPanel>
-          <Action.Push icon={Icon.Message} title="View Messages" target={<ChatMessagesView chat={chat} />} />
+          <Action.Push
+            icon={chat.isForum ? Icon.Hashtag : Icon.Message}
+            title={chat.isForum ? "View Topics" : "View Messages"}
+            target={chat.isForum ? <ChatTopicsView chat={chat} /> : <ChatMessagesView chat={chat} />}
+          />
+          {chat.isForum ? (
+            <Action.Push icon={Icon.Message} title="View All Messages" target={<ChatMessagesView chat={chat} />} />
+          ) : null}
           <Action.Push
             icon={Icon.Pencil}
-            title="Send Message"
+            title={chat.isForum ? "Send to General" : "Send Message"}
             target={<SendMessageForm chat={chat} onSuccess={onRefresh} />}
             shortcut={{ modifiers: ["cmd"], key: "n" }}
           />

--- a/extensions/telegram/src/components/chat-message-list-item-detail.tsx
+++ b/extensions/telegram/src/components/chat-message-list-item-detail.tsx
@@ -1,18 +1,39 @@
-import { List } from "@raycast/api";
-import { ChatMessage, Chat } from "../services/telegram-client";
+import { Icon, List } from "@raycast/api";
+import { ChatMessage, Chat, ChatTopic } from "../services/telegram-client";
 import { buildMarkdownWithMedia } from "../utils/markdown";
+import { getMediaDisplayTitle } from "../utils/media";
 
 interface ChatMessageListItemDetailProps {
   message: ChatMessage;
   chat: Chat;
+  topic?: ChatTopic;
 }
 
-export function ChatMessageListItemDetail({ message }: ChatMessageListItemDetailProps) {
+export function ChatMessageListItemDetail({ message, chat, topic }: ChatMessageListItemDetailProps) {
+  const sender = message.isOutgoing ? "You" : message.senderName || chat.title;
   const markdown = buildMarkdownWithMedia({
-    prefix: message.senderName ? `**${message.senderName}**\n\n` : undefined,
+    prefix: `**${sender}**\n\n`,
     text: message.text,
     media: message.media,
   });
 
-  return <List.Item.Detail markdown={markdown} />;
+  return (
+    <List.Item.Detail
+      markdown={markdown}
+      metadata={
+        <List.Item.Detail.Metadata>
+          <List.Item.Detail.Metadata.Label title="Sender" text={sender} icon={Icon.Person} />
+          <List.Item.Detail.Metadata.Label title="Sent" text={message.date.toLocaleString()} icon={Icon.Clock} />
+          {topic ? <List.Item.Detail.Metadata.Label title="Topic" text={topic.title} icon={Icon.Hashtag} /> : null}
+          {message.media ? (
+            <List.Item.Detail.Metadata.Label
+              title="Attachment"
+              text={getMediaDisplayTitle(message.media.type)}
+              icon={Icon.Paperclip}
+            />
+          ) : null}
+        </List.Item.Detail.Metadata>
+      }
+    />
+  );
 }

--- a/extensions/telegram/src/components/chat-message-list-item.tsx
+++ b/extensions/telegram/src/components/chat-message-list-item.tsx
@@ -1,7 +1,7 @@
 import { List, ActionPanel, Action, Icon, Image } from "@raycast/api";
 import { getAvatarIcon } from "../utils/avatar";
 import { getMediaTypeIcon, getMediaDisplayTitle } from "../utils/media";
-import { ChatMessage, Chat } from "../services/telegram-client";
+import { ChatMessage, Chat, ChatTopic } from "../services/telegram-client";
 import { ChatMessageListItemDetail } from "./chat-message-list-item-detail";
 import { SendMessageForm } from "./send-message-form";
 import { ToggleDetailAction, RefreshAction } from "./actions";
@@ -9,31 +9,31 @@ import { ToggleDetailAction, RefreshAction } from "./actions";
 interface ChatMessageListItemProps {
   message: ChatMessage;
   chat: Chat;
+  topic?: ChatTopic;
   isShowingDetail: boolean;
   onRefresh: () => void;
   onToggleDetail: () => void;
+  onShowConversation: () => void;
 }
 
 export function ChatMessageListItem({
   message,
   chat,
+  topic,
   isShowingDetail,
   onRefresh,
   onToggleDetail,
+  onShowConversation,
 }: ChatMessageListItemProps) {
-  let displayTitle = message.text;
-  if (!displayTitle && message.media) {
-    displayTitle = getMediaDisplayTitle(message.media.type);
-  }
+  const sender = message.isOutgoing ? "You" : message.senderName || chat.title;
+  const displayTitle = message.text || (message.media ? getMediaDisplayTitle(message.media.type) : "Message");
 
   let icon: Image.ImageLike = Icon.Message;
 
-  if (message.media?.filePath && (message.media.type === "photo" || message.media.type === "image")) {
-    icon = { source: message.media.filePath };
-  } else if (message.senderName) {
+  if (message.senderName || message.isOutgoing) {
     icon = getAvatarIcon({
       photo: message.senderPhoto,
-      name: message.senderName,
+      name: sender,
       type: "private",
     });
   } else if (message.media) {
@@ -42,38 +42,37 @@ export function ChatMessageListItem({
 
   const accessories: List.Item.Accessory[] = [];
 
-  if (message.media?.filePath && (message.media.type === "photo" || message.media.type === "image")) {
+  if (message.media) {
     accessories.push({
-      icon: { source: message.media.filePath },
-    });
-  }
-
-  if (message.senderName) {
-    accessories.push({
-      text: message.senderName,
+      icon: getMediaTypeIcon(message.media.type),
+      tooltip: getMediaDisplayTitle(message.media.type),
     });
   }
 
   accessories.push({
-    date: message.date,
+    text: message.date.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" }),
+    tooltip: message.date.toLocaleString(),
   });
 
   return (
     <List.Item
       key={message.id}
+      id={message.id.toString()}
       icon={icon}
-      title={displayTitle}
+      title={sender}
+      subtitle={!isShowingDetail ? displayTitle : undefined}
       accessories={accessories}
-      detail={isShowingDetail ? <ChatMessageListItemDetail message={message} chat={chat} /> : undefined}
+      detail={isShowingDetail ? <ChatMessageListItemDetail message={message} chat={chat} topic={topic} /> : undefined}
       actions={
         <ActionPanel>
           <Action.Push
             icon={Icon.Pencil}
             title="Send Message"
-            target={<SendMessageForm chat={chat} onSuccess={onRefresh} />}
+            target={<SendMessageForm chat={chat} topic={topic} onSuccess={onRefresh} />}
             shortcut={{ modifiers: ["cmd"], key: "n" }}
           />
-          <Action.CopyToClipboard content={message.text} title="Copy Message" />
+          <Action icon={Icon.Bubble} title="Show Reading View" onAction={onShowConversation} />
+          {message.text ? <Action.CopyToClipboard content={message.text} title="Copy Message" /> : null}
           <ToggleDetailAction isShowingDetail={isShowingDetail} onToggle={onToggleDetail} />
           <RefreshAction onRefresh={onRefresh} />
         </ActionPanel>

--- a/extensions/telegram/src/components/chat-messages-view.tsx
+++ b/extensions/telegram/src/components/chat-messages-view.tsx
@@ -1,20 +1,24 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { List, Icon } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
-import { getChatMessages, Chat } from "../services/telegram-client";
+import { getChatMessages, Chat, ChatTopic } from "../services/telegram-client";
 import { getConfig, ensureAuthenticated } from "../utils/auth";
 import { groupMessagesByDate } from "../utils/message";
 import { ChatMessageListItem } from "./chat-message-list-item";
+import { ChatConversationView } from "./chat-conversation-view";
 import { useDetailToggle } from "../hooks/use-detail-toggle";
 
 const SHOW_DETAIL_KEY = "view_chat_messages_show_detail";
 
 interface ChatMessagesViewProps {
   chat: Chat;
+  topic?: ChatTopic;
 }
 
-export function ChatMessagesView({ chat }: ChatMessagesViewProps) {
+export function ChatMessagesView({ chat, topic }: ChatMessagesViewProps) {
   const [searchText, setSearchText] = useState("");
+  const [viewMode, setViewMode] = useState<"conversation" | "list">("list");
+  const [selectedMessageId, setSelectedMessageId] = useState<string>();
   const [isShowingDetail, handleToggleDetail] = useDetailToggle(SHOW_DETAIL_KEY);
 
   const {
@@ -22,49 +26,83 @@ export function ChatMessagesView({ chat }: ChatMessagesViewProps) {
     isLoading,
     revalidate,
   } = useCachedPromise(
-    async (chatId: string, query: string) => {
+    async (chatId: string, topicId: number | undefined, query: string) => {
       const authenticated = await ensureAuthenticated();
       if (!authenticated) {
         return [];
       }
 
       const config = getConfig();
-      return await getChatMessages({ config, chatId, limit: 50, searchQuery: query || undefined });
+      return await getChatMessages({ config, chatId, topicId, limit: 50, searchQuery: query || undefined });
     },
-    [chat.id, searchText],
+    [chat.id, topic?.id, searchText],
     {
       initialData: [],
     },
   );
 
-  const groupedMessages = groupMessagesByDate(messages);
+  const chronologicalMessages = useMemo(
+    () => [...messages].sort((left, right) => left.date.getTime() - right.date.getTime()),
+    [messages],
+  );
+  const groupedMessages = groupMessagesByDate(chronologicalMessages);
+  const destination = topic ? `${chat.title} · ${topic.title}` : chat.title;
+  const newestMessageId = chronologicalMessages.at(-1)?.id.toString();
+
+  useEffect(() => {
+    setSelectedMessageId(newestMessageId);
+  }, [chat.id, topic?.id, newestMessageId]);
+
+  if (viewMode === "conversation") {
+    return (
+      <ChatConversationView
+        chat={chat}
+        topic={topic}
+        messages={chronologicalMessages}
+        isLoading={isLoading}
+        onRefresh={revalidate}
+        onShowCompactList={() => setViewMode("list")}
+      />
+    );
+  }
 
   return (
     <List
       isLoading={isLoading}
-      searchBarPlaceholder={`Search messages in ${chat.title}...`}
+      searchBarPlaceholder={`Search messages in ${destination}...`}
       onSearchTextChange={setSearchText}
+      selectedItemId={selectedMessageId}
+      onSelectionChange={(id) => setSelectedMessageId(id ?? undefined)}
       isShowingDetail={isShowingDetail}
-      navigationTitle={chat.title}
+      navigationTitle={destination}
       throttle
     >
       {messages.length === 0 && !isLoading ? (
         <List.EmptyView
           icon={Icon.Message}
           title="No Messages"
-          description={searchText ? "No messages match your search." : "This chat has no messages yet."}
+          description={searchText ? "No messages match your search." : "This conversation has no messages yet."}
         />
       ) : (
         Array.from(groupedMessages.entries()).map(([dateKey, dateMessages]) => (
-          <List.Section key={dateKey} title={dateKey}>
+          <List.Section
+            key={dateKey}
+            title={dateKey}
+            subtitle={`${dateMessages.length} ${dateMessages.length === 1 ? "message" : "messages"}`}
+          >
             {dateMessages.map((message) => (
               <ChatMessageListItem
                 key={message.id}
                 message={message}
                 chat={chat}
+                topic={topic}
                 isShowingDetail={isShowingDetail}
                 onRefresh={revalidate}
                 onToggleDetail={handleToggleDetail}
+                onShowConversation={() => {
+                  setSearchText("");
+                  setViewMode("conversation");
+                }}
               />
             ))}
           </List.Section>

--- a/extensions/telegram/src/components/chat-topic-list-item.tsx
+++ b/extensions/telegram/src/components/chat-topic-list-item.tsx
@@ -1,0 +1,99 @@
+import { Action, ActionPanel, Color, Icon, List } from "@raycast/api";
+import { Chat, ChatTopic } from "../services/telegram-client";
+import { getMediaDisplayTitle } from "../utils/media";
+import { buildMarkdownWithMedia } from "../utils/markdown";
+import { ChatMessagesView } from "./chat-messages-view";
+import { SendMessageForm } from "./send-message-form";
+import { RefreshAction, ToggleDetailAction } from "./actions";
+
+interface ChatTopicListItemProps {
+  chat: Chat;
+  topic: ChatTopic;
+  isShowingDetail: boolean;
+  onRefresh: () => void;
+  onToggleDetail: () => void;
+}
+
+function topicColor(color: number): string {
+  return `#${color.toString(16).padStart(6, "0")}`;
+}
+
+function lastMessagePreview(topic: ChatTopic): string | undefined {
+  const message = topic.lastMessage;
+  if (!message) return undefined;
+
+  const body = message.text || (message.media ? getMediaDisplayTitle(message.media.type) : "Message");
+  const sender = message.isOutgoing ? "You" : message.senderName;
+  return sender ? `${sender}: ${body}` : body;
+}
+
+export function ChatTopicListItem({ chat, topic, isShowingDetail, onRefresh, onToggleDetail }: ChatTopicListItemProps) {
+  const preview = lastMessagePreview(topic);
+  const accessories: List.Item.Accessory[] = [];
+
+  if (topic.unreadCount > 0) {
+    accessories.push({ tag: { value: topic.unreadCount.toString(), color: Color.Blue } });
+  }
+  if (topic.unreadMentionsCount > 0) {
+    accessories.push({ tag: { value: `@${topic.unreadMentionsCount}`, color: Color.Orange } });
+  }
+  accessories.push({ date: topic.lastActivityDate });
+
+  const icon = topic.isClosed
+    ? Icon.Lock
+    : topic.id === 1
+      ? Icon.Message
+      : { source: Icon.Hashtag, tintColor: topicColor(topic.iconColor) };
+
+  const detailSender = topic.lastMessage?.isOutgoing ? "You" : topic.lastMessage?.senderName;
+  const detailMarkdown = buildMarkdownWithMedia({
+    prefix: detailSender ? `**${detailSender}**\n\n` : undefined,
+    text: topic.lastMessage?.text || "No recent message preview is available.",
+    media: topic.lastMessage?.media,
+  });
+
+  return (
+    <List.Item
+      icon={icon}
+      title={topic.title}
+      subtitle={!isShowingDetail ? preview : undefined}
+      accessories={accessories}
+      detail={
+        isShowingDetail ? (
+          <List.Item.Detail
+            markdown={detailMarkdown}
+            metadata={
+              <List.Item.Detail.Metadata>
+                <List.Item.Detail.Metadata.Label title="Topic" text={topic.title} icon={Icon.Hashtag} />
+                <List.Item.Detail.Metadata.Label
+                  title="Status"
+                  text={topic.isClosed ? "Closed" : topic.isHidden ? "Hidden" : "Open"}
+                  icon={topic.isClosed ? Icon.Lock : Icon.CheckCircle}
+                />
+                <List.Item.Detail.Metadata.Label title="Unread" text={topic.unreadCount.toString()} />
+                <List.Item.Detail.Metadata.Label title="Last Activity" text={topic.lastActivityDate.toLocaleString()} />
+              </List.Item.Detail.Metadata>
+            }
+          />
+        ) : undefined
+      }
+      actions={
+        <ActionPanel>
+          <Action.Push
+            icon={Icon.Message}
+            title="View Topic Messages"
+            target={<ChatMessagesView chat={chat} topic={topic} />}
+          />
+          <Action.Push
+            icon={Icon.Pencil}
+            title="Send Message to Topic"
+            target={<SendMessageForm chat={chat} topic={topic} onSuccess={onRefresh} />}
+            shortcut={{ modifiers: ["cmd"], key: "n" }}
+          />
+          <ToggleDetailAction isShowingDetail={isShowingDetail} onToggle={onToggleDetail} />
+          <RefreshAction onRefresh={onRefresh} />
+        </ActionPanel>
+      }
+    />
+  );
+}

--- a/extensions/telegram/src/components/chat-topics-view.tsx
+++ b/extensions/telegram/src/components/chat-topics-view.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import { Icon, List } from "@raycast/api";
+import { useCachedPromise } from "@raycast/utils";
+import { Chat, getChatTopics } from "../services/telegram-client";
+import { getConfig, ensureAuthenticated } from "../utils/auth";
+import { useDetailToggle } from "../hooks/use-detail-toggle";
+import { ChatTopicListItem } from "./chat-topic-list-item";
+
+const SHOW_DETAIL_KEY = "view_chat_topics_show_detail";
+
+interface ChatTopicsViewProps {
+  chat: Chat;
+}
+
+export function ChatTopicsView({ chat }: ChatTopicsViewProps) {
+  const [searchText, setSearchText] = useState("");
+  const [isShowingDetail, handleToggleDetail] = useDetailToggle(SHOW_DETAIL_KEY);
+
+  const {
+    data: topics,
+    isLoading,
+    revalidate,
+  } = useCachedPromise(
+    async (chatId: string, query: string) => {
+      const authenticated = await ensureAuthenticated();
+      if (!authenticated) {
+        return [];
+      }
+
+      return await getChatTopics({
+        config: getConfig(),
+        chatId,
+        limit: 100,
+        searchQuery: query || undefined,
+      });
+    },
+    [chat.id, searchText],
+    { initialData: [] },
+  );
+
+  const pinnedTopics = topics.filter((topic) => topic.isPinned);
+  const otherTopics = topics.filter((topic) => !topic.isPinned);
+
+  return (
+    <List
+      isLoading={isLoading}
+      searchBarPlaceholder={`Search topics in ${chat.title}...`}
+      onSearchTextChange={setSearchText}
+      isShowingDetail={isShowingDetail}
+      navigationTitle={`${chat.title} · Topics`}
+      throttle
+    >
+      {topics.length === 0 && !isLoading ? (
+        <List.EmptyView
+          icon={Icon.Hashtag}
+          title={searchText ? "No Topics Found" : "No Topics"}
+          description={searchText ? "No topics match your search." : "This forum group has no visible topics."}
+        />
+      ) : (
+        <>
+          {pinnedTopics.length > 0 ? (
+            <List.Section title="Pinned" subtitle={`${pinnedTopics.length}`}>
+              {pinnedTopics.map((topic) => (
+                <ChatTopicListItem
+                  key={topic.id}
+                  chat={chat}
+                  topic={topic}
+                  isShowingDetail={isShowingDetail}
+                  onRefresh={revalidate}
+                  onToggleDetail={handleToggleDetail}
+                />
+              ))}
+            </List.Section>
+          ) : null}
+          {otherTopics.length > 0 ? (
+            <List.Section title="Topics" subtitle={`${otherTopics.length}`}>
+              {otherTopics.map((topic) => (
+                <ChatTopicListItem
+                  key={topic.id}
+                  chat={chat}
+                  topic={topic}
+                  isShowingDetail={isShowingDetail}
+                  onRefresh={revalidate}
+                  onToggleDetail={handleToggleDetail}
+                />
+              ))}
+            </List.Section>
+          ) : null}
+        </>
+      )}
+    </List>
+  );
+}

--- a/extensions/telegram/src/components/send-message-form.tsx
+++ b/extensions/telegram/src/components/send-message-form.tsx
@@ -1,20 +1,23 @@
 import { Form, ActionPanel, Action, Icon, showToast, Toast, popToRoot } from "@raycast/api";
-import { Chat } from "../services/telegram-client";
+import { Chat, ChatTopic } from "../services/telegram-client";
 import { useSendMessage } from "../hooks/use-send-message";
 
 interface SendMessageFormProps {
   chat: Chat;
+  topic?: ChatTopic;
   onSuccess?: () => void;
 }
 
-export function SendMessageForm({ chat, onSuccess }: SendMessageFormProps) {
+export function SendMessageForm({ chat, topic, onSuccess }: SendMessageFormProps) {
+  const destination = topic ? `${chat.title} · ${topic.title}` : chat.title;
   const { handleSubmit, itemProps, isSubmitting } = useSendMessage({
     chatId: chat.id,
+    topicId: topic?.id,
     onSuccess: async () => {
       await showToast({
         style: Toast.Style.Success,
         title: "Message Sent",
-        message: `Message sent to ${chat.title}`,
+        message: `Message sent to ${destination}`,
       });
 
       onSuccess?.();
@@ -25,7 +28,7 @@ export function SendMessageForm({ chat, onSuccess }: SendMessageFormProps) {
   return (
     <Form
       isLoading={isSubmitting}
-      navigationTitle={`Send Message to ${chat.title}`}
+      navigationTitle={`Send to ${destination}`}
       actions={
         <ActionPanel>
           <Action.SubmitForm icon={Icon.ArrowRight} title="Send Message" onSubmit={handleSubmit} />

--- a/extensions/telegram/src/hooks/use-send-message.ts
+++ b/extensions/telegram/src/hooks/use-send-message.ts
@@ -12,11 +12,12 @@ interface SendMessageFormValues {
 
 interface UseSendMessageOptions {
   chatId: string;
+  topicId?: number;
   onBeforeSubmit?: () => Promise<boolean> | boolean;
   onSuccess?: (params: { chatId: string; message: string }) => Promise<void> | void;
 }
 
-export function useSendMessage({ chatId, onBeforeSubmit, onSuccess }: UseSendMessageOptions) {
+export function useSendMessage({ chatId, topicId, onBeforeSubmit, onSuccess }: UseSendMessageOptions) {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const { handleSubmit, itemProps } = useForm<SendMessageFormValues>({
@@ -32,6 +33,7 @@ export function useSendMessage({ chatId, onBeforeSubmit, onSuccess }: UseSendMes
       try {
         await handleSendMessage({
           chatId,
+          topicId,
           message: values.message,
           files: values.files,
         });
@@ -75,10 +77,12 @@ function validateFiles(files: string[] | undefined): string | undefined {
 
 async function handleSendMessage({
   chatId,
+  topicId,
   message,
   files,
 }: {
   chatId: string;
+  topicId?: number;
   message: string;
   files: string[];
 }): Promise<void> {
@@ -92,6 +96,7 @@ async function handleSendMessage({
   await sendMessage({
     config,
     chatId,
+    topicId,
     message,
     filePaths: files || [],
   });

--- a/extensions/telegram/src/send-message.tsx
+++ b/extensions/telegram/src/send-message.tsx
@@ -1,31 +1,45 @@
 import { useState } from "react";
 import { Form, ActionPanel, Action, Icon, showToast, Toast, popToRoot } from "@raycast/api";
-import { useCachedPromise } from "@raycast/utils";
-import { getChats } from "./services/telegram-client";
+import { useCachedPromise, usePromise } from "@raycast/utils";
+import { getChats, getChatTopics } from "./services/telegram-client";
 import { getConfig, ensureAuthenticated } from "./utils/auth";
 import { useSendMessage } from "./hooks/use-send-message";
 
 export default function SendMessage() {
   const [selectedChatId, setSelectedChatId] = useState<string>("");
+  const [selectedTopicId, setSelectedTopicId] = useState<string>("");
 
-  const { data: chats, isLoading: isLoadingChats } = useCachedPromise(
-    async () => {
+  const { data: chats = [], isLoading: isLoadingChats } = usePromise(async () => {
+    const authenticated = await ensureAuthenticated();
+    if (!authenticated) {
+      return [];
+    }
+
+    const config = getConfig();
+    return await getChats({ config, limit: 100 });
+  }, []);
+
+  const selectedChat = chats.find((chat) => chat.id === selectedChatId);
+  const { data: topics, isLoading: isLoadingTopics } = useCachedPromise(
+    async (chatId: string) => {
+      if (!chatId || !chats.find((chat) => chat.id === chatId)?.isForum) {
+        return [];
+      }
+
       const authenticated = await ensureAuthenticated();
       if (!authenticated) {
         return [];
       }
 
-      const config = getConfig();
-      return await getChats({ config, limit: 100 });
+      return await getChatTopics({ config: getConfig(), chatId });
     },
-    [],
-    {
-      initialData: [],
-    },
+    [selectedChatId],
+    { initialData: [] },
   );
 
   const { handleSubmit, itemProps, isSubmitting } = useSendMessage({
     chatId: selectedChatId,
+    topicId: selectedTopicId ? Number(selectedTopicId) : undefined,
     onBeforeSubmit: async () => {
       if (!selectedChatId) {
         await showToast({
@@ -35,14 +49,23 @@ export default function SendMessage() {
         });
         return false;
       }
+      if (selectedChat?.isForum && !selectedTopicId) {
+        await showToast({
+          style: Toast.Style.Failure,
+          title: "No Topic Selected",
+          message: "Please select a topic in this forum group",
+        });
+        return false;
+      }
       return true;
     },
     onSuccess: async ({ chatId }) => {
       const selectedChat = chats.find((chat) => chat.id === chatId);
+      const selectedTopic = topics.find((topic) => topic.id.toString() === selectedTopicId);
       await showToast({
         style: Toast.Style.Success,
         title: "Message Sent",
-        message: `Message sent to ${selectedChat?.title || "chat"}`,
+        message: `Message sent to ${selectedTopic ? `${selectedChat?.title} · ${selectedTopic.title}` : selectedChat?.title || "chat"}`,
       });
       await popToRoot();
     },
@@ -50,7 +73,7 @@ export default function SendMessage() {
 
   return (
     <Form
-      isLoading={isLoadingChats || isSubmitting}
+      isLoading={isLoadingChats || isLoadingTopics || isSubmitting}
       actions={
         <ActionPanel>
           <Action.SubmitForm icon={Icon.ArrowRight} title="Send Message" onSubmit={handleSubmit} />
@@ -62,7 +85,10 @@ export default function SendMessage() {
         title="Chat"
         placeholder="Select a chat"
         value={selectedChatId}
-        onChange={setSelectedChatId}
+        onChange={(chatId) => {
+          setSelectedChatId(chatId);
+          setSelectedTopicId("");
+        }}
       >
         {chats
           .filter((chat) => chat.isPinned)
@@ -86,6 +112,25 @@ export default function SendMessage() {
             />
           ))}
       </Form.Dropdown>
+
+      {selectedChat?.isForum ? (
+        <Form.Dropdown
+          id="topic"
+          title="Topic"
+          placeholder="Select a topic"
+          value={selectedTopicId}
+          onChange={setSelectedTopicId}
+        >
+          {topics.map((topic) => (
+            <Form.Dropdown.Item
+              key={topic.id}
+              value={topic.id.toString()}
+              title={topic.title}
+              icon={topic.isClosed ? Icon.Lock : Icon.Hashtag}
+            />
+          ))}
+        </Form.Dropdown>
+      ) : null}
 
       <Form.TextArea title="Message" placeholder="Enter your message..." enableMarkdown {...itemProps.message} />
 

--- a/extensions/telegram/src/services/telegram-client.ts
+++ b/extensions/telegram/src/services/telegram-client.ts
@@ -55,6 +55,7 @@ export interface ChatMessage {
   senderId?: string;
   senderName?: string;
   senderPhoto?: string;
+  isOutgoing: boolean;
 }
 
 export interface Chat {
@@ -65,6 +66,21 @@ export interface Chat {
   unreadCount: number;
   photo?: string;
   isPinned: boolean;
+  isForum: boolean;
+}
+
+export interface ChatTopic {
+  id: number;
+  title: string;
+  iconColor: number;
+  iconEmojiId?: string;
+  lastMessage?: ChatMessage;
+  lastActivityDate: Date;
+  unreadCount: number;
+  unreadMentionsCount: number;
+  isPinned: boolean;
+  isClosed: boolean;
+  isHidden: boolean;
 }
 
 export interface TelegramConfig {
@@ -82,6 +98,15 @@ export interface GetChatsOptions {
 export interface GetMessagesOptions {
   config: TelegramConfig;
   chatId: string;
+  topicId?: number;
+  limit?: number;
+  searchQuery?: string;
+  skipMediaDownload?: boolean;
+}
+
+export interface GetChatTopicsOptions {
+  config: TelegramConfig;
+  chatId: string;
   limit?: number;
   searchQuery?: string;
   skipMediaDownload?: boolean;
@@ -97,6 +122,7 @@ export interface GetSavedMessagesOptions {
 export interface SendMessageOptions {
   config: TelegramConfig;
   chatId: string;
+  topicId?: number;
   message: string;
   filePaths?: string | string[];
 }
@@ -459,23 +485,34 @@ async function processChatMessage(
   let senderName: string | undefined;
   let senderPhoto: string | undefined;
 
-  // Try to get sender info from fromId
-  if (msg.fromId && msg.fromId instanceof Api.PeerUser) {
-    senderId = msg.fromId.userId.toString();
+  // Resolve users as well as chats/channels that are allowed to post as the sender.
+  if (msg.fromId) {
     try {
-      const user = await client.getEntity(msg.fromId.userId);
-      if (user instanceof Api.User) {
-        senderName = user.firstName || "";
-        if (user.lastName) senderName += ` ${user.lastName}`;
+      const sender = await client.getEntity(msg.fromId);
+      senderId = sender.id.toString();
 
-        if (user.deleted) {
+      if (sender instanceof Api.User) {
+        senderName = sender.firstName || "";
+        if (sender.lastName) senderName += ` ${sender.lastName}`;
+
+        if (sender.deleted) {
           senderName = "Deleted Account";
         } else if (!senderName.trim()) {
           senderName = "Unknown User";
         }
 
-        if (!skipMediaDownload && user.photo && "photoId" in user.photo) {
-          senderPhoto = await downloadProfilePhoto(client, user, user.id.toString(), "profile");
+        if (!skipMediaDownload && sender.photo && "photoId" in sender.photo) {
+          senderPhoto = await downloadProfilePhoto(client, sender, sender.id.toString(), "profile");
+        }
+      } else if (sender instanceof Api.Channel) {
+        senderName = sender.title;
+        if (!skipMediaDownload && sender.photo && "photoId" in sender.photo) {
+          senderPhoto = await downloadProfilePhoto(client, sender, sender.id.toString(), "channel");
+        }
+      } else if (sender instanceof Api.Chat) {
+        senderName = sender.title;
+        if (!skipMediaDownload && sender.photo && "photoId" in sender.photo) {
+          senderPhoto = await downloadProfilePhoto(client, sender, sender.id.toString(), "chat");
         }
       }
     } catch (error) {
@@ -507,6 +544,7 @@ async function processChatMessage(
     senderId,
     senderName,
     senderPhoto,
+    isOutgoing: Boolean(msg.out),
   };
 }
 
@@ -539,7 +577,7 @@ export async function getSavedMessages(options: GetSavedMessagesOptions): Promis
 }
 
 export async function getChatMessages(options: GetMessagesOptions): Promise<ChatMessage[]> {
-  const { config, chatId, limit = 50, searchQuery, skipMediaDownload = false } = options;
+  const { config, chatId, topicId, limit = 50, searchQuery, skipMediaDownload = false } = options;
 
   const client = await getClient(config);
 
@@ -548,11 +586,16 @@ export async function getChatMessages(options: GetMessagesOptions): Promise<Chat
   }
 
   const messages = await client.getMessages(chatId, {
-    limit,
-    search: searchQuery || undefined,
+    limit: topicId && searchQuery ? Math.max(limit, 100) : limit,
+    search: topicId ? undefined : searchQuery || undefined,
+    replyTo: topicId,
   });
 
-  const filteredMessages = messages.filter((msg) => msg.message || msg.media);
+  const normalizedQuery = searchQuery?.trim().toLocaleLowerCase();
+  const filteredMessages = messages
+    .filter((msg) => msg.message || msg.media)
+    .filter((msg) => !normalizedQuery || msg.message.toLocaleLowerCase().includes(normalizedQuery))
+    .slice(0, limit);
 
   // Get the chat entity to know who the chat partner is
   const entity = await client.getEntity(chatId);
@@ -564,6 +607,68 @@ export async function getChatMessages(options: GetMessagesOptions): Promise<Chat
   );
 
   return processedMessages;
+}
+
+export async function getChatTopics(options: GetChatTopicsOptions): Promise<ChatTopic[]> {
+  const { config, chatId, limit = 100, searchQuery, skipMediaDownload = false } = options;
+
+  const client = await getClient(config);
+
+  if (!client.connected) {
+    await client.connect();
+  }
+
+  const entity = await client.getEntity(chatId);
+  if (!(entity instanceof Api.Channel) || !entity.forum) {
+    return [];
+  }
+
+  const result = await client.invoke(
+    new Api.channels.GetForumTopics({
+      channel: entity,
+      q: searchQuery?.trim() || undefined,
+      offsetDate: 0,
+      offsetId: 0,
+      offsetTopic: 0,
+      limit,
+    }),
+  );
+
+  const messagesById = new Map(
+    result.messages
+      .filter((message): message is Api.Message => message instanceof Api.Message)
+      .map((message) => [message.id, message]),
+  );
+
+  const topics = await Promise.all(
+    result.topics
+      .filter((topic): topic is Api.ForumTopic => topic instanceof Api.ForumTopic)
+      .map(async (topic): Promise<ChatTopic> => {
+        const lastApiMessage = messagesById.get(topic.topMessage);
+        const lastMessage = lastApiMessage
+          ? await processChatMessage(client, lastApiMessage, skipMediaDownload, entity)
+          : undefined;
+
+        return {
+          id: topic.id,
+          title: topic.title,
+          iconColor: topic.iconColor,
+          iconEmojiId: topic.iconEmojiId?.toString(),
+          lastMessage,
+          lastActivityDate: lastMessage?.date || new Date(topic.date * 1000),
+          unreadCount: topic.unreadCount,
+          unreadMentionsCount: topic.unreadMentionsCount,
+          isPinned: Boolean(topic.pinned),
+          isClosed: Boolean(topic.closed),
+          isHidden: Boolean(topic.hidden),
+        };
+      }),
+  );
+
+  return topics.sort((a, b) => {
+    if (a.isPinned !== b.isPinned) return a.isPinned ? -1 : 1;
+    return b.lastActivityDate.getTime() - a.lastActivityDate.getTime();
+  });
 }
 
 export async function getChats(options: GetChatsOptions): Promise<Chat[]> {
@@ -630,6 +735,7 @@ export async function getChats(options: GetChatsOptions): Promise<Chat[]> {
         unreadCount: dialog.unreadCount,
         photo,
         isPinned: dialog.pinned || false,
+        isForum: entity instanceof Api.Channel && Boolean(entity.forum),
       };
     }),
   );
@@ -674,6 +780,7 @@ export async function getChatById(config: TelegramConfig, chatId: string): Promi
       type,
       unreadCount: 0,
       isPinned: false,
+      isForum: entity instanceof Api.Channel && Boolean(entity.forum),
     };
   } catch (error) {
     console.error("Failed to get chat by ID:", error);
@@ -682,7 +789,7 @@ export async function getChatById(config: TelegramConfig, chatId: string): Promi
 }
 
 export async function sendMessage(options: SendMessageOptions): Promise<void> {
-  const { config, chatId, message, filePaths } = options;
+  const { config, chatId, topicId, message, filePaths } = options;
 
   const client = await getClient(config);
 
@@ -693,7 +800,7 @@ export async function sendMessage(options: SendMessageOptions): Promise<void> {
   const files = filePaths ? (Array.isArray(filePaths) ? filePaths : [filePaths]) : [];
 
   if (files.length === 0) {
-    await client.sendMessage(chatId, { message });
+    await client.sendMessage(chatId, { message, replyTo: topicId });
     return;
   }
 
@@ -701,6 +808,7 @@ export async function sendMessage(options: SendMessageOptions): Promise<void> {
   await client.sendMessage(chatId, {
     message,
     file: files[0],
+    replyTo: topicId,
   });
 
   // If there are more files, send them in separate messages
@@ -709,6 +817,7 @@ export async function sendMessage(options: SendMessageOptions): Promise<void> {
       await client.sendMessage(chatId, {
         message: "",
         file: files[i],
+        replyTo: topicId,
       });
     }
   }

--- a/extensions/telegram/src/services/telegram-client.ts
+++ b/extensions/telegram/src/services/telegram-client.ts
@@ -3,6 +3,7 @@ import { StringSession } from "telegram/sessions";
 import { LocalStorage, environment } from "@raycast/api";
 import { Api } from "telegram/tl";
 import { computeCheck } from "telegram/Password";
+import { generateRandomBigInt } from "telegram/Helpers";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -585,13 +586,39 @@ export async function getChatMessages(options: GetMessagesOptions): Promise<Chat
     await client.connect();
   }
 
-  const messages = await client.getMessages(chatId, {
-    limit: topicId && searchQuery ? Math.max(limit, 100) : limit,
-    search: topicId ? undefined : searchQuery || undefined,
-    replyTo: topicId,
-  });
-
   const normalizedQuery = searchQuery?.trim().toLocaleLowerCase();
+  let messages: Api.Message[];
+
+  if (topicId && normalizedQuery) {
+    const searchResult = await client.invoke(
+      new Api.messages.Search({
+        peer: await client.getInputEntity(chatId),
+        q: searchQuery!.trim(),
+        topMsgId: topicId,
+        filter: new Api.InputMessagesFilterEmpty(),
+        minDate: 0,
+        maxDate: 0,
+        offsetId: 0,
+        addOffset: 0,
+        limit,
+        maxId: 0,
+        minId: 0,
+        hash: generateRandomBigInt(),
+      }),
+    );
+
+    messages =
+      "messages" in searchResult
+        ? searchResult.messages.filter((message): message is Api.Message => message instanceof Api.Message)
+        : [];
+  } else {
+    messages = await client.getMessages(chatId, {
+      limit,
+      search: searchQuery || undefined,
+      replyTo: topicId,
+    });
+  }
+
   const filteredMessages = messages
     .filter((msg) => msg.message || msg.media)
     .filter((msg) => !normalizedQuery || msg.message.toLocaleLowerCase().includes(normalizedQuery))

--- a/extensions/telegram/src/tools/analyze-messages.tsx
+++ b/extensions/telegram/src/tools/analyze-messages.tsx
@@ -9,6 +9,7 @@ import { handleTelegramError } from "../utils/errors";
 
 interface Arguments {
   chatId: string;
+  topicId?: number;
   query: string;
   limit?: number;
 }
@@ -19,7 +20,7 @@ interface Preferences {
 
 export default async function AnalyzeMessages(args: Arguments) {
   try {
-    const { chatId, query } = args;
+    const { chatId, topicId, query } = args;
     let limit = args.limit ?? 20;
 
     // Cap limit to prevent excessive token usage, middle-out will handle overflow gracefully
@@ -48,7 +49,7 @@ export default async function AnalyzeMessages(args: Arguments) {
     }
 
     const config = getConfig();
-    const messages = await getChatMessages({ config, chatId, limit, skipMediaDownload: false });
+    const messages = await getChatMessages({ config, chatId, topicId, limit, skipMediaDownload: false });
 
     const messageContext = messages
       .map((msg, idx) => {

--- a/extensions/telegram/src/tools/browse-chats.tsx
+++ b/extensions/telegram/src/tools/browse-chats.tsx
@@ -17,6 +17,7 @@ export default async function BrowseChats() {
         id: chat.id,
         title: chat.title,
         type: chat.type,
+        isForum: chat.isForum,
         lastMessage: chat.lastMessage?.text,
         lastMessageDate: chat.lastMessage?.date?.toISOString(),
         isPinned: chat.isPinned,

--- a/extensions/telegram/src/tools/browse-topics.tsx
+++ b/extensions/telegram/src/tools/browse-topics.tsx
@@ -1,0 +1,52 @@
+import { getChatById, getChatTopics } from "../services/telegram-client";
+import { getConfig, ensureAuthenticated } from "../utils/auth";
+import { handleTelegramError } from "../utils/errors";
+
+interface Arguments {
+  chatId: string;
+  query?: string;
+}
+
+export default async function BrowseTopics(args: Arguments) {
+  try {
+    const { chatId, query } = args;
+    if (!chatId) {
+      throw new Error("Chat ID is required");
+    }
+
+    const authenticated = await ensureAuthenticated();
+    if (!authenticated) {
+      throw new Error("Not authenticated with Telegram. Please run the 'Authenticate with Telegram' command first.");
+    }
+
+    const config = getConfig();
+    const chat = await getChatById(config, chatId);
+    if (!chat?.isForum) {
+      throw new Error("This chat is not a forum group");
+    }
+
+    const topics = await getChatTopics({
+      config,
+      chatId,
+      searchQuery: query,
+      skipMediaDownload: true,
+    });
+
+    return {
+      chat: { id: chat.id, title: chat.title },
+      topics: topics.map((topic) => ({
+        id: topic.id,
+        title: topic.title,
+        lastMessage: topic.lastMessage?.text,
+        lastMessageSender: topic.lastMessage?.isOutgoing ? "You" : topic.lastMessage?.senderName,
+        lastActivityDate: topic.lastActivityDate.toISOString(),
+        unreadCount: topic.unreadCount,
+        unreadMentionsCount: topic.unreadMentionsCount,
+        isPinned: topic.isPinned,
+        isClosed: topic.isClosed,
+      })),
+    };
+  } catch (error) {
+    return handleTelegramError(error);
+  }
+}

--- a/extensions/telegram/src/tools/read-messages.tsx
+++ b/extensions/telegram/src/tools/read-messages.tsx
@@ -4,12 +4,13 @@ import { handleTelegramError } from "../utils/errors";
 
 interface Arguments {
   chatId: string;
+  topicId?: number;
   limit?: number;
 }
 
 export default async function ReadMessages(args: Arguments) {
   try {
-    const { chatId, limit = 20 } = args;
+    const { chatId, topicId, limit = 20 } = args;
 
     if (!chatId) {
       throw new Error("Chat ID is required");
@@ -21,7 +22,7 @@ export default async function ReadMessages(args: Arguments) {
     }
 
     const config = getConfig();
-    const messages = await getChatMessages({ config, chatId, limit, skipMediaDownload: true });
+    const messages = await getChatMessages({ config, chatId, topicId, limit, skipMediaDownload: true });
 
     return {
       messages: messages.map((msg) => ({
@@ -29,6 +30,7 @@ export default async function ReadMessages(args: Arguments) {
         text: msg.text,
         senderName: msg.senderName,
         senderId: msg.senderId,
+        isOutgoing: msg.isOutgoing,
         date: msg.date.toISOString(),
         media: msg.media
           ? {

--- a/extensions/telegram/src/tools/send-message.tsx
+++ b/extensions/telegram/src/tools/send-message.tsx
@@ -8,13 +8,14 @@ import { handleTelegramError } from "../utils/errors";
 
 interface Arguments {
   chatId: string;
+  topicId?: number;
   message: string;
   useClipboardFile?: boolean;
 }
 
 export default async function SendMessage(args: Arguments) {
   try {
-    const { chatId, message, useClipboardFile } = args;
+    const { chatId, topicId, message, useClipboardFile } = args;
 
     if (!chatId) {
       throw new Error("Chat ID is required");
@@ -39,7 +40,7 @@ export default async function SendMessage(args: Arguments) {
     }
 
     const config = getConfig();
-    await sendMessage({ config, chatId, message, filePaths: filePath });
+    await sendMessage({ config, chatId, topicId, message, filePaths: filePath });
 
     return {
       message: "Message sent successfully",
@@ -55,6 +56,7 @@ export const confirmation: Tool.Confirmation<Arguments> = async (input) => {
 
   const infoItems = [
     { name: "To", value: chat?.title || input.chatId },
+    ...(input.topicId ? [{ name: "Topic ID", value: input.topicId.toString() }] : []),
     { name: "Message", value: input.message },
   ];
 

--- a/extensions/telegram/src/utils/avatar.ts
+++ b/extensions/telegram/src/utils/avatar.ts
@@ -1,4 +1,6 @@
 import { Icon, Image, Color } from "@raycast/api";
+import { existsSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 
 export interface AvatarOptions {
   photo?: string;
@@ -6,9 +8,31 @@ export interface AvatarOptions {
   type?: "private" | "group" | "supergroup" | "channel";
 }
 
+function getFallbackIcon(type: AvatarOptions["type"]): Icon {
+  switch (type) {
+    case "private":
+      return Icon.PersonCircle;
+    case "group":
+    case "supergroup":
+      return Icon.TwoPeople;
+    case "channel":
+      return Icon.Megaphone;
+    default:
+      return Icon.Message;
+  }
+}
+
 export function getAvatarIcon(options: AvatarOptions): Image.ImageLike {
-  if (options.photo) {
-    return { source: options.photo, mask: Image.Mask.Circle };
+  const fallbackIcon = getFallbackIcon(options.type);
+
+  if (options.photo && existsSync(options.photo)) {
+    return {
+      // Raycast's Windows renderer expects local images as file URLs. Passing
+      // the raw C:\\... path results in an empty placeholder icon.
+      source: pathToFileURL(options.photo).href,
+      fallback: fallbackIcon,
+      mask: Image.Mask.Circle,
+    };
   }
 
   // Generate a consistent color based on name
@@ -21,21 +45,8 @@ export function getAvatarIcon(options: AvatarOptions): Image.ImageLike {
   }
   const colorIndex = Math.abs(hash) % colors.length;
 
-  // Use different icons based on type
-  let iconSource: Icon;
-  switch (options.type) {
-    case "private":
-      iconSource = Icon.PersonCircle;
-      break;
-    case "group":
-      iconSource = Icon.Message;
-      break;
-    default:
-      iconSource = Icon.Message;
-  }
-
   return {
-    source: iconSource,
+    source: fallbackIcon,
     tintColor: colors[colorIndex],
   };
 }


### PR DESCRIPTION
## Description

This PR improves the existing Telegram extension with support for forum topics and a more organized message reading experience.

### What changed

- Add searchable topic navigation for forum-enabled Telegram groups
- Show pinned topics, unread counts, mentions, recent-message previews, and topic status
- Display messages chronologically, grouped by date, with the newest message focused at the bottom
- Improve message rows with sender avatars, media indicators, timestamps, and clearer previews
- Add an optional reading view for scanning a conversation as a transcript
- Support sending text and attachments directly to a specific forum topic
- Add topic support to the `browse-topics`, `read-messages`, `send-message`, and `analyze-messages` AI tools
- Preserve the existing behavior for private chats, regular groups, and Saved Messages

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with the [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)