### PR TITLE
google-chrome-profiles: add profile deletion

### DIFF
--- a/extensions/google-chrome-profiles/CHANGELOG.md
+++ b/extensions/google-chrome-profiles/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Google Chrome Profiles Changelog
 
+## [Feature] - {PR_MERGE_DATE}
+
+- Add a destructive action to delete a Chrome profile and its local data from the profile list.
+- Allow deleting an inactive profile while Chrome remains open; the active profile must be closed first.
+
 ## [Fix] - 2026-08-12
 
 - Fix opening a profile while Chrome is closed producing two windows: the requested profile, plus one for whichever profile was used last. The Bring to Front / New Tab / Open URL path began with `tell application "Google Chrome" to activate`, which launches Chrome with no arguments; a flagless Chrome restores every profile listed in `profile.last_active_profiles` (Local State), so the previous profile's window appeared before System Events ever clicked the Profiles menu. Branch on whether the browser is already running: when it is, the Profiles-menu click is unchanged and keeps the focus / add-a-tab / find-an-existing-tab semantics; when it is not, do a single cold start into the requested profile with `/usr/bin/open -n -a <bundle> --args --profile-directory=<dir> --new-window [url]`. `--profile-directory` is the profile a cold Chrome boots into, which is what suppresses the session restore.

--- a/extensions/google-chrome-profiles/CHANGELOG.md
+++ b/extensions/google-chrome-profiles/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Chrome Profiles Changelog
 
-## [Feature] - {PR_MERGE_DATE}
+## [Feature] - 2026-08-25
 
 - Add a destructive action to delete a Chrome profile and its local data from the profile list.
 - Allow deleting an inactive profile while Chrome remains open; the active profile must be closed first.

