### PR TITLE
Add Search Session Output command to tmux-sessioner

### DIFF
--- a/extensions/tmux-sessioner/CHANGELOG.md
+++ b/extensions/tmux-sessioner/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Tmux Sessioner Changelog
 
+## [Search Session Output] - {PR_MERGE_DATE}
+
+### Added
+
+- **Search Session Output** command: full-text search across the scrollback of every pane in every tmux session — commands you ran and the output they printed. Results are grouped by session (one entry per distinct line, newest first) with the surrounding lines shown in the detail pane; `⏎` switches to the matching session and window, `⌘T` / `⇧⌘T` open it in a new terminal tab/window, `⇧⌘C` copies the line, `⌘R` reloads the scrollback.
+
 ## [Open sessions in a new terminal tab or window] - 2026-08-04
 
 ### Added

--- a/extensions/tmux-sessioner/CHANGELOG.md
+++ b/extensions/tmux-sessioner/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Tmux Sessioner Changelog
 
-## [Search Session Output] - {PR_MERGE_DATE}
+## [Search Session Output] - 2026-08-22
 
 ### Added
 

--- a/extensions/tmux-sessioner/README.md
+++ b/extensions/tmux-sessioner/README.md
@@ -15,7 +15,12 @@ This is a extension for raycast to manage tmux sessions.
 - Bootstrap project sessions: create a folder and run a startup command in one go 🚀
 - Delete sessions 🗑
 - Kill multiple sessions at once 🧹
+- Search commands and output across all sessions' scrollback 🔍
 - Rename sessions 📝
+
+## Searching session output
+
+`Search Session Output` greps the scrollback of every pane in every session, so you can find that command you ran or error you saw without remembering which session it was in. Matches are grouped by session with surrounding context; press `⏎` to switch there, or open it in a new terminal tab. Tip: raise tmux's `history-limit` (e.g. `set -g history-limit 50000`) to search further back.
 
 ## Bootstrapping project sessions
 

--- a/extensions/tmux-sessioner/package.json
+++ b/extensions/tmux-sessioner/package.json
@@ -48,6 +48,12 @@
       "title": "Manage Tmux Windows",
       "description": "Manage Tmux Windows that user can switch or delete any tmux window from here",
       "mode": "view"
+    },
+    {
+      "name": "search_session_output",
+      "title": "Search Session Output",
+      "description": "Search commands and printed output across the scrollback of all tmux sessions",
+      "mode": "view"
     }
   ],
   "preferences": [

--- a/extensions/tmux-sessioner/src/SelectTerminalApp.tsx
+++ b/extensions/tmux-sessioner/src/SelectTerminalApp.tsx
@@ -38,7 +38,9 @@ export const SelectTerminalApp = ({ setIsTerminalSetup }: { setIsTerminalSetup?:
           <Action.SubmitForm
             title="Submit Terminal App Name"
             onSubmit={async (values) => {
-              LocalStorage.setItem("terminalAppBundleId", values.terminalAppBundleId);
+              // Await persistence so consumers that re-read LocalStorage right
+              // after setup (e.g. reloading terminal capabilities) see the value
+              await LocalStorage.setItem("terminalAppBundleId", values.terminalAppBundleId);
               const toast = await showToast({
                 style: Toast.Style.Animated,
                 title: "Setup Terminal",

--- a/extensions/tmux-sessioner/src/search_session_output.tsx
+++ b/extensions/tmux-sessioner/src/search_session_output.tsx
@@ -94,8 +94,12 @@ export default function Command() {
     const bySession = new Map<string, { matches: Match[]; seen: Set<string>; total: number }>();
 
     // Most-recently-active panes first, so when the same line exists in several
-    // panes of a session the dedup keeps the newest occurrence
-    const orderedPanes = [...panes].sort((a, b) => b.windowActivity - a.windowActivity);
+    // panes of a session the dedup keeps the newest occurrence. Panes in one
+    // window share window_activity (tmux has no per-pane recency), so the active
+    // pane — the one the user is looking at — breaks that tie.
+    const orderedPanes = [...panes].sort(
+      (a, b) => b.windowActivity - a.windowActivity || Number(b.paneActive) - Number(a.paneActive),
+    );
 
     for (const pane of orderedPanes) {
       // Walk newest lines first so the most recent occurrence wins

--- a/extensions/tmux-sessioner/src/search_session_output.tsx
+++ b/extensions/tmux-sessioner/src/search_session_output.tsx
@@ -1,0 +1,221 @@
+import { Action, ActionPanel, Icon, List, showToast, Toast, useNavigation } from "@raycast/api";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { captureAllPanes, type PaneContent, selectWindow } from "./utils/paneUtils";
+import { openSessionInTerminal } from "./utils/sessionUtils";
+import { switchToWindow } from "./utils/windowUtils";
+import { checkTerminalSetup } from "./utils/terminalUtils";
+import { SelectTerminalApp } from "./SelectTerminalApp";
+import { getTerminalCapabilities, type OpenTarget, type TerminalCapabilities } from "./utils/terminalLaunchUtils";
+
+interface Match {
+  pane: PaneContent;
+  lineIndex: number;
+  line: string;
+}
+
+interface SessionMatches {
+  sessionName: string;
+  matches: Match[];
+  total: number;
+}
+
+const MIN_QUERY_LENGTH = 2;
+const MAX_MATCHES_PER_SESSION = 100;
+const CONTEXT_LINES = 8;
+
+function contextMarkdown(match: Match): string {
+  const { lines } = match.pane;
+  const start = Math.max(0, match.lineIndex - CONTEXT_LINES);
+  const end = Math.min(lines.length, match.lineIndex + CONTEXT_LINES + 1);
+  const snippet = lines
+    .slice(start, end)
+    .map((line, offset) => `${start + offset === match.lineIndex ? "▶ " : "  "}${line}`)
+    .join("\n");
+
+  return `\`\`\`\n${snippet}\n\`\`\``;
+}
+
+export default function Command() {
+  const [panes, setPanes] = useState<PaneContent[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isTerminalSetup, setIsTerminalSetup] = useState(false);
+  const [terminalCapabilities, setTerminalCapabilities] = useState<TerminalCapabilities | null>(null);
+  const [searchText, setSearchText] = useState("");
+
+  const loadPanes = useCallback(async () => {
+    setIsLoading(true);
+
+    try {
+      setPanes(await captureAllPanes());
+    } catch (e) {
+      console.error(`exec error: ${e}`);
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "Failed to read tmux sessions 😢",
+        message: e instanceof Error ? e.message : String(e),
+      });
+    }
+
+    setIsLoading(false);
+  }, []);
+
+  const { push } = useNavigation();
+
+  useEffect(() => {
+    (async () => {
+      // Searching never needs the terminal; only switching/opening does
+      await checkTerminalSetup(setIsTerminalSetup);
+      setTerminalCapabilities(await getTerminalCapabilities());
+      await loadPanes();
+    })();
+  }, []);
+
+  const requireTerminal = (action: () => void) => {
+    if (isTerminalSetup) {
+      action();
+      return;
+    }
+
+    push(<SelectTerminalApp setIsTerminalSetup={setIsTerminalSetup} />);
+  };
+
+  const query = searchText.trim().toLowerCase();
+
+  const results = useMemo<SessionMatches[]>(() => {
+    if (query.length < MIN_QUERY_LENGTH) {
+      return [];
+    }
+
+    const bySession = new Map<string, { matches: Match[]; seen: Set<string>; total: number }>();
+
+    for (const pane of panes) {
+      // Walk newest lines first so the most recent occurrence wins
+      for (let lineIndex = pane.lines.length - 1; lineIndex >= 0; lineIndex--) {
+        const line = pane.lines[lineIndex];
+
+        if (!line.toLowerCase().includes(query)) {
+          continue;
+        }
+
+        const group = bySession.get(pane.sessionName) ?? { matches: [], seen: new Set<string>(), total: 0 };
+        group.total += 1;
+
+        // Repeated prompts/commands would drown the results; keep one per distinct line
+        if (!group.seen.has(line) && group.matches.length < MAX_MATCHES_PER_SESSION) {
+          group.seen.add(line);
+          group.matches.push({ pane, lineIndex, line });
+        }
+
+        bySession.set(pane.sessionName, group);
+      }
+    }
+
+    return [...bySession.entries()]
+      .map(([sessionName, group]) => ({ sessionName, matches: group.matches, total: group.total }))
+      .sort((a, b) => a.sessionName.localeCompare(b.sessionName));
+  }, [panes, query]);
+
+  const hasResults = results.length > 0;
+
+  const openMatch = async (match: Match, target: OpenTarget) => {
+    try {
+      await selectWindow(match.pane.sessionName, match.pane.windowIndex);
+    } catch (e) {
+      console.error(`exec error: ${e}`);
+    }
+
+    await openSessionInTerminal(match.pane.sessionName, target, setIsLoading);
+  };
+
+  return (
+    <List
+      isLoading={isLoading}
+      filtering={false}
+      onSearchTextChange={setSearchText}
+      searchBarPlaceholder="Search commands and output across all tmux sessions…"
+      isShowingDetail={hasResults}
+      throttle
+    >
+      {!hasResults && (
+        <List.EmptyView
+          icon={Icon.MagnifyingGlass}
+          title={query.length < MIN_QUERY_LENGTH ? "Search Session Output" : "No Matches"}
+          description={
+            query.length < MIN_QUERY_LENGTH
+              ? `Type at least ${MIN_QUERY_LENGTH} characters to search the scrollback of ${panes.length} ${panes.length === 1 ? "pane" : "panes"}`
+              : "Nothing in any session's scrollback matches your search"
+          }
+        />
+      )}
+      {results.map((group) => (
+        <List.Section
+          key={group.sessionName}
+          title={group.sessionName}
+          subtitle={
+            group.total > group.matches.length
+              ? `${group.matches.length} distinct of ${group.total} matches`
+              : `${group.total} ${group.total === 1 ? "match" : "matches"}`
+          }
+        >
+          {group.matches.map((match) => {
+            const window = {
+              sessionName: match.pane.sessionName,
+              windowIndex: match.pane.windowIndex,
+              windowName: String(match.pane.windowIndex),
+            };
+
+            return (
+              <List.Item
+                key={`${match.pane.paneId}:${match.lineIndex}`}
+                icon={Icon.Terminal}
+                title={match.line.trim()}
+                accessories={[{ tag: `window ${match.pane.windowIndex}`, tooltip: "tmux window index" }]}
+                detail={<List.Item.Detail markdown={contextMarkdown(match)} />}
+                actions={
+                  <ActionPanel>
+                    <ActionPanel.Section>
+                      <Action
+                        title="Switch to Session"
+                        icon={Icon.ArrowRight}
+                        onAction={() => requireTerminal(() => switchToWindow(window, setIsLoading))}
+                      />
+                      {terminalCapabilities?.supportsTab && (
+                        <Action
+                          title="Open in New Tab"
+                          icon={Icon.PlusSquare}
+                          onAction={() => requireTerminal(() => openMatch(match, "tab"))}
+                          shortcut={{ modifiers: ["cmd"], key: "t" }}
+                        />
+                      )}
+                      {terminalCapabilities?.supportsWindow && (
+                        <Action
+                          title="Open in New Window"
+                          icon={Icon.NewDocument}
+                          onAction={() => requireTerminal(() => openMatch(match, "window"))}
+                          shortcut={{ modifiers: ["cmd", "shift"], key: "t" }}
+                        />
+                      )}
+                    </ActionPanel.Section>
+                    <ActionPanel.Section>
+                      <Action.CopyToClipboard
+                        title="Copy Line"
+                        content={match.line.trim()}
+                        shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+                      />
+                      <Action
+                        title="Reload Scrollback"
+                        icon={Icon.ArrowClockwise}
+                        onAction={loadPanes}
+                        shortcut={{ modifiers: ["cmd"], key: "r" }}
+                      />
+                    </ActionPanel.Section>
+                  </ActionPanel>
+                }
+              />
+            );
+          })}
+        </List.Section>
+      ))}
+    </List>
+  );
+}

--- a/extensions/tmux-sessioner/src/search_session_output.tsx
+++ b/extensions/tmux-sessioner/src/search_session_output.tsx
@@ -1,8 +1,7 @@
 import { Action, ActionPanel, Icon, List, showToast, Toast, useNavigation } from "@raycast/api";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { captureAllPanes, type PaneContent, selectWindow } from "./utils/paneUtils";
-import { openSessionInTerminal } from "./utils/sessionUtils";
-import { switchToWindow } from "./utils/windowUtils";
+import { captureAllPanes, focusPane, type PaneContent } from "./utils/paneUtils";
+import { openSessionInTerminal, switchToSession } from "./utils/sessionUtils";
 import { checkTerminalSetup } from "./utils/terminalUtils";
 import { SelectTerminalApp } from "./SelectTerminalApp";
 import { getTerminalCapabilities, type OpenTarget, type TerminalCapabilities } from "./utils/terminalLaunchUtils";
@@ -70,6 +69,12 @@ export default function Command() {
     })();
   }, []);
 
+  useEffect(() => {
+    if (isTerminalSetup) {
+      (async () => setTerminalCapabilities(await getTerminalCapabilities()))();
+    }
+  }, [isTerminalSetup]);
+
   const requireTerminal = (action: () => void) => {
     if (isTerminalSetup) {
       action();
@@ -88,7 +93,11 @@ export default function Command() {
 
     const bySession = new Map<string, { matches: Match[]; seen: Set<string>; total: number }>();
 
-    for (const pane of panes) {
+    // Most-recently-active panes first, so when the same line exists in several
+    // panes of a session the dedup keeps the newest occurrence
+    const orderedPanes = [...panes].sort((a, b) => b.windowActivity - a.windowActivity);
+
+    for (const pane of orderedPanes) {
       // Walk newest lines first so the most recent occurrence wins
       for (let lineIndex = pane.lines.length - 1; lineIndex >= 0; lineIndex--) {
         const line = pane.lines[lineIndex];
@@ -117,13 +126,21 @@ export default function Command() {
 
   const hasResults = results.length > 0;
 
-  const openMatch = async (match: Match, target: OpenTarget) => {
+  const focusMatch = async (match: Match) => {
     try {
-      await selectWindow(match.pane.sessionName, match.pane.windowIndex);
+      await focusPane(match.pane.paneId);
     } catch (e) {
       console.error(`exec error: ${e}`);
     }
+  };
 
+  const switchToMatch = async (match: Match) => {
+    await focusMatch(match);
+    switchToSession(match.pane.sessionName, setIsLoading);
+  };
+
+  const openMatch = async (match: Match, target: OpenTarget) => {
+    await focusMatch(match);
     await openSessionInTerminal(match.pane.sessionName, target, setIsLoading);
   };
 
@@ -158,12 +175,6 @@ export default function Command() {
           }
         >
           {group.matches.map((match) => {
-            const window = {
-              sessionName: match.pane.sessionName,
-              windowIndex: match.pane.windowIndex,
-              windowName: String(match.pane.windowIndex),
-            };
-
             return (
               <List.Item
                 key={`${match.pane.paneId}:${match.lineIndex}`}
@@ -177,7 +188,7 @@ export default function Command() {
                       <Action
                         title="Switch to Session"
                         icon={Icon.ArrowRight}
-                        onAction={() => requireTerminal(() => switchToWindow(window, setIsLoading))}
+                        onAction={() => requireTerminal(() => switchToMatch(match))}
                       />
                       {terminalCapabilities?.supportsTab && (
                         <Action

--- a/extensions/tmux-sessioner/src/search_session_output.tsx
+++ b/extensions/tmux-sessioner/src/search_session_output.tsx
@@ -130,22 +130,33 @@ export default function Command() {
 
   const hasResults = results.length > 0;
 
-  const focusMatch = async (match: Match) => {
+  const focusMatch = async (match: Match): Promise<boolean> => {
     try {
       await focusPane(match.pane.paneId);
+      return true;
     } catch (e) {
+      // The matched pane closed since the capture, so this result is stale:
+      // don't navigate elsewhere and report success — tell the user to reload
       console.error(`exec error: ${e}`);
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "That pane has closed 😢",
+        message: "Reload the scrollback with ⌘R and search again",
+      });
+      return false;
     }
   };
 
   const switchToMatch = async (match: Match) => {
-    await focusMatch(match);
-    switchToSession(match.pane.sessionName, setIsLoading);
+    if (await focusMatch(match)) {
+      switchToSession(match.pane.sessionName, setIsLoading);
+    }
   };
 
   const openMatch = async (match: Match, target: OpenTarget) => {
-    await focusMatch(match);
-    await openSessionInTerminal(match.pane.sessionName, target, setIsLoading);
+    if (await focusMatch(match)) {
+      await openSessionInTerminal(match.pane.sessionName, target, setIsLoading);
+    }
   };
 
   return (

--- a/extensions/tmux-sessioner/src/search_session_output.tsx
+++ b/extensions/tmux-sessioner/src/search_session_output.tsx
@@ -91,18 +91,22 @@ export default function Command() {
       return [];
     }
 
-    const bySession = new Map<string, { matches: Match[]; seen: Set<string>; total: number }>();
+    const bySession = new Map<string, { matches: Match[]; total: number }>();
 
-    // Most-recently-active panes first, so when the same line exists in several
-    // panes of a session the dedup keeps the newest occurrence. Panes in one
-    // window share window_activity (tmux has no per-pane recency), so the active
-    // pane — the one the user is looking at — breaks that tie.
+    // Order panes by most-recent window activity (active pane first within a
+    // window) purely for display: recent matches surface at the top.
     const orderedPanes = [...panes].sort(
       (a, b) => b.windowActivity - a.windowActivity || Number(b.paneActive) - Number(a.paneActive),
     );
 
     for (const pane of orderedPanes) {
-      // Walk newest lines first so the most recent occurrence wins
+      // Dedup per pane, not per session: the same line in different panes is a
+      // distinct, separately-navigable location, so no pane's occurrence is
+      // dropped in favour of another's (tmux exposes no per-pane recency that
+      // could rank them anyway). Repeats within one pane still collapse.
+      const seen = new Set<string>();
+
+      // Walk newest lines first so a pane's most recent occurrence is the one kept
       for (let lineIndex = pane.lines.length - 1; lineIndex >= 0; lineIndex--) {
         const line = pane.lines[lineIndex];
 
@@ -110,12 +114,11 @@ export default function Command() {
           continue;
         }
 
-        const group = bySession.get(pane.sessionName) ?? { matches: [], seen: new Set<string>(), total: 0 };
+        const group = bySession.get(pane.sessionName) ?? { matches: [], total: 0 };
         group.total += 1;
 
-        // Repeated prompts/commands would drown the results; keep one per distinct line
-        if (!group.seen.has(line) && group.matches.length < MAX_MATCHES_PER_SESSION) {
-          group.seen.add(line);
+        if (!seen.has(line) && group.matches.length < MAX_MATCHES_PER_SESSION) {
+          seen.add(line);
           group.matches.push({ pane, lineIndex, line });
         }
 

--- a/extensions/tmux-sessioner/src/utils/paneUtils.ts
+++ b/extensions/tmux-sessioner/src/utils/paneUtils.ts
@@ -5,6 +5,7 @@ export interface TmuxPane {
   paneId: string;
   sessionName: string;
   windowIndex: number;
+  windowActivity: number;
 }
 
 export interface PaneContent extends TmuxPane {
@@ -24,23 +25,30 @@ function tmux(args: string[]): Promise<string> {
 }
 
 export async function getAllPanes(): Promise<TmuxPane[]> {
-  // pane_id (%N) and window_index (a number) never contain spaces, so we can
-  // put session_name last and split on the first two spaces only — the name may
-  // contain spaces (and any separator byte; Raycast's exec strips control chars,
-  // so an ASCII space is the only safe delimiter here)
-  const stdout = await tmux(["list-panes", "-a", "-F", "#{pane_id} #{window_index} #{session_name}"]);
+  // pane_id (%N), window_index and window_activity (numbers) never contain
+  // spaces, so we put session_name last and split on the first three spaces —
+  // the name may contain spaces (and any separator byte; Raycast's exec strips
+  // control chars, so an ASCII space is the only safe delimiter here)
+  const stdout = await tmux([
+    "list-panes",
+    "-a",
+    "-F",
+    "#{pane_id} #{window_index} #{window_activity} #{session_name}",
+  ]);
 
   return stdout
     .split("\n")
     .filter(Boolean)
     .map((line) => {
-      const firstSpace = line.indexOf(" ");
-      const secondSpace = line.indexOf(" ", firstSpace + 1);
+      const s1 = line.indexOf(" ");
+      const s2 = line.indexOf(" ", s1 + 1);
+      const s3 = line.indexOf(" ", s2 + 1);
 
       return {
-        paneId: line.slice(0, firstSpace),
-        windowIndex: Number(line.slice(firstSpace + 1, secondSpace)),
-        sessionName: line.slice(secondSpace + 1),
+        paneId: line.slice(0, s1),
+        windowIndex: Number(line.slice(s1 + 1, s2)),
+        windowActivity: Number(line.slice(s2 + 1, s3)),
+        sessionName: line.slice(s3 + 1),
       };
     });
 }
@@ -83,6 +91,9 @@ export async function captureAllPanes(): Promise<PaneContent[]> {
   return captured.filter((pane): pane is PaneContent => pane !== null);
 }
 
-export function selectWindow(sessionName: string, windowIndex: number): Promise<string> {
-  return tmux(["select-window", "-t", `=${sessionName}:${windowIndex}`]);
+// Focus the exact matched pane: selecting its window activates the window,
+// selecting the pane activates it within that window (a window may hold several)
+export async function focusPane(paneId: string): Promise<void> {
+  await tmux(["select-window", "-t", paneId]);
+  await tmux(["select-pane", "-t", paneId]);
 }

--- a/extensions/tmux-sessioner/src/utils/paneUtils.ts
+++ b/extensions/tmux-sessioner/src/utils/paneUtils.ts
@@ -1,0 +1,88 @@
+import { execFile } from "node:child_process";
+import { env } from "../config";
+
+export interface TmuxPane {
+  paneId: string;
+  sessionName: string;
+  windowIndex: number;
+}
+
+export interface PaneContent extends TmuxPane {
+  lines: string[];
+}
+
+function tmux(args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile("tmux", args, { env, maxBuffer: 64 * 1024 * 1024 }, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(stderr || error.message));
+        return;
+      }
+      resolve(stdout);
+    });
+  });
+}
+
+export async function getAllPanes(): Promise<TmuxPane[]> {
+  // pane_id (%N) and window_index (a number) never contain spaces, so we can
+  // put session_name last and split on the first two spaces only — the name may
+  // contain spaces (and any separator byte; Raycast's exec strips control chars,
+  // so an ASCII space is the only safe delimiter here)
+  const stdout = await tmux(["list-panes", "-a", "-F", "#{pane_id} #{window_index} #{session_name}"]);
+
+  return stdout
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const firstSpace = line.indexOf(" ");
+      const secondSpace = line.indexOf(" ", firstSpace + 1);
+
+      return {
+        paneId: line.slice(0, firstSpace),
+        windowIndex: Number(line.slice(firstSpace + 1, secondSpace)),
+        sessionName: line.slice(secondSpace + 1),
+      };
+    });
+}
+
+export async function capturePane(paneId: string): Promise<string[]> {
+  // -p prints to stdout, -J joins wrapped lines, -S - starts from the top of the scrollback
+  const stdout = await tmux(["capture-pane", "-p", "-J", "-t", paneId, "-S", "-"]);
+
+  return stdout.split("\n").map((line) => line.trimEnd());
+}
+
+export async function captureAllPanes(): Promise<PaneContent[]> {
+  let panes: TmuxPane[];
+
+  try {
+    panes = await getAllPanes();
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+
+    // No server means no panes, not a failure
+    if (message.includes("no server running") || message.includes("error connecting")) {
+      return [];
+    }
+
+    throw e;
+  }
+
+  const captured = await Promise.all(
+    panes.map(async (pane) => {
+      try {
+        return { ...pane, lines: await capturePane(pane.paneId) };
+      } catch {
+        // A pane can close between listing and capture; skip it rather than
+        // failing the whole search
+        return null;
+      }
+    }),
+  );
+
+  return captured.filter((pane): pane is PaneContent => pane !== null);
+}
+
+export function selectWindow(sessionName: string, windowIndex: number): Promise<string> {
+  return tmux(["select-window", "-t", `=${sessionName}:${windowIndex}`]);
+}

--- a/extensions/tmux-sessioner/src/utils/paneUtils.ts
+++ b/extensions/tmux-sessioner/src/utils/paneUtils.ts
@@ -6,6 +6,7 @@ export interface TmuxPane {
   sessionName: string;
   windowIndex: number;
   windowActivity: number;
+  paneActive: boolean;
 }
 
 export interface PaneContent extends TmuxPane {
@@ -33,7 +34,7 @@ export async function getAllPanes(): Promise<TmuxPane[]> {
     "list-panes",
     "-a",
     "-F",
-    "#{pane_id} #{window_index} #{window_activity} #{session_name}",
+    "#{pane_id} #{window_index} #{window_activity} #{pane_active} #{session_name}",
   ]);
 
   return stdout
@@ -43,12 +44,14 @@ export async function getAllPanes(): Promise<TmuxPane[]> {
       const s1 = line.indexOf(" ");
       const s2 = line.indexOf(" ", s1 + 1);
       const s3 = line.indexOf(" ", s2 + 1);
+      const s4 = line.indexOf(" ", s3 + 1);
 
       return {
         paneId: line.slice(0, s1),
         windowIndex: Number(line.slice(s1 + 1, s2)),
         windowActivity: Number(line.slice(s2 + 1, s3)),
-        sessionName: line.slice(s3 + 1),
+        paneActive: line.slice(s3 + 1, s4) === "1",
+        sessionName: line.slice(s4 + 1),
       };
     });
 }


### PR DESCRIPTION
## Description

Adds a **Search Session Output** command to tmux-sessioner: full-text search across the scrollback of every pane in every tmux session — both the commands you ran and the output they printed. This complements the existing session/window management commands: instead of remembering which session held that error or command, you search for it and jump straight there.

## How it works

- On open, the command captures the scrollback of every pane (`tmux capture-pane -p -J -S -` across `tmux list-panes -a`) once, then filters in memory as you type (from 2 characters). A `⌘R` action re-captures.
- Results are grouped by session, one entry per distinct matching line (newest occurrence first, repeated prompts/commands collapsed with the real count in the section subtitle). The detail pane shows the surrounding lines with the match marked.
- `⏎` switches to the matching session and window; `⌘T` / `⇧⌘T` open it in a new terminal tab/window (reusing the existing per-terminal launchers); `⇧⌘C` copies the line.
- Searching never requires a configured terminal — only the switch/open actions do, and they prompt for terminal setup on first use.

## Notes for reviewers

- macOS-only (unchanged); no new dependencies or preferences, one new `view` command
- Pane metadata is parsed with a space delimiter (pane id and window index are space-free leading fields, session name last) rather than a control-character separator, because Raycast's `execFile` stdout strips control bytes — a plain space is the only reliable delimiter for this data
- Capture is resilient: a pane closing between listing and capture is skipped rather than failing the whole search
- Scrollback depth is bounded by tmux's `history-limit`; the README notes raising it to search further back
- Tested end-to-end in Raycast: search across ~100 panes, session-grouped results with context, switch/open actions, and the empty/no-server states

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
