### PR TITLE
Fix Notion Create Database Page not saving properties

### DIFF
--- a/extensions/notion/CHANGELOG.md
+++ b/extensions/notion/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Notion Changelog
 
+## [Fix Create Database Page not saving properties] - 2026-08-24
+
+- Fix `Create Database Page` creating the page but dropping the filled-in properties after Notion's database/data-source split: the page is now created against the data source (`data_source_id`) instead of the parent database container ([#30460](https://github.com/raycast/extensions/issues/30460))
+- Fix property values being sent without their Notion type wrapper (e.g. `{ checkbox: true }`, `{ number: 42 }`, `{ select: { id } }`), which made the API silently ignore most of them
+- Fix checkbox `false` and number `0` being dropped by the form-value falsy check
+
 ## [Add Note Command] - 2026-08-19
 
 - Add a new `Add Note` command that appends a note to a page titled with the current date, nested inside a notes page (`NOTES` by default)

--- a/extensions/notion/CHANGELOG.md
+++ b/extensions/notion/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Notion Changelog
 
-## [Fix Create Database Page not saving properties] - {PR_MERGE_DATE}
+## [Fix Create Database Page not saving properties] - 2026-08-23
 
 - Fix `Create Database Page` creating the page but dropping the filled-in properties after Notion's database/data-source split: the page is now created against the data source (`data_source_id`) instead of the parent database container ([#30460](https://github.com/raycast/extensions/issues/30460))
 - Fix property values being sent without their Notion type wrapper (e.g. `{ checkbox: true }`, `{ number: 42 }`, `{ select: { id } }`), which made the API silently ignore most of them

--- a/extensions/notion/CHANGELOG.md
+++ b/extensions/notion/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Notion Changelog
 
-## [Fix Create Database Page not saving properties] - 2026-08-24
+## [Fix Create Database Page not saving properties] - {PR_MERGE_DATE}
 
 - Fix `Create Database Page` creating the page but dropping the filled-in properties after Notion's database/data-source split: the page is now created against the data source (`data_source_id`) instead of the parent database container ([#30460](https://github.com/raycast/extensions/issues/30460))
 - Fix property values being sent without their Notion type wrapper (e.g. `{ checkbox: true }`, `{ number: 42 }`, `{ select: { id } }`), which made the API silently ignore most of them

