### PR TITLE
[Skills] serialize CLI commands across processes

### DIFF
--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Skills Changelog
 
-## [Serialize Concurrent CLI Commands] - {PR_MERGE_DATE}
+## [Serialize Concurrent CLI Commands] - 2026-08-24
 
 - Prevent simultaneous Raycast commands from racing in the shared `npx` cache and intermittently failing with `ENOTEMPTY`
 - Read the installed-skill list and metadata from one locked snapshot so Manage Skills does not show mismatched data

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Skills Changelog
 
+## [Serialize Concurrent CLI Commands] - {PR_MERGE_DATE}
+
+- Prevent simultaneous Raycast commands from racing in the shared `npx` cache and intermittently failing with `ENOTEMPTY`
+- Read installed-skill metadata after pending updates finish so Manage Skills does not briefly show stale data
+
 ## [Updated contributor] - 2026-08-18
 
 ## [Fix Runtime Detection and Skill Lookup] - 2026-07-30

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Serialize Concurrent CLI Commands] - {PR_MERGE_DATE}
 
 - Prevent simultaneous Raycast commands from racing in the shared `npx` cache and intermittently failing with `ENOTEMPTY`
-- Read installed-skill metadata after pending updates finish so Manage Skills does not briefly show stale data
+- Read the installed-skill list and metadata from one locked snapshot so Manage Skills does not show mismatched data
 
 ## [Updated contributor] - 2026-08-18
 

--- a/extensions/skills/package-lock.json
+++ b/extensions/skills/package-lock.json
@@ -9,6 +9,7 @@
       "dependencies": {
         "@raycast/api": "^1.104.16",
         "@raycast/utils": "^2.2.4",
+        "proper-lockfile": "^4.1.2",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "semver": "^7.7.3"
@@ -16,6 +17,7 @@
       "devDependencies": {
         "@raycast/eslint-config": "^2.1.1",
         "@types/node": "^25.2.3",
+        "@types/proper-lockfile": "^4.1.4",
         "@types/react": "^19.2.13",
         "@types/semver": "^7.7.1",
         "eslint": "^10.0.0",
@@ -1279,6 +1281,16 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/proper-lockfile": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.4.tgz",
+      "integrity": "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "*"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.13",
       "dev": true,
@@ -1286,6 +1298,13 @@
       "dependencies": {
         "csstype": "^3.2.2"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
+      "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/semver": {
       "version": "7.7.1",
@@ -2085,7 +2104,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -2395,6 +2413,23 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "dev": true,
@@ -2432,6 +2467,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/safer-buffer": {

--- a/extensions/skills/package.json
+++ b/extensions/skills/package.json
@@ -109,6 +109,7 @@
   "dependencies": {
     "@raycast/api": "^1.104.16",
     "@raycast/utils": "^2.2.4",
+    "proper-lockfile": "^4.1.2",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "semver": "^7.7.3"
@@ -116,6 +117,7 @@
   "devDependencies": {
     "@raycast/eslint-config": "^2.1.1",
     "@types/node": "^25.2.3",
+    "@types/proper-lockfile": "^4.1.4",
     "@types/react": "^19.2.13",
     "@types/semver": "^7.7.1",
     "eslint": "^10.0.0",

--- a/extensions/skills/src/hooks/useInstalledSkills.ts
+++ b/extensions/skills/src/hooks/useInstalledSkills.ts
@@ -1,14 +1,11 @@
 import { useCachedPromise, type MutatePromise } from "@raycast/utils";
-import { checkForUpdates, getInstalledSkillsWithLock } from "../utils/installed-skills";
+import { getInstalledSkillsWithUpdateStatus } from "../utils/installed-skills";
 import { type InstalledSkill } from "../shared";
 
 export type MutateSkills = MutatePromise<InstalledSkill[] | undefined>;
 
 async function fetchSkillsWithUpdateStatus(): Promise<InstalledSkill[]> {
-  const skills = await getInstalledSkillsWithLock();
-  const updatable = await checkForUpdates().catch((): string[] => []);
-  const updatableSet = new Set(updatable);
-  return skills.map((skill) => ({ ...skill, hasUpdate: updatableSet.has(skill.name) }));
+  return getInstalledSkillsWithUpdateStatus();
 }
 
 export function useInstalledSkills() {

--- a/extensions/skills/src/hooks/useInstalledSkills.ts
+++ b/extensions/skills/src/hooks/useInstalledSkills.ts
@@ -5,10 +5,8 @@ import { type InstalledSkill } from "../shared";
 export type MutateSkills = MutatePromise<InstalledSkill[] | undefined>;
 
 async function fetchSkillsWithUpdateStatus(): Promise<InstalledSkill[]> {
-  const [skills, updatable] = await Promise.all([
-    getInstalledSkillsWithLock(),
-    checkForUpdates().catch((): string[] => []),
-  ]);
+  const skills = await getInstalledSkillsWithLock();
+  const updatable = await checkForUpdates().catch((): string[] => []);
   const updatableSet = new Set(updatable);
   return skills.map((skill) => ({ ...skill, hasUpdate: updatableSet.has(skill.name) }));
 }

--- a/extensions/skills/src/utils/installed-skills.ts
+++ b/extensions/skills/src/utils/installed-skills.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { getGithubToken } from "../preferences";
 import { stripGitSuffix, type InstalledSkill, type SkillLockEntry } from "../shared";
 import { listInstalledSkills } from "./skills-cli";
+import { withSkillsCliLock } from "./skills-cli-runner";
 
 const LOCK_FILE = ".skill-lock.json";
 const AGENTS_DIR = ".agents";
@@ -28,8 +29,21 @@ async function readSkillLock(): Promise<Record<string, SkillLockEntry>> {
 }
 
 export async function getInstalledSkillsWithLock(): Promise<InstalledSkill[]> {
-  const skills = await listInstalledSkills();
-  const lockEntries = await readSkillLock();
+  return (await getInstalledSkillsSnapshot()).skills;
+}
+
+async function getInstalledSkillsSnapshot(): Promise<{
+  skills: InstalledSkill[];
+  lockEntries: Record<string, SkillLockEntry>;
+}> {
+  return withSkillsCliLock(async (runLocked) => {
+    const skills = await listInstalledSkills(runLocked);
+    const lockEntries = await readSkillLock();
+    return { skills: mergeLockEntries(skills, lockEntries), lockEntries };
+  });
+}
+
+function mergeLockEntries(skills: InstalledSkill[], lockEntries: Record<string, SkillLockEntry>): InstalledSkill[] {
   return skills.map((skill) => {
     const lock = lockEntries[skill.name];
     if (!lock) return skill;
@@ -78,8 +92,7 @@ async function fetchRepoTree(source: string, token: string | undefined): Promise
  * Implemented against the GitHub Trees API rather than `npx skills check` because
  * the CLI's check command reinstalls outdated skills as a side effect since v1.5.0.
  */
-export async function checkForUpdates(): Promise<string[]> {
-  const lock = await readSkillLock();
+async function checkForUpdates(lock: Record<string, SkillLockEntry>): Promise<string[]> {
   const byRepo = new Map<string, Array<{ name: string; skillPath: string; expectedHash: string }>>();
 
   for (const [name, entry] of Object.entries(lock)) {
@@ -109,4 +122,11 @@ export async function checkForUpdates(): Promise<string[]> {
     }),
   );
   return results.flat();
+}
+
+export async function getInstalledSkillsWithUpdateStatus(): Promise<InstalledSkill[]> {
+  const { skills, lockEntries } = await getInstalledSkillsSnapshot();
+  const updatable = await checkForUpdates(lockEntries).catch((): string[] => []);
+  const updatableSet = new Set(updatable);
+  return skills.map((skill) => ({ ...skill, hasUpdate: updatableSet.has(skill.name) }));
 }

--- a/extensions/skills/src/utils/installed-skills.ts
+++ b/extensions/skills/src/utils/installed-skills.ts
@@ -28,7 +28,8 @@ async function readSkillLock(): Promise<Record<string, SkillLockEntry>> {
 }
 
 export async function getInstalledSkillsWithLock(): Promise<InstalledSkill[]> {
-  const [skills, lockEntries] = await Promise.all([listInstalledSkills(), readSkillLock()]);
+  const skills = await listInstalledSkills();
+  const lockEntries = await readSkillLock();
   return skills.map((skill) => {
     const lock = lockEntries[skill.name];
     if (!lock) return skill;

--- a/extensions/skills/src/utils/skills-cli-runner.ts
+++ b/extensions/skills/src/utils/skills-cli-runner.ts
@@ -64,8 +64,18 @@ export interface RunSkillsCliOptions {
   readOnly?: boolean;
 }
 
+export type SkillsCliRunner = (args: string[], options?: RunSkillsCliOptions) => Promise<string>;
+
 export async function runSkillsCli(args: string[], options: RunSkillsCliOptions = {}): Promise<string> {
-  return enqueueSkillsCliRun(() => withSkillsCliLock(() => runSkillsCliCommand(args, options.readOnly ?? false)));
+  return withSkillsCliLock((runLocked) => runLocked(args, options));
+}
+
+export async function withSkillsCliLock<T>(run: (runLocked: SkillsCliRunner) => Promise<T>): Promise<T> {
+  return enqueueSkillsCliRun(() =>
+    withCrossProcessSkillsCliLock(() =>
+      run((args, options = {}) => runSkillsCliCommand(args, options.readOnly ?? false)),
+    ),
+  );
 }
 
 async function enqueueSkillsCliRun<T>(run: () => Promise<T>): Promise<T> {
@@ -74,7 +84,7 @@ async function enqueueSkillsCliRun<T>(run: () => Promise<T>): Promise<T> {
   return runAfterPending;
 }
 
-async function withSkillsCliLock<T>(run: () => Promise<T>): Promise<T> {
+async function withCrossProcessSkillsCliLock<T>(run: () => Promise<T>): Promise<T> {
   await mkdir(environment.supportPath, { recursive: true });
   await writeFile(SKILLS_CLI_LOCK_TARGET, "", { flag: "a" });
   const release = await lockfile.lock(SKILLS_CLI_LOCK_TARGET, {

--- a/extensions/skills/src/utils/skills-cli-runner.ts
+++ b/extensions/skills/src/utils/skills-cli-runner.ts
@@ -1,6 +1,8 @@
-import { access, stat } from "node:fs/promises";
+import { access, mkdir, stat, writeFile } from "node:fs/promises";
 import { constants } from "node:fs";
-import { basename } from "node:path";
+import { basename, join } from "node:path";
+import { environment } from "@raycast/api";
+import lockfile from "proper-lockfile";
 import { getCustomNpxPath, shouldDisableSkillsCliTelemetry } from "../preferences";
 import { execFileAsync } from "./exec-async";
 import { getExecOptions } from "./exec-options";
@@ -11,6 +13,8 @@ let validatedCustomNpxPath: string | null = null;
 let pendingCustomNpxValidation: { path: string; promise: Promise<void> } | null = null;
 let pendingSkillsCliRun: Promise<unknown> = Promise.resolve();
 let bunxResolutionFailed = false;
+
+const SKILLS_CLI_LOCK_TARGET = join(environment.supportPath, "skills-cli");
 
 type ExecFailure = Error & {
   code?: string | number;
@@ -61,13 +65,26 @@ export interface RunSkillsCliOptions {
 }
 
 export async function runSkillsCli(args: string[], options: RunSkillsCliOptions = {}): Promise<string> {
-  return enqueueSkillsCliRun(() => runSkillsCliCommand(args, options.readOnly ?? false));
+  return enqueueSkillsCliRun(() => withSkillsCliLock(() => runSkillsCliCommand(args, options.readOnly ?? false)));
 }
 
 async function enqueueSkillsCliRun<T>(run: () => Promise<T>): Promise<T> {
   const runAfterPending = pendingSkillsCliRun.then(run, run);
   pendingSkillsCliRun = runAfterPending.catch(() => undefined);
   return runAfterPending;
+}
+
+async function withSkillsCliLock<T>(run: () => Promise<T>): Promise<T> {
+  await mkdir(environment.supportPath, { recursive: true });
+  await writeFile(SKILLS_CLI_LOCK_TARGET, "", { flag: "a" });
+  const release = await lockfile.lock(SKILLS_CLI_LOCK_TARGET, {
+    retries: { forever: true, factor: 1, minTimeout: 100, maxTimeout: 100, randomize: true },
+  });
+  try {
+    return await run();
+  } finally {
+    await release();
+  }
 }
 
 async function runSkillsCliCommand(args: string[], readOnly: boolean): Promise<string> {

--- a/extensions/skills/src/utils/skills-cli.ts
+++ b/extensions/skills/src/utils/skills-cli.ts
@@ -7,6 +7,7 @@ import {
   isInvalidCustomNpxPathError,
   isNpxResolutionError,
   runSkillsCli,
+  type SkillsCliRunner,
 } from "./skills-cli-runner";
 
 const home = homedir();
@@ -40,8 +41,8 @@ function parseSkillsListJson(stdout: string): InstalledSkill[] {
   }));
 }
 
-export async function listInstalledSkills(): Promise<InstalledSkill[]> {
-  const stdout = await runSkillsCli(["list", "-g", "--json"], { readOnly: true });
+export async function listInstalledSkills(runCli: SkillsCliRunner = runSkillsCli): Promise<InstalledSkill[]> {
+  const stdout = await runCli(["list", "-g", "--json"], { readOnly: true });
   try {
     return parseSkillsListJson(stdout);
   } catch {


### PR DESCRIPTION
Fixes #30486

## Description

`Update All Skills` and `Manage Skills` can launch separate `npx skills@latest` processes against the same npm cache. When their package installation phases overlap, npm can fail one process with `ENOTEMPTY` before the Skills CLI starts.

This change serializes Skills CLI invocations across Raycast command processes with a stale-safe filesystem lock. Manage Skills also waits for pending CLI work before reading installed-skill metadata, preventing stale or partially written state from being displayed after an update.

## Screencast

This change has no UI.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)