### PR TITLE
[Espanso] Fix trigger search and overflowing labels

### DIFF
--- a/extensions/espanso/CHANGELOG.md
+++ b/extensions/espanso/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Espanso Changelog
 
-## [Fix trigger search and overflowing labels] - {PR_MERGE_DATE}
+## [Fix trigger search and overflowing labels] - 2026-08-21
 
 ### Bug Fixes
 

--- a/extensions/espanso/CHANGELOG.md
+++ b/extensions/espanso/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Espanso Changelog
 
+## [Fix trigger search and overflowing labels] - {PR_MERGE_DATE}
+
+### Bug Fixes
+
+- Fixed Search Matches finding nothing for a trigger whenever the match also has a label. The label took the list title *instead of* the triggers, and Raycast's built-in filter only reads the title, subtitle and keywords — so every labeled match dropped its trigger out of the search index, and only turned up when the search term happened to appear in the label prose. Triggers are now indexed as keywords alongside the label, and punctuation-heavy triggers are also split into their parts, so `email` matches `;;email.ooo`.
+- Fixed a long label overflowing the detail panel. The Label tag neither wraps nor truncates, so it ran past the panel edge; it is now cut to fit. The full label is unaffected elsewhere — it is already the match's title.
+
 ## [Fix Espanso binary not being found] - 2026-08-03
 
 ### Bug Fixes

--- a/extensions/espanso/src/components/match-item/index.tsx
+++ b/extensions/espanso/src/components/match-item/index.tsx
@@ -2,8 +2,12 @@ import { useEffect, useState } from "react";
 import { pathToFileURL } from "node:url";
 import { Application, Action, ActionPanel, Clipboard, Icon, List } from "@raycast/api";
 import { FormattedMatch } from "../../lib/types";
-import { formatCategoryName, expandMatch, resolveImagePath } from "../../lib/utils";
+import { formatCategoryName, expandMatch, resolveImagePath, buildSearchKeywords, truncate } from "../../lib/utils";
 import EditMatchForm from "../edit-match-form";