--- a/extensions/google-chrome-profiles/src/index.tsx
+++ b/extensions/google-chrome-profiles/src/index.tsx
@@ -33,6 +33,7 @@ import {
   isValidUrl,
   formatAsUrl,
   openGoogleChrome,
+  readChromeLocalState,
   deleteChromeProfile,
   ChromeAction,
   ChromeTarget,
@@ -114,10 +115,7 @@ export default function Command() {
       try {
         // for google-chrome-profiles-1.png:
         // 1. comment the code below:
-        const path = join(homedir(), browser.dataPath, "Local State");
-        const localStateFileBuffer = await readFile(path);
-        const localStateFileText = localStateFileBuffer.toString("utf-8");
-        setLocalState(JSON.parse(localStateFileText));
+        setLocalState((await readChromeLocalState(browser)).state);
         // 2. uncomment function _createDataSetForScreenshot1() at the bottom of the file
         // 3. uncomment code below:
         // setLocalState(_createDataSetForScreenshot1());

--- a/extensions/google-chrome-profiles/src/index.tsx
+++ b/extensions/google-chrome-profiles/src/index.tsx
@@ -1,7 +1,9 @@
 import {
   Action,
   ActionPanel,
+  Alert,
   Clipboard,
+  confirmAlert,
   environment,
   getPreferenceValues,
   Icon,
@@ -31,12 +33,18 @@ import {
   isValidUrl,
   formatAsUrl,
   openGoogleChrome,
+  deleteChromeProfile,
   ChromeAction,
   ChromeTarget,
 } from "./util/util";
 import { getFavicon } from "@raycast/utils";
 
-const ProfileItem = (props: { index: number; profile: Profile; browser: BrowserConfig }) => {
+const ProfileItem = (props: {
+  index: number;
+  profile: Profile;
+  browser: BrowserConfig;
+  onDelete: (profile: Profile) => Promise<void>;
+}) => {
   const { index, profile, browser } = props;
 
   return (
@@ -83,6 +91,13 @@ const ProfileItem = (props: { index: number; profile: Profile; browser: BrowserC
               );
             }}
           />
+          <Action
+            title="Delete Profile"
+            icon={Icon.Trash}
+            style={Action.Style.Destructive}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "backspace" }}
+            onAction={() => props.onDelete(profile)}
+          />
         </ActionPanel>
       }
     />
@@ -121,13 +136,42 @@ export default function Command() {
   const infoCache = localState?.profile.info_cache;
   const profiles = infoCache && Object.keys(infoCache).map(extractProfileFromInfoCache(infoCache));
 
+  const deleteProfile = async (profile: Profile) => {
+    if (
+      !(await confirmAlert({
+        title: `Delete “${profile.name}” profile?`,
+        message: "This permanently deletes its bookmarks, history, passwords, and other local data.",
+        primaryAction: { title: "Delete Profile", style: Alert.ActionStyle.Destructive },
+      }))
+    ) {
+      return;
+    }
+
+    try {
+      setLocalState(await deleteChromeProfile(profile, browser));
+      await showToast(Toast.Style.Success, `Deleted ${profile.name}`);
+    } catch (error) {
+      await showToast(
+        Toast.Style.Failure,
+        "Could not delete profile",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  };
+
   return (
     <List isLoading={!profiles && !error} searchBarPlaceholder="Search Profile">
       {profiles &&
         profiles
           .sort(sortAlphabetically)
           .map((profile, index) => (
-            <ProfileItem key={profile.directory} index={index} profile={profile} browser={browser} />
+            <ProfileItem
+              key={profile.directory}
+              index={index}
+              profile={profile}
+              browser={browser}
+              onDelete={deleteProfile}
+            />
           ))}
     </List>
   );

--- a/extensions/google-chrome-profiles/src/util/types.ts
+++ b/extensions/google-chrome-profiles/src/util/types.ts
@@ -1,7 +1,12 @@
 import { getPreferenceValues } from "@raycast/api";
 
 export type GoogleChromeLocalState = {
-  profile: { info_cache: GoogleChromeInfoCache };
+  profile: {
+    info_cache: GoogleChromeInfoCache;
+    last_active_profiles?: string[];
+    last_used?: string;
+    profiles_order?: string[];
+  };
 };
 
 export type GoogleChromeInfoCache = { [key: string]: GoogleChromeInfoCacheProfile };

--- a/extensions/google-chrome-profiles/src/util/util.ts
+++ b/extensions/google-chrome-profiles/src/util/util.ts
@@ -69,19 +69,19 @@ export const deleteChromeProfile = async (profile: Profile, browser: BrowserConf
   try {
     profileStats = await lstat(profilePath);
   } catch (error) {
-    if (error instanceof Error && (error as NodeJS.ErrnoException).code === "ENOENT") {
-      throw new Error("Chrome profile directory not found");
-    }
-    throw error;
+    if (!(error instanceof Error) || (error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
   }
-  if (!profileStats.isDirectory()) throw new Error("Chrome profile path is not a directory");
-  if (await isProfileOpen(profilePath)) throw new Error(`Close the ${profile.name} profile before deleting it`);
+  if (profileStats && !profileStats.isDirectory()) throw new Error("Chrome profile path is not a directory");
 
-  const deletedProfilePath = join(dataDirectory, `.raycast-delete-${randomUUID()}`);
-  await rename(profilePath, deletedProfilePath);
+  let deletedProfilePath: string | undefined;
+  if (profileStats) {
+    if (await isProfileOpen(profilePath)) throw new Error(`Close the ${profile.name} profile before deleting it`);
+    deletedProfilePath = join(dataDirectory, `.raycast-delete-${randomUUID()}`);
+    await rename(profilePath, deletedProfilePath);
+  }
 
   try {
-    if (await isProfileOpen(deletedProfilePath)) {
+    if (deletedProfilePath && (await isProfileOpen(deletedProfilePath))) {
       throw new Error(`Close the ${profile.name} profile before deleting it`);
     }
     delete infoCache[profile.directory];
@@ -97,7 +97,7 @@ export const deleteChromeProfile = async (profile: Profile, browser: BrowserConf
     await writeFileAtomically(localStatePath, `${JSON.stringify(localState, null, 2)}\n`);
   } catch (error) {
     try {
-      await rename(deletedProfilePath, profilePath);
+      if (deletedProfilePath) await rename(deletedProfilePath, profilePath);
       await writeFileAtomically(localStatePath, originalLocalStateText);
     } catch {
       throw new Error("Profile deletion failed and could not be rolled back");
@@ -105,16 +105,18 @@ export const deleteChromeProfile = async (profile: Profile, browser: BrowserConf
     throw error;
   }
 
-  try {
-    await rm(deletedProfilePath, { recursive: true, force: true });
-  } catch (error) {
+  if (deletedProfilePath) {
     try {
-      await rename(deletedProfilePath, profilePath);
-      await writeFileAtomically(localStatePath, originalLocalStateText);
-    } catch {
-      throw new Error("Profile deletion failed and could not be rolled back");
+      await rm(deletedProfilePath, { recursive: true, force: true });
+    } catch (error) {
+      try {
+        await rename(deletedProfilePath, profilePath);
+        await writeFileAtomically(localStatePath, originalLocalStateText);
+      } catch {
+        throw new Error("Profile deletion failed and could not be rolled back");
+      }
+      throw error;
     }
-    throw error;
   }
   return localState;
 };

--- a/extensions/google-chrome-profiles/src/util/util.ts
+++ b/extensions/google-chrome-profiles/src/util/util.ts
@@ -11,7 +11,7 @@ import { BrowserConfig, GoogleChromeLocalState, Profile } from "./types";
 
 const execFileAsync = promisify(execFile);
 
-const profileIsOpen = async (profilePath: string) => {
+const isProfileOpen = async (profilePath: string) => {
   try {
     const { stdout } = await execFileAsync("/usr/sbin/lsof", ["-nP", "-t", "+D", profilePath], { timeout: 10000 });
     return stdout.trim().length > 0;
@@ -21,6 +21,22 @@ const profileIsOpen = async (profilePath: string) => {
     const code = error instanceof Error ? (error as { code?: string | number }).code : undefined;
     if (code === 1 || code === "1") return false;
     throw new Error("Could not determine whether the Chrome profile is open");
+  }
+};
+
+export const readChromeLocalState = async (browser: BrowserConfig) => {
+  const path = join(homedir(), browser.dataPath, "Local State");
+  const text = await readFile(path, "utf8");
+  return { path, text, state: JSON.parse(text) as GoogleChromeLocalState };
+};
+
+const writeFileAtomically = async (path: string, text: string) => {
+  const temporaryPath = `${path}.${randomUUID()}.tmp`;
+  try {
+    await writeFile(temporaryPath, text, "utf8");
+    await rename(temporaryPath, path);
+  } finally {
+    await rm(temporaryPath, { force: true }).catch(() => undefined);
   }
 };
 
@@ -42,8 +58,7 @@ export const deleteChromeProfile = async (profile: Profile, browser: BrowserConf
   const profilePath = resolve(dataDirectory, profile.directory);
   if (dirname(profilePath) !== dataDirectory) throw new Error("Invalid Chrome profile directory");
 
-  const localStatePath = join(dataDirectory, "Local State");
-  const localState = JSON.parse(await readFile(localStatePath, "utf8")) as GoogleChromeLocalState;
+  const { path: localStatePath, text: originalLocalStateText, state: localState } = await readChromeLocalState(browser);
   const infoCache = localState.profile?.info_cache;
   if (!infoCache || !Object.prototype.hasOwnProperty.call(infoCache, profile.directory)) {
     throw new Error("Profile no longer exists");
@@ -60,13 +75,13 @@ export const deleteChromeProfile = async (profile: Profile, browser: BrowserConf
     throw error;
   }
   if (!profileStats.isDirectory()) throw new Error("Chrome profile path is not a directory");
-  if (await profileIsOpen(profilePath)) throw new Error(`Close the ${profile.name} profile before deleting it`);
+  if (await isProfileOpen(profilePath)) throw new Error(`Close the ${profile.name} profile before deleting it`);
 
   const deletedProfilePath = join(dataDirectory, `.raycast-delete-${randomUUID()}`);
   await rename(profilePath, deletedProfilePath);
 
   try {
-    if (await profileIsOpen(deletedProfilePath)) {
+    if (await isProfileOpen(deletedProfilePath)) {
       throw new Error(`Close the ${profile.name} profile before deleting it`);
     }
     delete infoCache[profile.directory];
@@ -79,23 +94,28 @@ export const deleteChromeProfile = async (profile: Profile, browser: BrowserConf
     if (localState.profile.last_used === profile.directory) {
       localState.profile.last_used = Object.keys(infoCache)[0];
     }
-    const temporaryLocalStatePath = `${localStatePath}.${randomUUID()}.tmp`;
-    try {
-      await writeFile(temporaryLocalStatePath, `${JSON.stringify(localState, null, 2)}\n`, "utf8");
-      await rename(temporaryLocalStatePath, localStatePath);
-    } finally {
-      await rm(temporaryLocalStatePath, { force: true }).catch(() => undefined);
-    }
+    await writeFileAtomically(localStatePath, `${JSON.stringify(localState, null, 2)}\n`);
   } catch (error) {
     try {
       await rename(deletedProfilePath, profilePath);
+      await writeFileAtomically(localStatePath, originalLocalStateText);
     } catch {
       throw new Error("Profile deletion failed and could not be rolled back");
     }
     throw error;
   }
 
-  await rm(deletedProfilePath, { recursive: true, force: true });
+  try {
+    await rm(deletedProfilePath, { recursive: true, force: true });
+  } catch (error) {
+    try {
+      await rename(deletedProfilePath, profilePath);
+      await writeFileAtomically(localStatePath, originalLocalStateText);
+    } catch {
+      throw new Error("Profile deletion failed and could not be rolled back");
+    }
+    throw error;
+  }
   return localState;
 };
 

--- a/extensions/google-chrome-profiles/src/util/util.ts
+++ b/extensions/google-chrome-profiles/src/util/util.ts
@@ -1,11 +1,28 @@
 import { URL } from "url";
 import { writeFileSync, unlinkSync } from "fs";
-import { tmpdir } from "os";
-import { join } from "path";
-import { spawn } from "child_process";
+import { lstat, readFile, rename, rm, writeFile } from "fs/promises";
+import { tmpdir, homedir } from "os";
+import { dirname, join, resolve } from "path";
+import { spawn, execFile } from "child_process";
+import { promisify } from "util";
 import { randomUUID } from "crypto";
 import { showToast, Toast } from "@raycast/api";
-import { BrowserConfig } from "./types";
+import { BrowserConfig, GoogleChromeLocalState, Profile } from "./types";
+
+const execFileAsync = promisify(execFile);
+
+const profileIsOpen = async (profilePath: string) => {
+  try {
+    const { stdout } = await execFileAsync("/usr/sbin/lsof", ["-nP", "-t", "+D", profilePath], { timeout: 10000 });
+    return stdout.trim().length > 0;
+  } catch (error) {
+    const output = error instanceof Error && "stdout" in error ? String(error.stdout) : "";
+    if (output.trim()) return true;
+    const code = error instanceof Error ? (error as { code?: string | number }).code : undefined;
+    if (code === 1 || code === "1") return false;
+    throw new Error("Could not determine whether the Chrome profile is open");
+  }
+};
 
 export type ChromeTarget =
   | { action: "focus" }
@@ -18,6 +35,68 @@ export const ChromeAction = {
   NewTab: { action: "newTab" } as ChromeTarget,
   NewWindow: { action: "newWindow" } as ChromeTarget,
   openUrl: (url: string): ChromeTarget => ({ action: "openUrl", url }),
+};
+
+export const deleteChromeProfile = async (profile: Profile, browser: BrowserConfig) => {
+  const dataDirectory = resolve(homedir(), browser.dataPath);
+  const profilePath = resolve(dataDirectory, profile.directory);
+  if (dirname(profilePath) !== dataDirectory) throw new Error("Invalid Chrome profile directory");
+
+  const localStatePath = join(dataDirectory, "Local State");
+  const localState = JSON.parse(await readFile(localStatePath, "utf8")) as GoogleChromeLocalState;
+  const infoCache = localState.profile?.info_cache;
+  if (!infoCache || !Object.prototype.hasOwnProperty.call(infoCache, profile.directory)) {
+    throw new Error("Profile no longer exists");
+  }
+  if (Object.keys(infoCache).length === 1) throw new Error("Chrome must keep at least one profile");
+
+  let profileStats;
+  try {
+    profileStats = await lstat(profilePath);
+  } catch (error) {
+    if (error instanceof Error && (error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error("Chrome profile directory not found");
+    }
+    throw error;
+  }
+  if (!profileStats.isDirectory()) throw new Error("Chrome profile path is not a directory");
+  if (await profileIsOpen(profilePath)) throw new Error(`Close the ${profile.name} profile before deleting it`);
+
+  const deletedProfilePath = join(dataDirectory, `.raycast-delete-${randomUUID()}`);
+  await rename(profilePath, deletedProfilePath);
+
+  try {
+    if (await profileIsOpen(deletedProfilePath)) {
+      throw new Error(`Close the ${profile.name} profile before deleting it`);
+    }
+    delete infoCache[profile.directory];
+    localState.profile.last_active_profiles = localState.profile.last_active_profiles?.filter(
+      (directory) => directory !== profile.directory,
+    );
+    localState.profile.profiles_order = localState.profile.profiles_order?.filter(
+      (directory) => directory !== profile.directory,
+    );
+    if (localState.profile.last_used === profile.directory) {
+      localState.profile.last_used = Object.keys(infoCache)[0];
+    }
+    const temporaryLocalStatePath = `${localStatePath}.${randomUUID()}.tmp`;
+    try {
+      await writeFile(temporaryLocalStatePath, `${JSON.stringify(localState, null, 2)}\n`, "utf8");
+      await rename(temporaryLocalStatePath, localStatePath);
+    } finally {
+      await rm(temporaryLocalStatePath, { force: true }).catch(() => undefined);
+    }
+  } catch (error) {
+    try {
+      await rename(deletedProfilePath, profilePath);
+    } catch {
+      throw new Error("Profile deletion failed and could not be rolled back");
+    }
+    throw error;
+  }
+
+  await rm(deletedProfilePath, { recursive: true, force: true });
+  return localState;
 };
 
 export const createBookmarkListItem = (url: string, name?: string) => {


### PR DESCRIPTION
## Summary

- Add a destructive **Delete Profile** action to the profile list.
- Require confirmation and use a dedicated `⌘ ⇧ Backspace` shortcut.
- Delete the selected profile directory and update Chrome `Local State` atomically.
- Allow deleting inactive profiles while Chrome is running; block deletion when the selected profile is active.
- Prevent path traversal, deleting non-directories, and deleting the last profile.

## Testing

- `npm run lint`
- `npm run build`
- Tested deletion logic with a temporary two-profile fixture: the selected directory was removed, the sibling directory was preserved, and `Local State` was updated.