### PR TITLE
fix(duckduckgo-email): send User-Agent header to avoid bot protection 403s

### DIFF
--- a/extensions/duckduckgo-email/CHANGELOG.md
+++ b/extensions/duckduckgo-email/CHANGELOG.md
@@ -1,3 +1,6 @@
 # DuckDuckGo-Email Changelog
 
+## [1.0.1] - 2026-08-21
+- Send a User-Agent header so requests are not rejected by DuckDuckGo's bot protection
+
 ## [Initial Version] - 2024-03-28

--- a/extensions/duckduckgo-email/CHANGELOG.md
+++ b/extensions/duckduckgo-email/CHANGELOG.md
@@ -1,6 +1,6 @@
 # DuckDuckGo-Email Changelog
 
-## [1.0.1] - 2026-08-21
+## [1.0.1] - {PR_MERGE_DATE}
 - Send a User-Agent header so requests are not rejected by DuckDuckGo's bot protection
 
 ## [Initial Version] - 2024-03-28

--- a/extensions/duckduckgo-email/CHANGELOG.md
+++ b/extensions/duckduckgo-email/CHANGELOG.md
@@ -1,6 +1,6 @@
 # DuckDuckGo-Email Changelog
 
-## [1.0.1] - {PR_MERGE_DATE}
+## [1.0.1] - 2026-08-21
 - Send a User-Agent header so requests are not rejected by DuckDuckGo's bot protection
 
 ## [Initial Version] - 2024-03-28

--- a/extensions/duckduckgo-email/package-lock.json
+++ b/extensions/duckduckgo-email/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "duckduckgo-email",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "duckduckgo-email",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.69.0",

--- a/extensions/duckduckgo-email/package.json
+++ b/extensions/duckduckgo-email/package.json
@@ -19,7 +19,7 @@
       "mode": "no-view"
     }
   ],
-  "preferences":[
+  "preferences": [
     {
       "name": "token",
       "description": "Your DuckDuckGo token",
@@ -46,5 +46,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/duckduckgo-email/package.json
+++ b/extensions/duckduckgo-email/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "duckduckgo-email",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "title": "DuckDuckGo Email",
   "description": "A simple extension that generate DuckDuckGo email alias",
   "icon": "duckduckgo-icon.png",

--- a/extensions/duckduckgo-email/src/index.ts
+++ b/extensions/duckduckgo-email/src/index.ts
@@ -12,17 +12,28 @@ interface EmailResponse {
 }
 async function getEmail() {
   const preferences = getPreferenceValues<Preferences>();
-  console.log(preferences);
   const response = await fetch("https://quack.duckduckgo.com/api/email/addresses", {
     method: "POST",
     headers: {
       Authorization: `Bearer ${preferences.token}`,
+      // DuckDuckGo's bot protection rejects requests without a browser-like User-Agent
+      "User-Agent": "Mozilla/5.0",
     },
     redirect: "follow",
   });
-  const parsedResponse = (await response.json()) as EmailResponse;
-  if (parsedResponse.error) {
-    throw new Error(parsedResponse.error);
+  const body = await response.text();
+  let parsedResponse: EmailResponse;
+  try {
+    parsedResponse = JSON.parse(body) as EmailResponse;
+  } catch {
+    // Non-JSON body (e.g. empty 403 from bot protection)
+    parsedResponse = {};
+  }
+  if (!response.ok || parsedResponse.error) {
+    throw new Error(parsedResponse.error ?? `Request failed with status ${response.status}`);
+  }
+  if (!parsedResponse.address) {
+    throw new Error("No address in response");
   }
   return parsedResponse.address + "@duck.com";
 }


### PR DESCRIPTION
Generating an alias fails with "⚠️ Unknown error" for all users right now.

**Problem**

DuckDuckGo's bot protection on quack.duckduckgo.com rejects requests that don't send a browser-like User-Agent header. The extension sent only the Authorization header, so node-fetch's default UA got a 403 with an empty body. The empty body then made `response.json()` throw, which surfaced as "Unknown error" instead of anything useful.

I reproduced this today against the live API:

- Request mimicking the extension (node-fetch UA, Authorization only): HTTP 403, empty body
- Same request with a User-Agent header: HTTP 201, fresh alias returned

**Fix**

- Send `User-Agent: Mozilla/5.0` with the request
- Parse the response body safely and show DDG's error message or the HTTP status when something fails
- Removed a stray `console.log(preferences)` that printed the token into Raycast's debug log

Version bumped to 1.0.1 with a changelog entry.
