### PR TITLE
Update list-by-fullforms extension

### DIFF
--- a/extensions/list-by-fullforms/CHANGELOG.md
+++ b/extensions/list-by-fullforms/CHANGELOG.md
@@ -1,5 +1,21 @@
 # List by FullForms Changelog
 
+## [Recently Added Section, Description Callouts, and Raycast-Tagged Tokens] - {PR_MERGE_DATE}
+
+- The description field in Quick Add Entry and the entry edit form now speaks the web editor's callout syntax with one keystroke: Cmd+Shift+E, Cmd+Shift+N, and Cmd+Shift+R append an Example, Note, or Reference callout block and focus the field. A ⓘ tooltip on the field documents the syntax for hand-typing
+- New "Copy as Mention" action (Cmd+Shift+M) on Search Entries results copies the entry's mention token, ready to paste into any description; the web app renders it as a link to the entry
+- Fixed editing an entry silently removing mention links from its description: the edit form previously pre-filled from the display copy (which strips mention tokens for readability) and saved that back, so any edit flattened `[term](#id)` links to plain text. Edits now round-trip the raw description, keeping mentions intact
+
+- Search Entries now opens with a "Recently Added by You" section: your own newest entries, newest first, shown while the search bar is empty and scoped by the same workspace dropdown as search. Rows behave exactly like search results, with the detail pane, star toggle, edit, notes, report, copy, and speech actions all available, so the entry you just added is one keystroke away
+- Setup now links to `list.fullforms.com/account?token_client=raycast`, which opens the Generate dialog pre-filled and tags the minted token as Raycast's. Entries added from Raycast then read "via Raycast" in the web app's entry history panel instead of the generic "via API"; teammates viewing the same entry see the same label. Existing tokens were tagged retroactively server-side, so this needs no action from current users
+
+## [Full List Icon Parity with the Web] - 2026-07-27
+
+- Lists now show the same icon here as they do on the web. The glyph set grew from 30 keys to all 92 the web can store, so a list using any of the newer icons (fish, train, truck, ship, banknote, wallet, shopping cart, shirt, radio tower, flask, atom, crypto and the rest) no longer falls back to the default list icon
+- Lists that never had an icon picked now resolve to a far more specific one: the name-matching table grew from 9 rules to 55, adding money, legal, accounting, commerce, logistics, marketing, analytics, data, devops, AI, network, security, gaming, design, film, photography, education, team, transport, science, energy, water, outdoor, winter, crypto, broadcast, fashion, auth, mobile and print
+- Fixed name matching that picked confidently wrong icons. Terms now match only at the start of a word, so "Labels" and "Collaboration" no longer read as a lab, "Latest Releases" no longer reads as a test, and "Employee Training" no longer reads as a train. Where two terms both match, the more specific one wins, so "Plant Taxonomy" gets a leaf rather than a task clipboard
+- Split the single nature icon that used to cover everything living: fish, animals and pets now get their own marks instead of all sharing a leaf
+
 ## [Detail Pane Previews, Windows Shortcut Fixes, and Onboarding] - 2026-07-26
 
 - Fixed keyboard shortcuts on Windows: actions such as Open Last Added Entry (Ctrl+O), Open List / View Existing Entry (Ctrl+Shift+O), Edit Entry (Ctrl+E), Star Entry (Ctrl+S), and the note, report, and detail-toggle shortcuts now actually fire; previously their macOS Command bindings were silently ignored on Windows, so the keys did nothing even though the hints looked correct

--- a/extensions/list-by-fullforms/CHANGELOG.md
+++ b/extensions/list-by-fullforms/CHANGELOG.md
@@ -1,6 +1,6 @@
 # List by FullForms Changelog
 
-## [Recently Added Section, Description Callouts, and Raycast-Tagged Tokens] - {PR_MERGE_DATE}
+## [Recently Added Section, Description Callouts, and Raycast-Tagged Tokens] - 2026-08-24
 
 - The description field in Quick Add Entry and the entry edit form now speaks the web editor's callout syntax with one keystroke: Cmd+Shift+E, Cmd+Shift+N, and Cmd+Shift+R append an Example, Note, or Reference callout block and focus the field. A ⓘ tooltip on the field documents the syntax for hand-typing
 - New "Copy as Mention" action (Cmd+Shift+M) on Search Entries results copies the entry's mention token, ready to paste into any description; the web app renders it as a link to the entry

