### PR TITLE
Search Apple Music Command

### DIFF
--- a/extensions/music/.gitignore
+++ b/extensions/music/.gitignore
@@ -13,3 +13,4 @@ compiled_raycast_rust
 # misc
 .DS_Store
 CLAUDE.md
+.idea/

--- a/extensions/music/CHANGELOG.md
+++ b/extensions/music/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Apple Music Changelog
 
-## [Search Apple Music Command] - {PR_MERGE_DATE}
+## [Search Apple Music Command] - 2026-08-22
 
 - Added a new "Search Apple Music" command that searches the Apple Music catalog for songs and albums — with album tracklists, Open in Music, and Add to Library (checking first whether the item is already in your library).
 - Added Apple Music account sign-in (via Raycast's OAuth proxy) powering the catalog features.

--- a/extensions/music/CHANGELOG.md
+++ b/extensions/music/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Apple Music Changelog
 
+## [Search Apple Music Command] - {PR_MERGE_DATE}
+
+- Added a new "Search Apple Music" command that searches the Apple Music catalog for songs and albums — with album tracklists, Open in Music, and Add to Library (checking first whether the item is already in your library).
+- Added Apple Music account sign-in (via Raycast's OAuth proxy) powering the catalog features.
+
 ## [Background Refresh Fix] - 2026-08-21
 
 - Reduced background current-track refreshes to once per minute.

--- a/extensions/music/package.json
+++ b/extensions/music/package.json
@@ -16,7 +16,8 @@
     "hrishabhn",
     "bogdan_bucur",
     "xmok",
-    "byheaven"
+    "byheaven",
+    "christianmagill"
   ],
   "license": "MIT",
   "keywords": [
@@ -330,6 +331,21 @@
           "default": "30",
           "required": false
         }
+      ]
+    },
+    {
+      "name": "search-apple-music",
+      "title": "Search Apple Music",
+      "subtitle": "Apple Music",
+      "description": "Search the Apple Music catalog for songs and albums, and add them to your library.",
+      "disabledByDefault": true,
+      "mode": "view",
+      "keywords": [
+        "search",
+        "catalog",
+        "album",
+        "song",
+        "library"
       ]
     },
     {

--- a/extensions/music/src/components/catalog-actions.tsx
+++ b/extensions/music/src/components/catalog-actions.tsx
@@ -1,0 +1,67 @@
+import { Action, Alert, confirmAlert, Icon, showToast, Toast } from "@raycast/api";
+import { pipe } from "fp-ts/lib/function";
+import * as T from "fp-ts/Task";
+import * as TE from "fp-ts/TaskEither";
+
+import { addToLibrary, isInLibrary } from "../util/catalog-api";
+
+const ADD_TITLES = {
+  songs: "Add Song to Library",
+  albums: "Add Album to Library",
+} as const;
+
+/** Add a catalog item to the library, checking membership at action time and
+ * asking before re-adding an item that is already there. */
+export function AddToLibraryAction({ kind, id, title }: { kind: keyof typeof ADD_TITLES; id: string; title: string }) {
+  return (
+    <Action
+      title={ADD_TITLES[kind]}
+      icon={Icon.Plus}
+      shortcut={{ modifiers: ["cmd", "shift"], key: "l" }}
+      onAction={async () => {
+        await showToast({ style: Toast.Style.Animated, title: "Adding to Library…" });
+
+        const alreadyInLibrary = await pipe(
+          isInLibrary(kind, id),
+          // A failed check must not block the add — worst case the user
+          // misses a duplicate warning, not the add itself.
+          TE.getOrElse(() => T.of(false)),
+        )();
+
+        if (alreadyInLibrary) {
+          const confirmed = await confirmAlert({
+            title: "Already in Library",
+            message: `"${title}" is already in your library. Add it anyway?`,
+            icon: Icon.QuestionMark,
+            primaryAction: { title: "Add Anyway", style: Alert.ActionStyle.Default },
+          });
+          if (!confirmed) return;
+          await showToast({ style: Toast.Style.Animated, title: "Adding to Library…" });
+        }
+
+        await pipe(
+          addToLibrary(kind, id),
+          TE.match(
+            (error) => {
+              showToast({ style: Toast.Style.Failure, title: "Add to Library Failed", message: error.message });
+            },
+            () => {
+              // 202 means Apple accepted the add, not that it has landed — it
+              // arrives via cloud sync, so the copy promises "shortly".
+              showToast({
+                style: Toast.Style.Success,
+                title: `Added "${title}"`,
+                message: "It will appear in your library shortly.",
+              });
+            },
+          ),
+        )();
+      }}
+    />
+  );
+}
+
+export function OpenInMusicAction({ url }: { url: string | null }) {
+  if (!url) return null;
+  return <Action.OpenInBrowser title="Open in Music" icon={Icon.Music} url={url} />;
+}

--- a/extensions/music/src/components/catalog-actions.tsx
+++ b/extensions/music/src/components/catalog-actions.tsx
@@ -19,7 +19,7 @@ export function AddToLibraryAction({ kind, id, title }: { kind: keyof typeof ADD
       icon={Icon.Plus}
       shortcut={{ modifiers: ["cmd", "shift"], key: "l" }}
       onAction={async () => {
-        await showToast({ style: Toast.Style.Animated, title: "Adding to Library…" });
+        const toast = await showToast({ style: Toast.Style.Animated, title: "Adding to Library…" });
 
         const alreadyInLibrary = await pipe(
           isInLibrary(kind, id),
@@ -29,6 +29,9 @@ export function AddToLibraryAction({ kind, id, title }: { kind: keyof typeof ADD
         )();
 
         if (alreadyInLibrary) {
+          // An animated toast never resolves on its own — hide it before the
+          // alert so a Cancel doesn't leave it spinning forever.
+          await toast.hide();
           const confirmed = await confirmAlert({
             title: "Already in Library",
             message: `"${title}" is already in your library. Add it anyway?`,
@@ -63,5 +66,7 @@ export function AddToLibraryAction({ kind, id, title }: { kind: keyof typeof ADD
 
 export function OpenInMusicAction({ url }: { url: string | null }) {
   if (!url) return null;
-  return <Action.OpenInBrowser title="Open in Music" icon={Icon.Music} url={url} />;
+  // The music: scheme hands the page to Music.app; the https URL would open
+  // the web player in the browser instead.
+  return <Action.Open title="Open in Music" icon={Icon.Music} target={url.replace(/^https:/, "music:")} />;
 }

--- a/extensions/music/src/search-apple-music.tsx
+++ b/extensions/music/src/search-apple-music.tsx
@@ -1,0 +1,166 @@
+import { Action, ActionPanel, Icon, List, showToast, Toast, useNavigation } from "@raycast/api";
+import { usePromise } from "@raycast/utils";
+import { pipe } from "fp-ts/lib/function";
+import * as T from "fp-ts/Task";
+import * as TE from "fp-ts/TaskEither";
+import { useState } from "react";
+
+import { AddToLibraryAction, OpenInMusicAction } from "./components/catalog-actions";
+import { SignOutAction, withAppleMusicAuth } from "./util/apple-music-auth";
+import { artworkUrl, CatalogSearchResults, getCatalogAlbum, searchCatalog } from "./util/catalog-api";
+import { CatalogAlbum, CatalogSong } from "./util/models";
+
+const LIST_ART = 160;
+const EMPTY_RESULTS: CatalogSearchResults = { songs: [], albums: [] };
+
+function formatDuration(durationMs: number): string {
+  const seconds = Math.floor(durationMs / 1000);
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+function SearchAppleMusic() {
+  const [searchText, setSearchText] = useState("");
+
+  const { data, isLoading } = usePromise(
+    (query: string) =>
+      pipe(
+        searchCatalog(query),
+        TE.getOrElseW((error) => {
+          showToast({ style: Toast.Style.Failure, title: "Search Failed", message: error.message });
+          return T.of(EMPTY_RESULTS);
+        }),
+      )(),
+    [searchText],
+    { execute: searchText.length > 0 },
+  );
+
+  const albums = data?.albums ?? [];
+  const songs = data?.songs ?? [];
+
+  return (
+    <List
+      isLoading={isLoading}
+      searchBarPlaceholder="Search Apple Music for songs and albums"
+      onSearchTextChange={setSearchText}
+      throttle
+    >
+      {!searchText ? (
+        <List.EmptyView
+          title="Search Apple Music"
+          description="Type to search the catalog for songs and albums"
+          icon={Icon.Music}
+        />
+      ) : (
+        <>
+          {albums.length > 0 && (
+            <List.Section title="Albums" subtitle={`${albums.length}`}>
+              {albums.map((album) => (
+                <CatalogAlbumItem key={album.id} album={album} />
+              ))}
+            </List.Section>
+          )}
+          {songs.length > 0 && (
+            <List.Section title="Songs" subtitle={`${songs.length}`}>
+              {songs.map((song) => (
+                <CatalogSongItem key={song.id} song={song} />
+              ))}
+            </List.Section>
+          )}
+        </>
+      )}
+    </List>
+  );
+}
+
+function CatalogSongItem({ song, showAlbum = true }: { song: CatalogSong; showAlbum?: boolean }) {
+  const accessories: List.Item.Accessory[] = [];
+  if (song.contentRating === "explicit") accessories.push({ tag: "E", tooltip: "Explicit" });
+  if (showAlbum && song.album) accessories.push({ text: song.album });
+  if (song.durationMs) accessories.push({ text: formatDuration(song.durationMs) });
+  return (
+    <List.Item
+      icon={artworkUrl(song.artwork, LIST_ART) ?? Icon.Music}
+      title={song.title}
+      subtitle={song.artist}
+      accessories={accessories}
+      actions={
+        <ActionPanel>
+          <OpenInMusicAction url={song.url} />
+          {song.playable && <AddToLibraryAction kind="songs" id={song.id} title={song.title} />}
+          {song.url && <CopyLinkAction url={song.url} />}
+          <SignOutAction />
+        </ActionPanel>
+      }
+    />
+  );
+}
+
+function CatalogAlbumItem({ album }: { album: CatalogAlbum }) {
+  const { push } = useNavigation();
+  const accessories: List.Item.Accessory[] = [];
+  if (album.contentRating === "explicit") accessories.push({ tag: "E", tooltip: "Explicit" });
+  if (album.releaseDate) accessories.push({ text: album.releaseDate.slice(0, 4) });
+  accessories.push({ text: `${album.trackCount} Tracks` });
+  return (
+    <List.Item
+      icon={artworkUrl(album.artwork, LIST_ART) ?? Icon.Cd}
+      title={album.title}
+      subtitle={album.artist}
+      accessories={accessories}
+      actions={
+        <ActionPanel>
+          <OpenInMusicAction url={album.url} />
+          <AddToLibraryAction kind="albums" id={album.id} title={album.title} />
+          <Action
+            title="View Tracklist"
+            icon={Icon.List}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "a" }}
+            onAction={() => push(<CatalogAlbumView albumId={album.id} title={album.title} />)}
+          />
+          {album.url && <CopyLinkAction url={album.url} />}
+          <SignOutAction />
+        </ActionPanel>
+      }
+    />
+  );
+}
+
+function CatalogAlbumView({ albumId, title }: { albumId: string; title: string }) {
+  const { data, isLoading } = usePromise(
+    (id: string) =>
+      pipe(
+        getCatalogAlbum(id),
+        TE.getOrElseW((error) => {
+          showToast({ style: Toast.Style.Failure, title: "Could Not Load Album", message: error.message });
+          return T.of(null);
+        }),
+      )(),
+    [albumId],
+  );
+
+  return (
+    <List isLoading={isLoading} navigationTitle={title}>
+      {data && (
+        <List.Section
+          title={data.album.title}
+          subtitle={`${data.album.artist}${data.album.releaseDate ? ` · ${data.album.releaseDate}` : ""}`}
+        >
+          {data.tracks.map((track) => (
+            <CatalogSongItem key={track.id} song={track} showAlbum={false} />
+          ))}
+        </List.Section>
+      )}
+    </List>
+  );
+}
+
+// ⌘C stays unbound by convention — copy actions use ⌘⇧C.
+function CopyLinkAction({ url }: { url: string }) {
+  return (
+    <Action.CopyToClipboard title="Copy Link" content={url} shortcut={{ modifiers: ["cmd", "shift"], key: "c" }} />
+  );
+}
+
+export default withAppleMusicAuth(SearchAppleMusic);

--- a/extensions/music/src/util/apple-music-auth.tsx
+++ b/extensions/music/src/util/apple-music-auth.tsx
@@ -1,0 +1,219 @@
+import { Action, environment, Icon, LocalStorage, OAuth, showToast, Toast } from "@raycast/api";
+import { withAccessToken } from "@raycast/utils";
+
+// Apple Music authentication via Raycast's OAuth proxy. The auth handshake
+// below follows the reference implementation the Raycast team supplied.
+//
+// The proxy owns both halves of the Apple Music credential pair:
+//   GET  /developer-token  — a team-issued JWT (6-month life, rotated
+//                            server-side). Unlike the token the web player
+//                            ships, it carries no `root_https_origin` claim,
+//                            so it is not pinned to an origin and the public
+//                            api.music.apple.com host accepts it directly.
+//   /authorize + /token    — a standard PKCE flow that yields the Music user
+//                            token identifying this user's library.
+//
+// Neither token is persisted by us: the developer token is fetched per
+// request, and the user token lives in Raycast's encrypted OAuth store via
+// the PKCE client.
+
+const PROXY_BASE_URL = "https://apple-music-oauth.raycast.com";
+const API_BASE_URL = "https://api.music.apple.com";
+const CLIENT_ID = "raycast";
+
+const DEVELOPER_TOKEN_KEY = "apple-music.developer-token";
+// Treat the developer token as stale an hour before it actually lapses, so a
+// long-running command can't have it expire out from under it mid-flight.
+const DEVELOPER_TOKEN_SKEW_MS = 60 * 60 * 1000;
+// Cheapest authenticated endpoint Apple exposes — used only to ask "does this
+// user token still work?", never for its payload.
+const TOKEN_PROBE_PATH = "/v1/me/storefront";
+
+const client = new OAuth.PKCEClient({
+  redirectMethod: OAuth.RedirectMethod.Web,
+  providerName: "Apple Music",
+  providerId: "apple-music",
+  description: "Connect your Apple Music account",
+});
+
+function debugLog(message: string): void {
+  if (environment.isDevelopment) console.debug(`[AppleMusicAuth] ${message}`);
+}
+
+async function fetchTokens(authRequest: OAuth.AuthorizationRequest, authCode: string): Promise<OAuth.TokenResponse> {
+  const params = new URLSearchParams();
+  params.append("client_id", CLIENT_ID);
+  params.append("code", authCode);
+  params.append("code_verifier", authRequest.codeVerifier);
+  params.append("grant_type", "authorization_code");
+  params.append("redirect_uri", authRequest.redirectURI);
+
+  const response = await fetch(`${PROXY_BASE_URL}/token`, { method: "POST", body: params });
+  if (!response.ok) {
+    console.error("fetch tokens error:", await response.text());
+    throw new Error(response.statusText);
+  }
+  // Observed fields: access_token, token_type, expires_in, developer_token.
+  // `expires_in` being present is what makes the `isExpired()` check in
+  // `authorize` meaningful rather than permanently false.
+  return (await response.json()) as OAuth.TokenResponse;
+}
+
+/** Obtain a Music user token, opening the sign-in flow only when needed.
+ *
+ * Music user tokens cannot be refreshed — Apple issues no refresh token, and
+ * re-running the authorization flow is the only renewal path — so an expired
+ * set is discarded and the flow starts over. */
+async function authorize(): Promise<string> {
+  const tokenSet = await client.getTokens();
+  if (tokenSet?.accessToken) {
+    if (!tokenSet.isExpired()) return tokenSet.accessToken;
+    debugLog("stored user token reported expired; discarding and re-authorizing");
+    await client.removeTokens();
+  }
+
+  const authRequest = await client.authorizationRequest({
+    endpoint: `${PROXY_BASE_URL}/authorize`,
+    clientId: CLIENT_ID,
+    scope: "",
+  });
+  const { authorizationCode } = await client.authorize(authRequest);
+  const tokens = await fetchTokens(authRequest, authorizationCode);
+  await client.setTokens(tokens);
+  return tokens.access_token;
+}
+
+/** Ask Apple whether a user token is still accepted.
+ *
+ * A token can be invalidated server-side — signed out on another device, Apple
+ * ID password change, lapsed subscription — and nothing about that is visible
+ * locally: it is not a JWT, `isExpired()` still reports false, and the stored
+ * copy looks perfectly healthy. The only way to know is to ask.
+ *
+ * A network failure is NOT a rejected token, and must not be reported as one:
+ * forcing a sign-in prompt because the user's wifi dropped would be worse than
+ * the problem being solved. */
+async function isTokenAccepted(userToken: string): Promise<boolean> {
+  try {
+    const response = await appleMusicRequest(TOKEN_PROBE_PATH, userToken);
+    return response.status !== 401 && response.status !== 403;
+  } catch (error) {
+    debugLog(`token probe could not reach Apple, assuming the token is fine: ${error}`);
+    return true;
+  }
+}
+
+/** `authorize` plus a liveness check on the token it returned.
+ *
+ * Costs one extra request per command launch and buys the failure mode
+ * `authorize` structurally cannot catch: a revoked token sails through its
+ * expiry check, so without this a command would open, look healthy, and then
+ * fail on real work with no route to recovery but a manual sign-out. */
+async function authorizeAndValidate(): Promise<string> {
+  const storedBefore = (await client.getTokens())?.accessToken;
+  const token = await authorize();
+  // A token Apple just minted needs no liveness check — only a token that was
+  // already sitting in storage can have been revoked behind our back.
+  if (token !== storedBefore) return token;
+  if (await isTokenAccepted(token)) return token;
+
+  debugLog("Apple rejected the stored user token; clearing it and signing in again");
+  await client.removeTokens();
+  return authorize();
+}
+
+/** Wraps a command so the sign-in flow runs before the command body does —
+ * commands get a valid token or Raycast's own sign-in screen, and never have
+ * to guard individual call sites. Works for both view components and no-view
+ * async functions. */
+export const withAppleMusicAuth = withAccessToken({ authorize: authorizeAndValidate, client });
+
+/** Drop the stored user token. The next authenticated command prompts for a
+ * fresh sign-in, which is also how you switch accounts. */
+export async function signOut(): Promise<void> {
+  await client.removeTokens();
+}
+
+/** Sign-out affordance for the action panel of any authenticated command.
+ * Lives here rather than in a command of its own — signing out is rare
+ * enough that it doesn't warrant a slot in the root command list. */
+export function SignOutAction() {
+  return (
+    <Action
+      title="Sign out of Apple Music"
+      icon={Icon.Logout}
+      style={Action.Style.Destructive}
+      shortcut={{ modifiers: ["cmd", "shift"], key: "x" }}
+      onAction={async () => {
+        await signOut();
+        await showToast({
+          style: Toast.Style.Success,
+          title: "Signed Out",
+          message: "Reopen this command to sign in again.",
+        });
+      }}
+    />
+  );
+}
+
+type CachedDeveloperToken = { token: string; expiresAtMs: number };
+
+/** The proxy's developer token, cached until it nears expiry.
+ *
+ * The token is app-level rather than user-level (the endpoint needs no auth at
+ * all) and the proxy hands back a byte-identical string on repeated calls, so
+ * re-requesting it per API call is pure latency — ~140ms each, which a paging
+ * scan pays once per page. Cached in LocalStorage so it survives across
+ * command launches too. */
+async function getDeveloperToken(): Promise<string> {
+  const cachedRaw = await LocalStorage.getItem<string>(DEVELOPER_TOKEN_KEY);
+  if (cachedRaw) {
+    try {
+      const cached = JSON.parse(cachedRaw) as CachedDeveloperToken;
+      if (cached.token && cached.expiresAtMs - DEVELOPER_TOKEN_SKEW_MS > Date.now()) return cached.token;
+    } catch {
+      // Unparseable entry — fall through and refetch.
+    }
+  }
+
+  const response = await fetch(`${PROXY_BASE_URL}/developer-token`);
+  if (!response.ok) {
+    console.error("fetch developer token error:", await response.text());
+    throw new Error(response.statusText);
+  }
+  const { developer_token: developerToken, expires_at: expiresAtSeconds } = (await response.json()) as {
+    developer_token: string;
+    expires_at?: number;
+  };
+
+  // `expires_at` is UNIX SECONDS; Date.now() is milliseconds. Comparing them
+  // directly would make every cached token look long expired, silently turning
+  // the cache back into a fetch-per-call. If the field ever goes missing,
+  // skip caching rather than invent a lifetime.
+  if (developerToken && typeof expiresAtSeconds === "number") {
+    const entry: CachedDeveloperToken = { token: developerToken, expiresAtMs: expiresAtSeconds * 1000 };
+    await LocalStorage.setItem(DEVELOPER_TOKEN_KEY, JSON.stringify(entry));
+  } else {
+    debugLog("/developer-token returned no expires_at; not caching");
+  }
+  return developerToken;
+}
+
+/** One authenticated call to api.music.apple.com with an explicit user token. */
+async function appleMusicRequest(path: string, userToken: string, init?: RequestInit): Promise<Response> {
+  const developerToken = await getDeveloperToken();
+  return fetch(`${API_BASE_URL}${path}`, {
+    ...init,
+    headers: {
+      ...init?.headers,
+      Authorization: `Bearer ${developerToken}`,
+      "Music-User-Token": userToken,
+    },
+  });
+}
+
+/** Authenticated request against api.music.apple.com. `path` is everything
+ * after the host, e.g. `/v1/me/library/albums?limit=100`. */
+export async function appleMusicFetch(path: string, init?: RequestInit): Promise<Response> {
+  return appleMusicRequest(path, (await client.getTokens())?.accessToken ?? "", init);
+}

--- a/extensions/music/src/util/apple-music-auth.tsx
+++ b/extensions/music/src/util/apple-music-auth.tsx
@@ -40,6 +40,23 @@ function debugLog(message: string): void {
   if (environment.isDevelopment) console.debug(`[AppleMusicAuth] ${message}`);
 }
 
+/** Caches derived from the signed-in account (storefront, /v1/me responses)
+ * must not outlive the token they were built under — the next sign-in may be
+ * a different account, or the same account in a different storefront. Modules
+ * owning such a cache register a clearer here; all clearers run whenever the
+ * stored tokens are discarded (sign-out, expiry, revocation). */
+type AccountCacheClearer = () => void | Promise<void>;
+const accountCacheClearers: AccountCacheClearer[] = [];
+
+export function registerAccountCacheClearer(clear: AccountCacheClearer): void {
+  accountCacheClearers.push(clear);
+}
+
+async function discardTokens(): Promise<void> {
+  await client.removeTokens();
+  for (const clear of accountCacheClearers) await clear();
+}
+
 async function fetchTokens(authRequest: OAuth.AuthorizationRequest, authCode: string): Promise<OAuth.TokenResponse> {
   const params = new URLSearchParams();
   params.append("client_id", CLIENT_ID);
@@ -69,7 +86,7 @@ async function authorize(): Promise<string> {
   if (tokenSet?.accessToken) {
     if (!tokenSet.isExpired()) return tokenSet.accessToken;
     debugLog("stored user token reported expired; discarding and re-authorizing");
-    await client.removeTokens();
+    await discardTokens();
   }
 
   const authRequest = await client.authorizationRequest({
@@ -118,7 +135,7 @@ async function authorizeAndValidate(): Promise<string> {
   if (await isTokenAccepted(token)) return token;
 
   debugLog("Apple rejected the stored user token; clearing it and signing in again");
-  await client.removeTokens();
+  await discardTokens();
   return authorize();
 }
 
@@ -131,7 +148,7 @@ export const withAppleMusicAuth = withAccessToken({ authorize: authorizeAndValid
 /** Drop the stored user token. The next authenticated command prompts for a
  * fresh sign-in, which is also how you switch accounts. */
 export async function signOut(): Promise<void> {
-  await client.removeTokens();
+  await discardTokens();
 }
 
 /** Sign-out affordance for the action panel of any authenticated command.

--- a/extensions/music/src/util/catalog-api.ts
+++ b/extensions/music/src/util/catalog-api.ts
@@ -2,7 +2,7 @@ import { Cache, LocalStorage } from "@raycast/api";
 import * as E from "fp-ts/Either";
 import * as TE from "fp-ts/TaskEither";
 
-import { appleMusicFetch } from "./apple-music-auth";
+import { appleMusicFetch, registerAccountCacheClearer } from "./apple-music-auth";
 import { CatalogAlbum, CatalogSong } from "./models";
 
 // Shared Apple Music catalog client: storefront resolution, 429 backoff
@@ -19,6 +19,15 @@ const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
 const cache = new Cache({ namespace: "catalog-api" });
 const STOREFRONT_KEY = "catalog-storefront";
+
+// The storefront and every cached /v1/me response are account-scoped: a new
+// sign-in must not inherit the previous account's regional catalog or
+// personalized feeds. Dropping the whole response cache also costs the
+// catalog day-cache, which is an acceptable price for an event this rare.
+registerAccountCacheClearer(() => {
+  cache.clear();
+  return LocalStorage.removeItem(STOREFRONT_KEY);
+});
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 

--- a/extensions/music/src/util/catalog-api.ts
+++ b/extensions/music/src/util/catalog-api.ts
@@ -24,7 +24,15 @@ const STOREFRONT_KEY = "catalog-storefront";
 // sign-in must not inherit the previous account's regional catalog or
 // personalized feeds. Dropping the whole response cache also costs the
 // catalog day-cache, which is an acceptable price for an event this rare.
+//
+// The generation counter closes the race the clearer alone leaves open: a
+// lookup already in flight when the account changes would otherwise persist
+// the old account's response after the caches were wiped. Anything started
+// under an older generation may still return its result, but must not store it.
+let accountGeneration = 0;
+
 registerAccountCacheClearer(() => {
+  accountGeneration++;
   cache.clear();
   return LocalStorage.removeItem(STOREFRONT_KEY);
 });
@@ -62,22 +70,24 @@ async function cachedGet<T>(path: string, ttlMs = CACHE_TTL_MS): Promise<T> {
       // corrupt entry — refetch
     }
   }
+  const generation = accountGeneration;
   const res = await fetchWithRetry(path);
   if (!res.ok) throw new Error(`Apple Music API ${res.status} for ${path.split("?")[0]}`);
   const data = (await res.json()) as T;
-  cache.set(path, JSON.stringify({ at: Date.now(), data }));
+  if (generation === accountGeneration) cache.set(path, JSON.stringify({ at: Date.now(), data }));
   return data;
 }
 
 async function getStorefront(): Promise<string> {
   const stored = await LocalStorage.getItem<string>(STOREFRONT_KEY);
   if (stored) return stored;
+  const generation = accountGeneration;
   const res = await fetchWithRetry("/v1/me/storefront");
   if (!res.ok) throw new Error(`storefront lookup failed (${res.status})`);
   const json = (await res.json()) as { data?: { id: string }[] };
   const id = json.data?.[0]?.id;
   if (!id) throw new Error("storefront lookup returned no id");
-  await LocalStorage.setItem(STOREFRONT_KEY, id);
+  if (generation === accountGeneration) await LocalStorage.setItem(STOREFRONT_KEY, id);
   return id;
 }
 

--- a/extensions/music/src/util/catalog-api.ts
+++ b/extensions/music/src/util/catalog-api.ts
@@ -1,0 +1,209 @@
+import { Cache, LocalStorage } from "@raycast/api";
+import * as E from "fp-ts/Either";
+import * as TE from "fp-ts/TaskEither";
+
+import { appleMusicFetch } from "./apple-music-auth";
+import { CatalogAlbum, CatalogSong } from "./models";
+
+// Shared Apple Music catalog client: storefront resolution, 429 backoff
+// honouring Retry-After, and a day cache for GETs (the catalog changes on
+// the scale of days). Library writes and membership checks are never cached.
+// The public surface is TaskEither to match the rest of the codebase; the
+// fetch plumbing underneath stays promise-based.
+
+const SEARCH_LIMIT = 25;
+const MAX_RETRIES = 5;
+const RETRY_FLOOR_MS = 500;
+const RETRY_CEILING_MS = 60_000;
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+const cache = new Cache({ namespace: "catalog-api" });
+const STOREFRONT_KEY = "catalog-storefront";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function parseRetryDelay(retryAfter: string | null, attempt: number): number {
+  if (retryAfter) {
+    const asNumber = Number(retryAfter);
+    if (Number.isFinite(asNumber)) return Math.max(RETRY_FLOOR_MS, asNumber * 1000);
+    const asDate = Date.parse(retryAfter);
+    if (Number.isFinite(asDate)) return Math.max(RETRY_FLOOR_MS, asDate - Date.now());
+  }
+  return Math.min(RETRY_CEILING_MS, Math.max(RETRY_FLOOR_MS, 1000 * 2 ** attempt));
+}
+
+async function fetchWithRetry(path: string, init?: RequestInit): Promise<Response> {
+  let attempt = 0;
+  for (;;) {
+    const res = await appleMusicFetch(path, init);
+    if (res.status !== 429 || attempt >= MAX_RETRIES) return res;
+    await sleep(parseRetryDelay(res.headers.get("Retry-After"), attempt));
+    attempt++;
+  }
+}
+
+/** TTL-cached GET returning parsed JSON. Cache key is the request path. */
+async function cachedGet<T>(path: string, ttlMs = CACHE_TTL_MS): Promise<T> {
+  const hit = cache.get(path);
+  if (hit) {
+    try {
+      const { at, data } = JSON.parse(hit) as { at: number; data: T };
+      if (Date.now() - at < ttlMs) return data;
+    } catch {
+      // corrupt entry — refetch
+    }
+  }
+  const res = await fetchWithRetry(path);
+  if (!res.ok) throw new Error(`Apple Music API ${res.status} for ${path.split("?")[0]}`);
+  const data = (await res.json()) as T;
+  cache.set(path, JSON.stringify({ at: Date.now(), data }));
+  return data;
+}
+
+async function getStorefront(): Promise<string> {
+  const stored = await LocalStorage.getItem<string>(STOREFRONT_KEY);
+  if (stored) return stored;
+  const res = await fetchWithRetry("/v1/me/storefront");
+  if (!res.ok) throw new Error(`storefront lookup failed (${res.status})`);
+  const json = (await res.json()) as { data?: { id: string }[] };
+  const id = json.data?.[0]?.id;
+  if (!id) throw new Error("storefront lookup returned no id");
+  await LocalStorage.setItem(STOREFRONT_KEY, id);
+  return id;
+}
+
+/** Render an artwork URL template at a square pixel size. */
+export function artworkUrl(template: string | null, size: number): string | null {
+  return template ? template.replace("{w}", String(size)).replace("{h}", String(size)) : null;
+}
+
+const asContentRating = (raw: string | undefined): "clean" | "explicit" | null =>
+  raw === "clean" || raw === "explicit" ? raw : null;
+
+interface SongData {
+  id: string;
+  attributes?: {
+    name?: string;
+    artistName?: string;
+    albumName?: string;
+    durationInMillis?: number;
+    url?: string;
+    artwork?: { url?: string };
+    contentRating?: string;
+    playParams?: { id?: string };
+  };
+}
+
+interface AlbumData {
+  id: string;
+  attributes?: {
+    name?: string;
+    artistName?: string;
+    trackCount?: number;
+    releaseDate?: string;
+    url?: string;
+    artwork?: { url?: string };
+    contentRating?: string;
+  };
+}
+
+const parseSong = (s: SongData): CatalogSong => ({
+  id: s.id,
+  title: s.attributes?.name ?? "",
+  artist: s.attributes?.artistName ?? "",
+  album: s.attributes?.albumName ?? "",
+  durationMs: s.attributes?.durationInMillis ?? null,
+  artwork: s.attributes?.artwork?.url ?? null,
+  url: s.attributes?.url ?? null,
+  contentRating: asContentRating(s.attributes?.contentRating),
+  playable: Boolean(s.attributes?.playParams),
+});
+
+const parseAlbum = (a: AlbumData): CatalogAlbum => ({
+  id: a.id,
+  title: a.attributes?.name ?? "",
+  artist: a.attributes?.artistName ?? "",
+  trackCount: a.attributes?.trackCount ?? 0,
+  releaseDate: a.attributes?.releaseDate ?? null,
+  artwork: a.attributes?.artwork?.url ?? null,
+  url: a.attributes?.url ?? null,
+  contentRating: asContentRating(a.attributes?.contentRating),
+});
+
+export interface CatalogSearchResults {
+  songs: CatalogSong[];
+  albums: CatalogAlbum[];
+}
+
+interface SearchResponse {
+  results?: {
+    songs?: { data?: SongData[] };
+    albums?: { data?: AlbumData[] };
+  };
+}
+
+export const searchCatalog = (term: string): TE.TaskEither<Error, CatalogSearchResults> =>
+  TE.tryCatch(async () => {
+    const storefront = await getStorefront();
+    const path = `/v1/catalog/${storefront}/search?types=songs,albums&limit=${SEARCH_LIMIT}&term=${encodeURIComponent(term)}`;
+    const json = await cachedGet<SearchResponse>(path);
+    return {
+      songs: (json.results?.songs?.data ?? []).map(parseSong),
+      albums: (json.results?.albums?.data ?? []).map(parseAlbum),
+    };
+  }, E.toError);
+
+export interface CatalogAlbumDetail {
+  album: CatalogAlbum;
+  tracks: CatalogSong[];
+}
+
+interface AlbumDetailResponse {
+  data?: (AlbumData & { relationships?: { tracks?: { data?: SongData[] } } })[];
+}
+
+/** Album summary + full tracklist in one request. */
+export const getCatalogAlbum = (albumId: string): TE.TaskEither<Error, CatalogAlbumDetail | null> =>
+  TE.tryCatch(async () => {
+    const storefront = await getStorefront();
+    const json = await cachedGet<AlbumDetailResponse>(`/v1/catalog/${storefront}/albums/${albumId}?include=tracks`);
+    const a = json.data?.[0];
+    if (!a) return null;
+    return {
+      album: parseAlbum(a),
+      tracks: (a.relationships?.tracks?.data ?? []).map(parseSong),
+    };
+  }, E.toError);
+
+interface LibraryRelationshipResponse {
+  data?: { relationships?: { library?: { data?: unknown[] } } }[];
+}
+
+/** Whether a catalog item maps into the user's library — Apple's own linkage,
+ * via the `library` relationship on the catalog resource. Never cached: the
+ * answer changes the moment the user adds the item.
+ *
+ * Known caveats (measured): the mapping is pinned to the originally-added
+ * catalog edition, so a different edition of an owned album may not flag; and
+ * uploaded/cloud-only items never link. */
+export const isInLibrary = (kind: "albums" | "songs", id: string): TE.TaskEither<Error, boolean> =>
+  TE.tryCatch(async () => {
+    const storefront = await getStorefront();
+    const res = await fetchWithRetry(`/v1/catalog/${storefront}/${kind}/${encodeURIComponent(id)}?include=library`);
+    if (!res.ok) throw new Error(`Apple Music API ${res.status}`);
+    const json = (await res.json()) as LibraryRelationshipResponse;
+    return (json.data?.[0]?.relationships?.library?.data?.length ?? 0) > 0;
+  }, E.toError);
+
+/** Add a catalog song, album, or playlist to the user's library. Apple answers
+ * 202 Accepted with an empty body; the item lands asynchronously via cloud
+ * sync (normally seconds, occasionally minutes) — success copy must say it
+ * will appear shortly, never that it is already there. */
+export const addToLibrary = (kind: "songs" | "albums" | "playlists", id: string): TE.TaskEither<Error, void> =>
+  TE.tryCatch(async () => {
+    const res = await fetchWithRetry(`/v1/me/library?ids[${kind}]=${encodeURIComponent(id)}`, { method: "POST" });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(`Apple Music API ${res.status}${body ? `: ${body.slice(0, 200)}` : ""}`);
+    }
+  }, E.toError);

--- a/extensions/music/src/util/catalog-api.ts
+++ b/extensions/music/src/util/catalog-api.ts
@@ -87,7 +87,12 @@ async function getStorefront(): Promise<string> {
   const json = (await res.json()) as { data?: { id: string }[] };
   const id = json.data?.[0]?.id;
   if (!id) throw new Error("storefront lookup returned no id");
-  if (generation === accountGeneration) await LocalStorage.setItem(STOREFRONT_KEY, id);
+  if (generation === accountGeneration) {
+    await LocalStorage.setItem(STOREFRONT_KEY, id);
+    // The account changed while the write was in flight — it may have landed
+    // after the clearer's removal, so undo it.
+    if (generation !== accountGeneration) await LocalStorage.removeItem(STOREFRONT_KEY);
+  }
   return id;
 }
 

--- a/extensions/music/src/util/models.ts
+++ b/extensions/music/src/util/models.ts
@@ -37,6 +37,33 @@ export interface Album {
   count?: string;
 }
 
+export interface CatalogSong {
+  id: string;
+  title: string;
+  artist: string;
+  album: string;
+  durationMs: number | null;
+  /** Artwork URL template containing {w}/{h} placeholders — render with artworkUrl(). */
+  artwork: string | null;
+  /** music.apple.com page for the song — opens Music.app. */
+  url: string | null;
+  contentRating: "clean" | "explicit" | null;
+  /** Without playParams the catalog entry is a listed husk — visible but not
+   * playable/addable. Gate add actions on this. */
+  playable: boolean;
+}
+
+export interface CatalogAlbum {
+  id: string;
+  title: string;
+  artist: string;
+  trackCount: number;
+  releaseDate: string | null;
+  artwork: string | null;
+  url: string | null;
+  contentRating: "clean" | "explicit" | null;
+}
+
 export interface ScriptError extends Error {
   shortMessage: string;
   command: string;


### PR DESCRIPTION
## Description

Added a new "Search Apple Music" command that searches the Apple Music catalog for songs and albums — with album tracklists, Open in Music, and Add to Library (checking first whether the item is already in your library).
Added Apple Music account sign-in (via Raycast's OAuth proxy) powering the catalog features.

## Screencast

https://drive.google.com/file/d/11p8O76tKtVJG6HxzX5fKwUjnyOXy1geH/view?usp=sharing

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
