### PR TITLE
Fix Google Translate extension failing with JSON parse error (429 HTML block page)

### DIFF
--- a/extensions/google-translate/CHANGELOG.md
+++ b/extensions/google-translate/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Google Translate Changelog
 
+## [Fix translations failing with JSON parse error] - 2026-08-24
+
+- Switched the Google Translate API client identifier from `gtx` to `dict-chrome-ex` to avoid Google's 429 HTML block page for non-browser clients
+
 ## [Update] - 2026-08-10
 
 - Added a "Prioritize cross-language translations" preference to optionally move same-language results to the bottom

--- a/extensions/google-translate/CHANGELOG.md
+++ b/extensions/google-translate/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Translate Changelog
 
-## [Fix translations failing with JSON parse error] - {PR_MERGE_DATE}
+## [Fix translations failing with JSON parse error] - 2026-08-24
 
 - Switched the Google Translate API client identifier from `gtx` to `dict-chrome-ex` to avoid Google's 429 HTML block page for non-browser clients
 

--- a/extensions/google-translate/CHANGELOG.md
+++ b/extensions/google-translate/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Translate Changelog
 
-## [Fix translations failing with JSON parse error] - 2026-08-24
+## [Fix translations failing with JSON parse error] - {PR_MERGE_DATE}
 
 - Switched the Google Translate API client identifier from `gtx` to `dict-chrome-ex` to avoid Google's 429 HTML block page for non-browser clients
 

--- a/extensions/google-translate/vendor/@iamtraction-translate/src/index.ts
+++ b/extensions/google-translate/vendor/@iamtraction-translate/src/index.ts
@@ -45,7 +45,7 @@ export async function translate(text: string, options?: TranslateOption): Promis
     // URL & query string required by Google Translate.
     let baseUrl = "https://translate.google.com/translate_a/single";
     let data: any = {
-        client: "gtx",
+        client: "dict-chrome-ex",
         sl: options.from,
         tl: options.to,
         hl: options.to,


### PR DESCRIPTION
## Root cause

The vendored `@iamtraction/translate` library calls the Google Translate endpoint with `client=gtx`. Google now serves a 429 HTML block page to that client when the request originates from a non-browser TLS fingerprint (Node/undici), so `response.body.json()` throws `SyntaxError: Unexpected token '<', "<html><hea"... is not valid JSON` — the error reported in #30465, #30447, and #30371.

I confirmed this from the same machine at the same time:

| Client | Endpoint | Result |
|--------|----------|--------|
| curl (any UA) | `translate.google.com/.../single?client=gtx` | 200 JSON |
| undici / Node `https` (any UA) | `translate.google.com/.../single?client=gtx` | 429 HTML |
| undici | `translate.google.com/.../single?client=dict-chrome-ex` | 200 JSON |

The block is at the TLS-fingerprint layer, so header changes (User-Agent, Accept, etc.) do not resolve it.

## Change

Switch the API client identifier from `gtx` to `dict-chrome-ex` (the client Chrome itself uses for dictionary/translate lookups). The endpoint, query parameters, and response structure are identical — I diffed the full JSON responses for both clients and they match on every index the library parses (`body[0]` translation segments, `body[2]` / `body[8]` detected language, `body[7]` spell correction).

## Validation

- End-to-end: ran the actual vendored `translate()` function via `tsx` — `"hello"` (auto → es) returns `text: "Hola"`, `from.language.iso: "en"`, with the full rich `raw` body intact.
- Long-text POST path (>2048-char URL) also returns a correct translation.
- `ray lint` passes cleanly.

Fixes #30465.
