### PR TITLE
Update inoh extension

### DIFF
--- a/extensions/inoh/CHANGELOG.md
+++ b/extensions/inoh/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [iOS App Link] - {PR_MERGE_DATE}
+
+- The Apps section now opens the Inoh iOS app on the App Store instead of
+  showing a "coming soon" toast
+
+## [Plan State in the Header] - {PR_MERGE_DATE}
+
+- The plan badge now shows what is about to change: "Plus · ends 1 Sep" for a
+  pending cancellation, "Pro · Plus from 1 Sep" for a scheduled downgrade, and
+  "payment failed" when the card needs fixing
+- The account action matches: Resume Subscription, Fix Payment, or Manage
+  Subscription open the web app's new Plan & Billing page
+
+## [New Tagline] - {PR_MERGE_DATE}
+
+- Store description now leads with the Inoh tagline: the vocabulary app for the articulate
+
+## [Per-Plan Card Limits] - {PR_MERGE_DATE}
+
+- Total cards are now capped per plan: Free holds up to 300 cards, Plus up to
+  1,000, and Pro is unlimited
+- Hitting your plan's limit shows an "Upgrade Plan" action right on the toast
+- Pronunciation practice quotas are now monthly pools (Plus 1,000/month, Pro 10,000/month)
+
 ## [Free/Plus/Pro Plans] - 2026-08-17
 
 - Plans are now Free, Plus, and Pro. Total cards are capped per plan: Free

--- a/extensions/inoh/CHANGELOG.md
+++ b/extensions/inoh/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
 
-## [iOS App Link] - {PR_MERGE_DATE}
+## [iOS App Link] - 2026-08-22
 
 - The Apps section now opens the Inoh iOS app on the App Store instead of
   showing a "coming soon" toast
 
-## [Plan State in the Header] - {PR_MERGE_DATE}
+## [Plan State in the Header] - 2026-08-22
 
 - The plan badge now shows what is about to change: "Plus · ends 1 Sep" for a
   pending cancellation, "Pro · Plus from 1 Sep" for a scheduled downgrade, and
@@ -13,11 +13,11 @@
 - The account action matches: Resume Subscription, Fix Payment, or Manage
   Subscription open the web app's new Plan & Billing page
 
-## [New Tagline] - {PR_MERGE_DATE}
+## [New Tagline] - 2026-08-22
 
 - Store description now leads with the Inoh tagline: the vocabulary app for the articulate
 
-## [Per-Plan Card Limits] - {PR_MERGE_DATE}
+## [Per-Plan Card Limits] - 2026-08-22
 
 - Total cards are now capped per plan: Free holds up to 300 cards, Plus up to
   1,000, and Pro is unlimited

--- a/extensions/inoh/README.md
+++ b/extensions/inoh/README.md
@@ -2,7 +2,7 @@
 
 # Inoh
 
