### PR TITLE
Home Assistant: Add entity rename, hide, favorites, and quicklinks

### DIFF
--- a/extensions/homeassistant/CHANGELOG.md
+++ b/extensions/homeassistant/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Home Assistant Changelog
 
-## [Entity Customization] - {PR_MERGE_DATE}
+## [Entity Customization] - 2026-08-29
 
 - Add local rename, hide, and favorite actions for entities in list commands
 - Add Entity Settings command to manage hidden entities, custom display names, and favorites

--- a/extensions/homeassistant/CHANGELOG.md
+++ b/extensions/homeassistant/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Home Assistant Changelog
 
-## [Entity Customization] - 2026-08-23
+## [Entity Customization] - {PR_MERGE_DATE}
 
 - Add local rename, hide, and favorite actions for entities in list commands
 - Add Entity Settings command to manage hidden entities, custom display names, and favorites

--- a/extensions/homeassistant/CHANGELOG.md
+++ b/extensions/homeassistant/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Home Assistant Changelog
 
+## [Entity Customization] - 2026-08-23
+
+- Add local rename, hide, and favorite actions for entities in list commands
+- Add Entity Settings command to manage hidden entities, custom display names, and favorites
+- Add Save as Quicklink action to create Raycast quicklinks for entity list commands
+
 ## [Add contributor] - 2026-08-10
 
 - Add mattiacolombomc to the contributors list

