### PR TITLE
Fix Kagi Search unauthorized error by migrating to v1 Search API

### DIFF
--- a/extensions/kagi-search/CHANGELOG.md
+++ b/extensions/kagi-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Kagi Search Changelog
 
-## [1.2.6] - {PR_MERGE_DATE}
+## [1.2.6] - 2026-08-23
 
 * Fix "Unauthorized" error on search by migrating from the retired `v0` Search API (`Authorization: Bot`) to the `v1` Search API (`POST /api/v1/search` with `Authorization: Bearer`), matching the official [kagi-openapi-typescript](https://github.com/kagisearch/kagi-openapi-typescript) client
 

--- a/extensions/kagi-search/CHANGELOG.md
+++ b/extensions/kagi-search/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Kagi Search Changelog
 
+## [1.2.6] - {PR_MERGE_DATE}
+
+* Fix "Unauthorized" error on search by migrating from the retired `v0` Search API (`Authorization: Bot`) to the `v1` Search API (`POST /api/v1/search` with `Authorization: Bearer`), matching the official [kagi-openapi-typescript](https://github.com/kagisearch/kagi-openapi-typescript) client
+
 ## [1.2.5] - 2026-04-30
 * Fix crash when corrupted null value in history storage
 

--- a/extensions/kagi-search/src/utils/kagiApi.ts
+++ b/extensions/kagi-search/src/utils/kagiApi.ts
@@ -2,36 +2,40 @@
 import { nanoid } from "nanoid";
 import { SearchResult } from "./types";
 
+// Types match the official Kagi v1 API client:
+// https://github.com/kagisearch/kagi-openapi-typescript
+interface KagiSearchItem {
+  url: string;
+  title: string;
+  snippet?: string;
+  time?: string;
+}
+
 interface KagiSearchResponse {
-  meta: {
-    id: string;
-    node: string;
-    ms: number;
-    api_balance: number;
+  meta?: {
+    id?: string;
+    node?: string;
+    ms?: number;
+    api_balance?: number;
   };
-  data: Array<{
-    t: number;
-    url: string;
-    title: string;
-    snippet?: string;
-    published?: string;
-    thumbnail?: {
-      url: string;
-      width?: number;
-      height?: number;
-    };
-    list?: string[]; // for related searches (t=1)
-  }>;
+  data?: {
+    search?: KagiSearchItem[];
+    news?: KagiSearchItem[];
+    related_search?: KagiSearchItem[];
+  };
 }
 
 export async function searchWithKagiAPI(query: string, apiKey: string, signal: AbortSignal): Promise<SearchResult[]> {
-  const response = await fetch(`https://kagi.com/api/v0/search?q=${encodeURIComponent(query)}`, {
-    method: "GET",
+  const response = await fetch("https://kagi.com/api/v1/search", {
+    method: "POST",
     signal: signal,
     headers: {
-      Authorization: `Bot ${apiKey}`,
+      Authorization: `Bearer ${apiKey}`,
       "Content-Type": "application/json",
     },
+    body: JSON.stringify({
+      query: query,
+    }),
   });
 
   if (!response.ok) {
@@ -39,22 +43,14 @@ export async function searchWithKagiAPI(query: string, apiKey: string, signal: A
   }
 
   const data = (await response.json()) as KagiSearchResponse;
-  const results: SearchResult[] = [];
 
-  // Process search results (t=0)
-  data.data.forEach((item) => {
-    if (item.t === 0) {
-      results.push({
-        id: nanoid(),
-        query: item.title,
-        description: item.snippet || "",
-        url: item.url,
-        isApiResult: true,
-      });
-    }
-  });
-
-  return results;
+  return (data.data?.search ?? []).map((item) => ({
+    id: nanoid(),
+    query: item.title,
+    description: item.snippet || "",
+    url: item.url,
+    isApiResult: true,
+  }));
 }
 
 interface FastGPTResponse {


### PR DESCRIPTION
The extension called the retired v0 search endpoint with the old 'Authorization: Bot' scheme, which now returns 401 Unauthorized. Switch to POST /api/v1/search with Bearer auth and the grouped response shape defined by the official kagi-openapi-typescript client. FastGPT remains on v0, which is still current for that endpoint.  Closes #23164 

## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