-Add vocabulary cards to your [Inoh](https://inoh.app) decks directly from Raycast.
+[Inoh](https://inoh.app) is the vocabulary app for the articulate. This extension adds words to your Inoh decks directly from Raycast.
 
 ## Commands
 
@@ -41,3 +41,24 @@ the Inoh plans page in your browser; paid accounts get **Manage Subscription**,
 which opens your account settings on [inoh.app](https://inoh.app) to change or
 cancel the plan. After you upgrade, the badge updates the next time you open
 the extension.
+
+## End-to-end tests
+
+Raycast is closed-source and offers no way to drive an extension's views, so
+these tests exercise the extension's **real modules** — its Supabase client,
+auth, dictionary search, and FSRS card seeding — against a **local** Supabase
+stack. Nothing is mocked except `@raycast/api` itself, which only exists inside
+the Raycast runtime.
+
+```bash
+cd ../inoh-backend && pnpm db:start     # once per session
+cd -                                     # back here
+pnpm e2e:run
+```
+
+Covered: signing in with a real emailed code, the free-plan reading, dictionary
+search (hit and miss), adding a word with correct FSRS seeding, removing it,
+refusing a duplicate, and the free card cap's message.
+
+The views themselves are on the manual checklist in
+[inoh-backend/E2E.md](../inoh-backend/E2E.md).

--- a/extensions/inoh/e2e/backend.ts
+++ b/extensions/inoh/e2e/backend.ts
@@ -1,0 +1,155 @@
+/**
+ * Thin wrapper around the shared fixture CLI in `inoh-backend`.
+ *
+ * The CLI owns the knowledge (what a reset does, what each seed profile means,
+ * where a sign-in code comes from); this only spawns it and parses its JSON.
+ * The same file lives in each client repo's e2e suite — it is deliberately
+ * free of any knowledge worth sharing, so copying beats coupling five repos
+ * to one npm package they would each have to install. Point
+ * `INOH_BACKEND_DIR` at the backend checkout if it is not the sibling
+ * directory.
+ *
+ * `AccountState` and `SeededAccount` mirror the CLI's whole JSON contract
+ * rather than only the fields this repo's specs read today. That is deliberate:
+ * the wrapper is a verbatim copy in every client repo, and trimming each copy
+ * to its current callers would make them diverge. The contract is documented
+ * once, in inoh-backend/supabase/e2e/README.md.
+ */
+
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+// Reason: resolved from the working directory rather than this file, so the
+// same wrapper works whether the repo it lives in is CommonJS or ESM (where
+// `__dirname` does not exist). Vitest always runs from the repo root.
+const BACKEND_DIR = process.env.INOH_BACKEND_DIR ?? path.resolve(process.cwd(), "../inoh-backend");
+const CLI_PATH = path.join(BACKEND_DIR, "supabase/e2e/cli.ts");
+
+/**
+ * The account both specs drive. One address, so the UI spec and the module spec
+ * cannot disagree about which account is under test.
+ */
+export const TEST_ACCOUNT_EMAIL = "e2e-raycast@test.com";
+
+export type Plan = "free" | "plus" | "pro";
+export type SeedProfile = "learner" | "empty" | "pronunciation-cap" | "card-cap";
+
+export type SeededAccount = {
+  email: string;
+  userId: string;
+  username: string | null;
+  plan: Plan;
+  profile: SeedProfile;
+  deckId: string;
+  deckName: string;
+  cardCount: number;
+  words: string[];
+  dueWords: string[];
+  spareWords: string[];
+};
+
+export type AccountState = {
+  email: string;
+  userId: string;
+  username: string | null;
+  plan: Plan;
+  subscription: {
+    status: string;
+    billingInterval: string | null;
+    cancelAtPeriodEnd: boolean;
+    scheduledPlan: string | null;
+    scheduledBillingInterval: string | null;
+    hasStripeCustomer: boolean;
+  } | null;
+  decks: { id: string; name: string; isDefault: boolean; cardCount: number }[];
+  cardCount: number;
+  words: string[];
+  dueWordCount: number;
+  streak: { current: number; longest: number } | null;
+  pronunciationPracticesThisMonth: number;
+  cardRequests: { word: string; status: string }[];
+};
+
+/**
+ * Runs one fixture command.
+ *
+ * @param command - CLI command name, e.g. `reset-user`
+ * @param flags - Flags without their leading dashes
+ * @returns The command's parsed JSON output
+ * @throws When the stack is unreachable or the command rejects its input
+ */
+function _runFixtureCommand<T>(command: string, flags: Record<string, string> = {}): T {
+  const args = ["run", "--allow-env", "--allow-net", CLI_PATH, command];
+  for (const [name, value] of Object.entries(flags)) {
+    args.push(`--${name}`, value);
+  }
+  try {
+    // Reason: stdio 'pipe' for stdout only — the CLI logs progress on stderr,
+    // which is inherited so a failing run explains itself in the report.
+    const stdout = execFileSync("deno", args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "inherit"],
+    });
+    return JSON.parse(stdout) as T;
+  } catch (error) {
+    throw new Error(
+      `Fixture command \`${command}\` failed. Is the local stack up (\`pnpm db:start\` in ` +
+        `inoh-backend) and is ${CLI_PATH} present?\n${(error as Error).message}`,
+    );
+  }
+}
+
+/** Fails the run early, with the fix, when the local stack is not ready. */
+export const assertLocalStackReady = (): void => {
+  // The CLI exits non-zero when a check fails, which _runFixtureCommand turns
+  // into a throw — so reaching the next line is the assertion.
+  _runFixtureCommand("doctor");
+};
+
+/**
+ * Deletes, recreates, and seeds one account.
+ *
+ * @param options - The account's address, plan, and seed profile
+ * @returns The seeded account, including the words it was given
+ */
+export const resetAccount = (options: { email: string; plan?: Plan; profile?: SeedProfile }): SeededAccount =>
+  _runFixtureCommand<SeededAccount>("reset-user", {
+    email: options.email,
+    plan: options.plan ?? "free",
+    profile: options.profile ?? "learner",
+  });
+
+/**
+ * Waits for the newest sign-in email and returns its six-digit code.
+ *
+ * @param email - Recipient to watch
+ * @param sinceMs - Ignore mail that arrived at or before this instant, so a
+ *   code from an earlier test is never mistaken for this one
+ * @returns The six-digit code
+ */
+export const readSignInCode = (email: string, sinceMs: number): string =>
+  _runFixtureCommand<{ code: string }>("otp", {
+    email,
+    "newer-than-ms": String(sinceMs),
+  }).code;
+
+/**
+ * What the client actually wrote to the database.
+ *
+ * @param email - The account to snapshot
+ * @returns The account's persisted state
+ */
+export const readAccountState = (email: string): AccountState => _runFixtureCommand<AccountState>("state", { email });
+
+/**
+ * Creates a dictionary word that exists only on the local stack.
+ *
+ * A client pointed at production cannot find it, which is what makes driving
+ * a native UI blindly safe.
+ *
+ * @returns The word
+ */
+export const ensureSyntheticWord = (): string =>
+  _runFixtureCommand<{ words: string[] }>("ensure-synthetic-words", {
+    count: "1",
+  }).words[0];

--- a/extensions/inoh/e2e/raycast-ui.ts
+++ b/extensions/inoh/e2e/raycast-ui.ts
@@ -1,0 +1,150 @@
+/**
+ * Driving the Raycast UI blindly, and safely.
+ *
+ * Raycast is a closed-source native app: no browser, no CDP, and its window is
+ * absent from the macOS accessibility tree (`System Events` reports zero
+ * windows for the process). So its UI can be *typed into* but never *read*.
+ *
+ * That shapes the whole approach: input goes in through keystrokes, and every
+ * assertion is made against the database afterwards — which is a stronger claim
+ * than "the screenshot looked right" anyway. What stays unverified is pixels,
+ * and that is what the manual checklist is for.
+ *
+ * Three interlocks, because blind keystrokes on a developer's own machine
+ * deserve them:
+ *
+ *   1. Opt-in. Nothing runs unless `INOH_RAYCAST_UI=1`.
+ *   2. Focus. Keys are only ever sent while Raycast is genuinely frontmost, so
+ *      a word can never be typed into your editor.
+ *   3. A local-only probe word. The word under test exists only in the local
+ *      dictionary, so an extension secretly pointed at production cannot find
+ *      it — and therefore cannot add anything to a live account.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const LOCAL_CONFIG_PATH = path.resolve(process.cwd(), "assets/local-config.json");
+const RAYCAST_APP_NAME = "Raycast";
+/** Every command of this extension hangs off this deeplink prefix. */
+const EXTENSION_DEEPLINK_PREFIX = "raycast://extensions/tai/inoh/";
+const FOCUS_TIMEOUT_MS = 10_000;
+const POLL_INTERVAL_MS = 250;
+/** macOS virtual key codes; the numbers are the only thing naming the keys. */
+const RETURN_KEY_CODE = 36;
+const ESCAPE_KEY_CODE = 53;
+/** Raycast takes focus before the command's first render finishes. */
+const COMMAND_RENDER_SETTLE_MS = 1_200;
+/** Search is debounced and then hits the network. */
+const SEARCH_SETTLE_MS = 3_000;
+/** An action round-trips to Supabase before the deck reflects it. */
+const ACTION_SETTLE_MS = 3_000;
+
+const _sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const _runAppleScript = (script: string): string =>
+  execFileSync("osascript", ["-e", script], { encoding: "utf8" }).trim();
+
+/** Whether the suite is allowed to drive the real Raycast UI. */
+export const isRaycastUiEnabled = (): boolean => process.env.INOH_RAYCAST_UI === "1";
+
+/** Reads the name of the app currently in front. */
+const _readFrontmostAppName = (): string =>
+  _runAppleScript('tell application "System Events" to return name of first process whose frontmost is true');
+
+/**
+ * Refuses to run unless the extension under test is the locally developed one,
+ * pointed at the local stack.
+ *
+ * @throws When the dev build is not running, or is not configured for local
+ */
+export function assertLocalDevExtension(): void {
+  _assertLocalConfigPointsAtLoopback();
+  _assertDevServerRunning();
+}
+
+/** The extension only reads this file in development, and only for local runs. */
+function _assertLocalConfigPointsAtLoopback(): void {
+  if (!existsSync(LOCAL_CONFIG_PATH)) {
+    throw new Error(
+      `${LOCAL_CONFIG_PATH} is missing, so the extension would talk to production. ` +
+        "Create it with the local Supabase URL and key, then run `npm run dev`.",
+    );
+  }
+  const configFileText = readFileSync(LOCAL_CONFIG_PATH, "utf8");
+  const isPointingAtLoopback = /127\.0\.0\.1|localhost/.test(configFileText);
+  if (!isPointingAtLoopback) {
+    throw new Error(`${LOCAL_CONFIG_PATH} does not point at a loopback address. Refusing to drive the UI.`);
+  }
+}
+
+/** Raycast loads the local build, and reads local-config.json, only in development mode. */
+function _assertDevServerRunning(): void {
+  try {
+    execFileSync("pgrep", ["-f", "ray develop"], { stdio: "ignore" });
+  } catch {
+    throw new Error("No `ray develop` process found. Start it with `npm run dev`.");
+  }
+}
+
+/**
+ * Opens one of the extension's commands and waits for Raycast to take focus.
+ *
+ * @param commandName - The command's `name` from package.json, e.g. `add-card`
+ * @throws When Raycast does not come to the front
+ */
+export async function openExtensionCommand(commandName: string): Promise<void> {
+  execFileSync("open", [`${EXTENSION_DEEPLINK_PREFIX}${commandName}`]);
+
+  const deadline = Date.now() + FOCUS_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (_readFrontmostAppName() === RAYCAST_APP_NAME) {
+      // Reason: typing into the previous view would search the wrong list.
+      await _sleep(COMMAND_RENDER_SETTLE_MS);
+      return;
+    }
+    await _sleep(POLL_INTERVAL_MS);
+  }
+  throw new Error(
+    `Raycast never came to the front after opening "${commandName}" (frontmost: ${_readFrontmostAppName()}).`,
+  );
+}
+
+/** Guards every keystroke on Raycast actually being frontmost. */
+function _assertRaycastFocused(): void {
+  const frontmostAppName = _readFrontmostAppName();
+  if (frontmostAppName !== RAYCAST_APP_NAME) {
+    throw new Error(`Refusing to send keys: ${frontmostAppName} is frontmost, not Raycast. Nothing was typed.`);
+  }
+}
+
+/**
+ * Types text into whatever Raycast has focused, then waits for the search it
+ * triggers to settle — the wait is in the name because three seconds pass.
+ *
+ * @param text - The text to type; only sent while Raycast is frontmost
+ */
+export async function typeAndAwaitSearchResults(text: string): Promise<void> {
+  _assertRaycastFocused();
+  _runAppleScript(`tell application "System Events" to keystroke ${JSON.stringify(text)}`);
+  await _sleep(SEARCH_SETTLE_MS);
+}
+
+/**
+ * Presses Return — running the highlighted row's first action — then waits for
+ * that action to round-trip to Supabase.
+ */
+export async function pressReturnAndAwaitDeckUpdate(): Promise<void> {
+  _assertRaycastFocused();
+  _runAppleScript(`tell application "System Events" to key code ${RETURN_KEY_CODE}`);
+  await _sleep(ACTION_SETTLE_MS);
+}
+
+/** Closes Raycast, leaving the machine as it was found. */
+export function dismissRaycast(): void {
+  if (_readFrontmostAppName() !== RAYCAST_APP_NAME) {
+    return;
+  }
+  _runAppleScript(`tell application "System Events" to key code ${ESCAPE_KEY_CODE}`);
+}

