### PR TITLE
Update installed-extensions extension - Fix Raycast 2.0 stable on Windows

### DIFF
--- a/extensions/installed-extensions/CHANGELOG.md
+++ b/extensions/installed-extensions/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Installed Extensions Changelog
 
+## [Fix Windows Stable Support] - 2026-08-24
+
+- Add `com.raycast.windows` bundle ID mapping so Raycast 2.0 stable on Windows resolves `~/.config/raycast/extensions` instead of falling back to the beta `raycast-x` directory
+- Default to the stable `raycast` config directory on all platforms when the bundle ID cannot be determined
+
 ## [Add action] - 2026-07-09
 
 - Add `View Developer` action

--- a/extensions/installed-extensions/src/helpers/raycast-config.ts
+++ b/extensions/installed-extensions/src/helpers/raycast-config.ts
@@ -1,7 +1,6 @@
 import { showToast, Toast, environment } from "@raycast/api";
 import os from "os";
 import path from "path";
-import { isWindows } from "./utils";
 
 const BUNDLE_ID_TO_CONFIG_DIR: Record<string, string> = {
   "com.raycast-x.macos.internal": "raycast-x-internal",
@@ -13,6 +12,9 @@ const BUNDLE_ID_TO_CONFIG_DIR: Record<string, string> = {
   "com.raycast.macos": "raycast",
   "com.raycast-x.windows.internal": "raycast-x-internal",
   "com.raycast-x.windows": "raycast-x",
+  "com.raycast.windows.internal": "raycast-internal",
+  "com.raycast.windows.debug": "raycast-debug",
+  "com.raycast.windows": "raycast",
 };
 
 const BUNDLE_ID_MATCH_ORDER = Object.keys(BUNDLE_ID_TO_CONFIG_DIR).sort((a, b) => b.length - a.length);
@@ -50,7 +52,7 @@ export function getConfigDirNameFromBundleId(bundleId: string): string | undefin
 }
 
 function getDefaultConfigDirName(): string {
-  return isWindows ? "raycast-x" : "raycast";
+  return "raycast";
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes #30390 — the Installed Extensions extension shows nothing on Raycast 2.0 stable for Windows.

### Root cause

Raycast 2.0 stable on Windows uses the `com.raycast.windows` bundle ID (as opposed to the beta `com.raycast-x.windows`). The `BUNDLE_ID_TO_CONFIG_DIR` map in `raycast-config.ts` only had entries for the Windows beta (`com.raycast-x.windows*`), so the stable bundle ID was unrecognized. The extension fell back to the beta config directory (`~/.config/raycast-x/extensions`) and found no extensions, since Raycast 2.0 stable stores them in `~/.config/raycast/extensions`.

### Changes

- Add `com.raycast.windows`, `com.raycast.windows.internal`, and `com.raycast.windows.debug` bundle ID mappings to `BUNDLE_ID_TO_CONFIG_DIR`, matching the existing macOS stable pattern
- Default to the stable `raycast` config directory on all platforms when the bundle ID cannot be determined (the Windows beta default of `raycast-x` is no longer appropriate now that stable is the primary Windows release)
- Remove the now-unused `isWindows` import

## Screencast

N/A — bug fix, no new commands or UI.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration) — `ray` CLI not available in this environment; `npx tsc --noEmit` and `npx eslint` pass cleanly on the changed file
- [x] I checked that files in the `assets` folder are used by the extension itself — no assets changed
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it) — no README changes