### PR TITLE
Update media-flow extension

### DIFF
--- a/extensions/media-flow/.releaserc.json
+++ b/extensions/media-flow/.releaserc.json
@@ -1,0 +1,13 @@
+{
+  "branches": ["main"],
+  "tagFormat": "v${version}",
+  "plugins": [
+    ["@semantic-release/commit-analyzer", {
+      "preset": "conventionalcommits"
+    }],
+    ["@semantic-release/release-notes-generator", {
+      "preset": "conventionalcommits"
+    }],
+    "@semantic-release/github"
+  ]
+}

--- a/extensions/media-flow/CHANGELOG.md
+++ b/extensions/media-flow/CHANGELOG.md
@@ -1,6 +1,6 @@
 # MediaFlow Changelog
 
-## [Fix Now Playing menu bar crash] - {PR_MERGE_DATE}
+## [Fix Now Playing menu bar crash] - 2026-08-24
 
 - Fix a `renderEmpty timed out after 5000ms` crash in the Now Playing menu-bar command when nothing was playing and "Show when stopped" was disabled. The live-refresh stream no longer keeps the command running on the empty state, so the menu-bar item updates reliably.
 

--- a/extensions/media-flow/CHANGELOG.md
+++ b/extensions/media-flow/CHANGELOG.md
@@ -1,5 +1,9 @@
 # MediaFlow Changelog
 
+## [Fix Now Playing menu bar crash] - {PR_MERGE_DATE}
+
+- Fix a `renderEmpty timed out after 5000ms` crash in the Now Playing menu-bar command when nothing was playing and "Show when stopped" was disabled. The live-refresh stream no longer keeps the command running on the empty state, so the menu-bar item updates reliably.
+
 ## [Initial Release] - 2026-08-03
 
 - Now Playing menu bar: artwork, title/artist, live position, play/pause/skip, and

--- a/extensions/media-flow/MEDIAFLOW_SPEC.md
+++ b/extensions/media-flow/MEDIAFLOW_SPEC.md
@@ -1,0 +1,222 @@
+# MediaFlow — Raycast Extension Spec (v2, reality-checked 2026-07-11)
+
+**Project Name:** MediaFlow
+**Description:** A universal, open-source now-playing monitor and audio device switcher for macOS, living in the Raycast menu bar.
+**Repo:** https://github.com/egor-xyz/raycast-media-flow
+**Package manager:** npm
+
+> v1 of this spec targeted a fictional "Raycast v2 API" and several macOS APIs that no longer
+> work (MediaRemote direct linking, MPMediaQuery) or never existed (Slider, Form-Drafts-as-
+> preferences, MenuBarExtra popovers with custom layout). This v2 was verified against
+> developers.raycast.com and current macOS (15.4+/26) behavior. Every capability below is
+> confirmed buildable.
+
+---
+
+## Verified platform constraints (do not re-litigate)
+
+* `@raycast/api` is **1.x** (target `^1.104.0`). "Raycast 2.0" is an app rewrite, not an API bump.
+* `menu-bar` commands: background refresh `interval` minimum is **10s** (docs elsewhere say 1m; `ray build` accepts `"10s"`, and `nowPlaying` ships with it to cut background staleness). 1–2s background refresh is impossible.
+* While the menu is **open**, the command process stays alive — a `setInterval` + `setState` loop can live-update items (progress, position). It stops when the menu closes.
+* `MenuBarExtra` renders a **native NSMenu**. Only `MenuBarExtra.Item` (title, subtitle, icon, tooltip, onAction, shortcut, alternate), `.Submenu`, `.Section`, and `Separator` exist. No custom row layout, no progress bars, no inline buttons, no arbitrary artwork sizes, no multi-line rows.
+* **No Slider component** exists. Progress/volume shown via `getProgressIcon(progress)` (`@raycast/utils`) — a static circular pie icon — and discrete menu items.
+* Extension **preferences are read-only** at runtime (`getPreferenceValues()`); declared in `package.json`. Form Drafts only preserve unsubmitted form input. Runtime-mutable state (pinned source, chosen fallback artwork) lives in `LocalStorage`.
+* AI tools: `tools` array in `package.json`, one file per tool at `src/tools/<name>.ts`, optional `confirmation` export.
+* No Touch Bar, VoiceOver-label, or high-contrast APIs are exposed to extension authors. Dropped.
+* **Per-app muting is impossible** without a virtual audio driver. Dropped.
+* `MPMediaQuery` is iOS-only. Dropped.
+* Direct MediaRemote linking (`MRMediaRemoteGetNowPlayingInfo`) is entitlement-gated since macOS 15.4. The working path is the **`media-control` CLI** (ungive/mediaremote-adapter, Perl `com.apple.perl5` trust-model bypass) — maintained through macOS 26, no SIP disable. It can be closed by Apple in any point release, so the architecture must degrade gracefully to AppleScript-only mode.
+
+---
+
+## Detection engine (decided)
+
+**Primary:** `media-control get` (JSON: title, artist, album, duration, elapsed, playing, bundle id, base64 `artworkData`) spawned via `execFile`. Covers *any* app registered with the system Now Playing service: Music, Spotify, TIDAL, Deezer, Amazon Music, browsers, VLC, podcast apps.
+
+**Enrichment + fallback (AppleScript):**
+* **Music.app** — full dictionary: `player state`, `current track` (name/artist/album/duration/position), `artwork 1` raw bytes. Also play/pause/next/prev control.
+* **Spotify** — `player state`, `current track` (incl. `artwork url`, `spotify url`), play/pause/next/prev. Historically flaky; never sole source.
+* **Safari / Chrome** — active tab title + URL only (YouTube heuristic: strip `" - YouTube"`). No position/artwork.
+* **VLC** — transport control only (no reliable metadata via AppleScript).
+* **Firefox, TIDAL, Deezer, Amazon Music** — no AppleScript dictionary. Covered by media-control only.
+
+**Degraded mode:** if `media-control` is missing or errors, sources drop to AppleScript-covered apps and the menu shows an install hint (`brew install media-control`).
+
+---
+
+## Audio devices (all confirmed working)
+
+* List/switch output & input: `macos-audio-devices` npm binding (or `SwitchAudioSource` CLI fallback). `transportType` distinguishes Bluetooth vs USB/built-in → wireless badge.
+* System volume: `osascript -e "output volume of (get volume settings)"` / `set volume output volume N`.
+* Per-device volume where the device supports it.
+* ~~Per-app mute~~ — impossible, dropped.
+
+---
+
+## Commands
+
+### 1. `menu-bar` command — `nowPlaying` (mode: menu-bar, interval: 10s)
+
+Menu bar icon + title:
+* Icon: artwork thumbnail when playing (Image.ImageLike from cached artwork file), else waveform icon.
+* Title (optional, preference): `Title – Artist`, truncated ~30 chars.
+* Tooltip: `Title — Artist — App`.
+* Visibility preference: Always / Only when playing / Icon only.
+
+Menu structure (native NSMenu):
+```
+[Section: Now Playing]                      ← one per active source, playing first, pinned first
+  ♫ Title — Artist            (icon: artwork; subtitle: App • 1:23/3:45 ◔)  → onAction: open app
+  ▶/⏸ Play/Pause             (⌘P)
+  ⏭ Next  /  ⏮ Previous      (alternate item)
+  Overflow ▸ (Submenu): Open in App, Copy "Title — Artist", Copy URL, Pin/Unpin
+[Section: Audio]
+  Output ▸ (Submenu): ✓ AirPods Pro ⌁ · MacBook Speakers · … (onAction: switch)
+  Volume ▸ (Submenu): ◔ 75% · Mute · 25% · 50% · 75% · 100% · Louder ⌘↑ · Quieter ⌘↓
+[Section]
+  Details… (opens view command) · Hide/Show Title in Menu Bar · Open Extension Preferences · Refresh · Last update 12:03:44
+```
+* Progress rendered as `getProgressIcon(position/duration)` in the source item's icon slot or a dedicated item; text `1:23 / 3:45` in subtitle.
+* While menu open: 10s `setInterval` re-poll updates position/state live (kept long enough to
+  shrink the native-menu-rebuild window that could otherwise land a click on a shifted row).
+  The interval is skipped entirely for background-refresh launches (`LaunchType.Background`) so
+  it can't keep the process alive across the 10s command `interval`. Row order across re-polls
+  is stabilized via `stabilizeOrder()` (`src/core/mediaService.ts`), which preserves the
+  previous poll's relative ordering for known source ids and appends new ones — so a
+  `isPlaying` flip can't reshuffle Play/Pause vs. Next/Previous mid-open.
+* If nothing playing: placeholder item + quick-launch items for Music/Spotify.
+
+### 2. `view` command — `mediaDetails` (mode: view)
+
+The rich UI lives here (this replaces v1's impossible custom popover):
+* `List` of sources (left) with `List.Item.Detail`: large artwork (markdown image), metadata panel (title, artist, album, app, duration, position, device), progress text.
+* Actions: play/pause, next/prev, open in app, copy, pin, switch audio device (submenu action).
+* Auto-refresh every 2s via `usePromise` + interval revalidation.
+
+### 3. `view` command — `searchDevices` (mode: view)
+
+* List input+output devices, active check-mark, wireless badge, transport type tag, per-device volume where supported, switch on enter.
+
+### 4. `no-view` commands — dedicated playback shortcuts
+
+* `nextTrack` — "Next Track": skip the top (playing-first) media source.
+* `previousTrack` — "Previous Track": go back on the top media source.
+* `togglePlayPause` — "Play/Pause": toggle play/pause on the top media source.
+
+Each targets `getMediaSources().sources[0]`, shows a HUD confirming the action (or "No active
+media source" when nothing is playing), and is meant to be bound to a global hotkey — no menu
+navigation required.
+
+### 5. AI tools (`tools` in package.json)
+
+* `get-now-playing` — returns current track(s) JSON for Quick AI / AI chat.
+* `control-playback` — play/pause/next/prev with `confirmation` export.
+
+---
+
+## Preferences (package.json, read-only at runtime)
+
+* `menuBarStyle`: dropdown — `iconAndTitle` / `iconOnly` (default `iconAndTitle`)
+* `showWhenStopped`: checkbox — keep icon when nothing plays (default true)
+* `maxTitleLength`: textfield number (default 30)
+* `refreshInterval`: command-level `interval` (default `1m`)
+
+(No `primarySource` preference: source priority is covered by pinning + the
+playing-first sort in `getMediaSources()`, so a manual "preferred engine" toggle was
+intentionally dropped.)
+
+Runtime-mutable state in `LocalStorage`: pinned source id, last known artwork cache index,
+menu bar title hidden override (session-level toggle layered on top of the read-only
+`menuBarStyle` preference; clearing it falls back to the preference).
+
+---
+
+## Architecture
+
+```
+src/
+  nowPlaying.tsx            # menu-bar command
+  mediaDetails.tsx          # view command (rich UI)
+  searchDevices.tsx         # view command (audio devices)
+  nextTrack.tsx             # no-view command (skip forward on top source)
+  previousTrack.tsx         # no-view command (skip back on top source)
+  togglePlayPause.tsx       # no-view command (toggle play/pause on top source)
+  tools/
+    get-now-playing.ts
+    control-playback.ts
+  core/
+    types.ts                # MediaSource, AudioDevice, PlaybackCommand, SourceProvider
+    registry.ts             # provider registry (ordered, capability-aware)
+    mediaService.ts         # orchestrator: media-control + providers → MediaSource[]
+    artworkCache.ts         # base64 → ~/Library/Caches file, TTL 1h, LRU
+  providers/
+    mediaControl.ts         # media-control CLI adapter (primary)
+    music.ts                # Music.app AppleScript (enrich + control + raw artwork)
+    spotify.ts              # Spotify AppleScript (enrich + control + artwork url)
+    browser.ts              # Safari/Chrome tab-title heuristics
+  audio/
+    devices.ts              # macos-audio-devices wrapper + SwitchAudioSource fallback
+    volume.ts               # osascript volume get/set
+  lib/
+    applescript.ts          # runAppleScript helper w/ timeout + retry
+    exec.ts                 # execFile promisified w/ timeout
+    format.ts               # mm:ss, truncation
+tests/                      # vitest unit tests for core/, providers/ (mocked exec), lib/
+docs/                       # CONTRIBUTING, ADDING_NEW_SOURCE, ARCHITECTURE, AI_TOOLS
+.github/workflows/          # test.yml, lint.yml (+ existing pr-title, bump-version)
+```
+
+**Provider contract** (plugin architecture, unchanged in spirit from v1):
+
+```typescript
+interface SourceProvider {
+  id: string;                    // "music", "spotify", "browser-chrome"
+  displayName: string;
+  /** Bundle ids this provider can enrich/control (matched against media-control output) */
+  bundleIds: string[];
+  isAvailable(): Promise<boolean>;
+  getSource(): Promise<MediaSource | null>;
+  capabilities: { control: boolean; artwork: boolean; seek: boolean };
+  control?(cmd: PlaybackCommand): Promise<void>;
+}
+```
+
+New sources = new file in `providers/` + one `registry.register()` line.
+
+## Data model
+
+```typescript
+type PlaybackCommand = "play" | "pause" | "playpause" | "next" | "previous";
+
+interface MediaSource {
+  id: string;                  // bundle id or provider id
+  appName: string;
+  bundleId?: string;
+  title: string;
+  artist?: string;
+  album?: string;
+  artworkPath?: string;        // local cached file path (never remote at render time)
+  duration?: number;           // seconds
+  position?: number;           // seconds
+  isPlaying: boolean;
+  origin: "media-remote" | "applescript" | "browser";
+  url?: string;                // web/track url when known
+}
+
+interface AudioDevice {
+  id: string;
+  name: string;
+  kind: "input" | "output";
+  transportType: string;       // "bluetooth", "usb", "builtin", …
+  isWireless: boolean;
+  isDefault: boolean;
+  volume?: number;             // 0–1 when supported
+}
+```
+
+## Quality bar
+
+* TypeScript strict; ESLint via `@raycast/eslint-config`; vitest for unit tests (exec/osascript mocked).
+* All spawned CLIs wrapped with timeout (1.5s) + one retry; failures degrade the single source, never the whole menu.
+* Artwork cache: memory map + disk (`environment.supportPath`), TTL 1h.
+* MIT license. CI: lint + typecheck + test on PR; semantic-release on main (already configured).

--- a/extensions/media-flow/SECURITY.md
+++ b/extensions/media-flow/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+Reports of bugs and security issues are welcome through GitHub issues, which is the preferred way for most things.
+
+If you would prefer to disclose a sensitive vulnerability privately, you can use GitHub's private vulnerability reporting at https://github.com/egor-xyz/raycast-media-flow/security/advisories/new
+
+Thanks for helping keep this project safe.

--- a/extensions/media-flow/src/nowPlaying.tsx
+++ b/extensions/media-flow/src/nowPlaying.tsx
@@ -83,8 +83,18 @@ export default function Command() {
   // so next/previous land instantly instead of waiting out a poll. Without the engine there
   // is no event source (AppleScript-only providers), so fall back to periodic polling.
   const engineAvailable = data?.snapshot.engineAvailable ?? false;
+
+  const playing = data?.snapshot.sources.find((s) => s.isPlaying);
+  // Whether this render produces a menu-bar item at all. When it doesn't (nothing playing
+  // and the user hides the stopped state), Command() returns null below and Raycast has to
+  // "render empty" — and it waits for the command's runtime to go idle first. A live stream
+  // subprocess or poll timer would keep the runtime alive past Raycast's 5s budget and throw
+  // "renderEmpty timed out after 5000ms", so live updates must not run on the empty path.
+  const showMenu = isLoading || Boolean(playing) || prefs.showWhenStopped;
+
   useEffect(() => {
     if (environment.launchType === LaunchType.Background) return;
+    if (!showMenu) return;
     if (!engineAvailable) {
       const t = setInterval(() => revalidate(), OPEN_MENU_POLL_MS);
       return () => clearInterval(t);
@@ -101,15 +111,14 @@ export default function Command() {
       handle.stop();
       if (poll) clearInterval(poll);
     };
-  }, [revalidate, engineAvailable]);
+  }, [revalidate, engineAvailable, showMenu]);
 
-  const playing = data?.snapshot.sources.find((s) => s.isPlaying);
   const title =
     prefs.menuBarStyle === "iconAndTitle" && !data?.titleHidden && playing
       ? truncate(`${playing.title} – ${playing.artist ?? playing.appName}`, maxLen)
       : undefined;
 
-  if (!playing && !prefs.showWhenStopped && !isLoading) return null;
+  if (!showMenu) return null;
 
   return (
     <MenuBarExtra

--- a/extensions/media-flow/tests/core/mediaService.test.ts
+++ b/extensions/media-flow/tests/core/mediaService.test.ts
@@ -23,14 +23,7 @@ const mc = mediaControlProvider as unknown as {
 };
 
 function src(partial: Partial<MediaSource>): MediaSource {
-  return {
-    id: "x",
-    appName: "X",
-    title: "T",
-    isPlaying: false,
-    origin: "applescript",
-    ...partial,
-  };
+  return { id: "x", appName: "X", title: "T", isPlaying: false, origin: "applescript", ...partial };
 }
 
 function provider(
@@ -74,44 +67,25 @@ describe("getMediaSources", () => {
       provider(
         "spotify",
         ["com.spotify.client"],
-        src({
-          id: "com.spotify.client",
-          bundleId: "com.spotify.client",
-          title: "Fresh",
-          position: 10,
-        }),
+        src({ id: "com.spotify.client", bundleId: "com.spotify.client", title: "Fresh", position: 10 }),
       ),
     );
     const { sources, engineAvailable } = await getMediaSources();
     expect(engineAvailable).toBe(true);
     expect(sources).toHaveLength(1);
-    expect(sources[0]).toMatchObject({
-      title: "Fresh",
-      position: 10,
-      artworkPath: "/tmp/a.jpg",
-      isPlaying: true,
-    });
+    expect(sources[0]).toMatchObject({ title: "Fresh", position: 10, artworkPath: "/tmp/a.jpg", isPlaying: true });
   });
 
   it("keeps distinct sources separate, playing first", async () => {
     mc.isAvailable.mockResolvedValue(true);
     mc.getSource.mockResolvedValue(
-      src({
-        id: "com.apple.Music",
-        bundleId: "com.apple.Music",
-        isPlaying: false,
-        origin: "media-remote",
-      }),
+      src({ id: "com.apple.Music", bundleId: "com.apple.Music", isPlaying: false, origin: "media-remote" }),
     );
     registerProvider(
       provider(
         "spotify",
         ["com.spotify.client"],
-        src({
-          id: "com.spotify.client",
-          bundleId: "com.spotify.client",
-          isPlaying: true,
-        }),
+        src({ id: "com.spotify.client", bundleId: "com.spotify.client", isPlaying: true }),
       ),
     );
     const { sources } = await getMediaSources();
@@ -132,11 +106,7 @@ describe("getMediaSources", () => {
     const fb = provider(
       "browser-chrome",
       ["com.google.Chrome"],
-      src({
-        id: "browser-chrome",
-        bundleId: "com.google.Chrome",
-        title: "WrongTab",
-      }),
+      src({ id: "browser-chrome", bundleId: "com.google.Chrome", title: "WrongTab" }),
     );
     fb.fallbackOnly = true;
     registerProvider(fb);
@@ -150,11 +120,7 @@ describe("getMediaSources", () => {
     const fb = provider(
       "browser-chrome",
       ["com.google.Chrome"],
-      src({
-        id: "browser-chrome",
-        bundleId: "com.google.Chrome",
-        title: "TabTitle",
-      }),
+      src({ id: "browser-chrome", bundleId: "com.google.Chrome", title: "TabTitle" }),
     );
     fb.fallbackOnly = true;
     registerProvider(fb);
@@ -174,23 +140,13 @@ describe("getMediaSources", () => {
   it("keeps primary field when provider merges an explicitly undefined value", async () => {
     mc.isAvailable.mockResolvedValue(true);
     mc.getSource.mockResolvedValue(
-      src({
-        id: "com.spotify.client",
-        bundleId: "com.spotify.client",
-        artist: "Real Artist",
-        origin: "media-remote",
-      }),
+      src({ id: "com.spotify.client", bundleId: "com.spotify.client", artist: "Real Artist", origin: "media-remote" }),
     );
     registerProvider(
       provider(
         "spotify",
         ["com.spotify.client"],
-        src({
-          id: "com.spotify.client",
-          bundleId: "com.spotify.client",
-          title: "Fresh",
-          artist: undefined,
-        }),
+        src({ id: "com.spotify.client", bundleId: "com.spotify.client", title: "Fresh", artist: undefined }),
       ),
     );
     const { sources } = await getMediaSources();


### PR DESCRIPTION
## Description

Bugfix update for the **MediaFlow** extension.

Fixes a `Request frontend:main.extensionHost.renderEmpty timed out after 5000ms` crash in the **Now Playing** menu-bar command. When nothing was playing and the "Show when stopped" preference was disabled, the command returned `null` (empty render), but the live-refresh `media-control stream` subprocess (and its poll-timer fallback) kept the extension runtime alive past Raycast's 5s empty-render budget, throwing the timeout.

The live-update effect is now gated on whether a menu-bar item is actually rendered, so on the empty state the stream/timer tears down and the runtime goes idle.

Crash report: https://www.raycast.com/extension-issues/egorxyz/media-flow/7688456156

## Checklist

- [x] `npm run build` succeeds
- [x] `npm run lint` passes
- [x] Tests pass (`npm test`, 101 passing)
- [x] Updated `CHANGELOG.md`