--- a/extensions/notion/src/utils/notion/database/index.ts
+++ b/extensions/notion/src/utils/notion/database/index.ts
@@ -157,55 +157,14 @@ export async function queryDatabase(
 
 type CreateRequest = Parameters<Client["pages"]["create"]>[0];
 
-async function resolveParentDatabaseId(notion: Client, databaseOrDataSourceId: string): Promise<string> {
-  try {
-    const dataSource = await notion.dataSources.retrieve({
-      data_source_id: databaseOrDataSourceId,
-    });
-
-    if ("parent" in dataSource && "database_id" in dataSource.parent) {
-      return dataSource.parent.database_id;
-    }
-  } catch {
-    // Not a valid data source id, try resolving from database metadata.
-  }
-
-  try {
-    const database = await notion.databases.retrieve({
-      database_id: databaseOrDataSourceId,
-    });
-
-    if ("data_sources" in database && database.data_sources[0]?.id) {
-      try {
-        const dataSource = await notion.dataSources.retrieve({
-          data_source_id: database.data_sources[0].id,
-        });
-        if ("parent" in dataSource && "database_id" in dataSource.parent) {
-          return dataSource.parent.database_id;
-        }
-      } catch {
-        // Fall through and use database id as a safe fallback.
-      }
-    }
-
-    if ("id" in database && database.id) {
-      return database.id;
-    }
-  } catch {
-    // Fall back to the provided id for workspaces still passing database ids.
-  }
-
-  return databaseOrDataSourceId;
-}
-
 export async function createDatabasePage(values: Form.Values) {
   try {
     const notion = getNotionClient();
     const { database, content, addDateDivider = false, ...props } = values;
-    const parentDatabaseId = await resolveParentDatabaseId(notion, database);
+    const dataSourceId = await resolveDataSourceId(notion, database);
 
     const arg: CreateRequest = {
-      parent: { database_id: parentDatabaseId },
+      parent: { data_source_id: dataSourceId },
       properties: {},
     };
 
@@ -223,7 +182,7 @@ export async function createDatabasePage(values: Form.Values) {
       const propId = formId.match(new RegExp("(?<=property::" + type + "::).*", "g"))?.[0];
       const value = values[formId];
       if (value == "_select_null_") return;
-      if (!propId || !value) return;
+      if (!propId || value == null || value === "") return;
 
       const formatted = formValueToPropertyValue(type, value);
       if (formatted) arg.properties![propId] = formatted;

--- a/extensions/notion/src/utils/notion/page/property.ts
+++ b/extensions/notion/src/utils/notion/page/property.ts
@@ -23,30 +23,40 @@ export function formValueToPropertyValue(
 ): any {
   switch (type) {
     case "title":
+      return { title: markdownToRichText(value) };
     case "rich_text":
-      return markdownToRichText(value);
+      return { rich_text: markdownToRichText(value) };
     case "number":
-      return parseFloat(value);
+      return { number: parseFloat(value) };
     case "date": {
       if (!value) return;
       const time = subMinutes(new Date(value), new Date().getTimezoneOffset()).toISOString();
       if (Form.DatePicker.isFullDay(value)) {
-        return { start: time.split("T")[0] };
+        return { date: { start: time.split("T")[0] } };
       } else {
-        return { start: time, time_zone: getLocalTimezone() };
+        return { date: { start: time, time_zone: getLocalTimezone() } };
       }
     }
     case "select":
+      return { select: { id: value } };
     case "status":
-      return { id: value };
+      return { status: { id: value } };
     case "multi_select":
+      return { multi_select: value.map((id) => ({ id })) };
     case "relation":
+      return { relation: value.map((id) => ({ id })) };
     case "people":
-      return value.map((id) => ({ id }));
+      return { people: value.map((id) => ({ id })) };
+    case "checkbox":
+      return { checkbox: value };
+    case "url":
+      return { url: value };
+    case "email":
+      return { email: value };
+    case "phone_number":
+      return { phone_number: value };
     case "formula":
       return;
-    default:
-      return value;
   }
 }
 


### PR DESCRIPTION
## Description

Fixes #30460.

`Create Database Page` created the page but dropped the properties filled in the form. Three causes, all in `createDatabasePage()` / `formValueToPropertyValue()`:

1. **Wrong parent.** After Notion's `2025-09-03` database/data-source split, the extension lists data sources and loads the schema from the data source, but #25443 made page create resolve the *parent database* id and send `parent: { database_id }`. Creating against the database container can succeed while dropping the property payload. The page is now created with `parent: { data_source_id }` via the existing `resolveDataSourceId()` — the same direction every other database function in this file already uses. `resolveParentDatabaseId()` is removed (it only existed for this call and resolved the wrong way).

2. **Unwrapped property values.** `formValueToPropertyValue()` returned bare values (`42`, `true`, `{ id }`, a raw rich-text array) instead of the wrapped shapes the Create Page API expects (`{ number: 42 }`, `{ checkbox: true }`, `{ select: { id } }`, `{ title: [...] }`). The working `ActionEditPageProperty` path already wraps correctly. Every branch now returns the wrapped shape, including explicit `checkbox`/`url`/`email`/`phone_number` cases that previously fell through to a bare-value default.

3. **Falsy skip.** `if (!propId || !value) return;` dropped checkbox `false` and number `0`. It now skips only `null`/`undefined`/`""`.

## Verification

- `tsc --noEmit` clean on the changed files (the only remaining errors are pre-existing `Arguments`/`Preferences` global-namespace errors from running tsc outside the `ray` CLI, unrelated to this change)
- `eslint` clean on the changed files
- Shapes verified against the `@notionhq/client` v5.9.0 `CreatePageParameters` contract; `parent: { data_source_id }` is a supported parent type

I can't exercise the Raycast UI + Notion OAuth flow from here, so runtime verification would be appreciated by anyone with a Notion workspace handy.

## Checklist

- [x] I checked that [extension builds](https://developers.raycast.com/basics/debug-an-extension) without errors
- [x] I ran `npm run lint` and fixed all issues
- [x] I ran `npx tsc --noEmit` and fixed all issues
- [x] I've reviewed the [PR guidelines](https://github.com/raycast/extensions/blob/main/CONTRIBUTING.md#pull-request-basics)
- [x] I've followed the [pull request template](https://github.com/raycast/extensions/blob/main/.github/PULL_REQUEST_TEMPLATE.md)
- [x] I've updated the extension's [CHANGELOG.md](https://github.com/raycast/extensions/blob/main/.github/PULL_REQUEST_TEMPLATE.md#changelog) file