--- a/extensions/inoh/e2e/raycast-ui.ts
+++ b/extensions/inoh/e2e/raycast-ui.ts
@@ -26,9 +26,8 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 
 const LOCAL_CONFIG_PATH = path.resolve(process.cwd(), "assets/local-config.json");
+const MANIFEST_PATH = path.resolve(process.cwd(), "package.json");
 const RAYCAST_APP_NAME = "Raycast";
-/** Every command of this extension hangs off this deeplink prefix. */
-const EXTENSION_DEEPLINK_PREFIX = "raycast://extensions/tai/inoh/";
 const FOCUS_TIMEOUT_MS = 10_000;
 const POLL_INTERVAL_MS = 250;
 /** macOS virtual key codes; the numbers are the only thing naming the keys. */
@@ -89,13 +88,39 @@ function _assertDevServerRunning(): void {
 }
 
 /**
+ * Builds the deeplink Raycast answers for one of this extension's commands.
+ *
+ * Reason: a deeplink is the only way into a command from outside the Raycast
+ * runtime (`launchCommand` needs to be called from within a command), so every
+ * segment is read from the manifest instead of hardcoded — renaming the author,
+ * the extension, or the command then fails here loudly rather than opening
+ * something stale.
+ *
+ * @param commandName - The command's `name` from package.json, e.g. `add-card`
+ * @returns The `raycast://extensions/...` URL for that command
+ * @throws When the manifest declares no such command
+ */
+function _buildCommandDeeplink(commandName: string): string {
+  const manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf8")) as {
+    name: string;
+    author: string;
+    commands: { name: string }[];
+  };
+  const hasDeclaredCommand = manifest.commands.some((command) => command.name === commandName);
+  if (!hasDeclaredCommand) {
+    throw new Error(`package.json declares no command named "${commandName}".`);
+  }
+  return `raycast://extensions/${manifest.author}/${manifest.name}/${commandName}`;
+}
+
+/**
  * Opens one of the extension's commands and waits for Raycast to take focus.
  *
  * @param commandName - The command's `name` from package.json, e.g. `add-card`
- * @throws When Raycast does not come to the front
+ * @throws When Raycast does not come to the front, or the command is not in the manifest
  */
 export async function openExtensionCommand(commandName: string): Promise<void> {
-  execFileSync("open", [`${EXTENSION_DEEPLINK_PREFIX}${commandName}`]);
+  execFileSync("open", [_buildCommandDeeplink(commandName)]);
 
   const deadline = Date.now() + FOCUS_TIMEOUT_MS;
   while (Date.now() < deadline) {

--- a/extensions/inoh/e2e/specs/deck-flow.spec.ts
+++ b/extensions/inoh/e2e/specs/deck-flow.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * The Raycast extension's whole job, end to end against the local Supabase
+ * stack: sign in with an emailed code, search the dictionary, add a word to
+ * the deck, and take it back out.
+ *
+ * Raycast is closed-source with no way to drive an extension's UI from a test,
+ * so these specs exercise the extension's real modules — its Supabase client,
+ * its auth, its FSRS card seeding — rather than its rendering. What the
+ * rendering does with the results is the manual checklist's job.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { assertLocalStackReady, readAccountState, readSignInCode, resetAccount, TEST_ACCOUNT_EMAIL } from "../backend";
+import type { SeededAccount } from "../backend";
+import { requestEmailCode, signOutUser, verifyEmailCode } from "../../src/lib/auth";
+import { addCardToDeck, removeCardFromDeck } from "../../src/lib/card";
+import { searchDictionary } from "../../src/lib/dictionary";
+import { fetchSubscriptionState } from "../../src/lib/subscription";
+import { supabase } from "../../src/lib/supabase";
+
+/**
+ * Looks a word up in the dictionary, failing the test when it is not there.
+ *
+ * Takes the word rather than the account so a test that re-seeds cannot
+ * silently change which word is under test.
+ *
+ * @param word - The word to look up
+ * @returns Its dictionary entry
+ */
+async function findEntryOrFail(word: string) {
+  const [entry] = await searchDictionary(word);
+  expect(entry).toBeDefined();
+  return entry;
+}
+
+/**
+ * The `user_cards` rows an account holds for one dictionary entry.
+ *
+ * @param signedInUserId - Whose cards to read
+ * @param dictionaryId - The dictionary entry to look for
+ * @returns The matching rows, empty when the account does not have the card
+ */
+async function readUserCardsForEntry(signedInUserId: string, dictionaryId: string) {
+  const { data: cards } = await supabase
+    .from("user_cards")
+    .select("id, card_state, review_count")
+    .eq("user_id", signedInUserId)
+    .eq("dictionary_id", dictionaryId);
+  return cards ?? [];
+}
+
+/**
+ * Signs in through the extension's own auth module with a real emailed code.
+ *
+ * @param email - The seeded test account's address
+ * @returns The signed-in user
+ */
+async function signInAs(email: string) {
+  const requestedAtMs = Date.now();
+  await requestEmailCode(email);
+  return verifyEmailCode(email, readSignInCode(email, requestedAtMs));
+}
+
+let seededAccount: SeededAccount;
+/** The word the add/remove tests operate on: the first one left off the deck. */
+let probeWord: string;
+let signedInUserId: string;
+
+beforeAll(async () => {
+  assertLocalStackReady();
+  seededAccount = resetAccount({ email: TEST_ACCOUNT_EMAIL, profile: "learner" });
+  probeWord = seededAccount.spareWords[0];
+
+  signedInUserId = (await signInAs(TEST_ACCOUNT_EMAIL)).id;
+});
+
+afterAll(async () => {
+  await signOutUser();
+});
+
+describe("signing in", () => {
+  it("signs in as the seeded account and keeps the session", async () => {
+    expect(signedInUserId).toBe(seededAccount.userId);
+    const { data: sessionData } = await supabase.auth.getSession();
+    expect(sessionData.session?.user.email).toBe(TEST_ACCOUNT_EMAIL);
+  });
+
+  it("reports the account on the free plan", async () => {
+    const subscriptionState = await fetchSubscriptionState(signedInUserId);
+    expect(subscriptionState.tier).toBe("free");
+  });
+});
+
+describe("searching the dictionary", () => {
+  it("finds a word that exists", async () => {
+    const entries = await searchDictionary(probeWord);
+    expect(entries.map((entry) => entry.word)).toContain(probeWord);
+  });
+
+  it("returns nothing for a word that does not exist", async () => {
+    expect(await searchDictionary("zzzznotaword")).toEqual([]);
+  });
+});
+
+describe("adding and removing a card", () => {
+  it("adds a searched word to the deck", async () => {
+    const entry = await findEntryOrFail(probeWord);
+
+    const addResult = await addCardToDeck(signedInUserId, entry, seededAccount.deckId);
+    expect(addResult).toEqual({ success: true, cardId: expect.any(String) });
+    expect(readAccountState(TEST_ACCOUNT_EMAIL).words).toContain(entry.word);
+  });
+
+  it("seeds the new card as unreviewed, so it comes up for review", async () => {
+    const entry = await findEntryOrFail(probeWord);
+    const cards = await readUserCardsForEntry(signedInUserId, entry.id);
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0].card_state).toBe("new");
+    expect(cards[0].review_count).toBe(0);
+  });
+
+  it("removes a card from the deck", async () => {
+    const entry = await findEntryOrFail(probeWord);
+    const [card] = await readUserCardsForEntry(signedInUserId, entry.id);
+
+    const removeResult = await removeCardFromDeck(card.id as string);
+    expect(removeResult.success).toBe(true);
+    expect(readAccountState(TEST_ACCOUNT_EMAIL).words).not.toContain(entry.word);
+  });
+
+  it("reports a word already in the deck rather than duplicating it", async () => {
+    const entry = await findEntryOrFail(seededAccount.words[0]);
+
+    const duplicateAdd = await addCardToDeck(signedInUserId, entry, seededAccount.deckId);
+    expect(duplicateAdd).toEqual({ success: false, error: "This card is already in your deck" });
+    expect(readAccountState(TEST_ACCOUNT_EMAIL).cardCount).toBe(seededAccount.cardCount);
+  });
+});
+
+describe("the free card cap", () => {
+  it("refuses a card once the plan is full and says why", async () => {
+    const cappedAccount = resetAccount({ email: TEST_ACCOUNT_EMAIL, plan: "free", profile: "card-cap" });
+    const user = await signInAs(TEST_ACCOUNT_EMAIL);
+
+    const entry = await findEntryOrFail(cappedAccount.spareWords[0]);
+    const cappedAdd = await addCardToDeck(user.id, entry, cappedAccount.deckId);
+
+    expect(cappedAdd.success).toBe(false);
+    expect(cappedAdd).toMatchObject({
+      isPlanLimit: true,
+      // The message the extension shows must be the plan's own wording, with
+      // the `CARD_LIMIT:` marker the trigger prefixes already stripped.
+      error: expect.stringContaining("Free plan holds up to 300 cards"),
+    });
+    expect(readAccountState(TEST_ACCOUNT_EMAIL).cardCount).toBe(cappedAccount.cardCount);
+  });
+});