+
+// A metadata tag neither wraps nor truncates, so a long label runs past the panel edge. Cutting it
+// loses nothing: a match that has a label already shows it in full as the list item title.
+const MAX_LABEL_TAG_LENGTH = 50;
 
 interface MatchItemProps {
   id: string;
@@ -54,7 +58,7 @@ export default function MatchItem({
     <List.Item
       id={id}
       title={label ?? triggers.join(", ")}
-      keywords={replace && replace.length <= 200 ? [replace] : undefined}
+      keywords={buildSearchKeywords(triggers, replace)}
       subtitle={profile ? formatCategoryName(profile, separator) : ""}
       detail={
         <List.Item.Detail
@@ -68,7 +72,10 @@ export default function MatchItem({
               </List.Item.Detail.Metadata.TagList>
               {label && (
                 <List.Item.Detail.Metadata.TagList title="Label">
-                  <List.Item.Detail.Metadata.TagList.Item text={label} color="#d7d0d1" />
+                  <List.Item.Detail.Metadata.TagList.Item
+                    text={truncate(label, MAX_LABEL_TAG_LENGTH)}
+                    color="#d7d0d1"
+                  />
                 </List.Item.Detail.Metadata.TagList>
               )}
               {profile && (

--- a/extensions/espanso/src/lib/utils.test.ts
+++ b/extensions/espanso/src/lib/utils.test.ts
@@ -35,7 +35,7 @@ vi.mock("fs-extra", () => ({
 // Import after mocks are in place
 import fse from "fs-extra";
 import { getPreferenceValues } from "@raycast/api";
-import { getEspansoCmd, updateMatchInFile } from "./utils";
+import { buildSearchKeywords, getEspansoCmd, truncate, updateMatchInFile } from "./utils";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -392,5 +392,63 @@ describe("getEspansoCmd", () => {
   // surfaces a clear error rather than a silent wrong path.
   it("returns the bare command when nothing is found on disk", () => {
     expect(getEspansoCmd()).toBe("espanso");
+  });
+});
+
+describe("buildSearchKeywords", () => {
+  it("keeps the trigger searchable when a label owns the title", () => {
+    const keywords = buildSearchKeywords([";;email.ooo"], "Out of office");
+
+    expect(keywords).toContain(";;email.ooo");
+    expect(keywords).toContain("email");
+    expect(keywords).toContain("ooo");
+  });
+
+  it("drops single-character fragments left by punctuation", () => {
+    expect(buildSearchKeywords([";;p.email.ooo"], undefined)).not.toContain("p");
+  });
+
+  it("indexes every trigger of a multi-trigger match", () => {
+    const keywords = buildSearchKeywords([":sig", ":signature"], undefined);
+
+    expect(keywords).toEqual(expect.arrayContaining([":sig", "sig", ":signature", "signature"]));
+  });
+
+  it("includes short replacement text alongside the triggers", () => {
+    expect(buildSearchKeywords([":hi"], "Hello world")).toContain("Hello world");
+  });
+
+  it("omits replacement text past the length cap", () => {
+    const long = "x".repeat(201);
+
+    expect(buildSearchKeywords([":long"], long)).not.toContain(long);
+  });
+
+  it("omits blank replacement text", () => {
+    expect(buildSearchKeywords([":blank"], "   ")).toEqual([":blank", "blank"]);
+  });
+
+  it("deduplicates a trigger that tokenizes to itself", () => {
+    expect(buildSearchKeywords(["signature"], undefined)).toEqual(["signature"]);
+  });
+});
+
+describe("truncate", () => {
+  it("leaves text at or under the limit untouched", () => {
+    expect(truncate("Short label", 50)).toBe("Short label");
+    expect(truncate("x".repeat(50), 50)).toBe("x".repeat(50));
+  });
+
+  it("cuts overlong text to the limit, ellipsis included", () => {
+    const result = truncate("Out of office reply with contact details for the winter break", 30);
+
+    expect(result).toBe("Out of office reply with cont…");
+    expect(result).toHaveLength(30);
+  });
+
+  it("does not leave a space stranded before the ellipsis", () => {
+    expect(truncate("Out of office reply with contact details for the winter break", 50)).toBe(
+      "Out of office reply with contact details for the…",
+    );
   });
 });

--- a/extensions/espanso/src/lib/utils.ts
+++ b/extensions/espanso/src/lib/utils.ts
@@ -399,3 +399,22 @@ export const resolveImagePath = (imagePath: string, configDir: string): string =
   const withHome = withConfig.startsWith("~") ? withConfig.replace("~", process.env.HOME ?? "") : withConfig;
   return path.resolve(withHome);
 };
+
+// Raycast's built-in list filter only reads `title`, `subtitle` and `keywords`. A match with a
+// label puts the label in the title, so its triggers are searchable only if they also land in
+// `keywords`. Punctuation-heavy triggers like `;;email.ooo` are additionally split into their
+// alphanumeric parts, because keyword matching does not reliably reach a term sitting mid-string.
+const MAX_REPLACE_KEYWORD_LENGTH = 200;
+
+export const buildSearchKeywords = (triggers: string[], replace: string | undefined): string[] => {
+  const triggerKeywords = triggers.flatMap((trigger) => [
+    trigger,
+    ...trigger.split(/[^a-zA-Z0-9]+/).filter((part) => part.length > 1),
+  ]);
+  const replaceKeywords =
+    replace && replace.length <= MAX_REPLACE_KEYWORD_LENGTH && replace.trim().length ? [replace] : [];
+  return [...new Set([...triggerKeywords, ...replaceKeywords])];
+};
+
+export const truncate = (text: string, maxLength: number): string =>
+  text.length <= maxLength ? text : `${text.slice(0, maxLength - 1).trimEnd()}…`;


### PR DESCRIPTION
## Description

Two fixes to **Search Matches**.

### Matches with a label could not be found by their trigger

`MatchItem` built its title as `label ?? triggers.join(", ")`, so a match with a label showed the label *instead of* its triggers. Raycast's built-in list filter reads only `title`, `subtitle` and `keywords`, so the triggers of every labeled match fell out of the search index. Such a match was findable only when the search term happened to appear in the label prose.

Searching `email` against these three returned the first two and not the third, since they are the only ones whose label says "email":

```yaml
- trigger: ";;email.short"
  label: "Short email signature"
- trigger: ";;email.full"
  label: "Full email signature"
- trigger: ";;email.ooo"
  label: "Out of office reply"
```

Triggers now go into `keywords`, alongside the replacement text that was already there, so label and triggers are both searchable. Triggers are also split on non-alphanumeric characters, because keyword matching does not reliably reach a term sitting mid-string behind punctuation: `;;email.ooo` indexes as `[";;email.ooo", "email", "ooo"]`. Single-character fragments are dropped, so a one-letter namespace prefix does not become a keyword on every match.

### A long label overflowed the detail panel

The `Label` tag in the detail metadata neither wraps nor truncates, so a long label ran past the right edge of the panel. It is now cut to 50 characters with an ellipsis. Nothing is lost: a match with a label already shows it in full as the list item title.

Both changes have unit tests in `src/lib/utils.test.ts`, covering `buildSearchKeywords` and `truncate`. `npm run build`, `npm run lint`, `npm run typecheck` and `npm test` all pass.

## Screencast

Before this change, searching `email` returned two of the three matches above; `;;email.ooo` was missing. It now returns all three, and a long label sits inside the detail panel instead of running off the edge.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
