### PR TITLE
Link Commands: surface routers for services with a desktop app

### DIFF
--- a/extensions/link-commands/CHANGELOG.md
+++ b/extensions/link-commands/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Link Commands Changelog
 
-## [Surface Routers] - {PR_MERGE_DATE}
+## [Surface Routers] - 2026-08-30
 
 ### Added
 

--- a/extensions/link-commands/CHANGELOG.md
+++ b/extensions/link-commands/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Link Commands Changelog
 
+## [Surface Routers] - {PR_MERGE_DATE}
+
+### Added
+
+- **Desktop App** on the create form — pick the native app for a service and the command becomes a surface router: it opens the app where the app is installed, falls back to the URL where it is not, and gains an optional App/Web dropdown so either surface can be forced. One row per service instead of a launcher and a separate web pin competing for the same query. Offered only for URL targets without a `{query}`, since a search command has already spent its first argument.
+
+### Changed
+
+- The detail pane lists a dropdown argument's choices rather than its placeholder. A dropdown's choices are what it actually tells you — "Surface" names the axis but not what you can pick along it.
+
 ## [Initial Version] - 2026-08-21
 
 ### Added

--- a/extensions/link-commands/CHANGELOG.md
+++ b/extensions/link-commands/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Added
 
-- **Desktop App** on the create form — pick the native app for a service and the command becomes a surface router: it opens the app where the app is installed, falls back to the URL where it is not, and gains an optional App/Web dropdown so either surface can be forced. One row per service instead of a launcher and a separate web pin competing for the same query. Offered only for URL targets without a `{query}`, since a search command has already spent its first argument.
+- **Desktop App** on the create form — pick the native app for a service and the command becomes a surface router: it opens the app where the app is installed and the URL where it is not, so one command serves machines that differ in what they have. It takes no argument, which is what keeps it hotkey-able: Raycast raises the launcher to render an argument field, and an optional argument still prompts — it only permits an empty answer. Offered only for URL targets without a `{query}`, since `open -a` takes no query and a folder has no web surface to fall back to.
 
 ### Changed
 
-- The detail pane lists a dropdown argument's choices rather than its placeholder. A dropdown's choices are what it actually tells you — "Surface" names the axis but not what you can pick along it.
+- The detail pane lists a dropdown argument's choices rather than its placeholder. A dropdown's choices are what it actually tells you — a placeholder names the axis but not what you can pick along it.
 
 ## [Initial Version] - 2026-08-21
 