--- a/extensions/inoh/e2e/specs/raycast-ui.spec.ts
+++ b/extensions/inoh/e2e/specs/raycast-ui.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * Driving the real Raycast UI: open the Search Word command, type a word, and
+ * press Return to add it.
+ *
+ * Off by default. Raycast's UI can be typed into but not read (see
+ * `../raycast-ui.ts`), so this is the one suite that drives blind — it needs a
+ * `ray develop` session in the foreground and your machine to itself for a few
+ * seconds. Turn it on deliberately:
+ *
+ *   INOH_RAYCAST_UI=1 npm run e2e:test
+ *
+ * Prerequisites it checks for you: `assets/local-config.json` pointing at the
+ * local stack, and a running `ray develop`. One it cannot check — the dev
+ * extension must already be signed in as the account below, which a human does
+ * once. If it is signed in as someone else the final assertion fails and says
+ * so, and because the probe word exists only locally, nothing can reach a live
+ * account either way.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  assertLocalStackReady,
+  ensureSyntheticWord,
+  readAccountState,
+  resetAccount,
+  TEST_ACCOUNT_EMAIL,
+} from "../backend";
+import {
+  assertLocalDevExtension,
+  dismissRaycast,
+  isRaycastUiEnabled,
+  openExtensionCommand,
+  pressReturnAndAwaitDeckUpdate,
+  typeAndAwaitSearchResults,
+} from "../raycast-ui";
+
+describe.skipIf(!isRaycastUiEnabled())("the Search Word command", () => {
+  let probeWord: string;
+
+  beforeAll(() => {
+    assertLocalStackReady();
+    assertLocalDevExtension();
+    resetAccount({ email: TEST_ACCOUNT_EMAIL, profile: "empty" });
+    // A word that exists only in the local dictionary — the interlock that
+    // makes blind driving safe.
+    probeWord = ensureSyntheticWord();
+  });
+
+  afterAll(() => {
+    dismissRaycast();
+  });
+
+  it("adds a searched word to the deck", async () => {
+    expect(readAccountState(TEST_ACCOUNT_EMAIL).words).not.toContain(probeWord);
+
+    await openExtensionCommand("add-card");
+    await typeAndAwaitSearchResults(probeWord);
+    // The first action on a result row is "Add to Deck" (CommandRoot.tsx).
+    await pressReturnAndAwaitDeckUpdate();
+
+    // The database is the assertion: Raycast's own UI cannot be read.
+    expect(readAccountState(TEST_ACCOUNT_EMAIL).words).toContain(probeWord);
+  });
+});

