### PR TITLE
feat: add One to the MCP registry extension

### DIFF
--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Model Context Protocol Registry Changelog
 
-## [Add One MCP Server] - 2026-08-20
+## [Add One MCP Server] - {PR_MERGE_DATE}
 
 Add One to the official registry, connecting AI assistants to 700+ apps through four tools: list connected accounts, search a platform's actions, read an action's real API documentation, and execute it. The remote Streamable HTTP server uses One OAuth sign-in through an `mcp-remote` bridge.
 

--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Model Context Protocol Registry Changelog
 
+## [Add One MCP Server] - 2026-08-20
+
+Add One to the official registry, connecting AI assistants to 700+ apps through four tools: list connected accounts, search a platform's actions, read an action's real API documentation, and execute it. The remote Streamable HTTP server uses One OAuth sign-in through an `mcp-remote` bridge.
+
 ## [Add PostEverywhere MCP Server] - 2026-08-20
 
 - Added PostEverywhere (social media publishing to 11 platforms) to the official registry entries

--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Model Context Protocol Registry Changelog
 
-## [Add One MCP Server] - {PR_MERGE_DATE}
+## [Add One MCP Server] - 2026-08-21
 
 Add One to the official registry, connecting AI assistants to 700+ apps through four tools: list connected accounts, search a platform's actions, read an action's real API documentation, and execute it. The remote Streamable HTTP server uses One OAuth sign-in through an `mcp-remote` bridge.
 

--- a/extensions/model-context-protocol-registry/README.md
+++ b/extensions/model-context-protocol-registry/README.md
@@ -87,6 +87,7 @@ To add a new MCP registry to the registry, you need to create a new entry in the
 | [JobYap](https://jobyap.com/agents) | Search job postings aggregated from companies' official careers sites — salaries, locations, and a community discussion thread on every job. Remote Streamable HTTP MCP server; no auth required. |
 | [Tendem](https://github.com/Toloka/tendem-mcp) | Delegate tasks to vetted human experts - research, competitive analysis, fact-checking, copywriting, editing, design review, presentation polish, data cleaning and list building. Submit a task in natural language; Tendem's orchestrator scopes it and quotes a transparent price, and after explicit approval a vetted human expert executes it and returns verified results as markdown plus files. Remote Streamable HTTP MCP server with OAuth 2.0 sign-in on first use. |
 | [Structured](https://mcp.structured.app) | Structured is an all-in-one day planner that combines tasks and to-dos in a visual timeline. Its MCP server lets AI assistants view schedules and inbox tasks, and create, update, complete, delete, and manage recurring tasks. Remote Streamable HTTP server with Structured Cloud OAuth sign-in; some features require Structured Pro. |
+| [One](https://www.withone.ai/docs/mcp) | One connects AI tools to 700+ apps such as Gmail, Slack, Stripe, Shopify, HubSpot, Notion, and Linear through four tools: list connected accounts, search a platform's actions, read an action's real API documentation, and execute it. Remote Streamable HTTP server with One OAuth sign-in. |
 
 ### Community MCP Servers
 

--- a/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
+++ b/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
@@ -873,6 +873,21 @@ export const OFFICIAL_ENTRIES: RegistryEntry[] = [
       ],
     },
   },
+  {
+    name: "one",
+    title: "One",
+    description:
+      "One is an MCP server that connects your AI tools to 700+ apps like Gmail, Slack, Stripe, Shopify, HubSpot, Notion, and Linear. Four tools cover everything: list your connected accounts, search a platform's actions, read an action's real API documentation, and execute it. Remote Streamable HTTP server with One OAuth sign-in, so no API keys are stored locally.",
+    icon: "https://assets.withone.ai/logos/one-logo.png",
+    homepage: "https://www.withone.ai/docs/mcp",
+    configuration: {
+      command: "npx",
+      args: ["-y", "mcp-remote", "https://mcp.withone.ai/mcp"],
+      env: {
+        npm_config_yes: "true",
+      },
+    },
+  },
 ];
 
 export const COMMUNITY_ENTRIES: RegistryEntry[] = [


### PR DESCRIPTION
## Description

Adds One to the Official MCP Servers list in the Model Context Protocol Registry extension.

One is a hosted MCP server that connects AI tools to 700+ apps (Gmail, Slack, Stripe, Shopify, HubSpot, Notion, Linear, Salesforce, QuickBooks and more) through four tools: list connected accounts, search a platform's actions, read an action's real API documentation, and execute it. Actions are search-based, so the tool count stays at four no matter how many apps are connected.

It is a remote Streamable HTTP server with OAuth sign-in, so the entry uses the `mcp-remote` bridge, the same pattern as the existing Rube, Prisma, Circleback and Structured entries.

Submitted by One Systems, who maintain the server, so it goes in `OFFICIAL_ENTRIES`. The server is MIT licensed (https://github.com/withoneai/mcp) and published in the official MCP registry as `ai.withone/mcp`.

## Changes

- `src/registries/builtin/entries.ts`: new `OFFICIAL_ENTRIES` entry
- `README.md`: row in the Official MCP Servers table
- `CHANGELOG.md`: new entry

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I use the latest version of the Raycast API