--- a/extensions/link-commands/src/create-link-command.tsx
+++ b/extensions/link-commands/src/create-link-command.tsx
@@ -38,6 +38,7 @@ type CreateInput = {
   packageName: string;
   category: string;
   application: string;
+  desktopApplication: string;
   icon: string;
   author?: string;
   authorURL?: string;
@@ -62,6 +63,7 @@ const createScript = async (input: CreateInput) => {
     packageName: input.packageName.trim() || undefined,
     category: input.category.trim() || undefined,
     application: input.application || undefined,
+    desktopApplication: input.desktopApplication || undefined,
     author: input.author,
     authorURL: input.authorURL,
   };
@@ -97,6 +99,7 @@ const Command = () => {
   const [category, setCategory] = useState("");
   const [newCategory, setNewCategory] = useState("");
   const [application, setApplication] = useState("");
+  const [desktopApplication, setDesktopApplication] = useState("");
   const [icon, setIcon] = useState("");
   const [directory, setDirectory] = useState(directories[0] ?? "");
 
@@ -113,6 +116,10 @@ const Command = () => {
   // already holds the right answer for every service it has seen, so it is asked first.
   const learned = learnedPackages(discovered?.commands ?? []);
   const suggestedPackage = packageForTarget(target, learned) ?? brandFor(target);
+
+  // Mirrors the generator's own guard rather than restating it loosely: a search command has already
+  // spent argument1 on its query, and "the app or the folder" is not a choice a path target can offer.
+  const canRoute = /^https?:\/\//i.test(target.trim()) && !findPlaceholder(target);
 
   // The dropdown holds a sentinel while a new value is being typed; everything downstream sees
   // only the resolved string.
@@ -154,6 +161,7 @@ const Command = () => {
         packageName: packageName.trim() || suggestedPackage || "",
         category: chosenCategory,
         application,
+        desktopApplication,
         icon,
         author: preferences.defaultAuthor,
         authorURL: preferences.defaultAuthorURL,
@@ -255,6 +263,21 @@ Put {query} anywhere in a URL to make it a search command: Raycast prompts for t
           value={newCategory}
           onChange={setNewCategory}
         />
+      ) : null}
+
+      {canRoute ? (
+        <Form.Dropdown
+          id="desktopApplication"
+          title="Desktop App"
+          info="The native app for this service, if it has one. Picking it turns the command into a surface router: it opens the app where the app is installed, falls back to the target where it is not, and gains an App/Web dropdown so either can be forced."
+          value={desktopApplication}
+          onChange={setDesktopApplication}
+        >
+          <Form.Dropdown.Item title="None — always open the target" value="" />
+          {(applications ?? []).map((app) => (
+            <Form.Dropdown.Item key={app.path} title={app.name} value={app.path} icon={{ fileIcon: app.path }} />
+          ))}
+        </Form.Dropdown>
       ) : null}
 
       <Form.Dropdown id="application" title="Open With" value={application} onChange={setApplication}>

--- a/extensions/link-commands/src/create-link-command.tsx
+++ b/extensions/link-commands/src/create-link-command.tsx
@@ -117,8 +117,8 @@ const Command = () => {
   const learned = learnedPackages(discovered?.commands ?? []);
   const suggestedPackage = packageForTarget(target, learned) ?? brandFor(target);
 
-  // Mirrors the generator's own guard rather than restating it loosely: a search command has already
-  // spent argument1 on its query, and "the app or the folder" is not a choice a path target can offer.
+  // Mirrors the generator's own guard rather than restating it loosely: `open -a` takes no query, so a
+  // search target has nothing an app could stand in for, and a folder has no web surface to fall back to.
   const canRoute = /^https?:\/\//i.test(target.trim()) && !findPlaceholder(target);
 
   // The dropdown holds a sentinel while a new value is being typed; everything downstream sees
@@ -269,7 +269,7 @@ Put {query} anywhere in a URL to make it a search command: Raycast prompts for t
         <Form.Dropdown
           id="desktopApplication"
           title="Desktop App"
-          info="The native app for this service, if it has one. Picking it turns the command into a surface router: it opens the app where the app is installed, falls back to the target where it is not, and gains an App/Web dropdown so either can be forced."
+          info="The native app for this service, if it has one. Picking it turns the command into a surface router: it opens the app where the app is installed and the target where it is not, so the same command works on machines that differ in what they have. It stays argument-free, so it still fires from a hotkey."
           value={desktopApplication}
           onChange={setDesktopApplication}
         >

--- a/extensions/link-commands/src/lib/generate-script.ts
+++ b/extensions/link-commands/src/lib/generate-script.ts
@@ -1,5 +1,3 @@
-import { basename } from "node:path";
-
 const FALLBACK_LINK_ICON = "https://api.iconify.design/mingcute/link-line.svg";
 
 const FALLBACK_FOLDER_ICON = "https://api.iconify.design/mingcute/folder-line.svg";
@@ -30,8 +28,8 @@ export type ScriptDraft = {
   application?: string;
   /**
    * Absolute path to a native app that stands in for the target wherever it is installed. Its presence
-   * is what turns a plain opener into a surface router: the script gains an App/Web dropdown, and with
-   * no argument it prefers the app and falls back to the target.
+   * is what turns a plain opener into a surface router: the script opens the app where it is present and
+   * the target where it is not, so one command serves machines that differ in what is installed.
    */
   desktopApplication?: string;
   author?: string;
@@ -160,57 +158,38 @@ export const scriptFilename = (draft: ScriptDraft) => {
  */
 const escapeForShell = (value: string) => value.replace(/([\\"`$])/g, "\\$1");
 
-const SURFACE_ARGUMENT = {
-  type: "dropdown",
-  placeholder: "Surface",
-  optional: true,
-  data: [
-    { title: "App", value: "app" },
-    { title: "Web", value: "web" },
-  ],
-};
-
-const appNameOf = (appPath: string) => basename(appPath).replace(/\.app$/i, "");
-
 /**
- * A router spends `argument1` on its surface dropdown, so a target carrying a `{query}` placeholder
- * cannot be one — that argument is already the search term. A non-URL target is excluded for the same
- * kind of reason: "the app or the folder" is not a choice anyone means to offer.
+ * A native app cannot serve a search: `open -a` takes no query, so a target carrying a `{query}`
+ * placeholder has nothing an app could stand in for. A non-URL target is excluded for the same kind of
+ * reason — a folder has no web equivalent to fall back to.
  */
 const routerAppOf = (draft: ScriptDraft) =>
   draft.desktopApplication && !findPlaceholder(draft.target) && /^https?:\/\//i.test(draft.target)
     ? draft.desktopApplication
     : undefined;
 
+/**
+ * The app is opened by its own path rather than by a name derived from it. A basename is not an identity:
+ * two bundles can share one, and a renamed or unregistered app resolves to something else or to nothing,
+ * so `open -a` could miss the very bundle the presence check just confirmed.
+ *
+ * No argument, and so no dropdown. Raycast has to raise the launcher to render an argument field, which
+ * costs a command its hotkey — an optional argument still prompts, it only permits an empty answer. A
+ * router's whole value is firing without ceremony, so forcing a surface belongs on a second command
+ * rather than on this one.
+ */
 const routerBody = (draft: ScriptDraft, appPath: string) => {
-  const name = escapeForShell(appNameOf(appPath));
-  const openApp = `open -a "${name}"`;
   const openWeb = draft.application ? `open -a "${escapeForShell(draft.application)}" "$url"` : 'open "$url"';
 
   return [
     `url="${escapeForShell(draft.target)}"`,
     `app="${escapeForShell(appPath)}"`,
     "",
-    "case $1 in",
-    "  web)",
-    `    ${openWeb}`,
-    "    ;;",
-    "  app)",
-    "    if [[ -d $app ]]; then",
-    `      ${openApp}`,
-    "    else",
-    `      echo "${name}.app is not installed"`,
-    "      exit 1",
-    "    fi",
-    "    ;;",
-    "  *)",
-    "    if [[ -d $app ]]; then",
-    `      ${openApp}`,
-    "    else",
-    `      ${openWeb}`,
-    "    fi",
-    "    ;;",
-    "esac",
+    "if [[ -d $app ]]; then",
+    '  open "$app"',
+    "else",
+    `  ${openWeb}`,
+    "fi",
   ].join("\n");
 };
 
@@ -260,9 +239,7 @@ export const buildScript = (draft: ScriptDraft) => {
   ];
 
   if (subtitle) lines.push(`# @raycast.packageName ${singleLine(subtitle)}`);
-  if (routerAppOf(draft)) {
-    lines.push(`# @raycast.argument1 ${JSON.stringify(SURFACE_ARGUMENT)}`);
-  } else if (placeholder) {
+  if (placeholder) {
     // The argument is JSON, so it is serialised rather than quoted by hand — that escapes the quotes
     // and control characters a hand-built string would let straight through.
     lines.push(

--- a/extensions/link-commands/src/lib/generate-script.ts
+++ b/extensions/link-commands/src/lib/generate-script.ts
@@ -1,3 +1,5 @@
+import { basename } from "node:path";
+
 const FALLBACK_LINK_ICON = "https://api.iconify.design/mingcute/link-line.svg";
 
 const FALLBACK_FOLDER_ICON = "https://api.iconify.design/mingcute/folder-line.svg";
@@ -26,6 +28,12 @@ export type ScriptDraft = {
   /** `media` becomes ` · #media` on the subtitle. Never on the title. */
   category?: string;
   application?: string;
+  /**
+   * Absolute path to a native app that stands in for the target wherever it is installed. Its presence
+   * is what turns a plain opener into a surface router: the script gains an App/Web dropdown, and with
+   * no argument it prefers the app and falls back to the target.
+   */
+  desktopApplication?: string;
   author?: string;
   authorURL?: string;
   iconReference?: string;
@@ -152,6 +160,60 @@ export const scriptFilename = (draft: ScriptDraft) => {
  */
 const escapeForShell = (value: string) => value.replace(/([\\"`$])/g, "\\$1");
 
+const SURFACE_ARGUMENT = {
+  type: "dropdown",
+  placeholder: "Surface",
+  optional: true,
+  data: [
+    { title: "App", value: "app" },
+    { title: "Web", value: "web" },
+  ],
+};
+
+const appNameOf = (appPath: string) => basename(appPath).replace(/\.app$/i, "");
+
+/**
+ * A router spends `argument1` on its surface dropdown, so a target carrying a `{query}` placeholder
+ * cannot be one — that argument is already the search term. A non-URL target is excluded for the same
+ * kind of reason: "the app or the folder" is not a choice anyone means to offer.
+ */
+const routerAppOf = (draft: ScriptDraft) =>
+  draft.desktopApplication && !findPlaceholder(draft.target) && /^https?:\/\//i.test(draft.target)
+    ? draft.desktopApplication
+    : undefined;
+
+const routerBody = (draft: ScriptDraft, appPath: string) => {
+  const name = escapeForShell(appNameOf(appPath));
+  const openApp = `open -a "${name}"`;
+  const openWeb = draft.application ? `open -a "${escapeForShell(draft.application)}" "$url"` : 'open "$url"';
+
+  return [
+    `url="${escapeForShell(draft.target)}"`,
+    `app="${escapeForShell(appPath)}"`,
+    "",
+    "case $1 in",
+    "  web)",
+    `    ${openWeb}`,
+    "    ;;",
+    "  app)",
+    "    if [[ -d $app ]]; then",
+    `      ${openApp}`,
+    "    else",
+    `      echo "${name}.app is not installed"`,
+    "      exit 1",
+    "    fi",
+    "    ;;",
+    "  *)",
+    "    if [[ -d $app ]]; then",
+    `      ${openApp}`,
+    "    else",
+    `      ${openWeb}`,
+    "    fi",
+    "    ;;",
+    "esac",
+  ].join("\n");
+};
+
 const buildBody = (draft: ScriptDraft) => {
   const placeholder = findPlaceholder(draft.target);
 
@@ -164,6 +226,9 @@ const buildBody = (draft: ScriptDraft) => {
   // survive while the target's own `$` characters do not. A literal "$1" replacement string would be read
   // as a capture-group reference and expand to the placeholder's own name, hence the function form.
   const target = escapeForShell(draft.target);
+
+  const routerApp = routerAppOf(draft);
+  if (routerApp) return routerBody(draft, routerApp);
 
   if (placeholder) return `open "${target.replace(PLACEHOLDER_PATTERN, () => "$1")}"`;
   if (draft.application) return `open -a "${escapeForShell(draft.application)}" "${target}"`;
@@ -195,7 +260,9 @@ export const buildScript = (draft: ScriptDraft) => {
   ];
 
   if (subtitle) lines.push(`# @raycast.packageName ${singleLine(subtitle)}`);
-  if (placeholder) {
+  if (routerAppOf(draft)) {
+    lines.push(`# @raycast.argument1 ${JSON.stringify(SURFACE_ARGUMENT)}`);
+  } else if (placeholder) {
     // The argument is JSON, so it is serialised rather than quoted by hand — that escapes the quotes
     // and control characters a hand-built string would let straight through.
     lines.push(

--- a/extensions/link-commands/src/lib/search-view.tsx
+++ b/extensions/link-commands/src/lib/search-view.tsx
@@ -23,7 +23,7 @@ import { duplicateScript, makeExecutable } from "./script-operations";
 import { discoverScriptCommands } from "./discover-script-commands";
 import { resolveIcon } from "./resolve-icon";
 import { languageForScript } from "./script-language";
-import type { DiscoveryResult, ScriptCommand } from "./types";
+import type { DiscoveryResult, ScriptArgument, ScriptCommand } from "./types";
 
 /**
  * Declared here rather than using the generated `Preferences` global: this view is shared by two
@@ -40,6 +40,16 @@ type SearchPreferences = {
 const BODY_PREVIEW_LINES = 300;
 
 const RAYCAST_DIRECTORY_SETTINGS = "Raycast Settings → Extensions → Script Commands → Add Directories";
+
+/**
+ * A dropdown's choices are the whole of what it tells you — a placeholder like "Surface" names the
+ * axis but not what you can pick along it. Text and password arguments have no choices, so they fall
+ * back to the placeholder they prompt with.
+ */
+const argumentTags = (argument: ScriptArgument, index: number) =>
+  argument.data?.length
+    ? argument.data.map((choice) => choice.title)
+    : [argument.placeholder ?? argument.type ?? `argument${index + 1}`];
 
 const sourceBlock = (command: ScriptCommand) => {
   const lines = command.body.split("\n");
@@ -108,12 +118,11 @@ const ScriptMetadata = ({ command }: { command: ScriptCommand }) => {
 
       {command.argumentsList.length > 0 ? (
         <List.Item.Detail.Metadata.TagList title="Prompts For">
-          {command.argumentsList.map((argument, index) => (
-            <List.Item.Detail.Metadata.TagList.Item
-              key={index}
-              text={argument.placeholder ?? argument.type ?? `argument${index + 1}`}
-            />
-          ))}
+          {command.argumentsList.flatMap((argument, index) =>
+            argumentTags(argument, index).map((text) => (
+              <List.Item.Detail.Metadata.TagList.Item key={`${index}-${text}`} text={text} />
+            )),
+          )}
         </List.Item.Detail.Metadata.TagList>
       ) : null}
 


### PR DESCRIPTION
## Description

Two changes to **Link Commands**, both about services that exist as both a native app and a website.

### Surface routers

A service like Notion, Todoist or WhatsApp has a desktop app *and* a web version. Until now the only way to express that was a command per surface, and the split falls on the wrong axis: which one you want is a fact about the machine you are sitting at, not about what you typed. A command that opens `Notion.app` is simply broken on a machine that has no `Notion.app`.

**Create Link Command** gains a **Desktop App** field. Pick the native app for a target and the generated command becomes a surface router:

```zsh
url="https://www.notion.so/"
app="/Applications/Notion.app"

if [[ -d $app ]]; then
  open "$app"
else
  open "$url"
fi
```

The app where the app is installed, the URL where it is not — so the same command, synced across machines, does the right thing on each without being edited.

The path comes from `getApplications()` rather than being assembled from the name, and the script opens that path directly. A basename is not an identity: two bundles can share one, and a renamed or unregistered app resolves to something else or to nothing, so `open -a` could miss the very bundle the presence check just confirmed.

`Open With` still composes — set both, and the web branch opens in your chosen browser while the app branch stays native.

The field appears only for `http(s)` targets with no `{query}` in them. `open -a` takes no query, so a search target has nothing an app could stand in for, and a folder has no web surface to fall back to. `create-link-command.tsx` hides the field on the same condition the generator enforces, so the form never offers a router it would silently discard.

> [!NOTE]
> **No dropdown, deliberately.** An earlier revision of this PR put an optional `App`/`Web` argument on the router so either surface could be forced. That turned out to cost the command its hotkey: Raycast has to raise the launcher to render an argument field, and `optional` only permits an empty answer — it does not skip the prompt. A router's whole value is firing without ceremony, so forcing a surface belongs on a second, argument-free command rather than on this one.

### Dropdown arguments in the detail pane

**Search Link Commands** rendered every argument as its placeholder. For a text argument that is right — it is what Raycast prompts you with. For a dropdown it is not: a placeholder names the axis but says nothing about what you can pick along it, and the choices were already parsed and sitting unused on the model.

The detail pane now lists a dropdown's choices instead. Text and password arguments fall back to the placeholder exactly as before. This half is independent of the router above and applies to any dropdown argument, including hand-written ones.

## Screencast

Not yet attached — see the checklist note below.

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

**Draft, deliberately.** `npm run build`, `ray lint` and `tsc --noEmit` all pass, and the generator was exercised directly across the router case, the router-plus-`Open With` case, a plain link, and both guard cases. What has *not* happened is a click-through of the distribution build in Raycast, so that box stays unticked rather than being ticked ahead of the fact. The screencast follows once it has.