--- a/extensions/inoh/e2e/stubs/raycast-api.ts
+++ b/extensions/inoh/e2e/stubs/raycast-api.ts
@@ -1,0 +1,51 @@
+/**
+ * The slice of `@raycast/api` the extension's lib modules touch, standing in
+ * for the Raycast runtime.
+ *
+ * Raycast is closed-source and offers no way to drive an extension's UI from a
+ * test, so the end-to-end coverage here goes through the extension's real
+ * modules — its Supabase client, auth, dictionary search, and card writes —
+ * against the local Supabase stack. Only the rendering is unverified, and that
+ * is what the manual checklist in E2E.md covers.
+ *
+ * Aliased in place of the real package by `e2e/vitest.config.ts`.
+ */
+
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const LOCAL_SUPABASE_URL = "http://127.0.0.1:54321";
+const LOCAL_PUBLISHABLE_KEY = "sb_publishable_ACJWlzQHlZjBrEguHvfOxg_3BJgxAaH";
+
+/**
+ * A stand-in assets directory holding the same `local-config.json` a developer
+ * writes by hand, so `constants.ts` resolves the local stack through its real
+ * code path rather than a test-only branch.
+ */
+const ASSETS_PATH = mkdtempSync(path.join(tmpdir(), "inoh-raycast-e2e-assets-"));
+writeFileSync(
+  path.join(ASSETS_PATH, "local-config.json"),
+  JSON.stringify({
+    supabaseUrl: LOCAL_SUPABASE_URL,
+    supabasePublishableKey: LOCAL_PUBLISHABLE_KEY,
+  }),
+);
+
+export const environment = {
+  isDevelopment: true,
+  assetsPath: ASSETS_PATH,
+};
+
+/** Raycast's per-extension key/value store; in-memory here. */
+const localStorageEntries = new Map<string, string>();
+
+export const LocalStorage = {
+  getItem: async <T = string>(key: string): Promise<T | undefined> => localStorageEntries.get(key) as T | undefined,
+  setItem: async (key: string, value: string | number | boolean): Promise<void> => {
+    localStorageEntries.set(key, String(value));
+  },
+  removeItem: async (key: string): Promise<void> => {
+    localStorageEntries.delete(key);
+  },
+};

--- a/extensions/inoh/e2e/vitest.config.ts
+++ b/extensions/inoh/e2e/vitest.config.ts
@@ -1,0 +1,25 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+/**
+ * End-to-end config for the Raycast extension against the local Supabase
+ * stack.
+ *
+ * The specs import the extension's own modules and let them talk to a real
+ * backend — no mocking of Supabase, RLS, or the edge functions. Only
+ * `@raycast/api`, which exists solely inside the Raycast runtime, is aliased.
+ */
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@raycast/api": path.resolve(__dirname, "stubs/raycast-api.ts"),
+    },
+  },
+  test: {
+    include: ["e2e/specs/**/*.spec.ts"],
+    // One at a time: the specs share one local backend and one test account.
+    fileParallelism: false,
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
+  },
+});

--- a/extensions/inoh/package-lock.json
+++ b/extensions/inoh/package-lock.json
@@ -20,7 +20,8 @@
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "prettier": "^3.5.3",
-        "typescript": "^5.8.2"
+        "typescript": "^5.8.2",
+        "vitest": "^4.1.11"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -492,6 +493,24 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -529,6 +548,24 @@
       },
       "engines": {
         "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
@@ -914,6 +951,13 @@
         }
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1021,6 +1065,16 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.146.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.146.0.tgz",
+      "integrity": "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@raycast/api": {
@@ -1135,10 +1189,297 @@
         }
       }
     },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz",
