### PR TITLE
Update ticktick extension quick add with date/list/priority syntax

### DIFF
--- a/extensions/ticktick/CHANGELOG.md
+++ b/extensions/ticktick/CHANGELOG.md
@@ -1,5 +1,9 @@
 # TickTick Changelog
 
+## [Added] - {PR_MERGE_DATE}
+
+- `Quick Add Task` now parses natural-language and `*` dates, `~list`/`^list`, and `!priority` syntax.
+
 ## [Fixed] - 2026-07-21
 
 - Added `Later` section in date group

--- a/extensions/ticktick/README.md
+++ b/extensions/ticktick/README.md
@@ -1,1 +1,23 @@
 # TickTick Extension
+
+Use Raycast to create, find, and complete tasks in the TickTick macOS app.
+
+## Quick Add Syntax
+
+The **Quick Add Task** command recognizes a practical subset of TickTick's quick-add syntax:
+
+| Input                             | Result                             |
+| --------------------------------- | ---------------------------------- |
+| `Call the client tomorrow at 9am` | Timed task due tomorrow at 9:00 AM |
+| `Review the report next Monday`   | All-day task due next Monday       |
+| `Send the invoice at 4pm`         | Timed task due today at 4:00 PM    |
+| `Submit expenses *2026-08-25`     | All-day task due August 25, 2026   |
+| `Prepare agenda ~Client Work`     | Task in the `Client Work` list     |
+| `Fix production issue !high`      | High-priority task                 |
+
+Both `~List Name` and `^List Name` select a list. Priorities can be written as `!high`, `!medium`,
+`!low`, `!1`, `!2`, `!3`, or repeated exclamation marks. Date-only phrases create all-day tasks, while a
+time without a date means today.
+
+Tags, recurring dates, and assignees are not parsed because the TickTick macOS AppleScript interface does
+not expose those fields when creating a task.

--- a/extensions/ticktick/README.md
+++ b/extensions/ticktick/README.md
@@ -16,8 +16,9 @@ The **Quick Add Task** command recognizes a practical subset of TickTick's quick
 | `Fix production issue !high`      | High-priority task                 |
 
 Both `~List Name` and `^List Name` select a list. Priorities can be written as `!high`, `!medium`,
-`!low`, `!1`, `!2`, `!3`, or repeated exclamation marks. Date-only phrases create all-day tasks, while a
-time without a date means today.
+`!low`, `!1`, `!2`, `!3`, or `!none`. Date-only phrases create all-day tasks, while a time without a date
+means today. Natural-language dates and times are previewed for confirmation before the task is created;
+dates and times prefixed with `*` are treated as explicit and created immediately.
 
 Tags, recurring dates, and assignees are not parsed because the TickTick macOS AppleScript interface does
 not expose those fields when creating a task.

--- a/extensions/ticktick/package.json
+++ b/extensions/ticktick/package.json
@@ -9,7 +9,8 @@
     "Alireza",
     "yakitrak",
     "ridemountainpig",
-    "harsh_varshney"
+    "harsh_varshney",
+    "jason_lemieux"
   ],
   "license": "MIT",
   "categories": [
@@ -119,12 +120,12 @@
       "name": "quickAdd",
       "title": "Quick Add Task",
       "subtitle": "TickTick",
-      "description": "Quick way to add task in TickTick.",
+      "description": "Quickly add a task using natural-language dates, *dates, ~lists, and !priorities.",
       "mode": "no-view",
       "arguments": [
         {
           "name": "text",
-          "placeholder": "Title",
+          "placeholder": "Task tomorrow at 9 ~Work !high",
           "type": "text",
           "required": true
         },
@@ -254,6 +255,7 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
+    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test tests/*.test.mts",
     "publish": "ray publish"
   },
   "platforms": [

--- a/extensions/ticktick/src/quickAdd.tsx
+++ b/extensions/ticktick/src/quickAdd.tsx
@@ -43,7 +43,7 @@ export default async function QuickAddTask(props: LaunchProps) {
           ? "Low"
           : "None";
       const confirmed = await confirmAlert({
-        title: "Create Parsed Task?",
+        title: "Create This Task?",
         message: [`Title: ${parsed.title}`, `Due: ${dueDate}`, `List: ${projectName}`, `Priority: ${priority}`].join(
           "\n"
         ),

--- a/extensions/ticktick/src/quickAdd.tsx
+++ b/extensions/ticktick/src/quickAdd.tsx
@@ -3,20 +3,25 @@ import { addTask } from "./service/osScript";
 import { getProjects, initGlobalProjectInfo } from "./service/project";
 import { getDefaultDate } from "./service/preference";
 import { formatToServerDate } from "./utils/date";
+import { parseQuickAdd } from "./utils/quickAddParser";
 
 export default async function QuickAddTask(props: LaunchProps) {
   const toast = new Toast({ style: Toast.Style.Animated, title: "Creating task" });
   await toast.show();
   try {
     await initGlobalProjectInfo();
-    const title = (props.arguments.text ?? props.fallbackText).replace(/"/g, `\\"`);
+    const projects = getProjects();
+    const parsed = parseQuickAdd(props.arguments.text ?? props.fallbackText, projects);
+    const title = parsed.title.replace(/"/g, `\\"`);
     const description = props.arguments.description?.replace(/"/g, `\\"`);
+    const defaultDate = getDefaultDate();
     const result = await addTask({
-      projectId: getProjects().find((project) => project.name === "Inbox")?.id || "",
+      projectId: parsed.projectId || projects.find((project) => project.name === "Inbox")?.id || "",
       title,
       description,
-      dueDate: formatToServerDate(getDefaultDate()),
-      isAllDay: false,
+      dueDate: formatToServerDate(parsed.dueDate || defaultDate),
+      isAllDay: parsed.dueDate ? parsed.isAllDay : false,
+      priority: parsed.priority,
     });
 
     switch (result) {

--- a/extensions/ticktick/src/quickAdd.tsx
+++ b/extensions/ticktick/src/quickAdd.tsx
@@ -1,4 +1,4 @@
-import { closeMainWindow, LaunchProps, Toast } from "@raycast/api";
+import { Alert, closeMainWindow, confirmAlert, LaunchProps, showToast, Toast } from "@raycast/api";
 import { addTask } from "./service/osScript";
 import { getProjects, initGlobalProjectInfo } from "./service/project";
 import { getDefaultDate } from "./service/preference";
@@ -6,25 +6,59 @@ import { formatToServerDate } from "./utils/date";
 import { parseQuickAdd } from "./utils/quickAddParser";
 
 export default async function QuickAddTask(props: LaunchProps) {
-  const toast = new Toast({ style: Toast.Style.Animated, title: "Creating task" });
   const closeAfterDelay = () => setTimeout(() => closeMainWindow(), 500);
-  await toast.show();
   try {
     await initGlobalProjectInfo();
     const projects = getProjects();
     const parsed = parseQuickAdd(props.arguments.text ?? props.fallbackText, projects);
     if (!parsed.title) {
-      toast.style = Toast.Style.Failure;
-      toast.title = "Task title required";
-      toast.message = "Add a title in addition to the date, list, or priority.";
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Task title required",
+        message: "Add a title in addition to the date, list, or priority.",
+      });
       closeAfterDelay();
       return;
     }
+
+    const inbox = projects.find((project) => project.name === "Inbox");
+    const projectId = parsed.projectId || inbox?.id || "";
+    const projectName = projects.find((project) => project.id === projectId)?.name || "Inbox";
+    const defaultDate = getDefaultDate();
+
+    if (parsed.requiresConfirmation && parsed.dueDate) {
+      const dueDate = new Intl.DateTimeFormat(undefined, {
+        weekday: "short",
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+        ...(parsed.isAllDay ? {} : { hour: "numeric", minute: "2-digit" }),
+      }).format(parsed.dueDate);
+      const priority =
+        parsed.priority === "5"
+          ? "High"
+          : parsed.priority === "3"
+          ? "Medium"
+          : parsed.priority === "1"
+          ? "Low"
+          : "None";
+      const confirmed = await confirmAlert({
+        title: "Create Parsed Task?",
+        message: [`Title: ${parsed.title}`, `Due: ${dueDate}`, `List: ${projectName}`, `Priority: ${priority}`].join(
+          "\n"
+        ),
+        primaryAction: { title: "Create Task" },
+        dismissAction: { title: "Cancel", style: Alert.ActionStyle.Cancel },
+      });
+
+      if (!confirmed) return;
+    }
+
+    const toast = await showToast({ style: Toast.Style.Animated, title: "Creating task" });
     const title = parsed.title.replace(/"/g, `\\"`);
     const description = props.arguments.description?.replace(/"/g, `\\"`);
-    const defaultDate = getDefaultDate();
     const result = await addTask({
-      projectId: parsed.projectId || projects.find((project) => project.name === "Inbox")?.id || "",
+      projectId,
       title,
       description,
       dueDate: formatToServerDate(parsed.dueDate || defaultDate),
@@ -47,8 +81,7 @@ export default async function QuickAddTask(props: LaunchProps) {
         break;
     }
   } catch (error) {
-    toast.style = Toast.Style.Failure;
-    toast.title = "Something went wrong";
+    await showToast({ style: Toast.Style.Failure, title: "Something went wrong" });
   }
   closeAfterDelay();
 }

--- a/extensions/ticktick/src/quickAdd.tsx
+++ b/extensions/ticktick/src/quickAdd.tsx
@@ -7,11 +7,19 @@ import { parseQuickAdd } from "./utils/quickAddParser";
 
 export default async function QuickAddTask(props: LaunchProps) {
   const toast = new Toast({ style: Toast.Style.Animated, title: "Creating task" });
+  const closeAfterDelay = () => setTimeout(() => closeMainWindow(), 500);
   await toast.show();
   try {
     await initGlobalProjectInfo();
     const projects = getProjects();
     const parsed = parseQuickAdd(props.arguments.text ?? props.fallbackText, projects);
+    if (!parsed.title) {
+      toast.style = Toast.Style.Failure;
+      toast.title = "Task title required";
+      toast.message = "Add a title in addition to the date, list, or priority.";
+      closeAfterDelay();
+      return;
+    }
     const title = parsed.title.replace(/"/g, `\\"`);
     const description = props.arguments.description?.replace(/"/g, `\\"`);
     const defaultDate = getDefaultDate();
@@ -42,7 +50,5 @@ export default async function QuickAddTask(props: LaunchProps) {
     toast.style = Toast.Style.Failure;
     toast.title = "Something went wrong";
   }
-  setTimeout(() => {
-    closeMainWindow();
-  }, 500);
+  closeAfterDelay();
 }

--- a/extensions/ticktick/src/utils/quickAddParser.ts
+++ b/extensions/ticktick/src/utils/quickAddParser.ts
@@ -7,6 +7,7 @@ export interface ParsedQuickAdd {
   dueDate?: Date;
   isAllDay: boolean;
   priority?: "0" | "1" | "3" | "5";
+  requiresConfirmation: boolean;
 }
 
 const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -77,16 +78,19 @@ const resolveDate = (dateText: string, timeText: string | undefined, now: Date) 
   if (normalized === "today" || normalized === "tonight") date = moment(now);
   else if (normalized === "tomorrow") date = moment(now).add(1, "day");
   else if (normalized === "day after tomorrow") date = moment(now).add(2, "days");
-  else if (normalized === "next week") date = moment(now).add(1, "week").startOf("isoWeek");
+  else if (normalized === "next week") date = moment(now).add(1, "week");
   else if (/^in \d+ (?:days?|weeks?)$/.test(normalized)) {
     const relative = normalized.match(/^in (\d+) (days?|weeks?)$/);
     if (!relative) return undefined;
     date = moment(now).add(Number(relative[1]), relative[2].startsWith("week") ? "weeks" : "days");
   } else if (/^(?:next )?(?:mon|tue|wed|thu|fri|sat|sun)/.test(normalized)) {
+    const isFollowingWeek = normalized.startsWith("next ");
     const weekday = normalized.replace(/^next /, "").slice(0, 3);
     const weekdays = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
     let daysAhead = (weekdays.indexOf(weekday) - moment(now).day() + 7) % 7;
-    if (daysAhead === 0) daysAhead += 7;
+    // TickTick treats a bare weekday matching today as today, while "next"
+    // always selects that weekday in the following calendar week.
+    if (isFollowingWeek) daysAhead += 7;
     date = moment(now).add(daysAhead, "days");
   } else {
     const formats = [
@@ -137,28 +141,50 @@ const resolveDate = (dateText: string, timeText: string | undefined, now: Date) 
       if (!parsedTime.isValid()) return undefined;
       date.hour(parsedTime.hour()).minute(parsedTime.minute());
     }
+  } else if (normalized === "tonight") {
+    date.hour(20);
   }
   return date.toDate();
 };
 
 const parseDate = (text: string, now: Date) => {
   const patterns = [
-    new RegExp(`(?:^|\\s)\\*\\s*(${EXPLICIT_DATE_SOURCE})(?:\\s+(?:at\\s+)?(${TIME_SOURCE}))?(?=\\s|$|[,.;!?])`, "i"),
-    new RegExp(`(?:^|\\s)(?:at\\s+)?(${TIME_SOURCE})\\s+(${DATE_SOURCE})(?=\\s|$|[,.;!?])`, "i"),
-    new RegExp(`(?:^|\\s)(${DATE_SOURCE})(?:\\s+(?:at\\s+)?(${TIME_SOURCE}))?(?=\\s|$|[,.;!?])`, "i"),
+    {
+      pattern: new RegExp(
+        `(?:^|\\s)\\*\\s*(${EXPLICIT_DATE_SOURCE})(?:\\s+(?:at\\s+)?(${TIME_SOURCE}))?(?=\\s|$|[,.;!?])`,
+        "i"
+      ),
+      dateGroup: 1,
+      timeGroup: 2,
+      requiresConfirmation: false,
+    },
+    {
+      pattern: new RegExp(`(?:^|\\s)(?:at\\s+)?(${TIME_SOURCE})\\s+(${DATE_SOURCE})(?=\\s|$|[,.;!?])`, "i"),
+      dateGroup: 2,
+      timeGroup: 1,
+      requiresConfirmation: true,
+    },
+    {
+      pattern: new RegExp(`(?:^|\\s)(${DATE_SOURCE})(?:\\s+(?:at\\s+)?(${TIME_SOURCE}))?(?=\\s|$|[,.;!?])`, "i"),
+      dateGroup: 1,
+      timeGroup: 2,
+      requiresConfirmation: true,
+    },
   ];
 
-  for (const [index, pattern] of patterns.entries()) {
+  for (const { pattern, dateGroup, timeGroup, requiresConfirmation } of patterns) {
     const match = pattern.exec(text);
     if (!match || match.index === undefined) continue;
-    const dateText = index === 1 ? match[2] : match[1];
-    const timeText = index === 1 ? match[1] : match[2];
+    const dateText = match[dateGroup];
+    const timeText = match[timeGroup];
     const dueDate = resolveDate(dateText, timeText, now);
     if (!dueDate) continue;
+    const hasImplicitTime = dateText.toLowerCase() === "tonight";
     return {
       text: `${text.slice(0, match.index)} ${text.slice(match.index + match[0].length)}`,
       dueDate,
-      isAllDay: !timeText,
+      isAllDay: !timeText && !hasImplicitTime,
+      requiresConfirmation,
     };
   }
 
@@ -177,11 +203,12 @@ const parseDate = (text: string, now: Date) => {
         text: `${text.slice(0, timeOnlyMatch.index)} ${text.slice(timeOnlyMatch.index + timeOnlyMatch[0].length)}`,
         dueDate,
         isAllDay: false,
+        requiresConfirmation: !timeOnlyMatch[0].trimStart().startsWith("*"),
       };
     }
   }
 
-  return { text, isAllDay: false };
+  return { text, isAllDay: false, requiresConfirmation: false };
 };
 
 /** Parse the subset of TickTick quick-add syntax supported by the macOS AppleScript API. */
@@ -209,5 +236,6 @@ export const parseQuickAdd = (input: string, projects: Project[], now = new Date
     dueDate: date.dueDate,
     isAllDay: date.isAllDay,
     priority: priorityValue,
+    requiresConfirmation: date.requiresConfirmation,
   };
 };

--- a/extensions/ticktick/src/utils/quickAddParser.ts
+++ b/extensions/ticktick/src/utils/quickAddParser.ts
@@ -14,7 +14,7 @@ const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\
 const cleanTitle = (value: string) =>
   value
     .replace(/\s+/g, " ")
-    .replace(/\s+([,.;!?])/g, "$1")
+    .replace(/\s+([,.;?])/g, "$1")
     .trim();
 
 const parsePriority = (text: string) => {
@@ -35,15 +35,19 @@ const parsePriority = (text: string) => {
 };
 
 const parseProject = (text: string, projects: Project[]) => {
+  let firstMatch: { match: RegExpExecArray; project: Project } | undefined;
   for (const project of [...projects].sort((a, b) => b.name.length - a.name.length)) {
     const pattern = new RegExp(`(?:^|\\s)[~^]${escapeRegExp(project.name)}(?=\\s|$)`, "i");
     const match = pattern.exec(text);
-    if (match?.index !== undefined) {
-      return {
-        text: `${text.slice(0, match.index)} ${text.slice(match.index + match[0].length)}`,
-        projectId: project.id,
-      };
-    }
+    if (match?.index !== undefined && (!firstMatch || match.index < firstMatch.match.index))
+      firstMatch = { match, project };
+  }
+  if (firstMatch) {
+    const { match, project } = firstMatch;
+    return {
+      text: `${text.slice(0, match.index)} ${text.slice(match.index + match[0].length)}`,
+      projectId: project.id,
+    };
   }
   return { text };
 };
@@ -86,12 +90,31 @@ const resolveDate = (dateText: string, timeText: string | undefined, now: Date) 
     date = moment(now).add(daysAhead, "days");
   } else {
     const formats = [
+      "YYYY-MM-DD",
       "YYYY-M-D",
+      "MM/DD/YYYY",
+      "MM/D/YYYY",
+      "M/DD/YYYY",
       "M/D/YYYY",
+      "MM-DD-YYYY",
+      "MM-D-YYYY",
+      "M-DD-YYYY",
       "M-D-YYYY",
+      "MM/DD/YY",
+      "MM/D/YY",
+      "M/DD/YY",
       "M/D/YY",
+      "MM-DD-YY",
+      "MM-D-YY",
+      "M-DD-YY",
       "M-D-YY",
+      "MM/DD",
+      "MM/D",
+      "M/DD",
       "M/D",
+      "MM-DD",
+      "MM-D",
+      "M-DD",
       "M-D",
       "MMM D YYYY",
       "MMMM D YYYY",
@@ -110,7 +133,7 @@ const resolveDate = (dateText: string, timeText: string | undefined, now: Date) 
     if (time === "noon") date.hour(12);
     else if (time === "midnight") date.hour(0);
     else {
-      const parsedTime = moment(time, ["H", "H:mm", "ha", "h:mma"], true);
+      const parsedTime = moment(time, ["H", "HH", "H:mm", "HH:mm", "ha", "hha", "h:mma", "hh:mma"], true);
       if (!parsedTime.isValid()) return undefined;
       date.hour(parsedTime.hour()).minute(parsedTime.minute());
     }
@@ -120,7 +143,7 @@ const resolveDate = (dateText: string, timeText: string | undefined, now: Date) 
 
 const parseDate = (text: string, now: Date) => {
   const patterns = [
-    new RegExp(`(?:^|\\s)\\*\\s*(${EXPLICIT_DATE_SOURCE})(?:\\s+(?:at\\s+)?(${TIME_SOURCE}))?`, "i"),
+    new RegExp(`(?:^|\\s)\\*\\s*(${EXPLICIT_DATE_SOURCE})(?:\\s+(?:at\\s+)?(${TIME_SOURCE}))?(?=\\s|$|[,.;!?])`, "i"),
     new RegExp(`(?:^|\\s)(?:at\\s+)?(${TIME_SOURCE})\\s+(${DATE_SOURCE})(?=\\s|$|[,.;!?])`, "i"),
     new RegExp(`(?:^|\\s)(${DATE_SOURCE})(?:\\s+(?:at\\s+)?(${TIME_SOURCE}))?(?=\\s|$|[,.;!?])`, "i"),
   ];
@@ -163,14 +186,40 @@ const parseDate = (text: string, now: Date) => {
 
 /** Parse the subset of TickTick quick-add syntax supported by the macOS AppleScript API. */
 export const parseQuickAdd = (input: string, projects: Project[], now = new Date()): ParsedQuickAdd => {
-  const project = parseProject(input, projects);
-  const priority = parsePriority(project.text);
-  const date = parseDate(priority.text, now);
+  let remainingText = input;
+  let projectId: ParsedQuickAdd["projectId"];
+  let project = parseProject(remainingText, projects);
+  while (project.projectId) {
+    projectId = projectId || project.projectId;
+    remainingText = project.text;
+    project = parseProject(remainingText, projects);
+  }
+
+  let priorityValue: ParsedQuickAdd["priority"];
+  let priority = parsePriority(remainingText);
+  while (priority.priority) {
+    priorityValue = priorityValue || priority.priority;
+    remainingText = priority.text;
+    priority = parsePriority(remainingText);
+  }
+
+  const date = parseDate(remainingText, now);
+  remainingText = date.text;
+
+  // Consume additional date/time metadata so it cannot become the task title.
+  if (date.dueDate) {
+    let additionalDate = parseDate(remainingText, now);
+    while (additionalDate.dueDate) {
+      remainingText = additionalDate.text;
+      additionalDate = parseDate(remainingText, now);
+    }
+  }
+
   return {
-    title: cleanTitle(date.text),
-    projectId: project.projectId,
+    title: cleanTitle(remainingText),
+    projectId,
     dueDate: date.dueDate,
     isAllDay: date.isAllDay,
-    priority: priority.priority,
+    priority: priorityValue,
   };
 };

--- a/extensions/ticktick/src/utils/quickAddParser.ts
+++ b/extensions/ticktick/src/utils/quickAddParser.ts
@@ -58,9 +58,11 @@ const DATE_SOURCE = [
   "(?:mon(?:day)?|tue(?:sday)?|wed(?:nesday)?|thu(?:rsday)?|fri(?:day)?|sat(?:urday)?|sun(?:day)?)",
   "in \\d+ (?:days?|weeks?)",
   "\\d{4}-\\d{1,2}-\\d{1,2}",
-  "\\d{1,2}[/-]\\d{1,2}(?:[/-]\\d{2,4})?",
+  "\\d{1,2}[/-]\\d{1,2}[/-]\\d{2,4}",
   "(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?) \\d{1,2}(?:st|nd|rd|th)?(?:,? \\d{4})?",
 ].join("|");
+
+const EXPLICIT_DATE_SOURCE = `${DATE_SOURCE}|\\d{1,2}[/-]\\d{1,2}`;
 
 const TIME_SOURCE = "(?:noon|midnight|\\d{1,2}(?::\\d{2})?\\s*(?:am|pm)?)";
 
@@ -118,7 +120,7 @@ const resolveDate = (dateText: string, timeText: string | undefined, now: Date) 
 
 const parseDate = (text: string, now: Date) => {
   const patterns = [
-    new RegExp(`(?:^|\\s)\\*\\s*(${DATE_SOURCE})(?:\\s+(?:at\\s+)?(${TIME_SOURCE}))?`, "i"),
+    new RegExp(`(?:^|\\s)\\*\\s*(${EXPLICIT_DATE_SOURCE})(?:\\s+(?:at\\s+)?(${TIME_SOURCE}))?`, "i"),
     new RegExp(`(?:^|\\s)(?:at\\s+)?(${TIME_SOURCE})\\s+(${DATE_SOURCE})(?=\\s|$|[,.;!?])`, "i"),
     new RegExp(`(?:^|\\s)(${DATE_SOURCE})(?:\\s+(?:at\\s+)?(${TIME_SOURCE}))?(?=\\s|$|[,.;!?])`, "i"),
   ];

--- a/extensions/ticktick/src/utils/quickAddParser.ts
+++ b/extensions/ticktick/src/utils/quickAddParser.ts
@@ -18,16 +18,16 @@ const cleanTitle = (value: string) =>
     .trim();
 
 const parsePriority = (text: string) => {
-  const match = text.match(/(?:^|\s)(!{1,3}|!(?:none|low|medium|med|high|[0-3]))(?=\s|$)/i);
+  const match = text.match(/(?:^|\s)(!(?:none|low|medium|high|[1-3]))(?=\s|$)/i);
   if (!match || match.index === undefined) return { text };
 
   const token = match[1].toLowerCase();
   const priority: ParsedQuickAdd["priority"] =
-    token === "!none" || token === "!0"
+    token === "!none"
       ? "0"
-      : token === "!low" || token === "!3" || token === "!"
+      : token === "!low" || token === "!3"
       ? "1"
-      : token === "!medium" || token === "!med" || token === "!2" || token === "!!"
+      : token === "!medium" || token === "!2"
       ? "3"
       : "5";
 
@@ -187,33 +187,21 @@ const parseDate = (text: string, now: Date) => {
 /** Parse the subset of TickTick quick-add syntax supported by the macOS AppleScript API. */
 export const parseQuickAdd = (input: string, projects: Project[], now = new Date()): ParsedQuickAdd => {
   let remainingText = input;
-  let projectId: ParsedQuickAdd["projectId"];
-  let project = parseProject(remainingText, projects);
-  while (project.projectId) {
-    projectId = projectId || project.projectId;
-    remainingText = project.text;
-    project = parseProject(remainingText, projects);
-  }
+  const project = parseProject(remainingText, projects);
+  const projectId = project.projectId;
+  remainingText = project.text;
 
   let priorityValue: ParsedQuickAdd["priority"];
   let priority = parsePriority(remainingText);
   while (priority.priority) {
-    priorityValue = priorityValue || priority.priority;
+    // TickTick applies the last recognized priority when several are entered.
+    priorityValue = priority.priority;
     remainingText = priority.text;
     priority = parsePriority(remainingText);
   }
 
   const date = parseDate(remainingText, now);
   remainingText = date.text;
-
-  // Consume additional date/time metadata so it cannot become the task title.
-  if (date.dueDate) {
-    let additionalDate = parseDate(remainingText, now);
-    while (additionalDate.dueDate) {
-      remainingText = additionalDate.text;
-      additionalDate = parseDate(remainingText, now);
-    }
-  }
 
   return {
     title: cleanTitle(remainingText),

--- a/extensions/ticktick/src/utils/quickAddParser.ts
+++ b/extensions/ticktick/src/utils/quickAddParser.ts
@@ -1,0 +1,174 @@
+import moment from "moment";
+import type { Project } from "../service/project";
+
+export interface ParsedQuickAdd {
+  title: string;
+  projectId?: string;
+  dueDate?: Date;
+  isAllDay: boolean;
+  priority?: "0" | "1" | "3" | "5";
+}
+
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const cleanTitle = (value: string) =>
+  value
+    .replace(/\s+/g, " ")
+    .replace(/\s+([,.;!?])/g, "$1")
+    .trim();
+
+const parsePriority = (text: string) => {
+  const match = text.match(/(?:^|\s)(!{1,3}|!(?:none|low|medium|med|high|[0-3]))(?=\s|$)/i);
+  if (!match || match.index === undefined) return { text };
+
+  const token = match[1].toLowerCase();
+  const priority: ParsedQuickAdd["priority"] =
+    token === "!none" || token === "!0"
+      ? "0"
+      : token === "!low" || token === "!3" || token === "!"
+      ? "1"
+      : token === "!medium" || token === "!med" || token === "!2" || token === "!!"
+      ? "3"
+      : "5";
+
+  return { text: `${text.slice(0, match.index)} ${text.slice(match.index + match[0].length)}`, priority };
+};
+
+const parseProject = (text: string, projects: Project[]) => {
+  for (const project of [...projects].sort((a, b) => b.name.length - a.name.length)) {
+    const pattern = new RegExp(`(?:^|\\s)[~^]${escapeRegExp(project.name)}(?=\\s|$)`, "i");
+    const match = pattern.exec(text);
+    if (match?.index !== undefined) {
+      return {
+        text: `${text.slice(0, match.index)} ${text.slice(match.index + match[0].length)}`,
+        projectId: project.id,
+      };
+    }
+  }
+  return { text };
+};
+
+const DATE_SOURCE = [
+  "day after tomorrow",
+  "tomorrow",
+  "today",
+  "tonight",
+  "next week",
+  "next (?:mon(?:day)?|tue(?:sday)?|wed(?:nesday)?|thu(?:rsday)?|fri(?:day)?|sat(?:urday)?|sun(?:day)?)",
+  "(?:mon(?:day)?|tue(?:sday)?|wed(?:nesday)?|thu(?:rsday)?|fri(?:day)?|sat(?:urday)?|sun(?:day)?)",
+  "in \\d+ (?:days?|weeks?)",
+  "\\d{4}-\\d{1,2}-\\d{1,2}",
+  "\\d{1,2}[/-]\\d{1,2}(?:[/-]\\d{2,4})?",
+  "(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?) \\d{1,2}(?:st|nd|rd|th)?(?:,? \\d{4})?",
+].join("|");
+
+const TIME_SOURCE = "(?:noon|midnight|\\d{1,2}(?::\\d{2})?\\s*(?:am|pm)?)";
+
+const resolveDate = (dateText: string, timeText: string | undefined, now: Date) => {
+  const normalized = dateText.toLowerCase().replace(/(\d)(st|nd|rd|th)\b/g, "$1");
+  let date = moment(now);
+
+  if (normalized === "today" || normalized === "tonight") date = moment(now);
+  else if (normalized === "tomorrow") date = moment(now).add(1, "day");
+  else if (normalized === "day after tomorrow") date = moment(now).add(2, "days");
+  else if (normalized === "next week") date = moment(now).add(1, "week").startOf("isoWeek");
+  else if (/^in \d+ (?:days?|weeks?)$/.test(normalized)) {
+    const relative = normalized.match(/^in (\d+) (days?|weeks?)$/);
+    if (!relative) return undefined;
+    date = moment(now).add(Number(relative[1]), relative[2].startsWith("week") ? "weeks" : "days");
+  } else if (/^(?:next )?(?:mon|tue|wed|thu|fri|sat|sun)/.test(normalized)) {
+    const weekday = normalized.replace(/^next /, "").slice(0, 3);
+    const weekdays = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
+    let daysAhead = (weekdays.indexOf(weekday) - moment(now).day() + 7) % 7;
+    if (daysAhead === 0) daysAhead += 7;
+    date = moment(now).add(daysAhead, "days");
+  } else {
+    const formats = [
+      "YYYY-M-D",
+      "M/D/YYYY",
+      "M-D-YYYY",
+      "M/D/YY",
+      "M-D-YY",
+      "M/D",
+      "M-D",
+      "MMM D YYYY",
+      "MMMM D YYYY",
+      "MMM D",
+      "MMMM D",
+    ];
+    const parsed = moment(normalized.replace(",", ""), formats, true);
+    if (!parsed.isValid()) return undefined;
+    if (!/\d{4}/.test(normalized) && parsed.isBefore(moment(now), "day")) parsed.add(1, "year");
+    date = parsed;
+  }
+
+  date.startOf("day");
+  if (timeText) {
+    const time = timeText.toLowerCase().replace(/\s/g, "");
+    if (time === "noon") date.hour(12);
+    else if (time === "midnight") date.hour(0);
+    else {
+      const parsedTime = moment(time, ["H", "H:mm", "ha", "h:mma"], true);
+      if (!parsedTime.isValid()) return undefined;
+      date.hour(parsedTime.hour()).minute(parsedTime.minute());
+    }
+  }
+  return date.toDate();
+};
+
+const parseDate = (text: string, now: Date) => {
+  const patterns = [
+    new RegExp(`(?:^|\\s)\\*\\s*(${DATE_SOURCE})(?:\\s+(?:at\\s+)?(${TIME_SOURCE}))?`, "i"),
+    new RegExp(`(?:^|\\s)(?:at\\s+)?(${TIME_SOURCE})\\s+(${DATE_SOURCE})(?=\\s|$|[,.;!?])`, "i"),
+    new RegExp(`(?:^|\\s)(${DATE_SOURCE})(?:\\s+(?:at\\s+)?(${TIME_SOURCE}))?(?=\\s|$|[,.;!?])`, "i"),
+  ];
+
+  for (const [index, pattern] of patterns.entries()) {
+    const match = pattern.exec(text);
+    if (!match || match.index === undefined) continue;
+    const dateText = index === 1 ? match[2] : match[1];
+    const timeText = index === 1 ? match[1] : match[2];
+    const dueDate = resolveDate(dateText, timeText, now);
+    if (!dueDate) continue;
+    return {
+      text: `${text.slice(0, match.index)} ${text.slice(match.index + match[0].length)}`,
+      dueDate,
+      isAllDay: !timeText,
+    };
+  }
+
+  // TickTick treats a time without a date as a task due today.
+  const unambiguousTimeSource = "(?:noon|midnight|\\d{1,2}(?::\\d{2})?\\s*(?:am|pm))";
+  const timeOnlyPattern = new RegExp(
+    `(?:^|\\s)(?:(?:\\*|at)\\s*(${TIME_SOURCE})|(${unambiguousTimeSource}))(?=\\s|$|[,.;!?])`,
+    "i"
+  );
+  const timeOnlyMatch = timeOnlyPattern.exec(text);
+  if (timeOnlyMatch?.index !== undefined) {
+    const timeText = timeOnlyMatch[1] || timeOnlyMatch[2];
+    const dueDate = resolveDate("today", timeText, now);
+    if (dueDate) {
+      return {
+        text: `${text.slice(0, timeOnlyMatch.index)} ${text.slice(timeOnlyMatch.index + timeOnlyMatch[0].length)}`,
+        dueDate,
+        isAllDay: false,
+      };
+    }
+  }
+
+  return { text, isAllDay: false };
+};
+
+/** Parse the subset of TickTick quick-add syntax supported by the macOS AppleScript API. */
+export const parseQuickAdd = (input: string, projects: Project[], now = new Date()): ParsedQuickAdd => {
+  const project = parseProject(input, projects);
+  const priority = parsePriority(project.text);
+  const date = parseDate(priority.text, now);
+  return {
+    title: cleanTitle(date.text),
+    projectId: project.projectId,
+    dueDate: date.dueDate,
+    isAllDay: date.isAllDay,
+    priority: priority.priority,
+  };
+};

--- a/extensions/ticktick/tests/quickAddParser.test.mts
+++ b/extensions/ticktick/tests/quickAddParser.test.mts
@@ -7,6 +7,7 @@ const projects = [
   { id: "inbox", name: "Inbox" },
   { id: "client-work", name: "Client Work" },
 ];
+type ParsedPriority = "0" | "1" | "3" | "5";
 
 test("parses natural-language dates, multi-word lists, and priorities", () => {
   const parsed = parseQuickAdd("Send proposal at 9 tomorrow ~Client Work !high", projects, now);
@@ -73,21 +74,62 @@ test("exposes an empty title when the input contains only metadata", () => {
   assert.deepEqual(parsed.dueDate, new Date(2026, 7, 21));
 });
 
-test("consumes additional date metadata instead of treating it as a title", () => {
+test("uses the first date and preserves later date expressions like TickTick", () => {
   const parsed = parseQuickAdd("today tomorrow ~Inbox !high", projects, now);
 
-  assert.equal(parsed.title, "");
+  assert.equal(parsed.title, "tomorrow");
   assert.equal(parsed.projectId, "inbox");
   assert.equal(parsed.priority, "5");
   assert.deepEqual(parsed.dueDate, new Date(2026, 7, 20));
 });
 
-test("consumes repeated project and priority metadata in input order", () => {
+test("parses bare weekdays in titles like TickTick", () => {
+  const cases: Array<[string, string, Date]> = [
+    ["Monday report", "report", new Date(2026, 7, 24)],
+    ["Friday deployment checklist", "deployment checklist", new Date(2026, 7, 21)],
+    ["Prepare Monday report for Friday", "Prepare report for Friday", new Date(2026, 7, 24)],
+    ["Move Tuesday meeting to Thursday", "Move meeting to Thursday", new Date(2026, 7, 25)],
+  ];
+
+  for (const [input, expectedTitle, expectedDate] of cases) {
+    const parsed = parseQuickAdd(input, projects, now);
+    assert.equal(parsed.title, expectedTitle, input);
+    assert.deepEqual(parsed.dueDate, expectedDate, input);
+  }
+});
+
+test("uses the first project without consuming later project metadata", () => {
   const parsed = parseQuickAdd("today ~Client Work ~Inbox !high !low", projects, now);
 
-  assert.equal(parsed.title, "");
+  assert.equal(parsed.title, "~Inbox");
   assert.equal(parsed.projectId, "client-work");
-  assert.equal(parsed.priority, "5");
+  assert.equal(parsed.priority, "1");
+});
+
+test("supports TickTick priority syntax", () => {
+  const cases: Array<[string, ParsedPriority]> = [
+    ["!1", "5"],
+    ["!high", "5"],
+    ["!2", "3"],
+    ["!medium", "3"],
+    ["!3", "1"],
+    ["!low", "1"],
+    ["!none", "0"],
+  ];
+
+  for (const [token, expectedPriority] of cases) {
+    const parsed = parseQuickAdd(`Task ${token}`, projects, now);
+    assert.equal(parsed.title, "Task", token);
+    assert.equal(parsed.priority, expectedPriority, token);
+  }
+});
+
+test("does not parse unsupported priority aliases", () => {
+  for (const token of ["!", "!!", "!!!", "!0", "!med"]) {
+    const parsed = parseQuickAdd(`Task ${token}`, projects, now);
+    assert.equal(parsed.title, `Task ${token}`, token);
+    assert.equal(parsed.priority, undefined, token);
+  }
 });
 
 test("parses documented ISO and zero-padded numeric dates and times", () => {

--- a/extensions/ticktick/tests/quickAddParser.test.mts
+++ b/extensions/ticktick/tests/quickAddParser.test.mts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseQuickAdd } from "../src/utils/quickAddParser.ts";
+
+const now = new Date(2026, 7, 20, 14, 30);
+const projects = [
+  { id: "inbox", name: "Inbox" },
+  { id: "client-work", name: "Client Work" },
+];
+
+test("parses natural-language dates, multi-word lists, and priorities", () => {
+  const parsed = parseQuickAdd("Send proposal at 9 tomorrow ~Client Work !high", projects, now);
+
+  assert.equal(parsed.title, "Send proposal");
+  assert.equal(parsed.projectId, "client-work");
+  assert.equal(parsed.priority, "5");
+  assert.equal(parsed.isAllDay, false);
+  assert.deepEqual(parsed.dueDate, new Date(2026, 7, 21, 9));
+});
+
+test("parses explicit all-day dates and the legacy list marker", () => {
+  const parsed = parseQuickAdd("Renew registration *next Monday !2 ^Inbox", projects, now);
+
+  assert.equal(parsed.title, "Renew registration");
+  assert.equal(parsed.projectId, "inbox");
+  assert.equal(parsed.priority, "3");
+  assert.equal(parsed.isAllDay, true);
+  assert.deepEqual(parsed.dueDate, new Date(2026, 7, 24));
+});
+
+test("treats a time without a date as today", () => {
+  const cases: Array<[string, Date]> = [
+    ["Call client at 9", new Date(2026, 7, 20, 9)],
+    ["Call client 9am", new Date(2026, 7, 20, 9)],
+    ["Call client *4:15pm", new Date(2026, 7, 20, 16, 15)],
+  ];
+
+  for (const [input, expectedDate] of cases) {
+    const parsed = parseQuickAdd(input, projects, now);
+    assert.equal(parsed.title, "Call client", input);
+    assert.equal(parsed.isAllDay, false, input);
+    assert.deepEqual(parsed.dueDate, expectedDate, input);
+  }
+});
+
+test("does not treat ordinary numbers or month names as dates", () => {
+  for (const title of ["Buy 2 apples", "Plan May launch"]) {
+    const parsed = parseQuickAdd(title, projects, now);
+    assert.equal(parsed.title, title);
+    assert.equal(parsed.dueDate, undefined);
+  }
+});

--- a/extensions/ticktick/tests/quickAddParser.test.mts
+++ b/extensions/ticktick/tests/quickAddParser.test.mts
@@ -72,3 +72,50 @@ test("exposes an empty title when the input contains only metadata", () => {
   assert.equal(parsed.priority, "5");
   assert.deepEqual(parsed.dueDate, new Date(2026, 7, 21));
 });
+
+test("consumes additional date metadata instead of treating it as a title", () => {
+  const parsed = parseQuickAdd("today tomorrow ~Inbox !high", projects, now);
+
+  assert.equal(parsed.title, "");
+  assert.equal(parsed.projectId, "inbox");
+  assert.equal(parsed.priority, "5");
+  assert.deepEqual(parsed.dueDate, new Date(2026, 7, 20));
+});
+
+test("consumes repeated project and priority metadata in input order", () => {
+  const parsed = parseQuickAdd("today ~Client Work ~Inbox !high !low", projects, now);
+
+  assert.equal(parsed.title, "");
+  assert.equal(parsed.projectId, "client-work");
+  assert.equal(parsed.priority, "5");
+});
+
+test("parses documented ISO and zero-padded numeric dates and times", () => {
+  const cases: Array<[string, Date]> = [
+    ["Submit report *2026-08-25", new Date(2026, 7, 25)],
+    ["Submit report *05/07", new Date(2027, 4, 7)],
+    ["Submit report *08-25-2026", new Date(2026, 7, 25)],
+    ["Call client 09:30am", new Date(2026, 7, 20, 9, 30)],
+  ];
+
+  for (const [input, expectedDate] of cases) {
+    const parsed = parseQuickAdd(input, projects, now);
+    assert.equal(parsed.title, input.startsWith("Submit") ? "Submit report" : "Call client", input);
+    assert.deepEqual(parsed.dueDate, expectedDate, input);
+  }
+});
+
+test("does not partially parse malformed explicit metadata", () => {
+  for (const title of ["Task *tomorrowland", "Task *next weekday", "Task *September 3rdfoo"]) {
+    const parsed = parseQuickAdd(title, projects, now);
+    assert.equal(parsed.title, title);
+    assert.equal(parsed.dueDate, undefined);
+  }
+});
+
+test("preserves spacing before unrecognized exclamation text", () => {
+  const parsed = parseQuickAdd("Task !highly", projects, now);
+
+  assert.equal(parsed.title, "Task !highly");
+  assert.equal(parsed.priority, undefined);
+});

--- a/extensions/ticktick/tests/quickAddParser.test.mts
+++ b/extensions/ticktick/tests/quickAddParser.test.mts
@@ -17,6 +17,7 @@ test("parses natural-language dates, multi-word lists, and priorities", () => {
   assert.equal(parsed.priority, "5");
   assert.equal(parsed.isAllDay, false);
   assert.deepEqual(parsed.dueDate, new Date(2026, 7, 21, 9));
+  assert.equal(parsed.requiresConfirmation, true);
 });
 
 test("parses explicit all-day dates and the legacy list marker", () => {
@@ -26,7 +27,8 @@ test("parses explicit all-day dates and the legacy list marker", () => {
   assert.equal(parsed.projectId, "inbox");
   assert.equal(parsed.priority, "3");
   assert.equal(parsed.isAllDay, true);
-  assert.deepEqual(parsed.dueDate, new Date(2026, 7, 24));
+  assert.deepEqual(parsed.dueDate, new Date(2026, 7, 31));
+  assert.equal(parsed.requiresConfirmation, false);
 });
 
 test("treats a time without a date as today", () => {
@@ -41,6 +43,17 @@ test("treats a time without a date as today", () => {
     assert.equal(parsed.title, "Call client", input);
     assert.equal(parsed.isAllDay, false, input);
     assert.deepEqual(parsed.dueDate, expectedDate, input);
+    assert.equal(parsed.requiresConfirmation, !input.includes("*"), input);
+  }
+});
+
+test("only requires confirmation for unmarked date and time parsing", () => {
+  for (const input of ["Monday report", "Call client at 9", "Send proposal tomorrow at 9"]) {
+    assert.equal(parseQuickAdd(input, projects, now).requiresConfirmation, true, input);
+  }
+
+  for (const input of ["Monday report *Friday", "Call client *9am", "Task ~Inbox !high", "Plain task"]) {
+    assert.equal(parseQuickAdd(input, projects, now).requiresConfirmation, false, input);
   }
 });
 
@@ -89,6 +102,7 @@ test("parses bare weekdays in titles like TickTick", () => {
     ["Friday deployment checklist", "deployment checklist", new Date(2026, 7, 21)],
     ["Prepare Monday report for Friday", "Prepare report for Friday", new Date(2026, 7, 24)],
     ["Move Tuesday meeting to Thursday", "Move meeting to Thursday", new Date(2026, 7, 25)],
+    ["Thursday status", "status", new Date(2026, 7, 20)],
   ];
 
   for (const [input, expectedTitle, expectedDate] of cases) {
@@ -96,6 +110,31 @@ test("parses bare weekdays in titles like TickTick", () => {
     assert.equal(parsed.title, expectedTitle, input);
     assert.deepEqual(parsed.dueDate, expectedDate, input);
   }
+});
+
+test("treats next weekdays as weekdays in the following calendar week", () => {
+  const cases: Array<[string, Date]> = [
+    ["Task next Thursday", new Date(2026, 7, 27)],
+    ["Task next Monday", new Date(2026, 7, 31)],
+  ];
+
+  for (const [input, expectedDate] of cases) {
+    const parsed = parseQuickAdd(input, projects, now);
+    assert.equal(parsed.title, "Task", input);
+    assert.deepEqual(parsed.dueDate, expectedDate, input);
+  }
+});
+
+test("matches TickTick's relative-week and tonight defaults", () => {
+  const nextWeek = parseQuickAdd("Plan next week", projects, now);
+  assert.equal(nextWeek.title, "Plan");
+  assert.equal(nextWeek.isAllDay, true);
+  assert.deepEqual(nextWeek.dueDate, new Date(2026, 7, 27));
+
+  const tonight = parseQuickAdd("Read tonight", projects, now);
+  assert.equal(tonight.title, "Read");
+  assert.equal(tonight.isAllDay, false);
+  assert.deepEqual(tonight.dueDate, new Date(2026, 7, 20, 20));
 });
 
 test("uses the first project without consuming later project metadata", () => {

--- a/extensions/ticktick/tests/quickAddParser.test.mts
+++ b/extensions/ticktick/tests/quickAddParser.test.mts
@@ -44,9 +44,31 @@ test("treats a time without a date as today", () => {
 });
 
 test("does not treat ordinary numbers or month names as dates", () => {
-  for (const title of ["Buy 2 apples", "Plan May launch"]) {
+  for (const title of [
+    "Buy 2 apples",
+    "Plan May launch",
+    "Investigate regression 5-7 in staging",
+    "Deploy versions 5/7",
+  ]) {
     const parsed = parseQuickAdd(title, projects, now);
     assert.equal(parsed.title, title);
     assert.equal(parsed.dueDate, undefined);
   }
+});
+
+test("requires a marker for ambiguous short numeric dates", () => {
+  const parsed = parseQuickAdd("Submit report *5/7", projects, now);
+
+  assert.equal(parsed.title, "Submit report");
+  assert.equal(parsed.isAllDay, true);
+  assert.deepEqual(parsed.dueDate, new Date(2027, 4, 7));
+});
+
+test("exposes an empty title when the input contains only metadata", () => {
+  const parsed = parseQuickAdd("tomorrow ~Inbox !high", projects, now);
+
+  assert.equal(parsed.title, "");
+  assert.equal(parsed.projectId, "inbox");
+  assert.equal(parsed.priority, "5");
+  assert.deepEqual(parsed.dueDate, new Date(2026, 7, 21));
 });


### PR DESCRIPTION
## Description

Enhances TickTick's **Quick Add Task** command with a practical subset of the syntax supported by TickTick's web and desktop apps.

- Parses natural-language dates and times, including time-only input that defaults to today
- Supports explicit `*date` syntax, `~List`/`^List` selection, and `!priority`
- Creates all-day tasks for date-only input and timed tasks when a time is present
- Removes recognized metadata from the saved task title
- Rejects metadata-only input instead of creating a blank or misleading task
- Leaves ambiguous numeric ranges such as `5-7` in the title unless explicitly marked as `*5-7`
- Handles repeated metadata safely and preserves unrelated title text

Examples:

- `Call the client at 9am` → due today at 9:00 AM
- `Review the report next Monday` → all-day task due next Monday
- `Submit expenses *2026-08-25 ~Work !high` → high-priority task in Work due August 25

The parser intentionally does not handle tags, recurrence, or assignees because those fields are not exposed by TickTick's macOS AppleScript task-creation interface.

## Validation

- Added 11 parser test groups covering intended syntax and adversarial edge cases
- Ran `npm test`
- Ran `npm run build`
- Ran `npm run lint`
- Manually tested Quick Add in Raycast with time-only and date/time input

## Screencast

Not included because this is a no-view command and the change affects the resulting TickTick task rather than Raycast UI.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested the distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the README are placed outside of the `metadata` folder