### PR TITLE
feat(ci): validate complete metadata screenshot sets

### DIFF
--- a/.github/workflows/metadata_image_enforcer.yml
+++ b/.github/workflows/metadata_image_enforcer.yml
@@ -19,7 +19,8 @@ jobs:
           changed_files=$(gh api --paginate \
             "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files?per_page=100" \
             --jq '.[] | select(
-              .filename | test("^extensions/[^/]+/metadata/.+")
+              (.filename | test("^extensions/[^/]+/metadata/.+")) or
+              ((.previous_filename // "") | test("^extensions/[^/]+/metadata/.+"))
             ) | [.status, .filename, (.previous_filename // "")] | @tsv')
 
           if [[ -z "$changed_files" ]]; then

--- a/.github/workflows/metadata_image_enforcer.yml
+++ b/.github/workflows/metadata_image_enforcer.yml
@@ -16,30 +16,31 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          metadata_paths=$(gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json files | jq -r '
-            .files[]
-            | select(
-                (.path | test("^extensions/[^/]+/metadata/.+"))
-                and ((.path | endswith(".png")) or (.path | endswith(".jpg")) or (.path | endswith(".jpeg")) or (.path | endswith(".webp")) or (.path | endswith(".gif")) or (.path | endswith(".bmp")))
-              )
-            | .path
-          ' | sort)
+          changed_files=$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files?per_page=100" \
+            --jq '.[] | select(
+              .filename | test("^extensions/[^/]+/metadata/.+")
+            ) | [.status, .filename, (.previous_filename // "")] | @tsv')
 
-          if [[ -z "$metadata_paths" ]]; then
-            echo "No changed metadata images in this PR — skipping validation." >&2
+          if [[ -z "$changed_files" ]]; then
+            echo "No metadata changes in this PR — skipping validation." >&2
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
+          extension_paths=$(printf '%s\n' "$changed_files" \
+            | awk -F '\t' '{ print $2; if ($3 != "") print $3 }' \
+            | awk -F/ '{ print $1 "/" $2 }' \
+            | sort -u)
+
           {
             echo "skip=false"
-            echo "metadata_count=$(printf '%s\n' "$metadata_paths" | sed '/^$/d' | wc -l | tr -d ' ')"
-            echo "metadata_paths<<EOF"
-            printf '%s\n' "$metadata_paths"
+            echo "changed_files<<EOF"
+            printf '%s\n' "$changed_files" | sed $'s/\t$//'
             echo "EOF"
             echo "sparse_paths<<EOF"
             echo "scripts"
-            printf '%s\n' "$metadata_paths"
+            printf '%s\n' "$extension_paths"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
@@ -61,9 +62,13 @@ jobs:
         if: steps.sparse_paths.outputs.skip != 'true'
         run: python3 -m pip install --disable-pip-version-check numpy pillow
 
+      - name: Test metadata image checks
+        if: steps.sparse_paths.outputs.skip != 'true'
+        run: python3 -m unittest discover -s scripts/tests -v
+
       - name: Validate metadata images
         if: steps.sparse_paths.outputs.skip != 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          METADATA_IMAGE_PATHS: ${{ steps.sparse_paths.outputs.metadata_paths }}
+          METADATA_CHECK_CHANGED_FILES: ${{ steps.sparse_paths.outputs.changed_files }}
         run: python3 scripts/check_metadata_images.py

--- a/scripts/check_metadata_images.py
+++ b/scripts/check_metadata_images.py
@@ -344,12 +344,6 @@ def extension_platforms(extension_dir: Path) -> tuple[str, ...]:
     return tuple(platform for platform in platforms if isinstance(platform, str))
 
 
-def requires_macos_framing(extension_dir: Path) -> bool:
-    platforms = set(extension_platforms(extension_dir))
-    # Extensions created before the platforms field defaulted to macOS.
-    return not platforms or platforms == {"macOS"}
-
-
 def validate_image_dimensions(images: Sequence[Path]) -> list[str]:
     from PIL import Image
 
@@ -425,7 +419,6 @@ def run(repo_root: Path, extension_dirs: Sequence[Path]) -> int:
         return 0
 
     images: list[Path] = []
-    macos_framing_images: list[Path] = []
     issues: list[str] = []
     for extension_dir in extension_dirs:
         extension_images, structure_issues = validate_extension_structure(extension_dir)
@@ -433,8 +426,6 @@ def run(repo_root: Path, extension_dirs: Sequence[Path]) -> int:
         issues.extend(structure_issues)
         issues.extend(validate_image_dimensions(extension_images))
         issues.extend(validate_image_set(extension_dir, extension_images))
-        if requires_macos_framing(extension_dir):
-            macos_framing_images.extend(extension_images)
 
     print(
         f"Validating {len(images)} metadata image(s) across "
@@ -445,12 +436,12 @@ def run(repo_root: Path, extension_dirs: Sequence[Path]) -> int:
         print_issues(issues)
 
     validator_result = 0
-    if macos_framing_images:
+    if images:
         completed = subprocess.run(
             [
                 sys.executable,
                 str(validator),
-                *(str(image) for image in macos_framing_images),
+                *(str(image) for image in images),
             ],
             cwd=repo_root,
             check=False,

--- a/scripts/check_metadata_images.py
+++ b/scripts/check_metadata_images.py
@@ -1,56 +1,118 @@
 #!/usr/bin/env python3
-"""
-Validate metadata images with the Raycast image checker.
+"""Validate Raycast Store screenshots for one or more extensions.
 
-On GitHub pull requests, only changed metadata images are validated.
-If a PR does not touch any metadata images, the script exits successfully.
-Outside PR CI, it falls back to validating all metadata images in the repo.
+In pull-request CI, extensions with metadata changes are validated as a complete
+set. Screenshots are optional. Locally, pass an extension directory (or any
+path inside it) to validate the same scope without GitHub environment variables:
+
+    python3 scripts/check_metadata_images.py extensions/example
+
+With no arguments outside PR CI, every extension that has metadata is checked.
 """
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import subprocess
 import sys
 import urllib.error
 import urllib.request
-from pathlib import Path
+from collections import deque
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Sequence
 
 
 SUPPORTED_EXTS = {".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp"}
+STORE_EXT = ".png"
+MAX_SCREENSHOTS = 6
+BACKGROUND_RMS_LIMIT = 12.0
+EXPECTED_SIZE = (2000, 1250)
 
 
-def find_metadata_images(repo_root: Path) -> list[Path]:
+@dataclass(frozen=True)
+class ChangedFile:
+    filename: str
+    status: str
+    previous_filename: str | None = None
+
+
+@dataclass(frozen=True)
+class ImageProfile:
+    background: object
+    appearance: str
+    has_local_extension_icon: bool
+
+
+def extension_relative_path(path: str | Path) -> PurePosixPath | None:
+    parts = PurePosixPath(str(path).replace("\\", "/")).parts
+    try:
+        index = len(parts) - 1 - tuple(reversed(parts)).index("extensions")
+    except ValueError:
+        return None
+    if len(parts) <= index + 1:
+        return None
+    return PurePosixPath("extensions", parts[index + 1])
+
+
+def metadata_relative_path(path: str | Path) -> PurePosixPath | None:
+    extension = extension_relative_path(path)
+    if extension is None:
+        return None
+    parts = PurePosixPath(str(path).replace("\\", "/")).parts
+    index = len(parts) - 1 - tuple(reversed(parts)).index("extensions")
+    if len(parts) <= index + 3 or parts[index + 2] != "metadata":
+        return None
+    return PurePosixPath(*parts[index:])
+
+
+def is_metadata_image(path: str | Path) -> bool:
+    metadata_path = metadata_relative_path(path)
+    return metadata_path is not None and metadata_path.suffix.lower() in SUPPORTED_EXTS
+
+
+def find_metadata_images(extension_dir: Path) -> list[Path]:
+    metadata_dir = extension_dir / "metadata"
     return sorted(
         path
-        for path in repo_root.glob("extensions/**/metadata/**/*")
+        for path in metadata_dir.rglob("*")
         if path.is_file() and path.suffix.lower() in SUPPORTED_EXTS
     )
 
 
-def is_metadata_image(path: Path) -> bool:
-    return (
-        path.suffix.lower() in SUPPORTED_EXTS
-        and "extensions" in path.parts
-        and "metadata" in path.parts
+def find_extension_dirs(repo_root: Path) -> list[Path]:
+    return sorted(
+        package_json.parent
+        for package_json in (repo_root / "extensions").glob("*/package.json")
+        if (package_json.parent / "metadata").is_dir()
     )
 
 
-def get_metadata_images_from_env(repo_root: Path) -> list[Path] | None:
-    raw = os.environ.get("METADATA_IMAGE_PATHS", "").strip()
+def changed_files_from_env() -> list[ChangedFile] | None:
+    raw = os.environ.get("METADATA_CHECK_CHANGED_FILES", "").strip()
     if not raw:
-        return None
+        # Backward compatibility with the first version of the workflow.
+        image_paths = os.environ.get("METADATA_IMAGE_PATHS", "").strip()
+        if not image_paths:
+            return None
+        return [ChangedFile(path.strip(), "modified") for path in image_paths.splitlines()]
 
-    images: list[Path] = []
-    for rel_path in raw.splitlines():
-        path = repo_root / rel_path.strip()
-        if path.is_file() and is_metadata_image(path):
-            images.append(path)
-    return sorted(images)
+    changed_files: list[ChangedFile] = []
+    for line in raw.splitlines():
+        fields = line.split("\t")
+        if len(fields) not in {2, 3}:
+            raise ValueError(
+                "METADATA_CHECK_CHANGED_FILES entries must be "
+                "<status>\\t<filename>[\\t<previous_filename>]"
+            )
+        status, filename, *previous = fields
+        changed_files.append(ChangedFile(filename, status, previous[0] if previous else None))
+    return changed_files
 
 
-def get_pr_changed_metadata_images(repo_root: Path) -> list[Path] | None:
+def get_pr_changed_files() -> list[ChangedFile] | None:
     event_path = os.environ.get("GITHUB_EVENT_PATH")
     event_name = os.environ.get("GITHUB_EVENT_NAME")
     repository = os.environ.get("GITHUB_REPOSITORY")
@@ -63,14 +125,12 @@ def get_pr_changed_metadata_images(repo_root: Path) -> list[Path] | None:
         payload = json.loads(Path(event_path).read_text())
         pr_number = payload["pull_request"]["number"]
     except Exception as exc:
-        print(f"Could not read PR event payload: {exc}", file=sys.stderr)
-        raise SystemExit(1)
+        raise RuntimeError(f"Could not read PR event payload: {exc}") from exc
 
     if not repository or not token:
-        print("Missing GITHUB_REPOSITORY or GITHUB_TOKEN.", file=sys.stderr)
-        raise SystemExit(1)
+        raise RuntimeError("Missing GITHUB_REPOSITORY or GITHUB_TOKEN.")
 
-    changed_paths: list[str] = []
+    changed_files: list[ChangedFile] = []
     page = 1
     while True:
         url = (
@@ -89,55 +149,349 @@ def get_pr_changed_metadata_images(repo_root: Path) -> list[Path] | None:
             with urllib.request.urlopen(request) as response:
                 data = json.loads(response.read().decode("utf-8"))
         except urllib.error.URLError as exc:
-            print(f"Could not fetch PR files: {exc}", file=sys.stderr)
-            raise SystemExit(1)
+            raise RuntimeError(f"Could not fetch PR files: {exc}") from exc
 
         if not data:
             break
 
-        changed_paths.extend(
-            item["filename"]
+        changed_files.extend(
+            ChangedFile(
+                item["filename"],
+                item.get("status", "modified"),
+                item.get("previous_filename"),
+            )
             for item in data
-            if item.get("status") in {"added", "modified", "renamed"}
         )
         page += 1
 
-    changed_images: list[Path] = []
-    for rel_path in changed_paths:
-        path = repo_root / rel_path
-        if path.is_file() and is_metadata_image(path):
-            changed_images.append(path)
-
-    return sorted(changed_images)
+    return changed_files
 
 
-def main() -> int:
-    repo_root = Path(__file__).resolve().parent.parent
+def affected_extension_dirs(repo_root: Path, changed_files: Sequence[ChangedFile]) -> list[Path]:
+    relative_dirs: set[PurePosixPath] = set()
+
+    for changed_file in changed_files:
+        paths = [changed_file.filename]
+        if changed_file.previous_filename:
+            paths.append(changed_file.previous_filename)
+
+        for filename in paths:
+            extension = extension_relative_path(filename)
+            if extension is None:
+                continue
+            if metadata_relative_path(filename) is not None:
+                relative_dirs.add(extension)
+
+    return sorted(
+        path
+        for relative in relative_dirs
+        if (path := repo_root / relative).is_dir()
+    )
+
+
+def extension_dirs_from_args(repo_root: Path, paths: Sequence[str]) -> list[Path]:
+    extension_dirs: set[Path] = set()
+    for raw_path in paths:
+        path = Path(raw_path)
+        if not path.is_absolute():
+            path = repo_root / path
+        relative = extension_relative_path(path)
+        if relative is None:
+            raise ValueError(f"Path is not inside an extension: {raw_path}")
+        extension_dir = repo_root / relative
+        if not extension_dir.is_dir():
+            raise ValueError(f"Extension directory does not exist: {extension_dir}")
+        extension_dirs.add(extension_dir)
+    return sorted(extension_dirs)
+
+
+def validate_extension_structure(extension_dir: Path) -> tuple[list[Path], list[str]]:
+    metadata_dir = extension_dir / "metadata"
+    if not metadata_dir.is_dir():
+        return [], []
+
+    images = find_metadata_images(extension_dir)
+    issues: list[str] = []
+    if not images:
+        return images, issues
+
+    if len(images) > MAX_SCREENSHOTS:
+        issues.append(
+            f"{extension_dir.name}: metadata/ has {len(images)} screenshots "
+            f"(maximum {MAX_SCREENSHOTS})"
+        )
+
+    wrong_format = [image for image in images if image.suffix.lower() != STORE_EXT]
+    for image in wrong_format:
+        issues.append(f"{image}: Store screenshots must use PNG format")
+
+    return images, issues
+
+
+def _background_fingerprint(image: object) -> object:
+    import numpy as np
+    from PIL import Image
+
+    resampling = getattr(Image, "Resampling", Image).BILINEAR
+    resized = np.asarray(image.resize((100, 62), resampling), dtype=np.float32)
+    mask = np.ones((62, 100), dtype=bool)
+    mask[5:-5, 7:-7] = False
+    return resized[mask]
+
+
+def background_rms(first: object, second: object) -> float:
+    import numpy as np
+
+    return float(np.sqrt(np.mean((first - second) ** 2)))
+
+
+def _has_local_extension_icon(array: object, bbox: tuple[int, int, int, int]) -> bool:
+    import numpy as np
+
+    top, left, bottom, right = bbox
+    window_height = bottom - top
+    window_width = right - left
+    y0 = max(top, bottom - int(window_height * 0.12))
+    y1 = max(y0 + 1, bottom - int(window_height * 0.01))
+    x0 = left + int(window_width * 0.08)
+    x1 = left + int(window_width * 0.58)
+    footer = array[y0:y1, x0:x1].astype(np.int16)
+    if footer.size == 0:
+        return False
+
+    red, green, blue = footer[:, :, 0], footer[:, :, 1], footer[:, :, 2]
+    green_pixels = (green > 120) & (green > red + 35) & (green > blue + 15)
+    seen = np.zeros(green_pixels.shape, dtype=bool)
+    min_side = max(3, int(min(array.shape[:2]) * 0.012))
+    max_side = max(min_side, int(min(array.shape[:2]) * 0.04))
+
+    for start_y, start_x in zip(*np.where(green_pixels)):
+        if seen[start_y, start_x]:
+            continue
+        queue = deque([(int(start_y), int(start_x))])
+        seen[start_y, start_x] = True
+        count = 0
+        min_x = max_x = int(start_x)
+        min_y = max_y = int(start_y)
+
+        while queue:
+            y, x = queue.popleft()
+            count += 1
+            min_x, max_x = min(min_x, x), max(max_x, x)
+            min_y, max_y = min(min_y, y), max(max_y, y)
+            for dy in (-1, 0, 1):
+                for dx in (-1, 0, 1):
+                    next_y, next_x = y + dy, x + dx
+                    if (
+                        0 <= next_y < green_pixels.shape[0]
+                        and 0 <= next_x < green_pixels.shape[1]
+                        and green_pixels[next_y, next_x]
+                        and not seen[next_y, next_x]
+                    ):
+                        seen[next_y, next_x] = True
+                        queue.append((next_y, next_x))
+
+        width = max_x - min_x + 1
+        height = max_y - min_y + 1
+        if (
+            count >= max(8, int(min_side * min_side * 0.25))
+            and min_side <= width <= max_side
+            and min_side <= height <= max_side
+            and 0.7 <= width / height <= 1.3
+        ):
+            return True
+
+    return False
+
+
+def profile_image(image_path: Path) -> ImageProfile:
+    import numpy as np
+    from PIL import Image
+
+    from check_raycast_images import find_window_bbox
+
+    with Image.open(image_path) as source:
+        image = source.convert("RGB")
+    array = np.asarray(image)
+    bbox = find_window_bbox(array)
+    if bbox is None:
+        raise ValueError("could not detect the Raycast window")
+
+    top, left, bottom, right = bbox
+    interior = array[top:bottom, left:right].astype(np.float32)
+    luminance = (
+        0.2126 * interior[:, :, 0]
+        + 0.7152 * interior[:, :, 1]
+        + 0.0722 * interior[:, :, 2]
+    )
+    appearance = "light" if float(np.median(luminance)) >= 130 else "dark"
+    return ImageProfile(
+        background=_background_fingerprint(image),
+        appearance=appearance,
+        has_local_extension_icon=_has_local_extension_icon(array, bbox),
+    )
+
+
+def extension_platforms(extension_dir: Path) -> tuple[str, ...]:
+    try:
+        manifest = json.loads((extension_dir / "package.json").read_text())
+    except (OSError, json.JSONDecodeError):
+        return ()
+
+    platforms = manifest.get("platforms")
+    if not isinstance(platforms, list):
+        return ()
+    return tuple(platform for platform in platforms if isinstance(platform, str))
+
+
+def requires_macos_framing(extension_dir: Path) -> bool:
+    platforms = set(extension_platforms(extension_dir))
+    # Extensions created before the platforms field defaulted to macOS.
+    return not platforms or platforms == {"macOS"}
+
+
+def validate_image_dimensions(images: Sequence[Path]) -> list[str]:
+    from PIL import Image
+
+    issues: list[str] = []
+    for image in images:
+        try:
+            with Image.open(image) as source:
+                size = source.size
+        except Exception as exc:
+            issues.append(f"{image}: could not read screenshot dimensions: {exc}")
+            continue
+        if size != EXPECTED_SIZE:
+            issues.append(
+                f"{image}: wrong size {size[0]}×{size[1]} "
+                f"(expected {EXPECTED_SIZE[0]}×{EXPECTED_SIZE[1]})"
+            )
+    return issues
+
+
+def validate_image_set(extension_dir: Path, images: Sequence[Path]) -> list[str]:
+    issues: list[str] = []
+    profiles: list[tuple[Path, ImageProfile]] = []
+    for image in images:
+        try:
+            profile = profile_image(image)
+        except Exception as exc:
+            issues.append(f"{image}: could not inspect screenshot style: {exc}")
+            continue
+        profiles.append((image, profile))
+        if profile.has_local_extension_icon:
+            issues.append(
+                f"{image}: local extension icon is visible in the bottom bar; "
+                "recapture it with Raycast Window Capture and Save to Metadata"
+            )
+
+    # macOS and Windows captures have different chrome and may intentionally use
+    # different backgrounds. Metadata does not identify an individual image's
+    # platform, so set-level visual comparisons are only safe for extensions
+    # that declare exactly one platform.
+    if len(profiles) < 2 or len(set(extension_platforms(extension_dir))) != 1:
+        return issues
+
+    reference_path, reference = profiles[0]
+    for image, profile in profiles[1:]:
+        distance = background_rms(reference.background, profile.background)
+        if distance > BACKGROUND_RMS_LIMIT:
+            issues.append(
+                f"{image}: background does not match {reference_path.name} "
+                f"(difference {distance:.1f}, maximum {BACKGROUND_RMS_LIMIT:.1f})"
+            )
+        if profile.appearance != reference.appearance:
+            issues.append(
+                f"{image}: {profile.appearance} appearance does not match "
+                f"{reference_path.name} ({reference.appearance})"
+            )
+
+    return issues
+
+
+def print_issues(issues: Sequence[str]) -> None:
+    for issue in issues:
+        print(f"  \033[31m✗\033[0m {issue}", file=sys.stderr)
+
+
+def run(repo_root: Path, extension_dirs: Sequence[Path]) -> int:
     validator = repo_root / "scripts" / "check_raycast_images.py"
-
     if not validator.exists():
         print(f"Missing validator script: {validator}", file=sys.stderr)
         return 1
 
-    images = get_metadata_images_from_env(repo_root)
-    if images is None:
-        images = get_pr_changed_metadata_images(repo_root)
-    if images is None:
-        images = find_metadata_images(repo_root)
-        scope_label = "repository"
-    else:
-        scope_label = "pull request"
-
-    if not images:
-        print(f"No metadata images found for this {scope_label}.")
+    if not extension_dirs:
+        print("No metadata changes found for this pull request.")
         return 0
 
-    print(f"Validating {len(images)} metadata image(s) from the {scope_label}.")
-    cmd = ["python3", str(validator), *(str(image) for image in images)]
-    completed = subprocess.run(cmd, cwd=repo_root)
-    return completed.returncode
+    images: list[Path] = []
+    macos_framing_images: list[Path] = []
+    issues: list[str] = []
+    for extension_dir in extension_dirs:
+        extension_images, structure_issues = validate_extension_structure(extension_dir)
+        images.extend(extension_images)
+        issues.extend(structure_issues)
+        issues.extend(validate_image_dimensions(extension_images))
+        issues.extend(validate_image_set(extension_dir, extension_images))
+        if requires_macos_framing(extension_dir):
+            macos_framing_images.extend(extension_images)
+
+    print(
+        f"Validating {len(images)} metadata image(s) across "
+        f"{len(extension_dirs)} extension(s).",
+        flush=True,
+    )
+    if issues:
+        print_issues(issues)
+
+    validator_result = 0
+    if macos_framing_images:
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(validator),
+                *(str(image) for image in macos_framing_images),
+            ],
+            cwd=repo_root,
+            check=False,
+        )
+        validator_result = completed.returncode
+
+    return 1 if issues or validator_result else 0
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Extension directories or paths inside extensions to validate",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo_root = Path(__file__).resolve().parent.parent
+
+    try:
+        if args.paths:
+            extension_dirs = extension_dirs_from_args(repo_root, args.paths)
+        else:
+            changed_files = changed_files_from_env()
+            if changed_files is None:
+                changed_files = get_pr_changed_files()
+            extension_dirs = (
+                affected_extension_dirs(repo_root, changed_files)
+                if changed_files is not None
+                else find_extension_dirs(repo_root)
+            )
+    except (RuntimeError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    return run(repo_root, extension_dirs)
 
 
 if __name__ == "__main__":
     raise SystemExit(main())
-  

--- a/scripts/check_raycast_images.py
+++ b/scripts/check_raycast_images.py
@@ -83,6 +83,97 @@ def _padding_is_expected(top: int, left: int, bottom: int, right: int, h: int, w
     )
 
 
+def _find_capture_frame_bbox(
+    arr: np.ndarray, verbose: bool = False
+) -> tuple[int, int, int, int] | None:
+    """Find the outer frame produced by Raycast Window Capture.
+
+    Windows has stronger inner edges than macOS (notably the search separator
+    and Actions panel), so a centre-out scan can mistake those for the window.
+    Window Capture places the outer frame near 12.5% on every side; aggregate
+    edge strength in that band lets us prefer the real frame without depending
+    on platform-specific window chrome.
+    """
+    h, w = arr.shape[:2]
+    source = arr.astype(np.int16)
+    grad_x = np.max(np.abs(np.diff(source, axis=1)), axis=2)
+    grad_y = np.max(np.abs(np.diff(source, axis=0)), axis=2)
+
+    middle_rows = slice(int(h * 0.20), int(h * 0.80))
+    middle_cols = slice(int(w * 0.20), int(w * 0.80))
+    x_strength = np.percentile(grad_x[middle_rows, :], 75, axis=0)
+    y_strength = np.percentile(grad_y[:, middle_cols], 75, axis=1)
+
+    lo = EXPECTED_PAD - PAD_TOLERANCE
+    hi = EXPECTED_PAD + PAD_TOLERANCE
+
+    def strongest(
+        values: np.ndarray, start: int, stop: int, offset: int
+    ) -> tuple[int, float, float]:
+        band = values[start:stop]
+        index = start + int(np.argmax(band))
+        return index + offset, float(values[index]), float(np.median(band))
+
+    def nearest_coherent(
+        values: np.ndarray,
+        start: int,
+        stop: int,
+        preferred: int,
+        floor: float,
+    ) -> tuple[int, float]:
+        candidates = np.where(values[start:stop] >= max(10, floor + 8))[0] + start
+        if candidates.size == 0:
+            index = start + int(np.argmax(values[start:stop]))
+        else:
+            index = int(candidates[np.argmin(np.abs(candidates - preferred))])
+        return index, float(values[index])
+
+    left, left_peak, left_floor = strongest(x_strength, int(w * lo), int(w * hi), 1)
+    _, _, right_floor = strongest(
+        x_strength, int(w * (1 - hi)), int(w * (1 - lo)), 0
+    )
+    top, top_peak, top_floor = strongest(y_strength, int(h * lo), int(h * hi), 1)
+    _, _, bottom_floor = strongest(
+        y_strength, int(h * (1 - hi)), int(h * (1 - lo)), 0
+    )
+    right, right_peak = nearest_coherent(
+        x_strength,
+        int(w * (1 - hi)),
+        int(w * (1 - lo)),
+        w - left - 1,
+        right_floor,
+    )
+    bottom, bottom_peak = nearest_coherent(
+        y_strength,
+        int(h * (1 - hi)),
+        int(h * (1 - lo)),
+        h - top - 1,
+        bottom_floor,
+    )
+
+    peaks = (top_peak, left_peak, bottom_peak, right_peak)
+    floors = (top_floor, left_floor, bottom_floor, right_floor)
+    coherent_edges = all(
+        peak >= 10 and peak >= floor + 8 for peak, floor in zip(peaks, floors)
+    )
+    result = (top, left, bottom, right)
+
+    if verbose:
+        print(
+            "       Capture-frame scan — "
+            f"bbox:{result} peaks:{[round(peak, 1) for peak in peaks]} "
+            f"floors:{[round(floor, 1) for floor in floors]}"
+        )
+
+    if (
+        coherent_edges
+        and _bbox_is_sane(*result, h, w)
+        and _padding_is_expected(*result, h, w)
+    ):
+        return result
+    return None
+
+
 def _find_wide_horizontal_bbox(
     arr: np.ndarray,
     top: int,
@@ -164,6 +255,13 @@ def find_window_bbox(
     arr: np.ndarray, tol: int = DEFAULT_TOLERANCE, verbose: bool = False
 ) -> tuple[int, int, int, int] | None:
     h, w = arr.shape[:2]
+
+    capture_frame = _find_capture_frame_bbox(arr, verbose=verbose)
+    if capture_frame is not None:
+        if verbose:
+            print("       Detection method: outer Window Capture frame")
+        return capture_frame
+
     n = 25
     grad_high = max(30, min(90, 105 - tol))
     grad_low = max(15, grad_high - 30)

--- a/scripts/tests/test_check_metadata_images.py
+++ b/scripts/tests/test_check_metadata_images.py
@@ -16,6 +16,7 @@ SCRIPTS_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 import check_metadata_images as checker  # noqa: E402
+import check_raycast_images as framing_checker  # noqa: E402
 
 
 class PathSelectionTests(unittest.TestCase):
@@ -173,18 +174,59 @@ class ImageStyleTests(unittest.TestCase):
 
         self.assertEqual(issues, [])
 
-    def test_macos_framing_is_not_applied_to_windows_or_cross_platform_images(self) -> None:
-        cases = [
-            (["macOS"], True),
-            (["Windows"], False),
-            (["macOS", "Windows"], False),
-            ([], True),
-        ]
-        for platforms, expected in cases:
-            with self.subTest(platforms=platforms), tempfile.TemporaryDirectory() as temp_dir:
-                extension_dir = Path(temp_dir) / "example"
-                self.write_manifest(extension_dir, platforms)
-                self.assertEqual(checker.requires_macos_framing(extension_dir), expected)
+    def test_windows_capture_detector_prefers_outer_window_over_inner_panel(self) -> None:
+        array = np.full((1250, 2000, 3), 8, dtype=np.uint8)
+        array[150:1100, 250:1750] = 30
+        array[440:1000, 1030:1735] = 75
+
+        self.assertEqual(
+            framing_checker.find_window_bbox(array),
+            (150, 250, 1099, 1749),
+        )
+
+    def test_off_center_windows_capture_is_not_accepted_as_store_framing(self) -> None:
+        array = np.full((1250, 2000, 3), 8, dtype=np.uint8)
+        array[150:1100, 100:1600] = 100
+
+        bbox = framing_checker.find_window_bbox(array)
+
+        self.assertIsNotNone(bbox)
+        self.assertFalse(framing_checker._padding_is_expected(*bbox, 1250, 2000))
+
+    def test_run_sends_windows_screenshots_to_framing_validator(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            validator = repo_root / "scripts" / "check_raycast_images.py"
+            validator.parent.mkdir()
+            validator.touch()
+
+            extension_dir = repo_root / "extensions" / "media-switcher"
+            self.write_manifest(extension_dir, ["Windows"])
+            screenshots = [extension_dir / "metadata" / f"{index}.png" for index in range(3)]
+
+            with (
+                mock.patch.object(
+                    checker,
+                    "validate_extension_structure",
+                    return_value=(screenshots, []),
+                ),
+                mock.patch.object(checker, "validate_image_dimensions", return_value=[]),
+                mock.patch.object(checker, "validate_image_set", return_value=[]),
+                mock.patch.object(checker.subprocess, "run") as run_validator,
+            ):
+                run_validator.return_value.returncode = 0
+                result = checker.run(repo_root, [extension_dir])
+
+            self.assertEqual(result, 0)
+            run_validator.assert_called_once_with(
+                [
+                    sys.executable,
+                    str(validator),
+                    *(str(screenshot) for screenshot in screenshots),
+                ],
+                cwd=repo_root,
+                check=False,
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_check_metadata_images.py
+++ b/scripts/tests/test_check_metadata_images.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+from PIL import Image
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import check_metadata_images as checker  # noqa: E402
+
+
+class PathSelectionTests(unittest.TestCase):
+    def test_metadata_image_requires_the_expected_directory_shape(self) -> None:
+        self.assertTrue(checker.is_metadata_image("extensions/example/metadata/one.PNG"))
+        self.assertFalse(checker.is_metadata_image("extensions/metadata/assets/one.png"))
+        self.assertFalse(checker.is_metadata_image("extensions/example/assets/metadata.png"))
+        self.assertFalse(checker.is_metadata_image("metadata/one.png"))
+
+    def test_absolute_path_uses_the_repository_extensions_directory(self) -> None:
+        path = "/tmp/work/extensions/extensions/example/metadata/one.png"
+        self.assertEqual(
+            checker.extension_relative_path(path),
+            Path("extensions/example"),
+        )
+
+    def test_affected_extensions_include_metadata_changes_only(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            for name in ("new-extension", "screenshots", "source-only", "renamed"):
+                (repo_root / "extensions" / name).mkdir(parents=True)
+
+            changed_files = [
+                checker.ChangedFile("extensions/new-extension/package.json", "added"),
+                checker.ChangedFile("extensions/screenshots/metadata/one.png", "modified"),
+                checker.ChangedFile("extensions/source-only/src/index.tsx", "modified"),
+                checker.ChangedFile(
+                    "extensions/renamed/metadata/new.png",
+                    "renamed",
+                    "extensions/screenshots/metadata/old.png",
+                ),
+                checker.ChangedFile("extensions/deleted/package.json", "removed"),
+            ]
+
+            actual = checker.affected_extension_dirs(repo_root, changed_files)
+
+            self.assertEqual(
+                [path.name for path in actual],
+                ["renamed", "screenshots"],
+            )
+
+    def test_changed_files_environment_supports_renames(self) -> None:
+        value = (
+            "added\textensions/new/package.json\n"
+            "renamed\textensions/new/metadata/new.png\t"
+            "extensions/old/metadata/old.png"
+        )
+        with mock.patch.dict(os.environ, {"METADATA_CHECK_CHANGED_FILES": value}, clear=True):
+            self.assertEqual(
+                checker.changed_files_from_env(),
+                [
+                    checker.ChangedFile("extensions/new/package.json", "added"),
+                    checker.ChangedFile(
+                        "extensions/new/metadata/new.png",
+                        "renamed",
+                        "extensions/old/metadata/old.png",
+                    ),
+                ],
+            )
+
+
+class StructureTests(unittest.TestCase):
+    def test_missing_metadata_directory_is_allowed(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            extension_dir = Path(temp_dir) / "example"
+            extension_dir.mkdir()
+
+            images, issues = checker.validate_extension_structure(extension_dir)
+
+            self.assertEqual(images, [])
+            self.assertEqual(issues, [])
+
+    def test_requires_png_and_no_more_than_six_screenshots(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            extension_dir = Path(temp_dir) / "example"
+            metadata_dir = extension_dir / "metadata"
+            metadata_dir.mkdir(parents=True)
+            for index in range(6):
+                (metadata_dir / f"{index}.png").write_bytes(b"fixture")
+            (metadata_dir / "extra.jpg").write_bytes(b"fixture")
+
+            images, issues = checker.validate_extension_structure(extension_dir)
+
+            self.assertEqual(len(images), 7)
+            self.assertTrue(any("maximum 6" in issue for issue in issues))
+            self.assertTrue(any("must use PNG format" in issue for issue in issues))
+
+    def test_screenshot_dimensions_are_platform_independent(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            valid = Path(temp_dir) / "valid.png"
+            invalid = Path(temp_dir) / "invalid.png"
+            Image.new("RGB", checker.EXPECTED_SIZE).save(valid)
+            Image.new("RGB", (1250, 2000)).save(invalid)
+
+            self.assertEqual(checker.validate_image_dimensions([valid]), [])
+            self.assertIn("wrong size 1250×2000", checker.validate_image_dimensions([invalid])[0])
+
+
+class ImageStyleTests(unittest.TestCase):
+    @staticmethod
+    def write_manifest(extension_dir: Path, platforms: list[str]) -> None:
+        extension_dir.mkdir(parents=True, exist_ok=True)
+        (extension_dir / "package.json").write_text(json.dumps({"platforms": platforms}))
+
+    def test_background_fingerprint_distinguishes_wallpapers(self) -> None:
+        first = checker._background_fingerprint(Image.new("RGB", (400, 250), "#202020"))
+        same = checker._background_fingerprint(Image.new("RGB", (400, 250), "#202020"))
+        different = checker._background_fingerprint(Image.new("RGB", (400, 250), "#d06080"))
+
+        self.assertEqual(checker.background_rms(first, same), 0)
+        self.assertGreater(checker.background_rms(first, different), checker.BACKGROUND_RMS_LIMIT)
+
+    def test_detects_green_local_extension_badge_in_bottom_bar(self) -> None:
+        array = np.full((250, 400, 3), 35, dtype=np.uint8)
+        bbox = (30, 50, 220, 350)
+        array[200:210, 130:140] = (0, 210, 120)
+
+        self.assertTrue(checker._has_local_extension_icon(array, bbox))
+
+        array[200:210, 130:140] = (140, 140, 140)
+        self.assertFalse(checker._has_local_extension_icon(array, bbox))
+
+    def test_single_platform_images_are_compared_on_macos_and_windows(self) -> None:
+        for platform in ("macOS", "Windows"):
+            with self.subTest(platform=platform), tempfile.TemporaryDirectory() as temp_dir:
+                extension_dir = Path(temp_dir) / "example"
+                self.write_manifest(extension_dir, [platform])
+                first = Path("metadata/one.png")
+                second = Path("metadata/two.png")
+                profiles = {
+                    first: checker.ImageProfile(np.zeros((2, 3)), "dark", False),
+                    second: checker.ImageProfile(np.full((2, 3), 100), "light", True),
+                }
+
+                with mock.patch.object(checker, "profile_image", side_effect=profiles.__getitem__):
+                    issues = checker.validate_image_set(extension_dir, [first, second])
+
+                self.assertTrue(any("local extension icon" in issue for issue in issues))
+                self.assertTrue(any("background does not match" in issue for issue in issues))
+                self.assertTrue(any("light appearance does not match" in issue for issue in issues))
+
+    def test_cross_platform_images_are_not_compared_with_each_other(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            extension_dir = Path(temp_dir) / "example"
+            self.write_manifest(extension_dir, ["macOS", "Windows"])
+            first = Path("metadata/mac.png")
+            second = Path("metadata/windows.png")
+            profiles = {
+                first: checker.ImageProfile(np.zeros((2, 3)), "dark", False),
+                second: checker.ImageProfile(np.full((2, 3), 100), "light", False),
+            }
+
+            with mock.patch.object(checker, "profile_image", side_effect=profiles.__getitem__):
+                issues = checker.validate_image_set(extension_dir, [first, second])
+
+        self.assertEqual(issues, [])
+
+    def test_macos_framing_is_not_applied_to_windows_or_cross_platform_images(self) -> None:
+        cases = [
+            (["macOS"], True),
+            (["Windows"], False),
+            (["macOS", "Windows"], False),
+            ([], True),
+        ]
+        for platforms, expected in cases:
+            with self.subTest(platforms=platforms), tempfile.TemporaryDirectory() as temp_dir:
+                extension_dir = Path(temp_dir) / "example"
+                self.write_manifest(extension_dir, platforms)
+                self.assertEqual(checker.requires_macos_framing(extension_dir), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_check_metadata_images.py
+++ b/scripts/tests/test_check_metadata_images.py
@@ -77,6 +77,25 @@ class PathSelectionTests(unittest.TestCase):
                 ],
             )
 
+    def test_rename_out_of_metadata_still_affects_original_extension(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            extension_dir = repo_root / "extensions" / "example"
+            extension_dir.mkdir(parents=True)
+
+            actual = checker.affected_extension_dirs(
+                repo_root,
+                [
+                    checker.ChangedFile(
+                        "extensions/example/assets/screenshot.png",
+                        "renamed",
+                        "extensions/example/metadata/screenshot.png",
+                    )
+                ],
+            )
+
+            self.assertEqual(actual, [extension_dir])
+
 
 class StructureTests(unittest.TestCase):
     def test_missing_metadata_directory_is_allowed(self) -> None:


### PR DESCRIPTION
## Description

- Detect affected extensions from all metadata file changes, including renames
- Validate screenshot count, PNG format, dimensions, framing, and visual consistency
- Support local extension-scoped validation through command-line arguments
- Add metadata image unit tests to the CI workflow