+      "integrity": "sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.5.tgz",
+      "integrity": "sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.5.tgz",
+      "integrity": "sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.5.tgz",
+      "integrity": "sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.5.tgz",
+      "integrity": "sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.5.tgz",
+      "integrity": "sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.5.tgz",
+      "integrity": "sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.5.tgz",
+      "integrity": "sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.5.tgz",
+      "integrity": "sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.5.tgz",
+      "integrity": "sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.5.tgz",
+      "integrity": "sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.5.tgz",
+      "integrity": "sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.5.tgz",
+      "integrity": "sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.16.1.tgz",
       "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1220,6 +1561,31 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -1475,6 +1841,23 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
@@ -1621,6 +2004,119 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1726,6 +2222,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -1742,15 +2248,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -1774,6 +2280,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -1962,6 +2478,20 @@
         "node": ">=20"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2014,6 +2544,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dir-glob": {
@@ -2075,6 +2615,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.4",
@@ -2226,6 +2773,24 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint/node_modules/eslint-scope": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
@@ -2340,6 +2905,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2356,6 +2931,16 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2468,6 +3053,21 @@
         "minimatch": "^5.0.1"
       }
     },
+    "node_modules/filelist/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/filelist/node_modules/minimatch": {
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
@@ -2539,6 +3139,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/get-east-asian-width": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
@@ -2594,6 +3209,24 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
@@ -2883,20 +3516,10 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2948,6 +3571,279 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lilconfig": {
@@ -3250,6 +4146,16 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3330,12 +4236,45 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -3473,6 +4412,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3480,15 +4426,44 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -3619,6 +4594,40 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.5.tgz",
+      "integrity": "sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.146.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm-eabi": "1.2.5",
+        "@rolldown/binding-android-arm64": "1.2.5",
+        "@rolldown/binding-darwin-arm64": "1.2.5",
+        "@rolldown/binding-darwin-x64": "1.2.5",
+        "@rolldown/binding-freebsd-x64": "1.2.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.5",
+        "@rolldown/binding-linux-arm64-musl": "1.2.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-musl": "1.2.5",
+        "@rolldown/binding-openharmony-arm64": "1.2.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.5",
+        "@rolldown/binding-win32-x64-msvc": "1.2.5"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -3684,6 +4693,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -3735,6 +4751,30 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
@@ -3816,6 +4856,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
@@ -3827,19 +4874,29 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -3961,6 +5018,174 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/vite": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3975,6 +5200,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {

--- a/extensions/inoh/package.json
+++ b/extensions/inoh/package.json
@@ -62,5 +62,8 @@
     "*.{json,md}": [
       "prettier --write"
     ]
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/inoh/package.json
+++ b/extensions/inoh/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "inoh",
   "title": "Inoh",
-  "description": "Quickly add vocabulary cards to your Inoh decks",
+  "description": "The vocabulary app for the articulate. Add words to your Inoh decks without leaving Raycast",
   "icon": "extension-icon.png",
   "author": "tai",
   "categories": [
@@ -37,7 +37,8 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "prettier": "^3.5.3",
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.2",
+    "vitest": "^4.1.11"
   },
   "scripts": {
     "build": "ray build",
@@ -46,7 +47,12 @@
     "lint": "ray lint",
     "prepare": "husky",
     "prepublishOnly": "echo \"Error: no publish\" && exit 1",
-    "publish": "npx @raycast/api@latest publish"
+    "publish": "npx @raycast/api@latest publish",
+    "e2e:fixture": "deno run --allow-env --allow-net ${INOH_BACKEND_DIR:-../inoh-backend}/supabase/e2e/cli.ts",
+    "e2e:doctor": "npm run --silent e2e:fixture -- doctor",
+    "e2e:test": "vitest run --config e2e/vitest.config.ts",
+    "e2e:run": "npm run e2e:doctor && npm run e2e:test",
+    "e2e:test:ui": "INOH_RAYCAST_UI=1 vitest run --config e2e/vitest.config.ts"
   },
   "lint-staged": {
     "*.{ts,tsx}": [
@@ -56,12 +62,5 @@
     "*.{json,md}": [
       "prettier --write"
     ]
-  },
-  "platforms": [
-    "macOS"
-  ],
-  "overrides": {
-    "brace-expansion": "5.0.9",
-    "js-yaml@4": "4.3.1"
   }
 }

--- a/extensions/inoh/src/components/AccountActionSection.tsx
+++ b/extensions/inoh/src/components/AccountActionSection.tsx
@@ -1,5 +1,5 @@
 import { Action, ActionPanel, Icon, showToast, Toast } from "@raycast/api";
-import { ACCOUNT_SETTINGS_URL, PLANS_URL } from "../constants";
+import { BILLING_URL, PLANS_URL } from "../constants";
 import { canManageBilling } from "../lib/subscription";
 import type { SubscriptionState } from "../lib/subscription";
 import type { User } from "@supabase/supabase-js";
@@ -10,14 +10,32 @@ type AccountActionSectionProps = {
   onSignOut: () => Promise<void>;
 };
 
+type PlanAction = { title: string; url: string; icon: Icon };
+
+/**
+ * The one plan action for the account's state. Everything beyond a first
+ * upgrade happens in the web app's Plan & Billing hub, so the action just
+ * names what the user will do there.
+ */
+function _describePlanAction(state: SubscriptionState): PlanAction {
+  if (state.isPastDue) return { title: "Fix Payment", url: BILLING_URL, icon: Icon.Warning };
+  if (state.scheduledTier === "free") return { title: "Resume Subscription", url: BILLING_URL, icon: Icon.Redo };
+  if (canManageBilling(state)) return { title: "Manage Subscription", url: BILLING_URL, icon: Icon.CreditCard };
+  return { title: "Upgrade Plan", url: PLANS_URL, icon: Icon.Stars };
+}
+
 /**
  * Account email, one plan action, and sign-out, shown in the ActionPanel only
  * when signed in. Plans are upgraded and managed in the Inoh web app: free
- * users get "Upgrade Plan" (the plans page), while subscribers — and
- * `past_due` accounts that must fix their card — get "Manage Subscription"
- * (account settings, where the billing portal lives). Neither shows until
- * the plan has been read at least once.
+ * users get "Upgrade Plan" (the plans page); subscribers, accounts with a
+ * pending change, and `past_due` accounts that must fix their card go to
+ * Plan & Billing. Neither shows until the plan has been read at least once.
  */
+function PlanActionItem({ state }: { state: SubscriptionState }) {
+  const planAction = _describePlanAction(state);
+  return <Action.OpenInBrowser title={planAction.title} icon={planAction.icon} url={planAction.url} />;
+}
+
 export function AccountActionSection({ user, subscriptionState, onSignOut }: AccountActionSectionProps) {
   async function handleSignOut() {
     try {
@@ -35,12 +53,7 @@ export function AccountActionSection({ user, subscriptionState, onSignOut }: Acc
   return (
     <ActionPanel.Section title="Account">
       <Action.CopyToClipboard title={user.email ?? "Account"} content={user.email ?? ""} icon={Icon.Person} />
-      {subscriptionState &&
-        (canManageBilling(subscriptionState) ? (
-          <Action.OpenInBrowser title="Manage Subscription" icon={Icon.CreditCard} url={ACCOUNT_SETTINGS_URL} />
-        ) : (
-          <Action.OpenInBrowser title="Upgrade Plan" icon={Icon.Stars} url={PLANS_URL} />
-        ))}
+      {subscriptionState && <PlanActionItem state={subscriptionState} />}
       <Action title="Sign Out" icon={Icon.Logout} style={Action.Style.Destructive} onAction={handleSignOut} />
     </ActionPanel.Section>
   );

--- a/extensions/inoh/src/components/AppsActionSection.tsx
+++ b/extensions/inoh/src/components/AppsActionSection.tsx
@@ -1,24 +1,18 @@
-import { Action, ActionPanel, Color, Icon, showToast } from "@raycast/api";
-import { CHROME_EXTENSION_URL, OBSIDIAN_PLUGIN_URL, WEBSITE_URL } from "../constants";
-
-function _showComingSoonToast(appName: string) {
-  void showToast({ title: "Coming soon", message: `${appName} isn't available yet — stay tuned!` });
-}
+import { Action, ActionPanel, Color, Icon } from "@raycast/api";
+import { CHROME_EXTENSION_URL, IOS_APP_URL, OBSIDIAN_PLUGIN_URL, WEBSITE_URL } from "../constants";
 
 /**
  * Cross-promotion links to the other Inoh apps, shown in every ActionPanel.
- * iOS (App Store listing mid-rebrand) has no public page, so it toasts
- * instead of linking. Brand marks are Simple Icons SVGs in assets/, tinted
- * to match the theme.
+ * Brand marks are Simple Icons SVGs in assets/, tinted to match the theme.
  */
 export function AppsActionSection() {
   return (
     <ActionPanel.Section title="Apps">
-      {/* eslint-disable @raycast/prefer-title-case -- "iOS" is Apple's casing; the rule also mangles "(Coming Soon)" */}
-      <Action
-        title="iOS App (Coming Soon)"
+      {/* eslint-disable @raycast/prefer-title-case -- "iOS" is Apple's casing, which the rule mangles */}
+      <Action.OpenInBrowser
+        title="iOS App"
         icon={{ source: "apple.svg", tintColor: Color.PrimaryText }}
-        onAction={() => _showComingSoonToast("The iOS app")}
+        url={IOS_APP_URL}
       />
       {/* eslint-enable @raycast/prefer-title-case */}
       <Action.OpenInBrowser title="Web App" icon={Icon.Globe} url={WEBSITE_URL} />

--- a/extensions/inoh/src/components/CommandRoot.tsx
+++ b/extensions/inoh/src/components/CommandRoot.tsx
@@ -5,8 +5,8 @@ import { useDecks } from "../hooks/useDecks";
 import { useDictionarySearch } from "../hooks/useDictionarySearch";
 import { useUserCardIds } from "../hooks/useUserCardIds";
 import { useSubscriptionState } from "../hooks/useSubscriptionState";
-import { TIER_DISPLAY_NAMES } from "../lib/subscription";
-import type { SubscriptionTier } from "../lib/subscription";
+import { describePlanBadge } from "../lib/subscription";
+import type { SubscriptionState } from "../lib/subscription";
 import { PLANS_URL } from "../constants";
 import { addCardToDeck, removeCardFromDeck } from "../lib/card";
 import { pronounceWord } from "../lib/audio";
@@ -19,14 +19,18 @@ import type { DictionaryEntry } from "../types";
 
 /**
  * Header text: the account, plus a plan badge once the plan has been read
- * (e.g. "Inoh · me@example.com · Plus"). The header is the one place a List
- * shows something at all times without spending a row, so it carries the
- * badge; the matching Upgrade/Manage action lives in the Account section.
+ * (e.g. "Inoh · me@example.com · Plus", or "… · Plus · ends 1 Sep" when a
+ * change is pending). The header is the one place a List shows something at
+ * all times without spending a row, so it carries the badge; the matching
+ * plan action lives in the Account section.
  */
-function _buildNavigationTitle(email: string | undefined, tier: SubscriptionTier | undefined): string | undefined {
+function _buildNavigationTitle(
+  email: string | undefined,
+  subscriptionState: SubscriptionState | undefined,
+): string | undefined {
   if (!email) return undefined;
   const parts = ["Inoh", email];
-  if (tier) parts.push(TIER_DISPLAY_NAMES[tier]);
+  if (subscriptionState) parts.push(describePlanBadge(subscriptionState));
   return parts.join(" · ");
 }
 
@@ -165,7 +169,7 @@ export function CommandRoot({ initialSearchText }: { initialSearchText?: string 
     <List
       isLoading={isLoading}
       isShowingDetail={hasResults}
-      navigationTitle={_buildNavigationTitle(user?.email, subscriptionState?.tier)}
+      navigationTitle={_buildNavigationTitle(user?.email, subscriptionState)}
       searchText={searchText}
       searchBarPlaceholder="Search for a word..."
       onSearchTextChange={setSearchText}

--- a/extensions/inoh/src/constants.ts
+++ b/extensions/inoh/src/constants.ts
@@ -19,9 +19,9 @@ export const WEBSITE_URL = "https://inoh.app";
 
 /**
  * Product pages for the other Inoh ecosystem apps, listed in the Apps action
- * section. The iOS app (mid-rebrand) has no URL yet and surfaces as
- * "Coming soon" — add its constant once live.
+ * section.
  */
+export const IOS_APP_URL = "https://apps.apple.com/app/id6799947889";
 export const CHROME_EXTENSION_URL =
   "https://chromewebstore.google.com/detail/fihdhfkhbocbgmnhdigkljknabnjeoai?utm_source=item-share-cb";
 export const OBSIDIAN_PLUGIN_URL = "https://obsidian.md/plugins?id=inoh";
@@ -29,7 +29,8 @@ export const OBSIDIAN_PLUGIN_URL = "https://obsidian.md/plugins?id=inoh";
 /**
  * Plan pages in the Inoh web app. Upgrading and managing a subscription
  * happen there, not in the extension: the plans page lists live prices and
- * runs Stripe checkout, and Settings opens the billing portal for paid plans.
+ * runs Stripe checkout; Plan & Billing is where subscribers upgrade,
+ * downgrade, cancel, resume, and fix their card.
  */
 export const PLANS_URL = `${WEBSITE_URL}/subscription-plan`;
-export const ACCOUNT_SETTINGS_URL = `${WEBSITE_URL}/settings`;
+export const BILLING_URL = `${WEBSITE_URL}/billing`;

--- a/extensions/inoh/src/lib/subscription.ts
+++ b/extensions/inoh/src/lib/subscription.ts
@@ -12,23 +12,32 @@ export const TIER_DISPLAY_NAMES: Record<SubscriptionTier, string> = {
 
 /**
  * What the extension knows about the signed-in account's plan. Mirrors the
- * Inoh Obsidian plugin and Chrome extension, minus the renewal dates they
- * print — Raycast shows the plan as a badge and nothing more.
+ * Inoh Obsidian plugin and Chrome extension: the entitled tier, whether
+ * Stripe still has a subscription, and the one pending change (PRI-20493) so
+ * the badge can say "ends 1 Sep" instead of lying with a bare "Plus".
  */
 export type SubscriptionState = {
   /** The tier the user is entitled to right now; "free" when a paid plan lapsed. */
   tier: SubscriptionTier;
   /**
    * A Stripe subscription exists that can still bill or recover — including
-   * `past_due`, where the user is not entitled but does need the billing
-   * portal to fix their card.
+   * `past_due`, where the user is not entitled but does need to fix their card.
    */
   hasLiveStripeSubscription: boolean;
+  /** The last payment failed; the plan is on hold until the card is fixed. */
+  isPastDue: boolean;
+  /** Plan the subscription moves to at period end; null when nothing is pending. */
+  scheduledTier: SubscriptionTier | null;
+  /** ISO timestamp of the current period end (renewal or change date). */
+  currentPeriodEnd: string | null;
 };
 
 const FREE_SUBSCRIPTION: SubscriptionState = {
   tier: "free",
   hasLiveStripeSubscription: false,
+  isPastDue: false,
+  scheduledTier: null,
+  currentPeriodEnd: null,
 };
 
 /** The columns of `subscriptions` the extension reads. */
@@ -36,6 +45,8 @@ type SubscriptionRow = {
   plan: string;
   status: string;
   stripe_subscription_id: string | null;
+  scheduled_plan: string | null;
+  current_period_end: string | null;
 };
 
 /** Statuses where a paid plan is entitled — the backend's predicate, verbatim. */
@@ -57,13 +68,37 @@ export function isPaidTier(tier: SubscriptionTier): boolean {
 /**
  * Whether the account should be sent to billing management rather than the
  * plans page: subscribers change their plan there, and a `past_due` account
- * reads as free but still needs the portal to fix its card.
+ * reads as free but still needs to fix its card.
  *
  * @param state - The account's subscription state
  * @returns True when "Manage Subscription" is the right action
  */
 export function canManageBilling(state: SubscriptionState): boolean {
   return isPaidTier(state.tier) || state.hasLiveStripeSubscription;
+}
+
+const isTier = (value: string | null): value is SubscriptionTier =>
+  value === "free" || value === "plus" || value === "pro";
+
+const formatPeriodEnd = (isoDate: string | null): string | null =>
+  isoDate ? new Date(isoDate).toLocaleDateString("en-GB", { day: "numeric", month: "short" }) : null;
+
+/**
+ * The plan badge for the command header: the tier, plus the one thing that
+ * changes it ("Plus · ends 1 Sep", "Pro · Plus from 1 Sep", "Plus · payment failed").
+ *
+ * @param state - The account's subscription state
+ * @returns The badge text
+ */
+export function describePlanBadge(state: SubscriptionState): string {
+  const tierName = TIER_DISPLAY_NAMES[state.tier];
+  const periodEnd = formatPeriodEnd(state.currentPeriodEnd);
+  if (state.isPastDue) return `${tierName} · payment failed`;
+  if (state.scheduledTier === "free") return periodEnd ? `${tierName} · ends ${periodEnd}` : tierName;
+  if (state.scheduledTier && periodEnd) {
+    return `${tierName} · ${TIER_DISPLAY_NAMES[state.scheduledTier]} from ${periodEnd}`;
+  }
+  return tierName;
 }
 
 /**
@@ -81,7 +116,7 @@ export function canManageBilling(state: SubscriptionState): boolean {
 export async function fetchSubscriptionState(userId: string): Promise<SubscriptionState> {
   const { data: subscriptionRow, error } = await supabase
     .from("subscriptions")
-    .select("plan, status, stripe_subscription_id")
+    .select("plan, status, stripe_subscription_id, scheduled_plan, current_period_end")
     .eq("user_id", userId)
     .maybeSingle<SubscriptionRow>();
 
@@ -100,5 +135,8 @@ export async function fetchSubscriptionState(userId: string): Promise<Subscripti
   return {
     tier: isEntitledPaidPlan ? (subscriptionRow.plan as SubscriptionTier) : "free",
     hasLiveStripeSubscription,
+    isPastDue: subscriptionRow.status === "past_due",
+    scheduledTier: isTier(subscriptionRow.scheduled_plan) ? subscriptionRow.scheduled_plan : null,
+    currentPeriodEnd: subscriptionRow.current_period_end,
   };
 }


### PR DESCRIPTION
## Description

The Inoh iOS app is now live on the App Store, so the extension's **Apps** action section links to it instead of showing a "coming soon" toast.

Also included from the local repo since the last store update:
- Plan badge shows pending plan changes (ends / scheduled downgrade / payment failed) and the account action routes to the web app's Plan & Billing page
- Store description leads with the Inoh tagline
- Per-plan card limits and monthly pronunciation quotas

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder