### PR TITLE
Fix Mirror Displays failing on desktop Macs (incl. MacMini) with no built-in display

### DIFF
--- a/extensions/mirror-displays/CHANGELOG.md
+++ b/extensions/mirror-displays/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Mirror Displays Changelog
 
-## [Fix mirroring on desktop Macs] - {PR_MERGE_DATE}
+## [Fix mirroring on desktop Macs] - 2026-08-23
 
 - Fixed "Could not find the internal Mac display" error on Macs with no built-in display (Mac mini, Mac Studio, Mac Pro) by falling back to the system's main display as the primary screen.
 

--- a/extensions/mirror-displays/CHANGELOG.md
+++ b/extensions/mirror-displays/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Mirror Displays Changelog
 
+## [Fix mirroring on desktop Macs] - {PR_MERGE_DATE}
+
+- Fixed "Could not find the internal Mac display" error on Macs with no built-in display (Mac mini, Mac Studio, Mac Pro) by falling back to the system's main display as the primary screen.
+
 ## [New Features & Bugfixes] - 2026-04-02
 
 - Modernized UI to use a full-page Raycast List view instead of a background shortcut.

--- a/extensions/mirror-displays/assets/mirror.swift
+++ b/extensions/mirror-displays/assets/mirror.swift
@@ -41,6 +41,16 @@ for d in displays {
     }
 }
 
+if macDisplay == nil {
+    // Desktop Macs (Mac mini, Studio, Pro) have no built-in display.
+    // Fall back to the current main display as the "primary" screen.
+    let mainID = CGMainDisplayID()
+    if displays.contains(mainID) {
+        macDisplay = mainID
+        extDisplays.removeAll { $0 == mainID }
+    }
+}
+
 guard let mac = macDisplay else {
     fputs("Could not find the internal Mac display.\n", stderr)
     exit(1)

--- a/extensions/mirror-displays/package.json
+++ b/extensions/mirror-displays/package.json
@@ -6,7 +6,8 @@
   "icon": "extension_icon.png",
   "author": "yonbergman",
   "contributors": [
-    "leodbrs"
+    "leodbrs",
+    "viktor_m"
   ],
   "categories": [
     "Productivity"

--- a/extensions/mirror-displays/src/mirror-displays.tsx
+++ b/extensions/mirror-displays/src/mirror-displays.tsx
@@ -42,7 +42,7 @@ export default function Command() {
       <List.Item
         icon={Icon.Desktop}
         title="Mac → External"
-        subtitle="Mirror the MacBook screen onto the primary external display (uses first external when multiple connected)"
+        subtitle="Mirror the Mac's main display onto the primary external display (uses first external when multiple connected)"
         actions={
           <ActionPanel>
             <Action title="Mirror Mac to External" icon={Icon.Desktop} onAction={() => handleAction("mac")} />
@@ -52,7 +52,7 @@ export default function Command() {
       <List.Item
         icon={Icon.Monitor}
         title="External → Mac"
-        subtitle="Mirror the primary external display onto the MacBook screen (uses first external when multiple connected)"
+        subtitle="Mirror the primary external display onto the Mac's main display (uses first external when multiple connected)"
         actions={
           <ActionPanel>
             <Action title="Mirror External to Mac" icon={Icon.Monitor} onAction={() => handleAction("external")} />


### PR DESCRIPTION
Macs without a built-in display (Mac mini, Mac Studio, Mac Pro) have no display for which CGDisplayIsBuiltin() returns true, so the script always errored with "Could not find the internal Mac display." Fall back to the system's main display as the primary screen when no built-in display is found, leaving laptop behavior unchanged.

## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
