### PR TITLE
fix(keepassxc): auto-lock database after inactivity period

### DIFF
--- a/extensions/keepassxc/CHANGELOG.md
+++ b/extensions/keepassxc/CHANGELOG.md
@@ -1,5 +1,13 @@
 # KeePassXC Extension Changelog
 
+## [1.10.1]
+
+### Fixed
+
+- Auto-lock now actually re-prompts for the database password after the configured inactivity period (#30458). Previously the inactivity timer wrote the current time to local storage every few seconds forever, so the database was always considered "active" and never locked. Activity is now recorded only on genuine interaction, and a read-only watcher locks the database when the period elapses — whether the view stays open or Raycast was closed and reopened.
+
+- Clear the cached database entries (decrypted passwords, usernames, and TOTP codes) from local storage when the database locks, so secrets are not left readable after auto-lock.
+
 ## [1.10.0] - 2026-03-30
 
 ### Added

--- a/extensions/keepassxc/src/components/search-database.tsx
+++ b/extensions/keepassxc/src/components/search-database.tsx
@@ -5,6 +5,7 @@ import { List } from "@raycast/api";
 import Entry from "./entry";
 import FolderFilterDropdown from "./folder-filter-dropdown";
 import { KeePassLoader, showToastKeepassxcCliErrors } from "../utils/keepass-loader";
+import { InactivityTimer } from "../utils/inactivity-timer";
 import { PinLoader } from "../utils/pin-loader";
 import { getEntryId, getFolders } from "../utils/entry-helper";
 
@@ -73,6 +74,8 @@ export default function SearchDatabase({
         folders.length > 0 ? <FolderFilterDropdown folders={folders} onFolderChange={setEntriesFolder} /> : undefined
       }
       throttle={true}
+      onSearchTextChange={() => void InactivityTimer.recordActivity()}
+      onSelectionChange={() => void InactivityTimer.recordActivity()}
     >
       {pinnedEntries.length > 0 && (
         <List.Section title="Favorites">

--- a/extensions/keepassxc/src/components/unlock-database.tsx
+++ b/extensions/keepassxc/src/components/unlock-database.tsx
@@ -3,6 +3,7 @@ import { JSX } from "react/jsx-runtime";
 import { useForm } from "@raycast/utils";
 
 import { KeePassLoader, showToastKeepassxcCliErrors } from "../utils/keepass-loader";
+import { InactivityTimer } from "../utils/inactivity-timer";
 
 interface PasswordForm {
   password: string;
@@ -39,6 +40,7 @@ export default function UnlockDatabase({
         KeePassLoader.cacheCredentials(value.password, value.keyFile[0]);
         KeePassLoader.setCredentials(value.password, value.keyFile[0]);
         setIsUnlocked(true);
+        void InactivityTimer.recordActivity();
       }, showToastKeepassxcCliErrors);
     },
   });

--- a/extensions/keepassxc/src/search.tsx
+++ b/extensions/keepassxc/src/search.tsx
@@ -1,22 +1,20 @@
 import { useState, useEffect } from "react";
 import { JSX } from "react/jsx-runtime";
-import { Detail, getPreferenceValues } from "@raycast/api";
+import { Detail } from "@raycast/api";
 import { KeePassLoader } from "./utils/keepass-loader";
-import { InactivityTimer } from "./utils/inactivity-timer";
+import { InactivityTimer, LOCK_AFTER_MS } from "./utils/inactivity-timer";
 import SearchDatabase from "./components/search-database";
 import UnlockDatabase from "./components/unlock-database";
-
-// The amount of time (in minutes) after which the database should be locked due to inactivity
-const lockAfterInactivity = Number(getPreferenceValues().lockAfterInactivity);
 
 /**
  * The entry point of Search command
  *
  * This component determines whether the database is already unlocked or not,
  * and renders either the search interface or the unlock interface accordingly.
- * If the user has set the lockAfterInactivity preference, the component will
- * automatically launch an inactivity timer, which will lock the database after
- * the specified amount of time if the user doesn't interact with the database
+ * When auto-lock is enabled (`LOCK_AFTER_MS > 0`), a lock watcher is started
+ * once the database is unlocked — whether from cached credentials on mount or
+ * via the unlock form — and stopped when the database is locked or the command
+ * unmounts.
  *
  * @returns {JSX.Element} - The rendered component
  */
@@ -27,15 +25,16 @@ export default function Command(): JSX.Element {
   useEffect(() => {
     KeePassLoader.loadCredentialsCache().then((credentials) => {
       if (credentials.databasePassword || credentials.keyFile) {
-        if (lockAfterInactivity > 0) {
-          InactivityTimer.hasRecentActivity().then((hasRecentActivity) => {
-            if (hasRecentActivity) {
-              setIsUnlocked(true);
+        if (LOCK_AFTER_MS > 0) {
+          InactivityTimer.hasRecentActivity().then((recent) => {
+            if (recent) {
               KeePassLoader.setCredentials(credentials.databasePassword, credentials.keyFile);
+              setIsUnlocked(true);
+              void InactivityTimer.recordActivity();
             } else {
               KeePassLoader.deleteCredentialsCache();
+              KeePassLoader.clearCredentials();
             }
-            InactivityTimer.launchInactivityTimer();
             setIsLoaded(true);
           });
         } else {
@@ -44,13 +43,20 @@ export default function Command(): JSX.Element {
           setIsLoaded(true);
         }
       } else {
-        if (lockAfterInactivity > 0) {
-          InactivityTimer.launchInactivityTimer();
-        }
         setIsLoaded(true);
       }
     });
   }, []);
+
+  useEffect(() => {
+    if (!isUnlocked || LOCK_AFTER_MS <= 0) return () => {};
+    const cleanup = InactivityTimer.startLockWatcher(() => {
+      KeePassLoader.deleteCredentialsCache();
+      KeePassLoader.clearCredentials();
+      setIsUnlocked(false);
+    });
+    return () => cleanup();
+  }, [isUnlocked]);
 
   if (!isLoaded) {
     return <Detail />;

--- a/extensions/keepassxc/src/utils/inactivity-timer.ts
+++ b/extensions/keepassxc/src/utils/inactivity-timer.ts
@@ -1,34 +1,77 @@
 import { getPreferenceValues, LocalStorage } from "@raycast/api";
 
-class InactivityTimer {
-  static lockAfterInactivity: number = Number(getPreferenceValues().lockAfterInactivity);
+/** Lock threshold in milliseconds, computed once from preferences. "-1" (Never) becomes negative. */
+const LOCK_AFTER_MS = Number(getPreferenceValues().lockAfterInactivity) * 60_000;
 
+/** LocalStorage key under which the last activity timestamp is persisted. */
+const LAST_ACTIVITY_KEY = "lastActivity";
+
+/** Module-level debounce guard for `recordActivity` to avoid thrashing LocalStorage. */
+let lastWriteTime = 0;
+
+/** Reads and validates the last activity timestamp. Returns null for missing/empty/NaN. */
+const readLastActivityMs = async (): Promise<number | null> => {
+  const last = await LocalStorage.getItem<string>(LAST_ACTIVITY_KEY);
+  if (last === undefined || last === null || last === "") return null;
+  const ms = Number(last);
+  return Number.isNaN(ms) ? null : ms;
+};
+
+class InactivityTimer {
   /**
-   * Checks whether the user has performed an activity recently
+   * Checks whether the user has performed an activity recently.
    *
-   * @returns {Promise<boolean>} - Whether the user has performed an activity in the last
-   * `lockAfterInactivity` minutes
+   * Reads the last activity timestamp from LocalStorage and returns `true` if it
+   * falls within `LOCK_AFTER_MS`. A missing/empty/NaN stored value is treated as
+   * "locked" (returns `false`) so a fresh session never auto-unlocks. When
+   * auto-lock is disabled (`LOCK_AFTER_MS <= 0`, i.e. "Never"), always returns `true`.
+   *
+   * @returns {Promise<boolean>} - Whether the user has recent activity.
    */
   static hasRecentActivity = async (): Promise<boolean> => {
-    const lastActivity = await LocalStorage.getItem("lastActivity");
-    if (lastActivity) {
-      const timeDiff = (Date.now() - Number(lastActivity)) / 60000;
-      return timeDiff <= this.lockAfterInactivity;
-    }
-    return false;
+    if (LOCK_AFTER_MS <= 0) return true;
+    const ms = await readLastActivityMs();
+    if (ms === null) return false;
+    return Date.now() - ms <= LOCK_AFTER_MS;
   };
 
   /**
-   * Starts an interval that updates the lastActivity value in LocalStorage every 5 seconds
+   * Records user activity by persisting the current timestamp to LocalStorage.
    *
-   * This is used to detect user inactivity and lock the database after the specified
-   * `lockAfterInactivity` time
+   * No-op when auto-lock is disabled (`LOCK_AFTER_MS <= 0`). Otherwise debounced
+   * to at most one write per second using the module-level `lastWriteTime` guard,
+   * which persists across calls within a session.
+   *
+   * @returns {Promise<void>}
    */
-  static launchInactivityTimer = (): void => {
-    setInterval(() => {
-      LocalStorage.setItem("lastActivity", Date.now());
-    }, 5000);
+  static recordActivity = async (): Promise<void> => {
+    if (LOCK_AFTER_MS <= 0) return;
+    if (Date.now() - lastWriteTime < 1000) return;
+    lastWriteTime = Date.now();
+    await LocalStorage.setItem(LAST_ACTIVITY_KEY, Date.now());
+  };
+
+  /**
+   * Starts a read-only interval that invokes `onLock` once the last activity
+   * timestamp exceeds `LOCK_AFTER_MS`.
+   *
+   * No-op when auto-lock is disabled (`LOCK_AFTER_MS <= 0`), returning a no-op
+   * cleanup. The interval only reads LocalStorage — it never writes — so that
+   * inactivity is correctly detected rather than continually reset.
+   *
+   * @param {() => void} onLock - Callback invoked when the inactivity threshold is exceeded.
+   * @returns {() => void} - A cleanup function that stops the watcher.
+   */
+  static startLockWatcher = (onLock: () => void): (() => void) => {
+    if (LOCK_AFTER_MS <= 0) return () => {};
+    const id = setInterval(async () => {
+      const ms = await readLastActivityMs();
+      if (ms === null || Date.now() - ms > LOCK_AFTER_MS) {
+        onLock();
+      }
+    }, 10_000);
+    return () => clearInterval(id);
   };
 }
 
-export { InactivityTimer };
+export { InactivityTimer, LOCK_AFTER_MS };

--- a/extensions/keepassxc/src/utils/keepass-loader.ts
+++ b/extensions/keepassxc/src/utils/keepass-loader.ts
@@ -213,15 +213,16 @@ class KeePassLoader {
     });
 
   /**
-   * Removes the stored credentials from `LocalStorage`
+   * Removes the stored credentials and cached entries from `LocalStorage`
    *
-   * This function deletes the cached database password and key file path
-   * from LocalStorage, ensuring that the credentials are no longer stored
-   * locally
+   * This function deletes the cached database password, key file path, and the
+   * cached entries (decrypted CSV) from LocalStorage, ensuring that credentials
+   * and entry secrets are no longer stored locally. Called on every lock path.
    */
   static deleteCredentialsCache = () => {
     LocalStorage.removeItem("databasePassword");
     LocalStorage.removeItem("keyFile");
+    LocalStorage.removeItem("entries");
   };
 
   /**
@@ -345,6 +346,16 @@ class KeePassLoader {
   static setCredentials = (password: string = "", keyFile: string = "") => {
     this.setDatabasePassword(password);
     this.setKeyFile(keyFile);
+  };
+
+  /**
+   * Clears the in-memory database password and key file path
+   *
+   * Security hygiene on lock so secrets don't linger while the unlock form shows.
+   */
+  static clearCredentials = () => {
+    this.databasePassword = "";
+    this.keyFile = "";
   };
 }
 


### PR DESCRIPTION
> **Note:** This PR is a suggestion and is fully open to changes. I'm not a maintainer of this extension — happy to adjust the approach, naming, scope, or split the work differently based on your feedback. The goal is to get #30458 resolved; the implementation below is one way to do it.

## Summary

Fixes #30458 — the `lockAfterInactivity` preference existed but never actually locked the database after the configured inactivity period.

### Root cause

`InactivityTimer.launchInactivityTimer()` ran a `setInterval` that wrote `Date.now()` to LocalStorage every 5 seconds forever (never cleared). Because the interval unconditionally wrote the current time, `lastActivity` was always ≈ now, so `hasRecentActivity()` always returned `true` and the database never locked. Two additional gaps: the staleness check ran only on mount (no in-session check while the view stayed open), and any watcher needed to start when the user unlocked via the form mid-session — not only on mount.

### Changes

**`src/utils/inactivity-timer.ts`** — rewritten:
- Activity is recorded only on genuine user interaction (unlock, search, selection), debounced to ≤1 write/sec via a module-level guard. No blind timer writes.
- `startLockWatcher(onLock)` runs a **read-only** interval (every 10s) that checks `now - lastActivity` and fires `onLock` when exceeded — it never writes `Date.now()`, so inactivity is detected correctly. Returns a cleanup function.
- `hasRecentActivity()` and the watcher share a single `readLastActivityMs()` helper that returns `null` for missing/empty/NaN timestamps, so both paths treat a corrupt/absent value as "locked" (closes a latent `NaN > threshold` footgun).
- `LOCK_AFTER_MS` is exported as the single source of truth for the threshold.
- Removed the broken `launchInactivityTimer()` entirely.

**`src/search.tsx`** — rewired:
- Mount effect loads the credential cache and calls `hasRecentActivity()`; recent → unlock, stale → delete cache + clear in-memory creds and stay locked. Cached-unlock also records fresh activity so reopening near the threshold edge doesn't surprise-lock.
- New `useEffect` keyed on `[isUnlocked]` starts the lock watcher when unlocked (covering both mount-unlock and form-unlock) and tears it down on lock/unmount.
- Uses the exported `LOCK_AFTER_MS` instead of a duplicated preference read.

**`src/utils/keepass-loader.ts`**:
- Added `clearCredentials()` to wipe the in-memory password/key file on lock (security hygiene so secrets don't linger while the unlock form is shown).
- `deleteCredentialsCache()` now also removes the `entries` cache (the full decrypted CSV of passwords/usernames/TOTPs), so secrets are not left readable in LocalStorage after auto-lock.

**`src/components/unlock-database.tsx`** — records activity on successful unlock so the timeout clock starts fresh.

**`src/components/search-database.tsx`** — records activity on search text change and list selection change.

**`CHANGELOG.md`** — added `[1.10.1]` entry.

### How it works across scenarios

| Scenario | Behavior |
|---|---|
| View open, user goes idle | Read-only watcher fires `onLock` once `now - lastActivity` exceeds the threshold → cache + in-memory creds cleared → unlock form shown. |
| Raycast closed, reopened after X min | On mount, `hasRecentActivity()` reads the persisted timestamp; stale → cache deleted, stays locked. |
| Raycast closed, reopened < X min | Recent → credentials restored, unlocked, fresh activity recorded. |
| User unlocks via form, then goes idle | `setIsUnlocked(true)` triggers the `[isUnlocked]` effect → watcher starts → locks after threshold. |
| Active user (typing/navigating) | `recordActivity` keeps `lastActivity` fresh → stays unlocked. |
| "Never" (`lockAfterInactivity = -1`) | All timer methods no-op; no watcher, never locks. |

### Validation

- `npx tsc --noEmit` → exit 0
- `npx eslint src --max-warnings=0` → exit 0
- `ray build -e dist` → exit 0

### Manual test matrix

Runtime auto-lock can't be automated here (requires a `.kdbx` database and `keepassxc-cli`), so please verify manually:

1. Set **Lock after inactivity = 2 minutes**, unlock, leave the Raycast window open and idle for >2 min → should re-lock to the unlock form.
2. Unlock, close the Raycast window, wait >2 min, reopen → should show the unlock form.
3. Unlock, close, reopen <2 min → should stay unlocked.
4. Set **Never** → should never lock and run no watcher.
5. Unlock, then type/arrow-navigate/copy within the window → should stay unlocked past 2 min while active.

### Notes

- The `entries` LocalStorage cache (decrypted CSV) is now cleared on lock. The tradeoff is that the first paint after re-unlock waits for `refreshEntriesCache` instead of using the cache — acceptable for a security feature.
- Lock can fire up to ~10s late due to the poll interval granularity.

Closes #30458.