--- a/extensions/list-by-fullforms/README.md
+++ b/extensions/list-by-fullforms/README.md
@@ -18,8 +18,8 @@ List by FullForms brings your [FullForms](https://fullforms.com) List glossaries
 
 ## Setup
 
-1. Sign in to https://list.fullforms.com.
-2. Open Account, scroll to **API tokens**, click **Generate token**, and copy the value. It appears only once, so copy before closing.
+1. Open https://list.fullforms.com/account?token_client=raycast and sign in if prompted. The **Generate API token** dialog opens with the name pre-filled, and the minted token is tagged as Raycast's, so entries you add from Raycast read "via Raycast" in the web app's history panel.
+2. Click **Generate** and copy the value. It appears only once, so copy before closing.
 3. In Raycast, open this extension's preferences and paste the token into **API Token**.
 
 ## Commands
@@ -27,6 +27,8 @@ List by FullForms brings your [FullForms](https://fullforms.com) List glossaries
 ### Search Entries
 
 Type to search across your lists and entries. By default it searches every workspace you belong to in a single query; use the dropdown (shown when you belong to more than one workspace) to narrow to a single workspace.
+
+Before you type anything, the command shows **Recently Added by You**: your own newest entries, newest first, scoped by the same workspace dropdown. Every row works exactly like a search result (detail pane, star, edit, notes, report, copy, speech), so the entry you added a moment ago is one keystroke away. The section lists entries you created; teammates' additions don't appear in it.
 
 Results group by their parent list under section headers. When the same list name exists in more than one workspace, the workspace name is added to the header (`Glossary · FullForms` vs `Glossary · Personal`) so they stay distinct. Each row carries the list's colour and icon from the web, plus accessory markers for `⭐ starred` entries and `📄 entries with a private note`.
 
@@ -43,6 +45,7 @@ Shortcuts (on Windows, `Cmd` is `Ctrl` and `Opt` is `Alt`):
 - `Cmd+Shift+R` reports the entry to its list owner's moderation queue: pick a reason (typo, factual error, inappropriate, duplicate, other) and optionally add a note. Reporting has to be enabled on the list by its owner; if it isn't, you'll get a message saying so.
 - `Cmd+C` copies the entry term.
 - `Cmd+.` copies the definition.
+- `Cmd+Shift+M` copies the entry as a mention token (`[term](#id)`). Paste it into any entry description (here or on the web) and the web app renders it as a link to this entry.
 
 When a search returns no matches, an **Add Entry** action appears, pre-filled with your search term, so you can create the missing entry without leaving Search; it opens the same Quick Add form described below.
 
@@ -57,6 +60,8 @@ Field order is List → Type → Entry → Definition → Description → Tags (
 **Tags** is a single comma-separated field covering both existing and new tags. Type tag names separated by commas; on save each name is matched case-insensitively against the list's existing tags (reusing that tag) or created as a new one, so you never make an accidental duplicate. When the list already has tags, they are listed in the field's info tooltip (the ⓘ) so you can see what to reuse. The field clears when you switch lists. (Raycast's tag picker can only select from predefined items and can't create new ones by typing, so a single text field with server-side name resolution is the closest single-field port of the web's tag input.)
 
 **Duplicate detection** runs as you type: if an entry with the same term (case-insensitive exact match) already exists on the selected list, a soft `⚠` warning appears under the Entry field and a `Cmd+Shift+O · View Existing Entry` action shows up in the panel deep-linking to the duplicate. Same shape on the Definition field for definition-text matches. Partial matches don't warn (`open` won't flag an existing `Open AI`).
+
+**Description callouts and mentions**: the description field speaks the same lightweight markup as the web editor. `Cmd+Shift+E` / `Cmd+Shift+N` / `Cmd+Shift+R` append an Example, Note, or Reference callout (`> Example: ` and friends) as a new block and focus the field so you can keep typing; the web app and the Search detail pane render these as styled callouts. To mention another entry, copy its token from a Search Entries result with `Cmd+Shift+M` and paste it where you want the link. (The web's inline `@` and `/` popups can't exist in a native Raycast form, so these are the action-panel and clipboard equivalents.) The field's ⓘ tooltip carries a syntax cheat sheet. The same insert actions are available in the entry edit form.
 
 **AI helpers** (Raycast AI, requires a Raycast account with AI access): the action panel offers **Generate Definition** (`Cmd+G`), which writes a concise definition from the term, and **Generate Description** (`Cmd+Shift+G`), which writes a longer description from the term and definition. The result drops straight into the field, where you can edit it before saving. These actions only appear when your account has AI access. To dictate instead of typing, use Raycast's built-in dictation in any text field; it needs no setup here.
 

--- a/extensions/list-by-fullforms/package.json
+++ b/extensions/list-by-fullforms/package.json
@@ -42,7 +42,7 @@
       "name": "apiToken",
       "type": "password",
       "title": "API Token",
-      "description": "Generate one at list.fullforms.com/account under API tokens.",
+      "description": "Generate one at list.fullforms.com/account?token_client=raycast (opens the dialog pre-filled and tags the token as Raycast's).",
       "required": true,
       "placeholder": "ffl_..."
     },

--- a/extensions/list-by-fullforms/src/add-entry.tsx
+++ b/extensions/list-by-fullforms/src/add-entry.tsx
@@ -99,6 +99,11 @@ import {
   errorMessage,
   WRITABLE_ROLES,
 } from "./lib/api";
+import {
+  CALLOUTS,
+  appendCalloutPrefix,
+  descriptionFieldInfo,
+} from "./lib/descriptionMarkup";
 import { ENTRY_TYPES, entryTypeLabel } from "./lib/entryTypes";
 import { iconForList } from "./lib/listIconCatalog";
 import { crossShortcut, shortcutHint } from "./lib/platform";
@@ -576,6 +581,28 @@ export default function AddEntryCommand({
               />
             </ActionPanel.Section>
           )}
+          {/* Callout inserts, the action-panel port of the web's `/`
+              picker (Raycast forms can't host an inline popup; see
+              lib/descriptionMarkup.ts). Each appends its prefix to the
+              Description as a fresh block and focuses the field, so
+              the caret lands at the end, right after the prefix. */}
+          <ActionPanel.Section title="Insert into Description">
+            {CALLOUTS.map((c) => (
+              <Action
+                key={c.name}
+                title={`Insert ${c.name} Callout`}
+                icon={Icon.QuoteBlock}
+                shortcut={crossShortcut(["cmd", "shift"], c.shortcutKey)}
+                onAction={() => {
+                  setValue(
+                    "description",
+                    appendCalloutPrefix(values.description ?? "", c.prefix),
+                  );
+                  focus("description");
+                }}
+              />
+            ))}
+          </ActionPanel.Section>
           {lastAdded && (
             <Action.OpenInBrowser
               title="Open Last Added Entry"
@@ -657,6 +684,7 @@ export default function AddEntryCommand({
       <Form.TextArea
         title="Description"
         placeholder="Optional longer notes, examples, references…"
+        info={descriptionFieldInfo()}
         {...itemProps.description}
       />
 

--- a/extensions/list-by-fullforms/src/components/EntryEditForm.tsx
+++ b/extensions/list-by-fullforms/src/components/EntryEditForm.tsx
@@ -35,7 +35,13 @@ import {
 import { FormValidation, useForm } from "@raycast/utils";
 import { apiFetch, errorMessage } from "../lib/api";
 import type { Tag } from "../lib/api";
+import {
+  CALLOUTS,
+  appendCalloutPrefix,
+  descriptionFieldInfo,
+} from "../lib/descriptionMarkup";
 import { ENTRY_TYPES } from "../lib/entryTypes";
+import { crossShortcut } from "../lib/platform";
 import { parseTagNames, tagsFieldInfo } from "../lib/tags";
 
 // The entry fields this form needs, narrowed from the search row.
@@ -43,6 +49,11 @@ export interface EditableEntry {
   id: number;
   entry: string;
   definition: string;
+  // The RAW description text (mention tokens like [label](#id)
+  // intact), NOT the mention-stripped display copy the search rows
+  // render. This field round-trips through the PATCH verbatim, so
+  // callers passing the stripped copy would silently destroy mention
+  // links on save; EntrySearchRow passes descriptionRaw.
   description: string;
   type: string;
   listName: string;
@@ -82,55 +93,56 @@ export function EntryEditForm({
   // tags are preserved unless the user edits the field.
   const initialTags = (Array.isArray(entry.tags) ? entry.tags : []).join(", ");
 
-  const { handleSubmit, itemProps } = useForm<FormValues>({
-    onSubmit: async (input) => {
-      const toast = await showToast({
-        style: Toast.Style.Animated,
-        title: "Saving changes…",
-      });
-      try {
-        const tagNames = parseTagNames(input.tags);
-
-        // Send the full desired tag set as tag_names; the server replaces
-        // the entry's tags with the resolved set (an empty field clears
-        // them all, since the route omits an empty array and the RPC
-        // treats the absent param as "no tags").
-        const body: Record<string, unknown> = {
-          entry: input.entry ?? "",
-          definition: input.definition ?? "",
-          description: input.description ?? "",
-          type: input.type ?? "term",
-          tag_names: tagNames,
-        };
-
-        await apiFetch(`/api/v1/entries/${entry.id}`, {
-          method: "PATCH",
-          body: JSON.stringify(body),
+  const { handleSubmit, itemProps, setValue, values, focus } =
+    useForm<FormValues>({
+      onSubmit: async (input) => {
+        const toast = await showToast({
+          style: Toast.Style.Animated,
+          title: "Saving changes…",
         });
+        try {
+          const tagNames = parseTagNames(input.tags);
 
-        toast.style = Toast.Style.Success;
-        toast.title = "Entry updated";
-        onSaved();
-        pop();
-      } catch (error) {
-        toast.style = Toast.Style.Failure;
-        toast.title = "Could not update entry";
-        toast.message = errorMessage(error);
-      }
-    },
-    initialValues: {
-      entry: entry.entry ?? "",
-      type: entry.type || "term",
-      definition: entry.definition ?? "",
-      description: entry.description ?? "",
-      tags: initialTags,
-    },
-    validation: {
-      entry: FormValidation.Required,
-      definition: FormValidation.Required,
-      type: FormValidation.Required,
-    },
-  });
+          // Send the full desired tag set as tag_names; the server replaces
+          // the entry's tags with the resolved set (an empty field clears
+          // them all, since the route omits an empty array and the RPC
+          // treats the absent param as "no tags").
+          const body: Record<string, unknown> = {
+            entry: input.entry ?? "",
+            definition: input.definition ?? "",
+            description: input.description ?? "",
+            type: input.type ?? "term",
+            tag_names: tagNames,
+          };
+
+          await apiFetch(`/api/v1/entries/${entry.id}`, {
+            method: "PATCH",
+            body: JSON.stringify(body),
+          });
+
+          toast.style = Toast.Style.Success;
+          toast.title = "Entry updated";
+          onSaved();
+          pop();
+        } catch (error) {
+          toast.style = Toast.Style.Failure;
+          toast.title = "Could not update entry";
+          toast.message = errorMessage(error);
+        }
+      },
+      initialValues: {
+        entry: entry.entry ?? "",
+        type: entry.type || "term",
+        definition: entry.definition ?? "",
+        description: entry.description ?? "",
+        tags: initialTags,
+      },
+      validation: {
+        entry: FormValidation.Required,
+        definition: FormValidation.Required,
+        type: FormValidation.Required,
+      },
+    });
 
   return (
     <Form
@@ -141,6 +153,26 @@ export function EntryEditForm({
             icon={Icon.Check}
             onSubmit={handleSubmit}
           />
+          {/* Same callout inserts as Quick Add (the two forms share
+              the description markup vocabulary; see
+              lib/descriptionMarkup.ts). */}
+          <ActionPanel.Section title="Insert into Description">
+            {CALLOUTS.map((c) => (
+              <Action
+                key={c.name}
+                title={`Insert ${c.name} Callout`}
+                icon={Icon.QuoteBlock}
+                shortcut={crossShortcut(["cmd", "shift"], c.shortcutKey)}
+                onAction={() => {
+                  setValue(
+                    "description",
+                    appendCalloutPrefix(values.description ?? "", c.prefix),
+                  );
+                  focus("description");
+                }}
+              />
+            ))}
+          </ActionPanel.Section>
         </ActionPanel>
       }
     >
@@ -156,7 +188,11 @@ export function EntryEditForm({
 
       <Form.TextArea title="Definition" {...itemProps.definition} />
 
-      <Form.TextArea title="Description" {...itemProps.description} />
+      <Form.TextArea
+        title="Description"
+        info={descriptionFieldInfo()}
+        {...itemProps.description}
+      />
 
       <Form.TextField
         title="Tags"

--- a/extensions/list-by-fullforms/src/components/EntrySearchRow.tsx
+++ b/extensions/list-by-fullforms/src/components/EntrySearchRow.tsx
@@ -23,6 +23,7 @@ import {
   iconForWorkspace,
   listVisibility,
 } from "../lib/listIconCatalog";
+import { mentionToken } from "../lib/descriptionMarkup";
 import { crossShortcut, isMacOS } from "../lib/platform";
 import { composeSpeakable, speakText, stopSpeaking } from "../lib/tts";
 import { EntryEditForm } from "./EntryEditForm";
@@ -237,7 +238,14 @@ export function EntrySearchRow({
                     id: entry.id,
                     entry: entry.entry,
                     definition: entry.definition,
-                    description: entry.description,
+                    // The RAW description (mention tokens intact), not
+                    // the stripped display copy this row renders: the
+                    // form PATCHes its field back verbatim, so seeding
+                    // it with the stripped copy would silently rewrite
+                    // every [label](#id) mention to its bare label on
+                    // save. Fallback covers a cached pre-20261018
+                    // response during a server deploy.
+                    description: entry.descriptionRaw ?? entry.description,
                     type: entry.type,
                     listName: entry.listName,
                     tags: entry.tags,
@@ -293,6 +301,18 @@ export function EntrySearchRow({
             title="Copy Definition"
             content={entry.definition}
             shortcut={crossShortcut(["cmd"], ".")}
+          />
+          {/* Copy the entry's mention token, the plain-text form the
+              web's @-mention picker inserts into descriptions. Raycast
+              forms can't host an inline @ popup (no keystroke or
+              cursor APIs on Form.TextArea), so the mention flow is
+              clipboard-shaped instead: copy the token here, paste it
+              at the caret in a description field. The web read view
+              renders it as a link to this entry. */}
+          <Action.CopyToClipboard
+            title="Copy as Mention"
+            content={mentionToken(entry.entry, entry.id)}
+            shortcut={crossShortcut(["cmd", "shift"], "m")}
           />
           {/* TTS via macOS's built-in `say`. Two granularities: Cmd+T
               speaks the full payload (term + definition + description),

--- a/extensions/list-by-fullforms/src/lib/api.ts
+++ b/extensions/list-by-fullforms/src/lib/api.ts
@@ -99,6 +99,14 @@ export interface SearchEntryResult {
   entry: string;
   definition: string;
   description: string;
+  // The description exactly as stored, mention tokens ([label](#id))
+  // intact, from list-repo migration 20261018000000. `description`
+  // above is the mention-STRIPPED display copy; render that one, but
+  // EDIT this one: the edit form must round-trip the raw text or
+  // saving an edit silently rewrites every mention token to its bare
+  // label. Optional because a cached pre-migration response can lack
+  // it across a server deploy; editors fall back to `description`.
+  descriptionRaw?: string;
   type: string;
   listId: number;
   listName: string;
@@ -111,6 +119,22 @@ export interface SearchEntryResult {
   myNote: string | null;
   isStarred: boolean;
   tags: string[];
+}
+
+// One entry row from /api/v1/recent (api_recent_entries_for_token):
+// the caller's own most-recently-created entries, newest first. Since
+// list-repo migration 20261017000000 the row is the full search-row
+// shape plus createdAt, deliberately, so the Search command's
+// "Recently Added" empty-query section can render these through
+// EntrySearchRow with no re-joining. If SearchEntryResult widens
+// again, the recent RPC must follow (it copies the search RPC's field
+// expressions verbatim).
+export interface RecentEntryResult extends SearchEntryResult {
+  createdAt: string;
+}
+
+export interface RecentEntriesResponse {
+  entries: RecentEntryResult[];
 }
 
 const DEFAULT_BASE = "https://list.fullforms.com";
@@ -158,7 +182,7 @@ export async function apiFetch<T>(
 
   if (res.status === 401) {
     throw new Error(
-      "Token invalid or revoked. Open extension preferences and paste a fresh one from list.fullforms.com/account.",
+      "Token invalid or revoked. Open extension preferences and paste a fresh one from list.fullforms.com/account?token_client=raycast.",
     );
   }
   if (res.status === 429) {

--- a/extensions/list-by-fullforms/src/lib/descriptionMarkup.ts
+++ b/extensions/list-by-fullforms/src/lib/descriptionMarkup.ts
@@ -1,0 +1,104 @@
+// descriptionMarkup — the description field's lightweight markup
+// vocabulary, mirrored from the web app's description editor.
+//
+// On the web, descriptions are rich-edited in Tiptap: `/` opens a
+// slash picker that inserts callout line prefixes (DescriptionEditor
+// .vue → SLASH_ITEMS) and `@` opens an entry-mention picker that
+// inserts a plain-text `[label](#id)` token (entryMentions.js). Both
+// store PLAIN TEXT, which is what makes a Raycast port possible at
+// all: there is no rich editor here, but the syntax itself is just
+// characters in a TextArea.
+//
+// What Raycast can and cannot do with that:
+//
+//   * Inline `/` and `@` popups are NOT possible. Form.TextArea is a
+//     native control with no keystroke interception, no inline popup
+//     surface, and no cursor-position API.
+//   * Callouts port well anyway: they are whole-line blocks that
+//     naturally end a description, so an action-panel action that
+//     APPENDS the prefix (appendCalloutPrefix) loses almost nothing.
+//   * Mentions are mid-sentence constructs, so append-at-end is the
+//     wrong shape for them. The Raycast-native path is clipboard-
+//     shaped instead: a "Copy as Mention" action on Search Entries
+//     rows copies the token (mentionToken), and pasting is the one
+//     insertion that lands at the caret.
+//
+// The callout catalog mirrors the web's SLASH_ITEMS callout entries
+// verbatim (names, prefixes, hint copy). The web also offers glyph
+// tiles under `/`; those are deliberately not ported, since the OS
+// emoji/character pickers already insert at the caret and do it
+// better than an action-panel submenu could.
+
+import type { Keyboard } from "@raycast/api";
+import { shortcutHint } from "./platform";
+
+export interface Callout {
+  name: string;
+  // The literal line prefix inserted into the description, matching
+  // the web's CALLOUT_OPENER_RE vocabulary (`> Example:` etc.), which
+  // the read views on every surface promote to styled chips.
+  prefix: string;
+  // Secondary line for the action's tooltip, same copy as the web
+  // picker's hint.
+  hint: string;
+  // Key for the Cmd+Shift+<key> insert shortcut in the entry forms.
+  shortcutKey: Keyboard.KeyEquivalent;
+}
+
+export const CALLOUTS: Callout[] = [
+  {
+    name: "Example",
+    prefix: "> Example: ",
+    hint: "Highlight a worked example or sample usage",
+    shortcutKey: "e",
+  },
+  {
+    name: "Note",
+    prefix: "> Note: ",
+    hint: "Add an aside, caveat, or reminder",
+    shortcutKey: "n",
+  },
+  {
+    name: "Reference",
+    prefix: "> Reference: ",
+    hint: "Cite a source, document, or external resource",
+    shortcutKey: "r",
+  },
+];
+
+// Append a callout prefix to a description as its own block. Trailing
+// whitespace is trimmed first so repeated inserts can't pile up blank
+// lines, and the separator is a BLANK line, not a single newline: in
+// markdown `> a\n> b` merges into one blockquote, so a single newline
+// would fuse a new callout onto the previous one in the Search detail
+// pane (the web's line-based parser keeps them apart either way, but
+// the stored text should read correctly on both renderers). An empty
+// or whitespace-only description gets the bare prefix with no leading
+// separator.
+export function appendCalloutPrefix(current: string, prefix: string): string {
+  const base = (current ?? "").replace(/\s+$/, "");
+  return base ? `${base}\n\n${prefix}` : prefix;
+}
+
+// The plain-text mention token the web's `@` picker inserts
+// (DescriptionEditor.vue serializes mention nodes to exactly this).
+// The web read view renders it as a link to the entry; surfaces that
+// don't render mentions strip it down to the label server-side.
+export function mentionToken(term: string, id: number): string {
+  return `[${term}](#${id})`;
+}
+
+// ⓘ tooltip for the Description field in Quick Add + the entry
+// editor: documents the syntax for people who'd rather type it than
+// reach for the action panel, and teaches the mention flow, which has
+// no insert action of its own (see the header for why it's clipboard-
+// shaped). Function, not a constant, so the shortcut hint renders
+// per-OS (Cmd+Shift+M vs Ctrl+Shift+M).
+export function descriptionFieldInfo(): string {
+  return (
+    'Callouts: start a line with "> Example: ", "> Note: ", or ' +
+    '"> Reference: " (the action panel can insert these). ' +
+    "Mentions: paste an entry's mention token, like [GPS](#123); " +
+    `copy one from a Search Entries result with ${shortcutHint(["cmd", "shift"], "m")}.`
+  );
+}

--- a/extensions/list-by-fullforms/src/lib/listIconCatalog.ts
+++ b/extensions/list-by-fullforms/src/lib/listIconCatalog.ts
@@ -26,18 +26,43 @@ const LIST_COLOR_HEX: Record<string, string> = {
   slate: "#6b7280",
 };
 
-// Mirrors ICON_GLYPHS in app/utils/listIconCatalog.js, mapped to
-// the closest match in Raycast's Icon enum, in the same order as the
-// web file: the 20 picker glyphs first (list..chart), then the legacy
-// render-only glyphs the web retired from its picker (2026-07-16/07-17)
-// but still renders for lists that stored them (star..target).
-// Seven glyphs have no 1:1 in Raycast's set and use a closest-fit
-// substitute: briefcase→Building, food→MugSteam (no cutlery icon
-// exists), school→Pencil (no graduation cap), paw→Footprints (no paw),
-// palette→Brush, bank→BankNote (no columned-building icon), and the
-// legacy sparkle→Stars. The other 23 map directly or near-exactly.
-// Unknown / null glyphs fall back to Icon.List, same fallback the web
-// app's resolveListIcon uses when no glyph is set.
+// Mirrors ICON_GLYPHS in app/utils/listIconCatalog.js, mapped to the closest
+// match in Raycast's Icon enum, in the same order as the web file: the original
+// 20 picker glyphs (list..chart), the 10 the web briefly retired and then
+// reinstated (star..target), then the 62 extended Lucide keys.
+//
+// MUST cover every key the web can store. The web picker offers all 92 and its
+// keyword rules auto-assign 55 of them, so a missing key here renders as a
+// plain Icon.List — the exact cross-platform gap this mirror exists to close.
+// Synced 2026-07-27 against the web's 92-glyph table.
+//
+// Raycast's set is smaller than Lucide's, so these are closest-fit substitutes
+// rather than the same artwork: briefcase→Building, food→MugSteam (no cutlery),
+// school→Pencil (no graduation cap), paw→Footprints, palette→Brush,
+// sparkle→Stars, bank→Building (no columned landmark; shares with briefcase),
+// laptop→Desktop, database→HardDrive, server→Network, share-2→Link,
+// flame→Torch, award→Rosette, truck→Lorry (British name for the same thing),
+// gem→Crypto (the crypto keyword rule is what assigns this key, so Raycast's
+// literal Crypto mark reads better than a gemstone), radio-tower→Waveform
+// (radio waves), shirt→Swatch (a fabric swatch is the nearest apparel mark),
+// atom→Dna and flask-conical→EyeDropper (Raycast has no physics or lab glass
+// icon, so both borrow the nearest science mark), fish→Anchor (there is no fish
+// in the enum at all; an anchor is the wrong object but unambiguously marine,
+// the same kind of in-domain substitution as paw→Footprints), and four
+// deliberate duplicates where Raycast has one icon for two Lucide concepts:
+// book-open→Book, flower-2 and sprout→Leaf, handshake→TwoPeople.
+//
+// USE RAYCAST'S SET ONLY. Do not bundle our own (Lucide) artwork here, even for
+// a key with no good match. Tried and reverted 2026-07-27 for `fish`: Lucide is
+// drawn at 24px/2px-stroke and one such glyph among 91 native ones reads as a
+// mistake next to Raycast's own chrome, the map's type has to widen from
+// Record<string, Icon> to Image.ImageLike (so a typo'd asset name silently
+// renders nothing instead of failing to compile), and the "only when the native
+// option is misleading" bar is a judgment call that ratchets into a hybrid
+// nobody designed. Fix a bad match with a better native match; if there is
+// genuinely none, leave the key out and let it fall back to Icon.List. Losing
+// one glyph's precision is cheaper than losing the set's coherence + type safety.
+// Unknown / null glyphs fall back to Icon.List, same as the web's resolver.
 const LIST_GLYPH_ICON: Record<string, Icon> = {
   list: Icon.List,
   clipboard: Icon.Clipboard,
@@ -57,10 +82,10 @@ const LIST_GLYPH_ICON: Record<string, Icon> = {
   ball: Icon.SoccerBall,
   palette: Icon.Brush,
   plane: Icon.Airplane,
-  bank: Icon.BankNote,
+  bank: Icon.Building,
   chart: Icon.LineChart,
-  // Legacy render-only glyphs (retired from the web picker but kept so
-  // lists that already stored them keep rendering the same in both).
+  // Retired from the web picker 2026-07-16/07-17, then reinstated when it
+  // gained categories; mapped throughout so stored lists never broke.
   star: Icon.Star,
   heart: Icon.Heart,
   bolt: Icon.Bolt,
@@ -71,60 +96,625 @@ const LIST_GLYPH_ICON: Record<string, Icon> = {
   sparkle: Icon.Stars,
   tag: Icon.Tag,
   target: Icon.BullsEye,
+  // The 62 extended keys the web added 2026-07-16 / 07-27.
+  "book-open": Icon.Book,
+  "file-text": Icon.TextDocument,
+  clock: Icon.Clock,
+  bookmark: Icon.Bookmark,
+  pin: Icon.Pin,
+  package: Icon.Box,
+  gift: Icon.Gift,
+  key: Icon.Key,
+  "building-2": Icon.House,
+  wallet: Icon.Wallet,
+  "credit-card": Icon.CreditCard,
+  banknote: Icon.BankNote,
+  "piggy-bank": Icon.Coins,
+  "shopping-cart": Icon.Cart,
+  "shopping-bag": Icon.Store,
+  shirt: Icon.Swatch,
+  calculator: Icon.Calculator,
+  receipt: Icon.Receipt,
+  truck: Icon.Lorry,
+  laptop: Icon.Desktop,
+  monitor: Icon.Monitor,
+  smartphone: Icon.Mobile,
+  database: Icon.HardDrive,
+  server: Icon.Network,
+  code: Icon.Code,
+  keyboard: Icon.Keyboard,
+  wifi: Icon.Wifi,
+  "radio-tower": Icon.Waveform,
+  battery: Icon.Battery,
+  printer: Icon.Print,
+  camera: Icon.Camera,
+  "gamepad-2": Icon.GameController,
+  atom: Icon.Dna,
+  "flask-conical": Icon.EyeDropper,
+  user: Icon.Person,
+  mail: Icon.Envelope,
+  "message-circle": Icon.SpeechBubble,
+  phone: Icon.Phone,
+  bell: Icon.Bell,
+  megaphone: Icon.Megaphone,
+  "share-2": Icon.Link,
+  smile: Icon.Emoji,
+  handshake: Icon.TwoPeople,
+  "tree-pine": Icon.Tree,
+  "flower-2": Icon.Leaf,
+  sprout: Icon.Leaf,
+  sun: Icon.Sun,
+  moon: Icon.Moon,
+  droplet: Icon.Droplets,
+  flame: Icon.Torch,
+  mountain: Icon.Mountain,
+  snowflake: Icon.Snowflake,
+  bug: Icon.Bug,
+  fish: Icon.Anchor,
+  car: Icon.Car,
+  "train-front": Icon.Train,
+  ship: Icon.Boat,
+  award: Icon.Rosette,
+  trophy: Icon.Trophy,
+  crown: Icon.Crown,
+  gem: Icon.Crypto,
+  shield: Icon.Shield,
 };
 
 // Keyword-based fallback when a list has no explicit icon/color set.
-// Mirrors KEYWORD_RULES in app/utils/listIconCatalog.js exactly
-// (order matters, first match wins) so a list like "Project
-// Management" or "Vocabulary" gets the same themed icon + color in
-// Raycast as on the web.
-const KEYWORD_RULES: { match: RegExp; icon: string; color: string }[] = [
+// Mirrors KEYWORD_RULES in app/utils/listIconCatalog.js term-for-term, so a
+// list like "Project Management" or "Fish" resolves to the same themed icon +
+// color in Raycast as on the web. `words` are stems matched at a word START
+// with any suffix (`\bstem\w*`), so `animal` catches "Animals" and `comput`
+// catches "Computing". `exact` are short words that must stand ALONE
+// (`\bword\b`), because as stems they fire inside unrelated words: `lab` in
+// "Labels", `cat` in "Catalog", `train` in "Training", `tax` in "Taxonomy".
+// Matching is specificity-scored, NOT first-match-wins — see matchKeywordRule.
+type KeywordRule = {
+  icon: string;
+  color: string;
+  words: string[];
+  exact?: string[];
+};
+
+const KEYWORD_RULES: KeywordRule[] = [
   {
-    match: /(project|task|plan|management|kanban|sprint)/i,
     icon: "clipboard",
     color: "blue",
+    words: [
+      "project",
+      "task",
+      "plan",
+      "management",
+      "kanban",
+      "sprint",
+      "roadmap",
+      "backlog",
+      "milestone",
+    ],
   },
   {
-    match: /(business|work|office|company|finance|sales|marketing|mckinsey)/i,
     icon: "briefcase",
     color: "green",
+    words: [
+      "business",
+      "work",
+      "office",
+      "company",
+      "corporate",
+      "sales",
+      "startup",
+      "entrepreneur",
+      "mckinsey",
+    ],
   },
   {
-    match: /(medical|health|doctor|hospital|clinic|blood|lab|test|fitness)/i,
     icon: "medical",
     color: "red",
+    words: [
+      "medical",
+      "health",
+      "doctor",
+      "hospital",
+      "clinic",
+      "blood",
+      "disease",
+      "surgery",
+      "dental",
+      "therap",
+      "pharma",
+      "anatomy",
+      "symptom",
+      "diagnos",
+      "fitness",
+      "laborator",
+      "radiolog",
+      "cardiolog",
+      "neurolog",
+      "oncolog",
+      "immunolog",
+      "epidemiolog",
+      "vaccin",
+    ],
+    exact: ["lab", "labs", "test", "tests"],
   },
   {
-    match: /(comput|tech|code|develop|software|engineer|programming|dev)/i,
     icon: "terminal",
     color: "purple",
+    words: [
+      "comput",
+      "tech",
+      "code",
+      "develop",
+      "software",
+      "engineer",
+      "programming",
+    ],
+    exact: ["dev", "devs"],
   },
   {
-    match: /(book|read|library|reference|literature|dictionary|word|vocab)/i,
     icon: "book",
     color: "amber",
+    words: [
+      "book",
+      "read",
+      "library",
+      "reference",
+      "literature",
+      "dictionary",
+      "word",
+      "vocab",
+    ],
   },
   {
-    match: /(food|recipe|cook|cuisine|kitchen|meal|drink)/i,
     icon: "food",
     color: "orange",
+    words: [
+      "food",
+      "seafood",
+      "recipe",
+      "cook",
+      "cuisine",
+      "kitchen",
+      "meal",
+      "drink",
+      "baking",
+      "beverage",
+      "nutrition",
+      "coffee",
+      "wine",
+      "brewing",
+      "cocktail",
+      "confectioner",
+    ],
+    exact: ["tea"],
   },
   {
-    match: /(fish|bird|animal|nature|plant|flower|pet|wildlife|garden)/i,
     icon: "leaf",
     color: "cyan",
+    words: [
+      "plant",
+      "flower",
+      "garden",
+      "botan",
+      "herb",
+      "agricultur",
+      "farming",
+      "nature",
+    ],
   },
   {
-    match: /(music|song|sound|audio|band|album)/i,
     icon: "music",
     color: "pink",
+    words: ["music", "song", "sound", "audio", "album"],
+    exact: ["band", "bands"],
   },
   {
-    match: /(travel|country|city|geography|map|trip)/i,
     icon: "globe",
     color: "sky",
+    words: ["travel", "country", "geography", "tourism", "international"],
+    exact: ["map", "maps", "trip", "trips", "city"],
+  },
+  { icon: "fish", color: "sky", words: ["fish", "aquatic", "marine"] },
+  {
+    icon: "paw",
+    color: "amber",
+    words: ["animal", "wildlife", "breed", "mammal", "veterinar", "zoolog"],
+    exact: ["pet", "pets", "dog", "dogs", "cat", "cats", "bird", "birds"],
+  },
+  { icon: "tree-pine", color: "cyan", words: ["tree", "forest", "woodland"] },
+  {
+    icon: "cloud",
+    color: "slate",
+    words: ["weather", "climate", "meteorolog", "rain"],
+  },
+  { icon: "moon", color: "purple", words: ["astronom", "cosmolog", "planet"] },
+  {
+    icon: "bank",
+    color: "slate",
+    words: [
+      "legal",
+      "lawyer",
+      "litigation",
+      "court",
+      "judicial",
+      "constitution",
+      "statute",
+      "compliance",
+      "regulat",
+      "governance",
+      "contract",
+    ],
+    exact: ["law", "laws"],
+  },
+  {
+    icon: "banknote",
+    color: "green",
+    words: [
+      "banking",
+      "financ",
+      "currenc",
+      "payment",
+      "payroll",
+      "mortgage",
+      "insurance",
+      "trading",
+      "investment",
+      "lending",
+    ],
+    exact: ["bank", "banks", "money", "tax", "taxes", "loan", "loans"],
+  },
+  {
+    icon: "calculator",
+    color: "green",
+    words: ["accounting", "bookkeeping", "audit", "ledger", "invoic"],
+  },
+  {
+    icon: "shopping-cart",
+    color: "orange",
+    words: ["ecommerce", "retail", "shopping", "merchandis"],
+  },
+  {
+    icon: "package",
+    color: "slate",
+    words: [
+      "logistics",
+      "shipping",
+      "inventory",
+      "warehous",
+      "procurement",
+      "packaging",
+    ],
+  },
+  {
+    icon: "megaphone",
+    color: "orange",
+    words: ["marketing", "advertis", "branding", "promotion", "campaign"],
+    exact: ["seo"],
+  },
+  {
+    icon: "chart",
+    color: "blue",
+    words: [
+      "metric",
+      "analytic",
+      "statistic",
+      "forecast",
+      "benchmark",
+      "reporting",
+    ],
+    exact: ["kpi", "kpis"],
+  },
+  {
+    icon: "building-2",
+    color: "slate",
+    words: ["architect", "construction", "urban", "propert", "realty"],
+  },
+  {
+    icon: "database",
+    color: "purple",
+    words: ["data", "database", "dataset", "schema"],
+    exact: ["sql", "etl"],
+  },
+  {
+    icon: "server",
+    color: "purple",
+    words: [
+      "server",
+      "hosting",
+      "devops",
+      "deployment",
+      "kubernetes",
+      "container",
+      "infrastructure",
+    ],
+    exact: ["aws"],
+  },
+  {
+    icon: "memory",
+    color: "purple",
+    words: [
+      "hardware",
+      "processor",
+      "semiconductor",
+      "robotic",
+      "neural",
+      "machine",
+      "electronic",
+    ],
+    exact: ["ai", "ml", "gpu", "cpu"],
+  },
+  {
+    icon: "wifi",
+    color: "sky",
+    words: [
+      "network",
+      "wireless",
+      "telecom",
+      "bandwidth",
+      "protocol",
+      "internet",
+    ],
+  },
+  {
+    icon: "shield",
+    color: "slate",
+    words: [
+      "security",
+      "privacy",
+      "encryption",
+      "firewall",
+      "vulnerabilit",
+      "cryptograph",
+    ],
+  },
+  {
+    icon: "gamepad-2",
+    color: "purple",
+    words: ["gaming", "esports"],
+    exact: ["game", "games"],
+  },
+  {
+    icon: "palette",
+    color: "pink",
+    words: ["design", "typography", "illustration", "painting", "drawing"],
+    exact: ["art", "arts", "ux", "ui"],
+  },
+  {
+    icon: "camera",
+    color: "pink",
+    words: ["photograph", "camera", "videograph", "lens"],
+  },
+  {
+    icon: "film",
+    color: "pink",
+    words: ["film", "cinema", "movie", "animation", "screenwriting"],
+  },
+  {
+    icon: "school",
+    color: "amber",
+    words: [
+      "school",
+      "education",
+      "academic",
+      "university",
+      "college",
+      "curriculum",
+      "teaching",
+      "student",
+    ],
+    exact: ["exam", "exams"],
+  },
+  {
+    icon: "groups",
+    color: "blue",
+    words: [
+      "team",
+      "organization",
+      "communit",
+      "membership",
+      "workforce",
+      "staff",
+    ],
+    exact: ["hr"],
+  },
+  {
+    icon: "mail",
+    color: "blue",
+    words: ["email", "correspondence", "newsletter"],
+    exact: ["mail", "inbox", "smtp"],
+  },
+  {
+    icon: "message-circle",
+    color: "blue",
+    words: ["chat", "messaging", "conversation", "forum"],
+  },
+  {
+    icon: "ball",
+    color: "orange",
+    words: [
+      "sport",
+      "football",
+      "cricket",
+      "basketball",
+      "tennis",
+      "athletic",
+      "soccer",
+      "olympic",
+    ],
+  },
+  {
+    icon: "trophy",
+    color: "orange",
+    words: ["championship", "tournament", "league"],
+  },
+  {
+    icon: "award",
+    color: "amber",
+    words: ["certification", "accreditation", "qualification", "diploma"],
+  },
+  {
+    icon: "car",
+    color: "slate",
+    words: ["automotive", "vehicle", "transport", "driving", "motoring"],
+    exact: ["car", "cars", "ev", "evs"],
+  },
+  {
+    icon: "train-front",
+    color: "slate",
+    words: ["railway", "railroad", "locomotive", "tramway"],
+    exact: ["rail", "train", "trains", "transit", "metro", "subway"],
+  },
+  {
+    icon: "truck",
+    color: "slate",
+    words: ["trucking", "freight", "haulage", "courier"],
+  },
+  {
+    icon: "ship",
+    color: "sky",
+    words: [
+      "maritime",
+      "nautical",
+      "shipbuilding",
+      "seafaring",
+      "harbour",
+      "harbor",
+    ],
+    exact: ["ship", "ships", "boat", "boats", "port", "ports"],
+  },
+  {
+    icon: "plane",
+    color: "sky",
+    words: ["aviation", "airline", "aircraft", "flight", "aerospace"],
+  },
+  {
+    icon: "atom",
+    color: "purple",
+    words: ["physics", "quantum", "nuclear", "particle", "relativity"],
+    exact: ["atom", "atoms"],
+  },
+  {
+    icon: "flask-conical",
+    color: "cyan",
+    words: ["chemi", "biochem", "reagent", "titration", "compound"],
+  },
+  {
+    icon: "bolt",
+    color: "amber",
+    words: ["electric", "energy", "renewable", "petroleum", "voltage", "power"],
+    exact: ["oil", "oils", "solar"],
+  },
+  {
+    icon: "droplet",
+    color: "sky",
+    words: ["water", "hydro", "plumbing", "irrigation", "sanitation"],
+  },
+  {
+    icon: "mountain",
+    color: "cyan",
+    words: [
+      "hiking",
+      "climbing",
+      "mountaineer",
+      "trekking",
+      "camping",
+      "geolog",
+    ],
+  },
+  {
+    icon: "snowflake",
+    color: "sky",
+    words: ["winter", "skiing", "snowboard", "arctic", "glacier"],
+  },
+  {
+    icon: "gem",
+    color: "purple",
+    words: [
+      "cryptocurrenc",
+      "blockchain",
+      "bitcoin",
+      "ethereum",
+      "stablecoin",
+      "tokenomics",
+    ],
+    exact: ["crypto", "nft", "nfts", "defi", "dao", "web3"],
+  },
+  {
+    icon: "radio-tower",
+    color: "sky",
+    words: ["broadcast", "antenna", "transmitter", "shortwave"],
+    exact: ["radio", "radios"],
+  },
+  {
+    icon: "shirt",
+    color: "pink",
+    words: [
+      "fashion",
+      "apparel",
+      "textile",
+      "garment",
+      "clothing",
+      "footwear",
+      "tailoring",
+      "knitting",
+    ],
+  },
+  {
+    icon: "key",
+    color: "slate",
+    words: ["authentication", "password", "credential"],
+    exact: ["auth", "oauth", "sso", "mfa", "otp", "jwt"],
+  },
+  {
+    icon: "smartphone",
+    color: "purple",
+    words: ["mobile", "android"],
+    exact: ["app", "apps", "ios"],
+  },
+  {
+    icon: "printer",
+    color: "slate",
+    words: ["printing", "publishing", "typesetting"],
   },
 ];
+
+type ScoredTerm = { length: number; icon: string; color: string; re: RegExp };
+
+// Compiled once at module load: one regex per term, tagged with the TERM's
+// length, which is what the scorer compares. The matched text can't
+// discriminate — `\bplan\w*` and `\bplant\w*` both match "Plant" in full.
+const SCORED_TERMS: ScoredTerm[] = KEYWORD_RULES.flatMap((rule) => [
+  ...rule.words.map((term) => ({
+    length: term.length,
+    icon: rule.icon,
+    color: rule.color,
+    re: new RegExp(`\\b${term}\\w*`, "i"),
+  })),
+  ...(rule.exact ?? []).map((term) => ({
+    length: term.length,
+    icon: rule.icon,
+    color: rule.color,
+    re: new RegExp(`\\b${term}\\b`, "i"),
+  })),
+]);
+
+// Best keyword match for `name`, or null when nothing hits. The longest matched
+// term wins (specificity), so `plant` beats `plan` on "Plant Taxonomy"; equal
+// lengths keep the earlier rule, since SCORED_TERMS is built in KEYWORD_RULES
+// order and the comparison below only accepts a strict improvement.
+function matchKeywordRule(
+  name: string,
+): { icon: string; color: string } | null {
+  let best: ScoredTerm | null = null;
+  for (const term of SCORED_TERMS) {
+    // Length check first: cheaper than the regex, and it skips every term that
+    // couldn't beat the incumbent even on a match.
+    if (best && term.length <= best.length) continue;
+    if (term.re.test(name)) best = term;
+  }
+  return best ? { icon: best.icon, color: best.color } : null;
+}
 
 // Mirrors FALLBACK_PALETTE_KEYS in the web catalog: the deterministic
 // id-based color for lists that match no keyword rule, so every list
@@ -159,7 +749,7 @@ export function iconForList({
   let resolvedIcon = icon;
   let resolvedColor = color;
   if (!(icon && LIST_GLYPH_ICON[icon] && color && LIST_COLOR_HEX[color])) {
-    const rule = KEYWORD_RULES.find((r) => r.match.test(name));
+    const rule = matchKeywordRule(name);
     if (rule) {
       resolvedIcon = icon ?? rule.icon;
       resolvedColor = color ?? rule.color;

--- a/extensions/list-by-fullforms/src/search.tsx
+++ b/extensions/list-by-fullforms/src/search.tsx
@@ -219,15 +219,29 @@ export default function SearchCommand() {
     ? `${apiBase()}/api/v1/recent?limit=10`
     : `${apiBase()}/api/v1/recent?limit=10&workspace_id=${workspaceId}`;
 
+  // NO keepPreviousData here, deliberately, unlike the search fetch
+  // above. That flag keeps the prior arguments' results on screen while
+  // a new request lands, which is right for search (the URL changes on
+  // every keystroke, so dropping data mid-type would flicker the whole
+  // list). This query's URL changes on exactly ONE event: a workspace
+  // switch. Keeping the previous data there would render the OLD
+  // workspace's entries under the NEW workspace selection, and since
+  // these rows carry live star / edit / note / report actions, the user
+  // could act on rows that aren't in the scope they're looking at.
+  // Without the flag, a switch to a workspace not yet loaded this
+  // session shows the loading state instead (isLoading covers it), and
+  // the two common paths stay flicker-free anyway because useFetch
+  // caches per arguments: clearing the search bar re-reads the same URL
+  // from cache, as does returning to a workspace viewed earlier.
   const recentQuery = useFetch<RecentEntriesResponse>(recentUrl, {
     headers: authHeaders(),
     execute: !trimmed,
-    keepPreviousData: true,
     onError: () => {},
   });
 
-  // Array.isArray guard per the house convention: keepPreviousData can
-  // briefly serve a cached pre-migration shape across a server deploy.
+  // Array.isArray guard per the house convention: useFetch's cache
+  // persists between command runs, so the first paint after a server
+  // redeploy can briefly serve a cached pre-migration shape.
   const recentEntries =
     !trimmed && Array.isArray(recentQuery.data?.entries)
       ? recentQuery.data.entries

--- a/extensions/list-by-fullforms/src/search.tsx
+++ b/extensions/list-by-fullforms/src/search.tsx
@@ -27,6 +27,14 @@
 //      to the entry detail modal; Enter on a list opens the list
 //      page.
 //
+// Empty-query state: a "Recently Added by You" section fills the view
+// with the caller's own newest entries via /api/v1/recent, workspace-
+// scoped by the same dropdown (rows are search-row-shaped since
+// list-repo migration 20261017000000, so EntrySearchRow renders them
+// unchanged, star toggle and all). When the caller has none (new
+// account, or nothing created since the web's created_by column
+// landed), the "Start typing to search" empty view shows as before.
+//
 // Detail-view toggle (Cmd+I, default ON): the panel opens with a
 // markdown preview of the selected entry on the right side — term +
 // type chip + short definition + long-form description, with the
@@ -58,6 +66,7 @@ import {
   showToast,
 } from "@raycast/api";
 import { useFetch } from "@raycast/utils";
+import type { MutatePromise } from "@raycast/utils";
 import { useEffect, useMemo, useState } from "react";
 import {
   apiBase,
@@ -71,6 +80,7 @@ import type {
   WorkspacesResponse,
   ListsResponse,
   ListRow,
+  RecentEntriesResponse,
   SearchEntryResult,
   Workspace,
 } from "./lib/api";
@@ -195,10 +205,40 @@ export default function SearchCommand() {
     },
   });
 
+  // Recently Added: the caller's own newest entries, filling the
+  // empty-query state instead of a bare "start typing" screen. Backed
+  // by /api/v1/recent (list-repo migration 20261017000000 widened its
+  // rows to the search-row shape precisely so EntrySearchRow renders
+  // them unchanged). The workspace dropdown scopes it exactly like
+  // search does. Only fetched while the query is empty; a non-empty
+  // query hands the view over to search. Errors degrade silently to
+  // the plain empty state: the workspaces fetch above already toasts
+  // the launch-time failure modes (bad token, server down), and a
+  // second toast for a decorative section would be noise.
+  const recentUrl = isAll
+    ? `${apiBase()}/api/v1/recent?limit=10`
+    : `${apiBase()}/api/v1/recent?limit=10&workspace_id=${workspaceId}`;
+
+  const recentQuery = useFetch<RecentEntriesResponse>(recentUrl, {
+    headers: authHeaders(),
+    execute: !trimmed,
+    keepPreviousData: true,
+    onError: () => {},
+  });
+
+  // Array.isArray guard per the house convention: keepPreviousData can
+  // briefly serve a cached pre-migration shape across a server deploy.
+  const recentEntries =
+    !trimmed && Array.isArray(recentQuery.data?.entries)
+      ? recentQuery.data.entries
+      : [];
+
   const entries = searchQuery.data?.entries ?? [];
   const lists = searchQuery.data?.lists ?? [];
   const isLoading =
-    workspacesQuery.isLoading || (!!trimmed && searchQuery.isLoading);
+    workspacesQuery.isLoading ||
+    (!!trimmed && searchQuery.isLoading) ||
+    (!trimmed && recentQuery.isLoading);
 
   // Group entries by listId so each parent list owns a Section. Map
   // preserves insertion order, so sections appear in the order entries
@@ -253,16 +293,25 @@ export default function SearchCommand() {
   // round-trip. The mutate's optimisticUpdate runs synchronously
   // before the network call lands; if the API errors, mutate rolls
   // the local state back automatically and we surface a toast.
-  const toggleEntryStar = async (entry: SearchEntryResult) => {
+  // Generic over the response shape because two fetches host
+  // starrable rows: the search results and the Recently Added
+  // section. Each call site passes its own query's mutate.
+  const toggleEntryStar = async <T extends { entries: SearchEntryResult[] }>(
+    entry: SearchEntryResult,
+    mutate: MutatePromise<T | undefined>,
+  ) => {
     const willBeStarred = !entry.isStarred;
     try {
-      await searchQuery.mutate(
+      await mutate(
         apiFetch(`/api/v1/entries/${entry.id}/star`, {
           method: willBeStarred ? "POST" : "DELETE",
         }),
         {
           optimisticUpdate(current) {
             if (!current) return current;
+            // Cast because TS can't prove a spread-with-override
+            // still satisfies an arbitrary T; only `entries` is
+            // swapped, so it does.
             return {
               ...current,
               entries: current.entries.map((row) =>
@@ -270,7 +319,7 @@ export default function SearchCommand() {
                   ? { ...row, isStarred: willBeStarred }
                   : row,
               ),
-            };
+            } as T;
           },
         },
       );
@@ -293,7 +342,10 @@ export default function SearchCommand() {
       searchText={query}
       onSearchTextChange={setQuery}
       throttle
-      isShowingDetail={showingDetail && entries.length + lists.length > 0}
+      isShowingDetail={
+        showingDetail &&
+        (trimmed ? entries.length + lists.length > 0 : recentEntries.length > 0)
+      }
       searchBarPlaceholder="Search entries and lists…"
       searchBarAccessory={
         workspaces.length > 1 ? (
@@ -321,30 +373,35 @@ export default function SearchCommand() {
         ) : undefined
       }
     >
-      {entriesByList.map((bucket) => (
+      {/* Empty-query state: the caller's own newest entries, flat and
+          newest-first rather than grouped by list, because recency IS
+          the ordering claim and grouping would scramble it. The header
+          says "by You" on purpose: the endpoint filters on
+          created_by = caller (there is no updated_by column to widen
+          it), so on a shared team glossary this is your additions,
+          not an activity feed. Gated on !trimmed so the two modes
+          never mix; the search sections below are gated the same way
+          in reverse, which also stops keepPreviousData's stale rows
+          from lingering after the query is cleared. */}
+      {!trimmed && recentEntries.length > 0 && (
         <List.Section
-          key={`list-section-${bucket.listId}`}
-          title={
-            showWorkspaceInHeader
-              ? `${bucket.listName} · ${bucket.workspaceName}`
-              : bucket.listName
-          }
-          subtitle={String(bucket.entries.length)}
+          title="Recently Added by You"
+          subtitle={String(recentEntries.length)}
         >
-          {bucket.entries.map((e) => {
-            // Gate "Edit Entry" on the caller's role for this entry's
-            // list (from the lists fetch). Absent while lists load, or
-            // for a public list the caller only favorited (viewer) →
-            // no Edit action.
+          {recentEntries.map((e) => {
+            // Same Edit gate as the search rows: writable role on the
+            // entry's list, from the lists fetch. Recent entries are
+            // the caller's own creations so this is nearly always
+            // true, but a demotion to viewer since creating one isn't.
             const editableList = listsById.get(e.listId);
             const canEdit =
               !!editableList && WRITABLE_ROLES.has(editableList.effective_role);
             return (
               <EntrySearchRow
-                key={`entry-${e.id}`}
+                key={`recent-${e.id}`}
                 entry={e}
-                listIcon={bucket.listIcon}
-                listColor={bucket.listColor}
+                listIcon={e.listIcon}
+                listColor={e.listColor}
                 workspaceAvatarUrl={
                   workspacesById.get(e.workspaceId)?.avatar_url ?? null
                 }
@@ -356,77 +413,121 @@ export default function SearchCommand() {
                     ? editableList.tags
                     : []
                 }
-                onToggleStar={() => toggleEntryStar(e)}
-                onMutated={() => searchQuery.revalidate()}
+                onToggleStar={() => toggleEntryStar(e, recentQuery.mutate)}
+                onMutated={() => recentQuery.revalidate()}
               />
             );
           })}
         </List.Section>
-      ))}
+      )}
 
-      <List.Section
-        title="Lists"
-        subtitle={trimmed ? String(lists.length) : undefined}
-      >
-        {lists.map((l) => {
-          const vis = listVisibility(l.isPublic, l.workspaceType);
-          return (
-            <List.Item
-              key={`list-${l.id}`}
-              icon={iconForList({
-                icon: l.icon,
-                color: l.color,
-                name: l.name,
-                id: l.id,
-              })}
-              title={l.name}
-              subtitle={showingDetail ? undefined : (l.description ?? "")}
-              accessories={
-                showWorkspaceInHeader && !showingDetail
-                  ? [{ text: l.workspaceName }]
-                  : undefined
-              }
-              detail={
-                <List.Item.Detail
-                  markdown={[
-                    `## ${l.name}`,
-                    "",
-                    l.description ? l.description : "_No description._",
-                  ].join("\n")}
-                  metadata={
-                    <List.Item.Detail.Metadata>
-                      <List.Item.Detail.Metadata.Link
-                        title="Open"
-                        text={apiHost()}
-                        target={`${apiBase()}/${l.id}`}
-                      />
-                      <List.Item.Detail.Metadata.Separator />
-                      <List.Item.Detail.Metadata.Label
-                        title="Visibility"
-                        text={vis.label}
-                        icon={vis.icon}
-                      />
-                      <List.Item.Detail.Metadata.Label
-                        title="Workspace"
-                        text={l.workspaceName}
-                      />
-                    </List.Item.Detail.Metadata>
+      {!!trimmed &&
+        entriesByList.map((bucket) => (
+          <List.Section
+            key={`list-section-${bucket.listId}`}
+            title={
+              showWorkspaceInHeader
+                ? `${bucket.listName} · ${bucket.workspaceName}`
+                : bucket.listName
+            }
+            subtitle={String(bucket.entries.length)}
+          >
+            {bucket.entries.map((e) => {
+              // Gate "Edit Entry" on the caller's role for this entry's
+              // list (from the lists fetch). Absent while lists load, or
+              // for a public list the caller only favorited (viewer) →
+              // no Edit action.
+              const editableList = listsById.get(e.listId);
+              const canEdit =
+                !!editableList &&
+                WRITABLE_ROLES.has(editableList.effective_role);
+              return (
+                <EntrySearchRow
+                  key={`entry-${e.id}`}
+                  entry={e}
+                  listIcon={bucket.listIcon}
+                  listColor={bucket.listColor}
+                  workspaceAvatarUrl={
+                    workspacesById.get(e.workspaceId)?.avatar_url ?? null
                   }
+                  showingDetail={showingDetail}
+                  detailToggleAction={toggleDetailAction}
+                  canEdit={canEdit}
+                  listTags={
+                    editableList && Array.isArray(editableList.tags)
+                      ? editableList.tags
+                      : []
+                  }
+                  onToggleStar={() => toggleEntryStar(e, searchQuery.mutate)}
+                  onMutated={() => searchQuery.revalidate()}
                 />
-              }
-              actions={
-                <ActionPanel>
-                  <Action.OpenInBrowser
-                    title="Open List"
-                    url={`${apiBase()}/${l.id}`}
+              );
+            })}
+          </List.Section>
+        ))}
+
+      {!!trimmed && (
+        <List.Section title="Lists" subtitle={String(lists.length)}>
+          {lists.map((l) => {
+            const vis = listVisibility(l.isPublic, l.workspaceType);
+            return (
+              <List.Item
+                key={`list-${l.id}`}
+                icon={iconForList({
+                  icon: l.icon,
+                  color: l.color,
+                  name: l.name,
+                  id: l.id,
+                })}
+                title={l.name}
+                subtitle={showingDetail ? undefined : (l.description ?? "")}
+                accessories={
+                  showWorkspaceInHeader && !showingDetail
+                    ? [{ text: l.workspaceName }]
+                    : undefined
+                }
+                detail={
+                  <List.Item.Detail
+                    markdown={[
+                      `## ${l.name}`,
+                      "",
+                      l.description ? l.description : "_No description._",
+                    ].join("\n")}
+                    metadata={
+                      <List.Item.Detail.Metadata>
+                        <List.Item.Detail.Metadata.Link
+                          title="Open"
+                          text={apiHost()}
+                          target={`${apiBase()}/${l.id}`}
+                        />
+                        <List.Item.Detail.Metadata.Separator />
+                        <List.Item.Detail.Metadata.Label
+                          title="Visibility"
+                          text={vis.label}
+                          icon={vis.icon}
+                        />
+                        <List.Item.Detail.Metadata.Label
+                          title="Workspace"
+                          text={l.workspaceName}
+                        />
+                      </List.Item.Detail.Metadata>
+                    }
                   />
-                  {toggleDetailAction}
-                </ActionPanel>
-              }
-            />
-          );
-        })}
-      </List.Section>
+                }
+                actions={
+                  <ActionPanel>
+                    <Action.OpenInBrowser
+                      title="Open List"
+                      url={`${apiBase()}/${l.id}`}
+                    />
+                    {toggleDetailAction}
+                  </ActionPanel>
+                }
+              />
+            );
+          })}
+        </List.Section>
+      )}
 
       <List.EmptyView
         icon={Icon.MagnifyingGlass}

--- a/extensions/list-by-fullforms/test/descriptionMarkup.test.ts
+++ b/extensions/list-by-fullforms/test/descriptionMarkup.test.ts
@@ -1,0 +1,93 @@
+// Tests for the description markup helpers (lib/descriptionMarkup.ts):
+// the callout catalog mirrored from the web's DescriptionEditor.vue
+// SLASH_ITEMS, the append-as-block insert logic behind the forms'
+// "Insert ... Callout" actions, and the mention token the Search rows'
+// "Copy as Mention" action emits. The catalog block is a parity check
+// against the web the same way listIconCatalog.test.ts pins its
+// keyword table: if the web renames a callout or changes a prefix,
+// this file is the tripwire to move the mirror in lockstep.
+
+import { describe, expect, it } from "vitest";
+import {
+  CALLOUTS,
+  appendCalloutPrefix,
+  descriptionFieldInfo,
+  mentionToken,
+} from "../src/lib/descriptionMarkup";
+import { shortcutHint } from "../src/lib/platform";
+
+describe("CALLOUTS catalog", () => {
+  it("mirrors the web's three callout slash items verbatim", () => {
+    expect(CALLOUTS.map((c) => [c.name, c.prefix])).toEqual([
+      ["Example", "> Example: "],
+      ["Note", "> Note: "],
+      ["Reference", "> Reference: "],
+    ]);
+  });
+
+  it("uses prefixes the web's CALLOUT_OPENER_RE recognizes", () => {
+    // Mirror of entryMentions.js CALLOUT_OPENER_RE: every prefix must
+    // parse as a callout opener once content follows it, or the web
+    // read view won't promote the inserted line to a chip.
+    const openerRe = /^> (Examples?|Notes?|References?|Image): ?(.*)$/i;
+    for (const c of CALLOUTS) {
+      expect(`${c.prefix}some content`).toMatch(openerRe);
+    }
+  });
+
+  it("assigns each callout a distinct insert-shortcut key", () => {
+    const keys = CALLOUTS.map((c) => c.shortcutKey);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});
+
+describe("appendCalloutPrefix", () => {
+  const prefix = "> Example: ";
+
+  it("returns the bare prefix on an empty description", () => {
+    expect(appendCalloutPrefix("", prefix)).toBe(prefix);
+  });
+
+  it("treats a whitespace-only description as empty", () => {
+    expect(appendCalloutPrefix("  \n\n ", prefix)).toBe(prefix);
+  });
+
+  it("appends as a blank-line-separated block", () => {
+    expect(appendCalloutPrefix("Some text.", prefix)).toBe(
+      `Some text.\n\n${prefix}`,
+    );
+  });
+
+  it("normalizes trailing newlines instead of piling them up", () => {
+    expect(appendCalloutPrefix("Some text.\n\n\n", prefix)).toBe(
+      `Some text.\n\n${prefix}`,
+    );
+  });
+
+  it("keeps consecutive callouts as separate blocks", () => {
+    // A single-newline separator would merge `> a` and `> b` into one
+    // markdown blockquote in the Search detail pane; the blank line is
+    // what keeps a second insert visually distinct.
+    const first = appendCalloutPrefix("", "> Example: ") + "GPS on a phone";
+    const second = appendCalloutPrefix(first, "> Note: ");
+    expect(second).toBe("> Example: GPS on a phone\n\n> Note: ");
+  });
+});
+
+describe("mentionToken", () => {
+  it("emits the web's plain-text mention shape", () => {
+    expect(mentionToken("Deep Learning", 42)).toBe("[Deep Learning](#42)");
+  });
+});
+
+describe("descriptionFieldInfo", () => {
+  it("documents every callout prefix and the copy-as-mention shortcut", () => {
+    const info = descriptionFieldInfo();
+    for (const c of CALLOUTS) {
+      expect(info).toContain(`"${c.prefix.trim()} "`);
+    }
+    // The hint must match the actual Copy as Mention binding
+    // (Cmd+Shift+M via crossShortcut), rendered for the current OS.
+    expect(info).toContain(shortcutHint(["cmd", "shift"], "m"));
+  });
+});

--- a/extensions/list-by-fullforms/test/listIconCatalog.test.ts
+++ b/extensions/list-by-fullforms/test/listIconCatalog.test.ts
@@ -22,9 +22,8 @@ describe("iconForList", () => {
     ).toEqual({ source: "Clipboard", tintColor: "#1d9bf0" });
   });
 
-  it("honors keyword-rule ordering (first match wins)", () => {
-    // "test" appears in the medical rule; a name matching an earlier rule
-    // should still take the earlier rule. "code" → terminal/purple.
+  it("resolves a keyword rule with its own color", () => {
+    // "code" → terminal/purple. Nothing longer competes in this name.
     expect(
       iconForList({ icon: null, color: null, name: "Code Notes", id: 1 }),
     ).toEqual({ source: "Terminal", tintColor: "#8b5cf6" });
@@ -66,6 +65,112 @@ describe("iconForList", () => {
     // Unknown explicit icon isn't a valid glyph, so tier 1 fails and it
     // resolves via the id fallback path, landing on the default list glyph.
     expect(result.source).toBe("List");
+  });
+});
+
+// Parity block mirroring the web's tests/listIconCatalog.test.js and the
+// mobile app's test/list_icon_catalog_test.dart. All three assert the same
+// cases on purpose: lists.icon / lists.color are shared keys, and a list
+// created before the web started persisting its resolved appearance stores
+// icon = null and is re-resolved independently on each client, so a divergence
+// here renders the same list differently per platform. Change one, change all.
+describe("keyword resolution parity with the web catalog", () => {
+  // No rule targets the `list` key, so a "List" source means "no keyword match"
+  // and the resolver fell through to the default glyph.
+  const srcFor = (name: string) =>
+    iconForList({ icon: null, color: null, name, id: 0 }).source;
+
+  it("does not match terms mid-word", () => {
+    expect(srcFor("Labels & Tags")).toBe("List"); // `lab`
+    expect(srcFor("Collaboration Glossary")).toBe("List"); // `lab`
+    expect(srcFor("Devotional Terms")).toBe("List"); // `dev`
+    expect(srcFor("Latest Releases")).toBe("List"); // `test`
+    expect(srcFor("Selfish Behaviour")).toBe("List"); // `fish`
+    expect(srcFor("Facebook Ads")).toBe("List"); // `book`
+    expect(srcFor("Catalog Numbers")).toBe("List"); // `cat`
+    expect(srcFor("Taxonomy Basics")).toBe("List"); // `tax`
+    expect(srcFor("Employee Training")).toBe("List"); // `train`
+    expect(srcFor("Carbon Credits")).toBe("List"); // `car`
+    expect(srcFor("Portfolio Theory")).toBe("List"); // `port`
+    expect(srcFor("Digital Transition")).toBe("List"); // `transit`
+  });
+
+  it("still matches the short terms standing alone", () => {
+    expect(srcFor("Lab Results")).toBe("MedicalSupport");
+    expect(srcFor("Dev Tools")).toBe("Terminal");
+    expect(srcFor("Pet Care")).toBe("Footprints");
+    expect(srcFor("Train")).toBe("Train");
+    expect(srcFor("Labor Law")).toBe("Building"); // `law` beats a stale `lab`
+  });
+
+  it("keeps stem inflections working", () => {
+    expect(srcFor("Q3 Planning")).toBe("Clipboard");
+    expect(srcFor("Computing Terms")).toBe("Terminal");
+    expect(srcFor("Flowering Plants")).toBe("Leaf");
+    expect(srcFor("Recipes")).toBe("MugSteam");
+  });
+
+  it("scores by specificity, not rule order", () => {
+    // `plant` (leaf, 5) beats `plan` (clipboard, 4) despite clipboard being
+    // the earlier rule — first-match-wins made this a clipboard.
+    expect(srcFor("Plant Taxonomy")).toBe("Leaf");
+    // Equal lengths still fall back to rule order: `plan` and `city` both 4.
+    expect(srcFor("City Planning")).toBe("Clipboard");
+  });
+
+  it("resolves the subject, not the product's own domain nouns", () => {
+    expect(srcFor("Fish Glossary")).toBe("Anchor");
+    expect(srcFor("Medical Glossary")).toBe("MedicalSupport");
+  });
+
+  it("covers the widened domains", () => {
+    expect(srcFor("Fish")).toBe("Anchor"); // no fish in the enum; marine stand-in
+    expect(srcFor("Dog Breeds")).toBe("Footprints");
+    expect(srcFor("Banking Terms")).toBe("BankNote");
+    expect(srcFor("Legal Terms")).toBe("Building");
+    expect(srcFor("Accounting Standards")).toBe("Calculator");
+    expect(srcFor("Machine Learning")).toBe("MemoryChip");
+    expect(srcFor("Kubernetes Terms")).toBe("Network");
+    expect(srcFor("Security Terms")).toBe("Shield");
+    expect(srcFor("Transport")).toBe("Car");
+    expect(srcFor("Railway Terms")).toBe("Train");
+    expect(srcFor("Freight Terms")).toBe("Lorry");
+    expect(srcFor("Maritime Vocabulary")).toBe("Boat");
+    expect(srcFor("Physics Terms")).toBe("Dna");
+    expect(srcFor("Chemistry")).toBe("EyeDropper");
+    expect(srcFor("Crypto Terms")).toBe("Crypto");
+    expect(srcFor("Ham Radio")).toBe("Waveform");
+    expect(srcFor("Fashion Terms")).toBe("Swatch");
+    expect(srcFor("OAuth Scopes")).toBe("Key");
+    expect(srcFor("Mobile Apps")).toBe("Mobile");
+    expect(srcFor("Football Terms")).toBe("SoccerBall");
+    expect(srcFor("School Subjects")).toBe("Pencil");
+  });
+
+  // Three near-collisions that resolve only because a longer, more specific
+  // term out-scores a shorter one in a DIFFERENT rule.
+  it("resolves the crypto / radio / atom near-collisions", () => {
+    expect(srcFor("Cryptography")).toBe("Shield"); // cryptograph > crypto
+    expect(srcFor("Radiology")).toBe("MedicalSupport"); // radiolog > radio
+    expect(srcFor("Atomic Design")).toBe("Brush"); // atom is exact
+  });
+
+  it("renders the extended glyph keys the web can store", () => {
+    // The gap this port closes: before it, any of these fell back to Icon.List.
+    for (const [key, source] of [
+      ["fish", "Anchor"],
+      ["train-front", "Train"],
+      ["banknote", "BankNote"],
+      ["gem", "Crypto"],
+      ["flask-conical", "EyeDropper"],
+      ["radio-tower", "Waveform"],
+      ["shirt", "Swatch"],
+      ["atom", "Dna"],
+    ] as const) {
+      expect(
+        iconForList({ icon: key, color: "blue", name: "x", id: 1 }).source,
+      ).toBe(source);
+    }
   });
 });
 


### PR DESCRIPTION
## Description

Feature update for List by FullForms (glossary lists at `list.fullforms.com`, talking to its `/api/v1/*` endpoints with a user-generated API token).

- **Recently Added section**: Search Entries now opens with a "Recently Added by You" section while the search bar is empty, showing the caller's own newest entries (via `GET /api/v1/recent`), scoped by the same workspace dropdown as search. Rows carry the full search-row surface: detail pane, star toggle, edit, private notes, report, copy, and macOS text-to-speech.
- **Description callouts**: the description field in Quick Add Entry and the entry edit form gains insert actions (Cmd+Shift+E / N / R, Ctrl on Windows) for the web editor's Example / Note / Reference callout syntax, plus an info tooltip documenting the syntax.
- **Copy as Mention** (Cmd+Shift+M) on search results copies the entry's mention token for pasting into descriptions; the web app renders it as a link to the entry.
- **Fix**: editing an entry no longer silently strips mention links from its description (the form now round-trips the raw description instead of the display copy).
- **Full list icon parity with the web**: the list icon glyph set grew from 30 to 92 keys and the name-keyword auto-assignment table from 9 to 55 rules, with word-start matching and specificity scoring fixing several confidently wrong matches.
- **Onboarding**: setup now links to the token page with `?token_client=raycast`, so minted tokens tag entries as added "via Raycast" in the web app's history panel.

## Screencast

![Search Entries](https://raw.githubusercontent.com/mrmithunmathew/raycast-extensions/ext/list-by-fullforms/extensions/list-by-fullforms/metadata/list-by-fullforms-1.png)

![Quick Add Entry](https://raw.githubusercontent.com/mrmithunmathew/raycast-extensions/ext/list-by-fullforms/extensions/list-by-fullforms/metadata/list-by-fullforms-2.png)

![Suggest Entry](https://raw.githubusercontent.com/mrmithunmathew/raycast-extensions/ext/list-by-fullforms/extensions/list-by-fullforms/metadata/list-by-fullforms-3.png)

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