--- a/extensions/homeassistant/package.json
+++ b/extensions/homeassistant/package.json
@@ -26,6 +26,13 @@
       "mode": "view"
     },
     {
+      "name": "entity-settings",
+      "title": "Entity Settings",
+      "subtitle": "Home Assistant",
+      "description": "Manage hidden entities and custom display names",
+      "mode": "view"
+    },
+    {
       "name": "customentities",
       "title": "Custom Entities",
       "subtitle": "Home Assistant",

--- a/extensions/homeassistant/pnpm-workspace.yaml
+++ b/extensions/homeassistant/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/extensions/homeassistant/pnpm-workspace.yaml
+++ b/extensions/homeassistant/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-allowBuilds:
-  esbuild: true

--- a/extensions/homeassistant/src/components/battery/list.tsx
+++ b/extensions/homeassistant/src/components/battery/list.tsx
@@ -1,14 +1,16 @@
-import { useHAStates } from "@components/hooks";
+import { useVisibleHAStates } from "@components/hooks";
 import { useStateSearch } from "@components/state/hooks";
 import { StateListItem } from "@components/state/list";
+import { sortStatesWithFavoritesFirst, useEntityOverrides } from "@lib/entity-overrides";
 import { List, showToast, Toast } from "@raycast/api";
 import React, { useState } from "react";
 import { sortBatteries } from "./utils";
 
 export function BatteryList(): React.ReactElement {
   const [searchText, setSearchText] = useState<string>();
-  const { states: allStates, error, isLoading } = useHAStates();
-  const { states } = useStateSearch(searchText, "", "battery", allStates);
+  const { states: allStates, error, isLoading } = useVisibleHAStates();
+  const { entityAliases, favoriteEntityIds } = useEntityOverrides();
+  const { states } = useStateSearch(searchText, "", "battery", allStates, entityAliases);
 
   if (error) {
     showToast({
@@ -22,7 +24,7 @@ export function BatteryList(): React.ReactElement {
     return <List isLoading={true} searchBarPlaceholder="Loading" />;
   }
 
-  const sortedStates = sortBatteries(states);
+  const sortedStates = sortStatesWithFavoritesFirst(sortBatteries(states) ?? states, favoriteEntityIds, entityAliases);
   return (
     <List searchBarPlaceholder="Filter by name or ID..." isLoading={isLoading} onSearchTextChange={setSearchText}>
       {sortedStates?.map((state) => (

--- a/extensions/homeassistant/src/components/battery/list.tsx
+++ b/extensions/homeassistant/src/components/battery/list.tsx
@@ -1,7 +1,7 @@
 import { useVisibleHAStates } from "@components/hooks";
 import { useStateSearch } from "@components/state/hooks";
 import { StateListItem } from "@components/state/list";
-import { sortStatesWithFavoritesFirst, useEntityOverrides } from "@lib/entity-overrides";
+import { prioritizeFavoriteStates, useEntityOverrides } from "@lib/entity-overrides";
 import { List, showToast, Toast } from "@raycast/api";
 import React, { useState } from "react";
 import { sortBatteries } from "./utils";
@@ -24,7 +24,8 @@ export function BatteryList(): React.ReactElement {
     return <List isLoading={true} searchBarPlaceholder="Loading" />;
   }
 
-  const sortedStates = sortStatesWithFavoritesFirst(sortBatteries(states) ?? states, favoriteEntityIds, entityAliases);
+  const batteryStates = sortBatteries(states) ?? states;
+  const sortedStates = prioritizeFavoriteStates(batteryStates, favoriteEntityIds);
   return (
     <List searchBarPlaceholder="Filter by name or ID..." isLoading={isLoading} onSearchTextChange={setSearchText}>
       {sortedStates?.map((state) => (

--- a/extensions/homeassistant/src/components/battery/list.tsx
+++ b/extensions/homeassistant/src/components/battery/list.tsx
@@ -1,7 +1,7 @@
 import { useVisibleHAStates } from "@components/hooks";
 import { useStateSearch } from "@components/state/hooks";
 import { StateListItem } from "@components/state/list";
-import { prioritizeFavoriteStates, useEntityOverrides } from "@lib/entity-overrides";
+import { partitionFavoriteStates, useEntityOverrides } from "@lib/entity-overrides";
 import { List, showToast, Toast } from "@raycast/api";
 import React, { useState } from "react";
 import { sortBatteries } from "./utils";
@@ -25,12 +25,22 @@ export function BatteryList(): React.ReactElement {
   }
 
   const batteryStates = sortBatteries(states) ?? states;
-  const sortedStates = prioritizeFavoriteStates(batteryStates, favoriteEntityIds);
+  const { favorites, others } = partitionFavoriteStates(batteryStates, favoriteEntityIds);
+
   return (
     <List searchBarPlaceholder="Filter by name or ID..." isLoading={isLoading} onSearchTextChange={setSearchText}>
-      {sortedStates?.map((state) => (
-        <StateListItem key={state.entity_id} state={state} />
-      ))}
+      {favorites.length > 0 && (
+        <List.Section title="Favorites" subtitle={`${favorites.length}`}>
+          {favorites.map((state) => (
+            <StateListItem key={state.entity_id} state={state} />
+          ))}
+        </List.Section>
+      )}
+      <List.Section title={favorites.length > 0 ? "Batteries" : undefined} subtitle={`${others.length}`}>
+        {others.map((state) => (
+          <StateListItem key={state.entity_id} state={state} />
+        ))}
+      </List.Section>
     </List>
   );
 }

--- a/extensions/homeassistant/src/components/camera/grid.tsx
+++ b/extensions/homeassistant/src/components/camera/grid.tsx
@@ -1,8 +1,9 @@
 import { EntityStandardActionSections } from "@components/entity";
-import { useHAStates } from "@components/hooks";
+import { useVisibleHAStates } from "@components/hooks";
 import { useStateSearch } from "@components/state/hooks";
+import { sortStatesWithFavoritesFirst, useEntityOverrides } from "@lib/entity-overrides";
 import { State } from "@lib/haapi";
-import { getFriendlyName } from "@lib/utils";
+import { getDisplayName } from "@lib/utils";
 import { Action, ActionPanel, Color, Grid, Image, List, Toast, getPreferenceValues, showToast } from "@raycast/api";
 import React from "react";
 import {
@@ -35,10 +36,11 @@ export function getCameraRefreshInterval(): number | null {
 
 function CameraGridItem(props: { state: State }): React.ReactElement {
   const s = props.state;
+  const { getAlias } = useEntityOverrides();
   const { localFilepath, imageFilepath } = useImage(s.entity_id);
   const content: Image.ImageLike =
     s.state === "unavailable" ? { source: "video.svg", tintColor: Color.Blue } : { source: localFilepath || "" };
-  const titleParts = [getFriendlyName(s)];
+  const titleParts = [getDisplayName(s, getAlias(s.entity_id))];
   if (s.state === "unavailable") {
     titleParts.push("❌");
   }
@@ -55,7 +57,7 @@ function CameraGridItem(props: { state: State }): React.ReactElement {
     <Grid.Item
       content={content}
       title={titleParts.join(" ")}
-      quickLook={imageFilepath ? { name: getFriendlyName(s), path: imageFilepath } : undefined}
+      quickLook={imageFilepath ? { name: getDisplayName(s, getAlias(s.entity_id)), path: imageFilepath } : undefined}
       accessory={{ icon: motionIcon() }}
       actions={
         <ActionPanel>
@@ -76,8 +78,9 @@ function CameraGridItem(props: { state: State }): React.ReactElement {
 }
 
 export function CameraGrid(): React.ReactElement {
-  const { states: allStates, error, isLoading } = useHAStates();
-  const { states } = useStateSearch(undefined, "camera", "", allStates);
+  const { states: allStates, error, isLoading } = useVisibleHAStates();
+  const { entityAliases, favoriteEntityIds } = useEntityOverrides();
+  const { states } = useStateSearch(undefined, "camera", "", allStates, entityAliases);
 
   if (error) {
     showToast({
@@ -91,6 +94,8 @@ export function CameraGrid(): React.ReactElement {
     return <List isLoading={true} searchBarPlaceholder="Loading" />;
   }
 
+  const sortedStates = sortStatesWithFavoritesFirst(states, favoriteEntityIds, entityAliases);
+
   return (
     <Grid
       searchBarPlaceholder="Filter by Name"
@@ -99,7 +104,7 @@ export function CameraGrid(): React.ReactElement {
       columns={3}
       fit={Grid.Fit.Fill}
     >
-      {states?.map((s) => (
+      {sortedStates.map((s) => (
         <CameraGridItem key={s.entity_id} state={s} />
       ))}
     </Grid>

--- a/extensions/homeassistant/src/components/camera/grid.tsx
+++ b/extensions/homeassistant/src/components/camera/grid.tsx
@@ -1,7 +1,7 @@
 import { EntityStandardActionSections } from "@components/entity";
 import { useVisibleHAStates } from "@components/hooks";
 import { useStateSearch } from "@components/state/hooks";
-import { prioritizeFavoriteStates, useEntityOverrides } from "@lib/entity-overrides";
+import { partitionFavoriteStates, useEntityOverrides } from "@lib/entity-overrides";
 import { State } from "@lib/haapi";
 import { getDisplayName } from "@lib/utils";
 import { Action, ActionPanel, Color, Grid, Image, List, Toast, getPreferenceValues, showToast } from "@raycast/api";
@@ -94,7 +94,7 @@ export function CameraGrid(): React.ReactElement {
     return <List isLoading={true} searchBarPlaceholder="Loading" />;
   }
 
-  const sortedStates = prioritizeFavoriteStates(states, favoriteEntityIds);
+  const { favorites, others } = partitionFavoriteStates(states, favoriteEntityIds);
 
   return (
     <Grid
@@ -104,9 +104,18 @@ export function CameraGrid(): React.ReactElement {
       columns={3}
       fit={Grid.Fit.Fill}
     >
-      {sortedStates.map((s) => (
-        <CameraGridItem key={s.entity_id} state={s} />
-      ))}
+      {favorites.length > 0 && (
+        <Grid.Section title="Favorites" subtitle={`${favorites.length}`}>
+          {favorites.map((s) => (
+            <CameraGridItem key={s.entity_id} state={s} />
+          ))}
+        </Grid.Section>
+      )}
+      <Grid.Section title={favorites.length > 0 ? "Cameras" : undefined} subtitle={`${others.length}`}>
+        {others.map((s) => (
+          <CameraGridItem key={s.entity_id} state={s} />
+        ))}
+      </Grid.Section>
     </Grid>
   );
 }

--- a/extensions/homeassistant/src/components/camera/grid.tsx
+++ b/extensions/homeassistant/src/components/camera/grid.tsx
@@ -1,7 +1,7 @@
 import { EntityStandardActionSections } from "@components/entity";
 import { useVisibleHAStates } from "@components/hooks";
 import { useStateSearch } from "@components/state/hooks";
-import { sortStatesWithFavoritesFirst, useEntityOverrides } from "@lib/entity-overrides";
+import { prioritizeFavoriteStates, useEntityOverrides } from "@lib/entity-overrides";
 import { State } from "@lib/haapi";
 import { getDisplayName } from "@lib/utils";
 import { Action, ActionPanel, Color, Grid, Image, List, Toast, getPreferenceValues, showToast } from "@raycast/api";
@@ -94,7 +94,7 @@ export function CameraGrid(): React.ReactElement {
     return <List isLoading={true} searchBarPlaceholder="Loading" />;
   }
 
-  const sortedStates = sortStatesWithFavoritesFirst(states, favoriteEntityIds, entityAliases);
+  const sortedStates = prioritizeFavoriteStates(states, favoriteEntityIds);
 
   return (
     <Grid

--- a/extensions/homeassistant/src/components/door/list.tsx
+++ b/extensions/homeassistant/src/components/door/list.tsx
@@ -1,7 +1,7 @@
 import { useVisibleHAStates } from "@components/hooks";
 import { useStateSearch } from "@components/state/hooks";
 import { StateListItem } from "@components/state/list";
-import { sortStatesWithFavoritesFirst, useEntityOverrides } from "@lib/entity-overrides";
+import { partitionFavoriteStates, useEntityOverrides } from "@lib/entity-overrides";
 import { List, Toast, showToast } from "@raycast/api";
 import React, { useState } from "react";
 
@@ -23,12 +23,19 @@ export function DoorsList(): React.ReactElement {
     return <List isLoading={true} searchBarPlaceholder="Loading" />;
   }
 
-  const sortedStates = sortStatesWithFavoritesFirst(states, favoriteEntityIds, entityAliases);
-  const updateRequiredStates = sortedStates.filter((s) => s.state === "on");
-  const otherStates = sortedStates.filter((s) => s.state !== "on");
+  const { favorites, others } = partitionFavoriteStates(states, favoriteEntityIds);
+  const updateRequiredStates = others.filter((s) => s.state === "on");
+  const otherStates = others.filter((s) => s.state !== "on");
 
   return (
     <List searchBarPlaceholder="Filter by name or ID..." isLoading={isLoading} onSearchTextChange={setSearchText}>
+      {favorites.length > 0 && (
+        <List.Section title="Favorites" subtitle={`${favorites.length}`}>
+          {favorites.map((state) => (
+            <StateListItem key={state.entity_id} state={state} />
+          ))}
+        </List.Section>
+      )}
       <List.Section title="Open Doors" subtitle={`${updateRequiredStates?.length}`}>
         {updateRequiredStates?.map((state) => (
           <StateListItem key={state.entity_id} state={state} />

--- a/extensions/homeassistant/src/components/door/list.tsx
+++ b/extensions/homeassistant/src/components/door/list.tsx
@@ -1,13 +1,15 @@
-import { useHAStates } from "@components/hooks";
+import { useVisibleHAStates } from "@components/hooks";
 import { useStateSearch } from "@components/state/hooks";
 import { StateListItem } from "@components/state/list";
+import { sortStatesWithFavoritesFirst, useEntityOverrides } from "@lib/entity-overrides";
 import { List, Toast, showToast } from "@raycast/api";
 import React, { useState } from "react";
 
 export function DoorsList(): React.ReactElement {
   const [searchText, setSearchText] = useState<string>();
-  const { states: allStates, error, isLoading } = useHAStates();
-  const { states } = useStateSearch(searchText, "", "door", allStates);
+  const { states: allStates, error, isLoading } = useVisibleHAStates();
+  const { entityAliases, favoriteEntityIds } = useEntityOverrides();
+  const { states } = useStateSearch(searchText, "", "door", allStates, entityAliases);
 
   if (error) {
     showToast({
@@ -21,8 +23,9 @@ export function DoorsList(): React.ReactElement {
     return <List isLoading={true} searchBarPlaceholder="Loading" />;
   }
 
-  const updateRequiredStates = states.filter((s) => s.state === "on");
-  const otherStates = states.filter((s) => s.state !== "on");
+  const sortedStates = sortStatesWithFavoritesFirst(states, favoriteEntityIds, entityAliases);
+  const updateRequiredStates = sortedStates.filter((s) => s.state === "on");
+  const otherStates = sortedStates.filter((s) => s.state !== "on");
 
   return (
     <List searchBarPlaceholder="Filter by name or ID..." isLoading={isLoading} onSearchTextChange={setSearchText}>

--- a/extensions/homeassistant/src/components/entity.tsx
+++ b/extensions/homeassistant/src/components/entity.tsx
@@ -1,9 +1,87 @@
 import { ha } from "@lib/common";
+import { useEntityOverrides } from "@lib/entity-overrides";
+import { createEntityQuicklink } from "@lib/entity-quicklink";
 import { State } from "@lib/haapi";
-import { Action, ActionPanel, Color, Icon } from "@raycast/api";
+import { Action, ActionPanel, Color, Icon, Toast, showToast } from "@raycast/api";
 import React from "react";
 import { HAOpenUrlInAction } from "./actions";
 import { EntityAttributesList } from "./attributes";
+import { EntityRenameForm } from "./entity/rename-form";
+
+export function RenameEntityAction({ state }: { state: State }) {
+  return (
+    <Action.Push
+      title="Rename Entity"
+      target={<EntityRenameForm state={state} />}
+      shortcut={{ modifiers: ["cmd", "shift"], key: "r" }}
+      icon={{ source: Icon.Pencil, tintColor: Color.PrimaryText }}
+    />
+  );
+}
+
+export function ResetCustomNameAction({ state }: { state: State }) {
+  const { getAlias, clearAlias } = useEntityOverrides();
+  const alias = getAlias(state.entity_id);
+  if (!alias) {
+    return null;
+  }
+  return (
+    <Action
+      title="Reset Custom Name"
+      icon={{ source: Icon.ArrowCounterClockwise, tintColor: Color.PrimaryText }}
+      onAction={async () => {
+        clearAlias(state.entity_id);
+        await showToast({ style: Toast.Style.Success, title: "Custom Name Removed" });
+      }}
+    />
+  );
+}
+
+export function HideEntityAction({ state }: { state: State }) {
+  const { hideEntity } = useEntityOverrides();
+  return (
+    <Action
+      title="Hide Entity"
+      shortcut={{ modifiers: ["cmd", "shift"], key: "h" }}
+      icon={{ source: Icon.EyeDisabled, tintColor: Color.PrimaryText }}
+      onAction={async () => {
+        hideEntity(state.entity_id);
+        await showToast({ style: Toast.Style.Success, title: "Entity Hidden" });
+      }}
+    />
+  );
+}
+
+export function ToggleFavoriteAction({ state }: { state: State }) {
+  const { isFavorite, toggleFavorite } = useEntityOverrides();
+  const favorite = isFavorite(state.entity_id);
+  return (
+    <Action
+      title={favorite ? "Remove from Favorites" : "Add to Favorites"}
+      shortcut={{ modifiers: ["cmd", "shift"], key: "f" }}
+      icon={{ source: favorite ? Icon.StarDisabled : Icon.Star, tintColor: Color.Yellow }}
+      onAction={async () => {
+        toggleFavorite(state.entity_id);
+        await showToast({
+          style: Toast.Style.Success,
+          title: favorite ? "Removed from Favorites" : "Added to Favorites",
+        });
+      }}
+    />
+  );
+}
+
+export function SaveAsQuicklinkAction({ state }: { state: State }) {
+  const { getAlias } = useEntityOverrides();
+  const quicklink = createEntityQuicklink(state, getAlias(state.entity_id));
+  return (
+    <Action.CreateQuicklink
+      title="Save as Quicklink"
+      shortcut={{ modifiers: ["cmd", "shift"], key: "l" }}
+      quicklink={quicklink}
+    />
+  );
+}
 
 export function OpenEntityHistoryAction({ state }: { state: State }) {
   const historyUrl = ha.navigateUrl(`history?entity_id=${state.entity_id}`);
@@ -67,6 +145,13 @@ export function CopyEntityIDAction({ state }: { state: State }) {
 export function EntityStandardActionSections({ state: s }: { state: State }) {
   return (
     <React.Fragment>
+      <ActionPanel.Section title="Customization">
+        <ToggleFavoriteAction state={s} />
+        <SaveAsQuicklinkAction state={s} />
+        <RenameEntityAction state={s} />
+        <ResetCustomNameAction state={s} />
+        <HideEntityAction state={s} />
+      </ActionPanel.Section>
       <ActionPanel.Section title="Attributes">
         <ShowAttributesAction state={s} />
       </ActionPanel.Section>

--- a/extensions/homeassistant/src/components/entity/rename-form.tsx
+++ b/extensions/homeassistant/src/components/entity/rename-form.tsx
@@ -1,0 +1,35 @@
+import { useEntityOverrides } from "@lib/entity-overrides";
+import { State } from "@lib/haapi";
+import { getDisplayName } from "@lib/utils";
+import { Action, ActionPanel, Form, Toast, showToast, useNavigation } from "@raycast/api";
+import React from "react";
+
+export function EntityRenameForm(props: { state: State }): React.ReactElement {
+  const s = props.state;
+  const { pop } = useNavigation();
+  const { getAlias, setAlias } = useEntityOverrides();
+  const currentName = getDisplayName(s, getAlias(s.entity_id));
+
+  const handle = async (input: Form.Values) => {
+    const name = (input.name as string) ?? "";
+    setAlias(s.entity_id, name);
+    await showToast({
+      style: Toast.Style.Success,
+      title: name.trim().length > 0 ? "Custom Name Saved" : "Custom Name Removed",
+    });
+    pop();
+  };
+
+  return (
+    <Form
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Save" onSubmit={handle} />
+        </ActionPanel>
+      }
+    >
+      <Form.TextField id="name" title="Display Name" defaultValue={currentName} placeholder={s.entity_id} />
+      <Form.Description text="This name is only used in Raycast and does not change Home Assistant." />
+    </Form>
+  );
+}

--- a/extensions/homeassistant/src/components/hooks.tsx
+++ b/extensions/homeassistant/src/components/hooks.tsx
@@ -1,5 +1,6 @@
 import { getHAAreas } from "@components/area/utils";
 import { getHADevices } from "@components/device/utils";
+import { filterHiddenEntities, useEntityOverrides } from "@lib/entity-overrides";
 import { State } from "@lib/haapi";
 import { useCachedState } from "@raycast/utils";
 import { Connection, entitiesColl, subscribeEntities } from "home-assistant-js-websocket";
@@ -127,4 +128,15 @@ export function useHAStates(): {
   }, []);
 
   return { states, error, isLoading };
+}
+
+export function useVisibleHAStates(): {
+  states?: State[];
+  error?: Error;
+  isLoading: boolean;
+} {
+  const { states, error, isLoading } = useHAStates();
+  const { hiddenEntityIds } = useEntityOverrides();
+  const visibleStates = filterHiddenEntities(states, hiddenEntityIds);
+  return { states: visibleStates, error, isLoading };
 }

--- a/extensions/homeassistant/src/components/motion/list.tsx
+++ b/extensions/homeassistant/src/components/motion/list.tsx
@@ -1,13 +1,15 @@
-import { useHAStates } from "@components/hooks";
+import { useVisibleHAStates } from "@components/hooks";
 import { useStateSearch } from "@components/state/hooks";
 import { StateListItem } from "@components/state/list";
+import { sortStatesWithFavoritesFirst, useEntityOverrides } from "@lib/entity-overrides";
 import { List, Toast, showToast } from "@raycast/api";
 import React, { useState } from "react";
 
 export function MotionsList(): React.ReactElement {
   const [searchText, setSearchText] = useState<string>();
-  const { states: allStates, error, isLoading } = useHAStates();
-  const { states } = useStateSearch(searchText, "binary_sensor", "motion", allStates);
+  const { states: allStates, error, isLoading } = useVisibleHAStates();
+  const { entityAliases, favoriteEntityIds } = useEntityOverrides();
+  const { states } = useStateSearch(searchText, "binary_sensor", "motion", allStates, entityAliases);
 
   if (error) {
     showToast({
@@ -21,8 +23,9 @@ export function MotionsList(): React.ReactElement {
     return <List isLoading={true} searchBarPlaceholder="Loading" />;
   }
 
-  const updateRequiredStates = states.filter((s) => s.state === "on");
-  const otherStates = states.filter((s) => s.state !== "on");
+  const sortedStates = sortStatesWithFavoritesFirst(states, favoriteEntityIds, entityAliases);
+  const updateRequiredStates = sortedStates.filter((s) => s.state === "on");
+  const otherStates = sortedStates.filter((s) => s.state !== "on");
 
   return (
     <List searchBarPlaceholder="Filter by name or ID..." isLoading={isLoading} onSearchTextChange={setSearchText}>

--- a/extensions/homeassistant/src/components/motion/list.tsx
+++ b/extensions/homeassistant/src/components/motion/list.tsx
@@ -1,7 +1,7 @@
 import { useVisibleHAStates } from "@components/hooks";
 import { useStateSearch } from "@components/state/hooks";
 import { StateListItem } from "@components/state/list";
-import { sortStatesWithFavoritesFirst, useEntityOverrides } from "@lib/entity-overrides";
+import { partitionFavoriteStates, useEntityOverrides } from "@lib/entity-overrides";
 import { List, Toast, showToast } from "@raycast/api";
 import React, { useState } from "react";
 
@@ -23,12 +23,19 @@ export function MotionsList(): React.ReactElement {
     return <List isLoading={true} searchBarPlaceholder="Loading" />;
   }
 
-  const sortedStates = sortStatesWithFavoritesFirst(states, favoriteEntityIds, entityAliases);
-  const updateRequiredStates = sortedStates.filter((s) => s.state === "on");
-  const otherStates = sortedStates.filter((s) => s.state !== "on");
+  const { favorites, others } = partitionFavoriteStates(states, favoriteEntityIds);
+  const updateRequiredStates = others.filter((s) => s.state === "on");
+  const otherStates = others.filter((s) => s.state !== "on");
 
   return (
     <List searchBarPlaceholder="Filter by name or ID..." isLoading={isLoading} onSearchTextChange={setSearchText}>
+      {favorites.length > 0 && (
+        <List.Section title="Favorites" subtitle={`${favorites.length}`}>
+          {favorites.map((state) => (
+            <StateListItem key={state.entity_id} state={state} />
+          ))}
+        </List.Section>
+      )}
       <List.Section title="Motion detected" subtitle={`${updateRequiredStates?.length}`}>
         {updateRequiredStates?.map((state) => (
           <StateListItem key={state.entity_id} state={state} />

--- a/extensions/homeassistant/src/components/state/hooks.tsx
+++ b/extensions/homeassistant/src/components/state/hooks.tsx
@@ -6,6 +6,7 @@ export function useStateSearch(
   domain: string,
   device_class?: string,
   allStates?: State[],
+  aliases?: Record<string, string>,
 ): {
   states?: State[] | undefined;
 } {
@@ -21,17 +22,21 @@ export function useStateSearch(
         haStates = haStates.filter((s) => s.attributes.device_class === device_class);
       }
       if (query) {
-        haStates = haStates.filter(
-          (e) =>
-            e.entity_id.toLowerCase().includes(query.toLowerCase()) ||
-            (e.attributes.friendly_name || "").toLowerCase().includes(query.toLowerCase()),
-        );
+        const q = query.toLowerCase();
+        haStates = haStates.filter((e) => {
+          const alias = aliases?.[e.entity_id];
+          return (
+            e.entity_id.toLowerCase().includes(q) ||
+            (e.attributes.friendly_name || "").toLowerCase().includes(q) ||
+            (alias || "").toLowerCase().includes(q)
+          );
+        });
       }
       haStates = haStates.slice(0, 1000);
       setStates(haStates);
     } else {
       return undefined;
     }
-  }, [query, allStates]);
+  }, [query, allStates, aliases]);
   return { states };
 }

--- a/extensions/homeassistant/src/components/state/list.tsx
+++ b/extensions/homeassistant/src/components/state/list.tsx
@@ -5,7 +5,7 @@ import { ClimateActionPanel } from "@components/climate/actions";
 import { CoverActionPanel } from "@components/cover/actions";
 import { EntityStandardActionSections } from "@components/entity";
 import { FanActionPanel } from "@components/fan/actions";
-import { useHAStates } from "@components/hooks";
+import { useVisibleHAStates } from "@components/hooks";
 import { InputBooleanActionPanel } from "@components/input_boolean/actions";
 import { InputButtonActionPanel } from "@components/input_button/actions";
 import { InputDateTimeActionPanel } from "@components/input_datetime/actions";
@@ -24,10 +24,11 @@ import { UpdateActionPanel } from "@components/update/actions";
 import { VacuumActionPanel } from "@components/vacuum/actions";
 import { WeatherActionPanel } from "@components/weather/actions";
 import { ZoneActionPanel } from "@components/zone/actions";
+import { filterHiddenEntities, partitionFavoriteStates, useEntityOverrides } from "@lib/entity-overrides";
 import { ha, shouldDisplayEntityID } from "@lib/common";
 import { State } from "@lib/haapi";
-import { getStateTooltip } from "@lib/utils";
-import { ActionPanel, Color, Image, List, Toast, showToast } from "@raycast/api";
+import { getDisplayName, getStateTooltip } from "@lib/utils";
+import { ActionPanel, Color, Icon, Image, List, Toast, showToast } from "@raycast/api";
 import React, { useMemo, useState } from "react";
 import { useStateSearch } from "./hooks";
 import { getIcon, getStateValue } from "./utils";
@@ -38,11 +39,16 @@ export function StatesList(props: {
   entitiesState?: State[] | undefined;
 }): React.ReactElement {
   const [searchText, setSearchText] = useState<string>();
-  const { states: allStates, error, isLoading } = useHAStates();
-  const { states } = useStateSearch(searchText, props.domain, props.deviceClass, props.entitiesState ?? allStates);
+  const { states: allStates, error, isLoading } = useVisibleHAStates();
+  const { entityAliases, hiddenEntityIds, favoriteEntityIds } = useEntityOverrides();
+  const sourceStates = useMemo(() => {
+    const raw = props.entitiesState ?? allStates;
+    return filterHiddenEntities(raw, hiddenEntityIds) ?? raw;
+  }, [props.entitiesState, allStates, hiddenEntityIds]);
+  const { states } = useStateSearch(searchText, props.domain, props.deviceClass, sourceStates, entityAliases);
   const statesById = useMemo(
-    () => new Map((props.entitiesState ?? allStates ?? []).map((state) => [state.entity_id, state])),
-    [allStates, props.entitiesState],
+    () => new Map((sourceStates ?? []).map((state) => [state.entity_id, state])),
+    [sourceStates],
   );
 
   if (error) {
@@ -57,21 +63,37 @@ export function StatesList(props: {
     return <List isLoading={true} searchBarPlaceholder="Loading" />;
   }
 
+  const sortByDisplayName = (items: State[]) =>
+    [...items].sort((a, b) =>
+      getDisplayName(a, entityAliases[a.entity_id]).localeCompare(getDisplayName(b, entityAliases[b.entity_id])),
+    );
+  const { favorites, others } = partitionFavoriteStates(states, favoriteEntityIds);
+  const favoriteStates = sortByDisplayName(favorites);
+  const otherStates = sortByDisplayName(others);
+
   return (
     <List searchBarPlaceholder="Filter by name or ID..." isLoading={isLoading} onSearchTextChange={setSearchText}>
-      {states
-        ?.sort((a, b) =>
-          (a.attributes.friendly_name || a.entity_id).localeCompare(b.attributes.friendly_name || b.entity_id),
-        )
-        .map((state) => (
+      {favoriteStates.length > 0 && (
+        <List.Section title="Favorites" subtitle={`${favoriteStates.length}`}>
+          {favoriteStates.map((state) => (
+            <StateListItem key={state.entity_id} state={state} statesById={statesById} />
+          ))}
+        </List.Section>
+      )}
+      <List.Section title={favoriteStates.length > 0 ? "Entities" : undefined} subtitle={`${otherStates.length}`}>
+        {otherStates.map((state) => (
           <StateListItem key={state.entity_id} state={state} statesById={statesById} />
         ))}
+      </List.Section>
     </List>
   );
 }
 
 export function StateListItem(props: { state: State; statesById?: ReadonlyMap<string, State> }): React.ReactElement {
   const state = props.state;
+  const { getAlias, isFavorite } = useEntityOverrides();
+  const displayName = getDisplayName(state, getAlias(state.entity_id));
+  const favorite = isFavorite(state.entity_id);
   const areaName = state.area_name;
 
   let icon: Image.ImageLike | undefined;
@@ -143,11 +165,19 @@ export function StateListItem(props: { state: State; statesById?: ReadonlyMap<st
   return (
     <List.Item
       key={state.entity_id}
-      title={state.attributes.friendly_name || state.entity_id}
+      title={displayName}
       subtitle={subtitle(state)}
       actions={<StateActionPanel state={state} />}
       icon={icon || getIcon(state)}
       accessories={[
+        ...(favorite
+          ? [
+              {
+                icon: { source: Icon.Star, tintColor: Color.Yellow },
+                tooltip: "Favorite",
+              },
+            ]
+          : []),
         {
           text: firstAccessoryTitle(state),
           icon: firstAccessoryIcon(state),

--- a/extensions/homeassistant/src/components/update/list.tsx
+++ b/extensions/homeassistant/src/components/update/list.tsx
@@ -3,7 +3,7 @@ import { useHAStates, useVisibleHAStates } from "@components/hooks";
 import { useStateSearch } from "@components/state/hooks";
 import { StateListItem } from "@components/state/list";
 import { PrimaryIconColor } from "@components/state/utils";
-import { sortStatesWithFavoritesFirst, useEntityOverrides } from "@lib/entity-overrides";
+import { partitionFavoriteStates, useEntityOverrides } from "@lib/entity-overrides";
 import { ha } from "@lib/common";
 import { State } from "@lib/haapi";
 import { getStateTooltip } from "@lib/utils";
@@ -71,14 +71,21 @@ export function UpdatesList(): React.ReactElement {
     return <List isLoading={true} searchBarPlaceholder="Loading" />;
   }
 
-  const sortedStates = sortStatesWithFavoritesFirst(states, favoriteEntityIds, entityAliases);
-  const updateRequiredStates = sortedStates.filter((s) => s.state === "on");
-  const otherStates = sortedStates.filter((s) => s.state !== "on");
+  const { favorites, others } = partitionFavoriteStates(states, favoriteEntityIds);
+  const updateRequiredStates = others.filter((s) => s.state === "on");
+  const otherStates = others.filter((s) => s.state !== "on");
 
   const hacsState = allStatesUnfiltered?.find((s) => s.entity_id === "sensor.hacs");
 
   return (
     <List searchBarPlaceholder="Filter by name or ID..." isLoading={isLoading} onSearchTextChange={setSearchText}>
+      {favorites.length > 0 && (
+        <List.Section title="Favorites" subtitle={`${favorites.length}`}>
+          {favorites.map((state) => (
+            <StateListItem key={state.entity_id} state={state} />
+          ))}
+        </List.Section>
+      )}
       <List.Section title="Update Available" subtitle={`${updateRequiredStates?.length}`}>
         {updateRequiredStates?.map((state) => (
           <StateListItem key={state.entity_id} state={state} />

--- a/extensions/homeassistant/src/components/update/list.tsx
+++ b/extensions/homeassistant/src/components/update/list.tsx
@@ -1,8 +1,9 @@
 import { ShowAttributesAction } from "@components/entity";
-import { useHAStates } from "@components/hooks";
+import { useHAStates, useVisibleHAStates } from "@components/hooks";
 import { useStateSearch } from "@components/state/hooks";
 import { StateListItem } from "@components/state/list";
 import { PrimaryIconColor } from "@components/state/utils";
+import { sortStatesWithFavoritesFirst, useEntityOverrides } from "@lib/entity-overrides";
 import { ha } from "@lib/common";
 import { State } from "@lib/haapi";
 import { getStateTooltip } from "@lib/utils";
@@ -53,8 +54,10 @@ function HACSUpdateItems(props: { state: State | undefined }): React.ReactElemen
 
 export function UpdatesList(): React.ReactElement {
   const [searchText, setSearchText] = useState<string>();
-  const { states: allStates, error, isLoading } = useHAStates();
-  const { states } = useStateSearch(searchText, "update", "", allStates);
+  const { states: allStates, error, isLoading } = useVisibleHAStates();
+  const { states: allStatesUnfiltered } = useHAStates();
+  const { entityAliases, favoriteEntityIds } = useEntityOverrides();
+  const { states } = useStateSearch(searchText, "update", "", allStates, entityAliases);
 
   if (error) {
     showToast({
@@ -68,10 +71,11 @@ export function UpdatesList(): React.ReactElement {
     return <List isLoading={true} searchBarPlaceholder="Loading" />;
   }
 
-  const updateRequiredStates = states.filter((s) => s.state === "on");
-  const otherStates = states.filter((s) => s.state !== "on");
+  const sortedStates = sortStatesWithFavoritesFirst(states, favoriteEntityIds, entityAliases);
+  const updateRequiredStates = sortedStates.filter((s) => s.state === "on");
+  const otherStates = sortedStates.filter((s) => s.state !== "on");
 
-  const hacsState = allStates?.find((s) => s.entity_id === "sensor.hacs");
+  const hacsState = allStatesUnfiltered?.find((s) => s.entity_id === "sensor.hacs");
 
   return (
     <List searchBarPlaceholder="Filter by name or ID..." isLoading={isLoading} onSearchTextChange={setSearchText}>

--- a/extensions/homeassistant/src/components/window/list.tsx
+++ b/extensions/homeassistant/src/components/window/list.tsx
@@ -1,13 +1,15 @@
-import { useHAStates } from "@components/hooks";
+import { useVisibleHAStates } from "@components/hooks";
 import { useStateSearch } from "@components/state/hooks";
 import { StateListItem } from "@components/state/list";
+import { sortStatesWithFavoritesFirst, useEntityOverrides } from "@lib/entity-overrides";
 import { List, Toast, showToast } from "@raycast/api";
 import React, { useState } from "react";
 
 export function WindowsList(): React.ReactElement {
   const [searchText, setSearchText] = useState<string>();
-  const { states: allStates, error, isLoading } = useHAStates();
-  const { states } = useStateSearch(searchText, "binary_sensor", "window", allStates);
+  const { states: allStates, error, isLoading } = useVisibleHAStates();
+  const { entityAliases, favoriteEntityIds } = useEntityOverrides();
+  const { states } = useStateSearch(searchText, "binary_sensor", "window", allStates, entityAliases);
 
   if (error) {
     showToast({
@@ -21,8 +23,9 @@ export function WindowsList(): React.ReactElement {
     return <List isLoading={true} searchBarPlaceholder="Loading" />;
   }
 
-  const updateRequiredStates = states.filter((s) => s.state === "on");
-  const otherStates = states.filter((s) => s.state !== "on");
+  const sortedStates = sortStatesWithFavoritesFirst(states, favoriteEntityIds, entityAliases);
+  const updateRequiredStates = sortedStates.filter((s) => s.state === "on");
+  const otherStates = sortedStates.filter((s) => s.state !== "on");
 
   return (
     <List searchBarPlaceholder="Filter by name or ID..." isLoading={isLoading} onSearchTextChange={setSearchText}>

--- a/extensions/homeassistant/src/components/window/list.tsx
+++ b/extensions/homeassistant/src/components/window/list.tsx
@@ -1,7 +1,7 @@
 import { useVisibleHAStates } from "@components/hooks";
 import { useStateSearch } from "@components/state/hooks";
 import { StateListItem } from "@components/state/list";
-import { sortStatesWithFavoritesFirst, useEntityOverrides } from "@lib/entity-overrides";
+import { partitionFavoriteStates, useEntityOverrides } from "@lib/entity-overrides";
 import { List, Toast, showToast } from "@raycast/api";
 import React, { useState } from "react";
 
@@ -23,12 +23,19 @@ export function WindowsList(): React.ReactElement {
     return <List isLoading={true} searchBarPlaceholder="Loading" />;
   }
 
-  const sortedStates = sortStatesWithFavoritesFirst(states, favoriteEntityIds, entityAliases);
-  const updateRequiredStates = sortedStates.filter((s) => s.state === "on");
-  const otherStates = sortedStates.filter((s) => s.state !== "on");
+  const { favorites, others } = partitionFavoriteStates(states, favoriteEntityIds);
+  const updateRequiredStates = others.filter((s) => s.state === "on");
+  const otherStates = others.filter((s) => s.state !== "on");
 
   return (
     <List searchBarPlaceholder="Filter by name or ID..." isLoading={isLoading} onSearchTextChange={setSearchText}>
+      {favorites.length > 0 && (
+        <List.Section title="Favorites" subtitle={`${favorites.length}`}>
+          {favorites.map((state) => (
+            <StateListItem key={state.entity_id} state={state} />
+          ))}
+        </List.Section>
+      )}
       <List.Section title="Open Windows" subtitle={`${updateRequiredStates?.length}`}>
         {updateRequiredStates?.map((state) => (
           <StateListItem key={state.entity_id} state={state} />

--- a/extensions/homeassistant/src/components/zone/list.tsx
+++ b/extensions/homeassistant/src/components/zone/list.tsx
@@ -1,8 +1,9 @@
 import { useHAStates, useVisibleHAStates } from "@components/hooks";
 import { useStateSearch } from "@components/state/hooks";
 import { StateListItem } from "@components/state/list";
-import { sortStatesWithFavoritesFirst, useEntityOverrides } from "@lib/entity-overrides";
+import { partitionFavoriteStates, useEntityOverrides } from "@lib/entity-overrides";
 import { State } from "@lib/haapi";
+import { getDisplayName } from "@lib/utils";
 import { List, Toast, showToast } from "@raycast/api";
 import React, { useEffect, useState } from "react";
 
@@ -54,13 +55,28 @@ export function ZonesList(): React.ReactElement {
     return <List isLoading={true} searchBarPlaceholder="Loading" />;
   }
 
-  const sortedStates = sortStatesWithFavoritesFirst(states, favoriteEntityIds, entityAliases);
+  const sortByDisplayName = (items: State[]) =>
+    [...items].sort((a, b) =>
+      getDisplayName(a, entityAliases[a.entity_id]).localeCompare(getDisplayName(b, entityAliases[b.entity_id])),
+    );
+  const { favorites, others } = partitionFavoriteStates(states, favoriteEntityIds);
+  const favoriteStates = sortByDisplayName(favorites);
+  const otherStates = sortByDisplayName(others);
 
   return (
     <List searchBarPlaceholder="Filter by name or ID..." isLoading={isLoading} onSearchTextChange={setSearchText}>
-      {sortedStates?.map((state) => (
-        <StateListItem key={state.entity_id} state={state} />
-      ))}
+      {favoriteStates.length > 0 && (
+        <List.Section title="Favorites" subtitle={`${favoriteStates.length}`}>
+          {favoriteStates.map((state) => (
+            <StateListItem key={state.entity_id} state={state} />
+          ))}
+        </List.Section>
+      )}
+      <List.Section title={favoriteStates.length > 0 ? "Zones" : undefined} subtitle={`${otherStates.length}`}>
+        {otherStates.map((state) => (
+          <StateListItem key={state.entity_id} state={state} />
+        ))}
+      </List.Section>
     </List>
   );
 }

--- a/extensions/homeassistant/src/components/zone/list.tsx
+++ b/extensions/homeassistant/src/components/zone/list.tsx
@@ -1,6 +1,7 @@
-import { useHAStates } from "@components/hooks";
+import { useHAStates, useVisibleHAStates } from "@components/hooks";
 import { useStateSearch } from "@components/state/hooks";
 import { StateListItem } from "@components/state/list";
+import { sortStatesWithFavoritesFirst, useEntityOverrides } from "@lib/entity-overrides";
 import { State } from "@lib/haapi";
 import { List, Toast, showToast } from "@raycast/api";
 import React, { useEffect, useState } from "react";
@@ -37,8 +38,9 @@ export function ZoneList(props: { state: State }): React.ReactElement {
 
 export function ZonesList(): React.ReactElement {
   const [searchText, setSearchText] = useState<string>();
-  const { states: allStates, error, isLoading } = useHAStates();
-  const { states } = useStateSearch(searchText, "zone", "", allStates);
+  const { states: allStates, error, isLoading } = useVisibleHAStates();
+  const { entityAliases, favoriteEntityIds } = useEntityOverrides();
+  const { states } = useStateSearch(searchText, "zone", "", allStates, entityAliases);
 
   if (error) {
     showToast({
@@ -52,9 +54,11 @@ export function ZonesList(): React.ReactElement {
     return <List isLoading={true} searchBarPlaceholder="Loading" />;
   }
 
+  const sortedStates = sortStatesWithFavoritesFirst(states, favoriteEntityIds, entityAliases);
+
   return (
     <List searchBarPlaceholder="Filter by name or ID..." isLoading={isLoading} onSearchTextChange={setSearchText}>
-      {states?.map((state) => (
+      {sortedStates?.map((state) => (
         <StateListItem key={state.entity_id} state={state} />
       ))}
     </List>

--- a/extensions/homeassistant/src/entity-settings.tsx
+++ b/extensions/homeassistant/src/entity-settings.tsx
@@ -12,8 +12,7 @@ export default function EntitySettingsCommand() {
   const statesById = useMemo(() => new Map((states ?? []).map((state) => [state.entity_id, state])), [states]);
 
   const aliasEntries = useMemo(
-    () =>
-      Object.entries(entityAliases).sort(([, a], [, b]) => a.localeCompare(b)),
+    () => Object.entries(entityAliases).sort(([, a], [, b]) => a.localeCompare(b)),
     [entityAliases],
   );
 
@@ -88,11 +87,7 @@ export default function EntitySettingsCommand() {
                 actions={
                   <ActionPanel>
                     <ActionPanel.Section title="Visibility">
-                      <Action
-                        title="Show Entity"
-                        icon={Icon.Eye}
-                        onAction={() => showEntity(entityId)}
-                      />
+                      <Action title="Show Entity" icon={Icon.Eye} onAction={() => showEntity(entityId)} />
                     </ActionPanel.Section>
                   </ActionPanel>
                 }

--- a/extensions/homeassistant/src/entity-settings.tsx
+++ b/extensions/homeassistant/src/entity-settings.tsx
@@ -1,0 +1,136 @@
+import { useHAStates } from "@components/hooks";
+import { useEntityOverrides } from "@lib/entity-overrides";
+import { getDisplayName, getFriendlyName } from "@lib/utils";
+import { Action, ActionPanel, Color, Icon, List } from "@raycast/api";
+import React, { useMemo } from "react";
+
+export default function EntitySettingsCommand() {
+  const { states, isLoading } = useHAStates();
+  const { hiddenEntities, entityAliases, favoriteEntities, showEntity, clearAlias, removeFavorite } =
+    useEntityOverrides();
+
+  const statesById = useMemo(() => new Map((states ?? []).map((state) => [state.entity_id, state])), [states]);
+
+  const aliasEntries = useMemo(
+    () =>
+      Object.entries(entityAliases).sort(([, a], [, b]) => a.localeCompare(b)),
+    [entityAliases],
+  );
+
+  const sortedHiddenEntities = useMemo(
+    () =>
+      [...hiddenEntities].sort((a, b) => {
+        const stateA = statesById.get(a);
+        const stateB = statesById.get(b);
+        const nameA = stateA ? getFriendlyName(stateA) : a;
+        const nameB = stateB ? getFriendlyName(stateB) : b;
+        return nameA.localeCompare(nameB);
+      }),
+    [hiddenEntities, statesById],
+  );
+
+  const sortedFavoriteEntities = useMemo(
+    () =>
+      [...favoriteEntities].sort((a, b) => {
+        const stateA = statesById.get(a);
+        const stateB = statesById.get(b);
+        const nameA = stateA ? getDisplayName(stateA, entityAliases[a]) : a;
+        const nameB = stateB ? getDisplayName(stateB, entityAliases[b]) : b;
+        return nameA.localeCompare(nameB);
+      }),
+    [favoriteEntities, statesById, entityAliases],
+  );
+
+  return (
+    <List isLoading={isLoading} searchBarPlaceholder="Filter entities...">
+      <List.Section title="Favorites" subtitle={`${sortedFavoriteEntities.length}`}>
+        {sortedFavoriteEntities.length === 0 ? (
+          <List.Item title="No Favorites" icon={Icon.Star} />
+        ) : (
+          sortedFavoriteEntities.map((entityId) => {
+            const state = statesById.get(entityId);
+            const title = state ? getDisplayName(state, entityAliases[entityId]) : entityId;
+            return (
+              <List.Item
+                key={entityId}
+                title={title}
+                subtitle={entityId}
+                icon={{ source: Icon.Star, tintColor: Color.Yellow }}
+                actions={
+                  <ActionPanel>
+                    <ActionPanel.Section title="Favorites">
+                      <Action
+                        title="Remove from Favorites"
+                        icon={Icon.StarDisabled}
+                        onAction={() => removeFavorite(entityId)}
+                      />
+                    </ActionPanel.Section>
+                  </ActionPanel>
+                }
+              />
+            );
+          })
+        )}
+      </List.Section>
+      <List.Section title="Hidden Entities" subtitle={`${sortedHiddenEntities.length}`}>
+        {sortedHiddenEntities.length === 0 ? (
+          <List.Item title="No Hidden Entities" icon={Icon.Eye} />
+        ) : (
+          sortedHiddenEntities.map((entityId) => {
+            const state = statesById.get(entityId);
+            const friendlyName = state ? getFriendlyName(state) : entityId;
+            return (
+              <List.Item
+                key={entityId}
+                title={friendlyName}
+                subtitle={entityId}
+                icon={{ source: Icon.EyeDisabled, tintColor: Color.SecondaryText }}
+                actions={
+                  <ActionPanel>
+                    <ActionPanel.Section title="Visibility">
+                      <Action
+                        title="Show Entity"
+                        icon={Icon.Eye}
+                        onAction={() => showEntity(entityId)}
+                      />
+                    </ActionPanel.Section>
+                  </ActionPanel>
+                }
+              />
+            );
+          })
+        )}
+      </List.Section>
+      <List.Section title="Custom Names" subtitle={`${aliasEntries.length}`}>
+        {aliasEntries.length === 0 ? (
+          <List.Item title="No Custom Names" icon={Icon.Pencil} />
+        ) : (
+          aliasEntries.map(([entityId, alias]) => {
+            const state = statesById.get(entityId);
+            const originalName = state ? getFriendlyName(state) : entityId;
+            return (
+              <List.Item
+                key={entityId}
+                title={alias}
+                subtitle={`${originalName} · ${entityId}`}
+                icon={{ source: Icon.Pencil, tintColor: Color.PrimaryText }}
+                actions={
+                  <ActionPanel>
+                    <ActionPanel.Section title="Customization">
+                      <Action
+                        title="Remove Custom Name"
+                        icon={Icon.Trash}
+                        style={Action.Style.Destructive}
+                        onAction={() => clearAlias(entityId)}
+                      />
+                    </ActionPanel.Section>
+                  </ActionPanel>
+                }
+              />
+            );
+          })
+        )}
+      </List.Section>
+    </List>
+  );
+}

--- a/extensions/homeassistant/src/lib/entity-overrides.ts
+++ b/extensions/homeassistant/src/lib/entity-overrides.ts
@@ -34,9 +34,13 @@ export function useEntityOverrides() {
   const [hiddenEntities, setHiddenEntities] = useCachedState<string[]>("hidden-entities", [], {
     cacheNamespace: CACHE_NAMESPACE,
   });
-  const [entityAliases, setEntityAliases] = useCachedState<Record<string, string>>("entity-aliases", {}, {
-    cacheNamespace: CACHE_NAMESPACE,
-  });
+  const [entityAliases, setEntityAliases] = useCachedState<Record<string, string>>(
+    "entity-aliases",
+    {},
+    {
+      cacheNamespace: CACHE_NAMESPACE,
+    },
+  );
   const [favoriteEntities, setFavoriteEntities] = useCachedState<string[]>("favorite-entities", [], {
     cacheNamespace: CACHE_NAMESPACE,
   });

--- a/extensions/homeassistant/src/lib/entity-overrides.ts
+++ b/extensions/homeassistant/src/lib/entity-overrides.ts
@@ -5,6 +5,16 @@ import { useCallback, useMemo } from "react";
 
 const CACHE_NAMESPACE = "entity-overrides";
 
+export function prioritizeFavoriteStates(states: State[], favoriteEntityIds: Set<string>): State[] {
+  if (favoriteEntityIds.size === 0) {
+    return states;
+  }
+  return [
+    ...states.filter((state) => favoriteEntityIds.has(state.entity_id)),
+    ...states.filter((state) => !favoriteEntityIds.has(state.entity_id)),
+  ];
+}
+
 export function sortStatesWithFavoritesFirst(
   states: State[],
   favoriteEntityIds: Set<string>,
@@ -16,9 +26,7 @@ export function sortStatesWithFavoritesFirst(
     if (aFavorite !== bFavorite) {
       return aFavorite ? -1 : 1;
     }
-    return getDisplayName(a, entityAliases[a.entity_id]).localeCompare(
-      getDisplayName(b, entityAliases[b.entity_id]),
-    );
+    return getDisplayName(a, entityAliases[a.entity_id]).localeCompare(getDisplayName(b, entityAliases[b.entity_id]));
   });
 }
 
@@ -52,9 +60,13 @@ export function useEntityOverrides() {
   const [hiddenEntities, setHiddenEntities] = useCachedState<string[]>("hidden-entities", [], {
     cacheNamespace: CACHE_NAMESPACE,
   });
-  const [entityAliases, setEntityAliases] = useCachedState<Record<string, string>>("entity-aliases", {}, {
-    cacheNamespace: CACHE_NAMESPACE,
-  });
+  const [entityAliases, setEntityAliases] = useCachedState<Record<string, string>>(
+    "entity-aliases",
+    {},
+    {
+      cacheNamespace: CACHE_NAMESPACE,
+    },
+  );
   const [favoriteEntities, setFavoriteEntities] = useCachedState<string[]>("favorite-entities", [], {
     cacheNamespace: CACHE_NAMESPACE,
   });

--- a/extensions/homeassistant/src/lib/entity-overrides.ts
+++ b/extensions/homeassistant/src/lib/entity-overrides.ts
@@ -1,0 +1,178 @@
+import { State } from "@lib/haapi";
+import { getDisplayName } from "@lib/utils";
+import { useCachedState } from "@raycast/utils";
+import { useCallback, useMemo } from "react";
+
+const CACHE_NAMESPACE = "entity-overrides";
+
+export function sortStatesWithFavoritesFirst(
+  states: State[],
+  favoriteEntityIds: Set<string>,
+  entityAliases: Record<string, string>,
+): State[] {
+  return [...states].sort((a, b) => {
+    const aFavorite = favoriteEntityIds.has(a.entity_id);
+    const bFavorite = favoriteEntityIds.has(b.entity_id);
+    if (aFavorite !== bFavorite) {
+      return aFavorite ? -1 : 1;
+    }
+    return getDisplayName(a, entityAliases[a.entity_id]).localeCompare(
+      getDisplayName(b, entityAliases[b.entity_id]),
+    );
+  });
+}
+
+export function partitionFavoriteStates(
+  states: State[],
+  favoriteEntityIds: Set<string>,
+): { favorites: State[]; others: State[] } {
+  const favorites: State[] = [];
+  const others: State[] = [];
+  for (const state of states) {
+    if (favoriteEntityIds.has(state.entity_id)) {
+      favorites.push(state);
+    } else {
+      others.push(state);
+    }
+  }
+  return { favorites, others };
+}
+
+export function filterHiddenEntities(states: State[] | undefined, hiddenEntityIds: Set<string>): State[] | undefined {
+  if (!states) {
+    return states;
+  }
+  if (hiddenEntityIds.size === 0) {
+    return states;
+  }
+  return states.filter((state) => !hiddenEntityIds.has(state.entity_id));
+}
+
+export function useEntityOverrides() {
+  const [hiddenEntities, setHiddenEntities] = useCachedState<string[]>("hidden-entities", [], {
+    cacheNamespace: CACHE_NAMESPACE,
+  });
+  const [entityAliases, setEntityAliases] = useCachedState<Record<string, string>>("entity-aliases", {}, {
+    cacheNamespace: CACHE_NAMESPACE,
+  });
+  const [favoriteEntities, setFavoriteEntities] = useCachedState<string[]>("favorite-entities", [], {
+    cacheNamespace: CACHE_NAMESPACE,
+  });
+
+  const hiddenEntityIds = useMemo(() => new Set(hiddenEntities), [hiddenEntities]);
+  const favoriteEntityIds = useMemo(() => new Set(favoriteEntities), [favoriteEntities]);
+
+  const isHidden = useCallback(
+    (entityId: string) => {
+      return hiddenEntityIds.has(entityId);
+    },
+    [hiddenEntityIds],
+  );
+
+  const getAlias = useCallback(
+    (entityId: string) => {
+      return entityAliases[entityId];
+    },
+    [entityAliases],
+  );
+
+  const hideEntity = useCallback(
+    (entityId: string) => {
+      if (hiddenEntityIds.has(entityId)) {
+        return;
+      }
+      setHiddenEntities((current) => [...current, entityId]);
+    },
+    [hiddenEntityIds, setHiddenEntities],
+  );
+
+  const showEntity = useCallback(
+    (entityId: string) => {
+      setHiddenEntities((current) => current.filter((id) => id !== entityId));
+    },
+    [setHiddenEntities],
+  );
+
+  const setAlias = useCallback(
+    (entityId: string, name: string) => {
+      const trimmed = name.trim();
+      if (trimmed.length === 0) {
+        setEntityAliases((current) => {
+          const next = { ...current };
+          delete next[entityId];
+          return next;
+        });
+        return;
+      }
+      setEntityAliases((current) => ({ ...current, [entityId]: trimmed }));
+    },
+    [setEntityAliases],
+  );
+
+  const clearAlias = useCallback(
+    (entityId: string) => {
+      setEntityAliases((current) => {
+        if (!(entityId in current)) {
+          return current;
+        }
+        const next = { ...current };
+        delete next[entityId];
+        return next;
+      });
+    },
+    [setEntityAliases],
+  );
+
+  const isFavorite = useCallback(
+    (entityId: string) => {
+      return favoriteEntityIds.has(entityId);
+    },
+    [favoriteEntityIds],
+  );
+
+  const addFavorite = useCallback(
+    (entityId: string) => {
+      if (favoriteEntityIds.has(entityId)) {
+        return;
+      }
+      setFavoriteEntities((current) => [...current, entityId]);
+    },
+    [favoriteEntityIds, setFavoriteEntities],
+  );
+
+  const removeFavorite = useCallback(
+    (entityId: string) => {
+      setFavoriteEntities((current) => current.filter((id) => id !== entityId));
+    },
+    [setFavoriteEntities],
+  );
+
+  const toggleFavorite = useCallback(
+    (entityId: string) => {
+      if (favoriteEntityIds.has(entityId)) {
+        removeFavorite(entityId);
+      } else {
+        addFavorite(entityId);
+      }
+    },
+    [favoriteEntityIds, addFavorite, removeFavorite],
+  );
+
+  return {
+    hiddenEntities,
+    hiddenEntityIds,
+    favoriteEntities,
+    favoriteEntityIds,
+    entityAliases,
+    isHidden,
+    isFavorite,
+    getAlias,
+    hideEntity,
+    showEntity,
+    setAlias,
+    clearAlias,
+    addFavorite,
+    removeFavorite,
+    toggleFavorite,
+  };
+}

--- a/extensions/homeassistant/src/lib/entity-overrides.ts
+++ b/extensions/homeassistant/src/lib/entity-overrides.ts
@@ -1,34 +1,8 @@
 import { State } from "@lib/haapi";
-import { getDisplayName } from "@lib/utils";
 import { useCachedState } from "@raycast/utils";
 import { useCallback, useMemo } from "react";
 
 const CACHE_NAMESPACE = "entity-overrides";
-
-export function prioritizeFavoriteStates(states: State[], favoriteEntityIds: Set<string>): State[] {
-  if (favoriteEntityIds.size === 0) {
-    return states;
-  }
-  return [
-    ...states.filter((state) => favoriteEntityIds.has(state.entity_id)),
-    ...states.filter((state) => !favoriteEntityIds.has(state.entity_id)),
-  ];
-}
-
-export function sortStatesWithFavoritesFirst(
-  states: State[],
-  favoriteEntityIds: Set<string>,
-  entityAliases: Record<string, string>,
-): State[] {
-  return [...states].sort((a, b) => {
-    const aFavorite = favoriteEntityIds.has(a.entity_id);
-    const bFavorite = favoriteEntityIds.has(b.entity_id);
-    if (aFavorite !== bFavorite) {
-      return aFavorite ? -1 : 1;
-    }
-    return getDisplayName(a, entityAliases[a.entity_id]).localeCompare(getDisplayName(b, entityAliases[b.entity_id]));
-  });
-}
 
 export function partitionFavoriteStates(
   states: State[],
@@ -60,13 +34,9 @@ export function useEntityOverrides() {
   const [hiddenEntities, setHiddenEntities] = useCachedState<string[]>("hidden-entities", [], {
     cacheNamespace: CACHE_NAMESPACE,
   });
-  const [entityAliases, setEntityAliases] = useCachedState<Record<string, string>>(
-    "entity-aliases",
-    {},
-    {
-      cacheNamespace: CACHE_NAMESPACE,
-    },
-  );
+  const [entityAliases, setEntityAliases] = useCachedState<Record<string, string>>("entity-aliases", {}, {
+    cacheNamespace: CACHE_NAMESPACE,
+  });
   const [favoriteEntities, setFavoriteEntities] = useCachedState<string[]>("favorite-entities", [], {
     cacheNamespace: CACHE_NAMESPACE,
   });

--- a/extensions/homeassistant/src/lib/entity-quicklink.ts
+++ b/extensions/homeassistant/src/lib/entity-quicklink.ts
@@ -1,0 +1,39 @@
+import { State } from "@lib/haapi";
+import { getDisplayName } from "@lib/utils";
+import { createDeeplink } from "@raycast/utils";
+
+const commandByDomain: Record<string, string> = {
+  light: "lights",
+  switch: "switches",
+  cover: "covers",
+  fan: "fans",
+  media_player: "mediaplayers",
+  automation: "automations",
+  vacuum: "vacuums",
+  camera: "cameras",
+  script: "scripts",
+  button: "buttons",
+  scene: "scenes",
+  person: "persons",
+  sensor: "sensors",
+  binary_sensor: "binarysensors",
+  climate: "climate",
+  weather: "weather",
+  zone: "zones",
+};
+
+export function getEntityListCommand(entityId: string): string {
+  const domain = entityId.split(".")[0];
+  return commandByDomain[domain] ?? "index";
+}
+
+export function createEntityQuicklink(state: State, alias?: string): { name: string; link: string } {
+  const displayName = getDisplayName(state, alias);
+  return {
+    name: `${displayName}`,
+    link: createDeeplink({
+      command: getEntityListCommand(state.entity_id),
+      fallbackText: state.entity_id,
+    }),
+  };
+}

--- a/extensions/homeassistant/src/lib/utils.ts
+++ b/extensions/homeassistant/src/lib/utils.ts
@@ -58,6 +58,10 @@ export function getFriendlyName(state: State): string {
   return state.attributes.friendly_name || state.entity_id;
 }
 
+export function getDisplayName(state: State, alias?: string): string {
+  return alias || state.attributes.friendly_name || state.entity_id;
+}
+
 export function getStateTooltip(state: State): string {
   const lastChanged = formatToHumanDateTime(state.last_changed) || "?";
   const lastUpdated = formatToHumanDateTime(state.last_updated) || "?";


### PR DESCRIPTION
## Summary

- Add local entity customization in list commands: rename (`⌘⇧R`), hide (`⌘⇧H`), and toggle favorite (`⌘⇧F`)
- Add **Entity Settings** command to manage hidden entities, custom display names, and favorites
- Add **Save as Quicklink** action (`⌘⇧L`) to create Raycast quicklinks that open the matching entity list with the entity ID prefilled in search
- Favorites appear in a dedicated section at the top of entity lists

All overrides are stored locally in Raycast and do not modify Home Assistant.

## Test plan

- [ ] Open **All Entities** and verify rename, hide, favorite, and quicklink actions appear under Customization
- [ ] Hide an entity and confirm it disappears from the list without navigating back to Raycast root
- [ ] Add entities to favorites and confirm they appear in the Favorites section at the top
- [ ] Open **Entity Settings** and verify hidden entities, custom names, and favorites can be managed
- [ ] Use **Save as Quicklink** and confirm the quicklink opens the correct list command with the entity ID prefilled


Made with [Cursor](https://cursor.com)