### PR TITLE
perf(extensions): reduce background refresh frequency

### DIFF
--- a/extensions/audio-device/CHANGELOG.md
+++ b/extensions/audio-device/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Audio Device Changelog
 
+## [Fix] - 2026-08-21
+
+- Reduce background device enforcement refreshes from every 10 seconds to every minute.
+
 ## [Bugfix] - 2026-05-27
 
 - Show a confirmation when manually running the enforce device commands.

--- a/extensions/audio-device/README.md
+++ b/extensions/audio-device/README.md
@@ -6,9 +6,9 @@ Switch audio devices, lock volumes, and stop macOS from changing your sound sett
 
 **Switch devices.** Open "Set Output Device" or "Set Input Device". Press Enter to switch. The window stays open so you can keep working.
 
-**Lock a device in place.** Press Cmd+Shift+D on any device to make it your default. If macOS switches away (after sleep, Bluetooth reconnect, plugging in a monitor), the extension switches back within 10 seconds. Manually switching gives you a 1-minute grace period before enforcement resumes.
+**Lock a device in place.** Press Cmd+Shift+D on any device to make it your default. If macOS switches away (after sleep, Bluetooth reconnect, plugging in a monitor), the extension switches back on the next background refresh (roughly every minute). Manually switching gives you a 1-minute grace period before enforcement resumes.
 
-**Lock a volume level.** Press Cmd+Shift+V on any device to pin its volume. If macOS resets it, the extension restores it within 10 seconds. Changes under 2% are ignored so minor system adjustments don't trigger a reset.
+**Lock a volume level.** Press Cmd+Shift+V on any device to pin its volume. If macOS resets it, the extension restores it on the next background refresh (roughly every minute). Changes under 2% are ignored so minor system adjustments don't trigger a reset.
 
 **See volume levels.** Each device shows its current volume percentage. HDMI/DisplayPort devices that don't support software volume control show "Volume controlled by device".
 
@@ -41,7 +41,7 @@ Switch audio devices, lock volumes, and stop macOS from changing your sound sett
 
 ## How enforcement works
 
-The enforce commands run silently every 10 seconds. They check two things:
+The enforce commands run silently every minute. They check two things:
 
 1. **Default device** — if your default device is connected but not active, switch to it. Skipped for 1 minute after a manual switch so you can temporarily use another device.
 2. **Pinned volumes** — if a pinned volume has drifted by 2% or more, reset it.

--- a/extensions/audio-device/package.json
+++ b/extensions/audio-device/package.json
@@ -63,17 +63,17 @@
       "name": "auto-switch-input",
       "title": "Enforce Input Device",
       "subtitle": "Audio Device",
-      "description": "Keeps your default input device and pinned volumes in place. Runs silently in the background every 10 seconds. If you disable this, your default device and pinned volumes will stop being enforced — macOS may switch devices or reset volumes after sleep, Bluetooth reconnects, etc.",
+      "description": "Keeps your default input device and pinned volumes in place. Runs silently in the background every minute. If you disable this, your default device and pinned volumes will stop being enforced — macOS may switch devices or reset volumes after sleep, Bluetooth reconnects, etc.",
       "mode": "no-view",
-      "interval": "10s"
+      "interval": "1m"
     },
     {
       "name": "auto-switch-output",
       "title": "Enforce Output Device",
       "subtitle": "Audio Device",
-      "description": "Keeps your default output device and pinned volumes in place. Runs silently in the background every 10 seconds. If you disable this, your default device and pinned volumes will stop being enforced — macOS may switch devices or reset volumes after sleep, Bluetooth reconnects, etc.",
+      "description": "Keeps your default output device and pinned volumes in place. Runs silently in the background every minute. If you disable this, your default device and pinned volumes will stop being enforced — macOS may switch devices or reset volumes after sleep, Bluetooth reconnects, etc.",
       "mode": "no-view",
-      "interval": "10s"
+      "interval": "1m"
     },
     {
       "name": "customize-order",

--- a/extensions/audio-device/src/customize-order.tsx
+++ b/extensions/audio-device/src/customize-order.tsx
@@ -10,7 +10,7 @@ The old priority-ordering system (where you ranked multiple devices as fallbacks
 
 1. Open **Set Output Device** or **Set Input Device**
 2. Press **Cmd+Shift+D** on the device you want to select as default
-3. That device will be automatically restored within 10 seconds if macOS switches away
+3. That device will be automatically restored on the next background refresh (roughly every minute) if macOS switches away
 `;
 
 export default function Command() {

--- a/extensions/coffee/CHANGELOG.md
+++ b/extensions/coffee/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Coffee Changelog
 
+## [Fix] - 2026-08-21
+
+- Reduced background status refreshes to once per minute.
+
 ## [Fix] - 2026-08-20
 
 - Fixed future caffeination schedules not activating automatically and ensured they stop at the configured end time.

--- a/extensions/coffee/package.json
+++ b/extensions/coffee/package.json
@@ -128,7 +128,7 @@
       "title": "Caffeinate Status",
       "description": "Show the current caffeination status",
       "mode": "no-view",
-      "interval": "15s"
+      "interval": "1m"
     }
   ],
   "tools": [

--- a/extensions/desktoprenamer/CHANGELOG.md
+++ b/extensions/desktoprenamer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # DesktopRenamer Changelog
 
+## [Fix] - 2026-08-21
+
+- Reduced background desktop status refreshes to once per minute.
+
 ## [Window Actions] - 2026-08-03
 
 - Added window actions to `Batch Move Windows` and `List Windows` commands

--- a/extensions/desktoprenamer/package.json
+++ b/extensions/desktoprenamer/package.json
@@ -23,7 +23,7 @@
       "title": "Current Desktop",
       "description": "Show the currently active desktop with live status.",
       "mode": "no-view",
-      "interval": "10s"
+      "interval": "1m"
     },
     {
       "name": "rename-current-space",

--- a/extensions/everhour/CHANGELOG.md
+++ b/extensions/everhour/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Everhour
 
+## [Fix] - 2026-08-21
+
+- Reduced background timer status refreshes to once per minute.
+
 ## [Fix] - 2024-10-25
 
 - Fix for issue [#14813](https://github.com/raycast/extensions/issues/14813)

--- a/extensions/everhour/package.json
+++ b/extensions/everhour/package.json
@@ -35,7 +35,7 @@
       "subtitle": "Everhour",
       "description": "View, Start, Stop the current timer",
       "mode": "no-view",
-      "interval": "10s",
+      "interval": "1m",
       "arguments": [
         {
           "name": "quickAction",

--- a/extensions/laravel-herd/CHANGELOG.md
+++ b/extensions/laravel-herd/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Laravel Herd Changelog
 
+## Background Refresh Fix - 2026-08-21
+
+- Reduced recent-site metadata refreshes to once per minute.
+
 ## Bugfix - 2025-06-11
 - Fixes a bug where »Open in IDE« was not working in some cases. #19610
 

--- a/extensions/laravel-herd/package.json
+++ b/extensions/laravel-herd/package.json
@@ -98,7 +98,7 @@
       "subtitle": "Laravel Herd",
       "description": "Opens the database of your most recent site.",
       "mode": "no-view",
-      "interval": "5s"
+      "interval": "1m"
     },
     {
       "name": "open-recent-site-tinker",
@@ -114,7 +114,7 @@
       "subtitle": "Laravel Herd",
       "description": "Opens the Log Viewer for your most recent site.",
       "mode": "no-view",
-      "interval": "5s"
+      "interval": "1m"
     },
     {
       "name": "open-docs",

--- a/extensions/moodist/CHANGELOG.md
+++ b/extensions/moodist/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Fix] — 2026-08-21
+
+- Reduced background keep-alive checks to once per minute.
+
 ## [1.0.0] — 2026-04-08
 
 Initial release.

--- a/extensions/moodist/package.json
+++ b/extensions/moodist/package.json
@@ -66,7 +66,7 @@
       "subtitle": "Moodist",
       "description": "Background task that restarts sounds if they stop unexpectedly",
       "mode": "no-view",
-      "interval": "20s",
+      "interval": "1m",
       "disabledByDefault": true
     }
   ],

--- a/extensions/music/CHANGELOG.md
+++ b/extensions/music/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Apple Music Changelog
 
+## [Background Refresh Fix] - 2026-08-21
+
+- Reduced background current-track refreshes to once per minute.
+
 ## [Fix Library Album Search] - 2026-06-15
 
 - Fixed `Play Library Album` so searching by artist name shows matching albums from the library.

--- a/extensions/music/package.json
+++ b/extensions/music/package.json
@@ -131,7 +131,7 @@
       "description": "Get info about currently playing track.",
       "disabledByDefault": true,
       "mode": "no-view",
-      "interval": "30s"
+      "interval": "1m"
     },
     {
       "name": "remove-current-playing-from-current-playlist",

--- a/extensions/shutdown-timer/CHANGELOG.md
+++ b/extensions/shutdown-timer/CHANGELOG.md
@@ -1,3 +1,7 @@
 # Shutdown Timer Changelog
 
+## [Fix] - 2026-08-21
+
+- Reduced background remaining-time refreshes to once per minute.
+
 ## [Initial Version] - 2025-06-16

--- a/extensions/shutdown-timer/package.json
+++ b/extensions/shutdown-timer/package.json
@@ -15,7 +15,7 @@
             "title": "Remaining Time",
             "description": "Tells you how much time remaining",
             "mode": "no-view",
-            "interval": "30s"
+            "interval": "1m"
         },
         {
             "name": "schedule-shutdown",

--- a/extensions/sonos/CHANGELOG.md
+++ b/extensions/sonos/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Sonos Changelog
 
+## [Fix] - 2026-08-21
+
+- Reduced background playback-state refreshes to once per minute.
+
 ## [Bug fix] - 2026-05-20
 
 - Fix an error when setting the active group while another Sonos command is using the event listener port

--- a/extensions/sonos/package.json
+++ b/extensions/sonos/package.json
@@ -22,7 +22,7 @@
       "subtitle": "Sonos",
       "description": "Toggle the playback state of the active group",
       "mode": "no-view",
-      "interval": "5s"
+      "interval": "1m"
     },
     {
       "name": "set-group",

--- a/extensions/tailscale/CHANGELOG.md
+++ b/extensions/tailscale/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Tailscale Changelog
 
+## [Fix] - 2026-08-21
+
+- Reduced background connection-status refreshes to once per minute.
+
 ## [Add new features] - 2026-05-07
 
 - Added Menu bar indicator: shows an icon when connected, nothing when disconnected

--- a/extensions/tailscale/package.json
+++ b/extensions/tailscale/package.json
@@ -78,7 +78,7 @@
       "subtitle": "Tailscale",
       "description": "Show Tailscale's connection status.",
       "mode": "no-view",
-      "interval": "30s",
+      "interval": "1m",
       "preferences": [
         {
           "name": "showHostname",

--- a/extensions/wip/CHANGELOG.md
+++ b/extensions/wip/CHANGELOG.md
@@ -1,5 +1,9 @@
 # WIP Changelog
 
+## [Fix] - 2026-08-21
+
+- Reduced background streak refreshes to once per minute.
+
 ## [Improved authentication error handling] - 2025-06-16
 
 - Improve authentication error handling

--- a/extensions/wip/package.json
+++ b/extensions/wip/package.json
@@ -24,7 +24,7 @@
       "subtitle": "WIP",
       "description": "Show WIP Streak",
       "mode": "no-view",
-      "interval": "10s"
+      "interval": "1m"
     },
     {
       "name": "done",


### PR DESCRIPTION
## Description

- Change periodic background commands to refresh once per minute
- Reduce unnecessary polling across audio, status, timer, and media extensions
- Update documentation and changelogs to reflect the new refresh interval

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
