### PR TITLE
gitlab-docs: Fix SVG library for Raycast 2.0

### DIFF
--- a/extensions/gitlab-docs/CHANGELOG.md
+++ b/extensions/gitlab-docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GitLab Docs Changelog
 
+## [SVG grid view fix for Raycast 2.0] - 2026-08-24
+
+- Fixes the visual alignment of the SVG icons in the grid view for Raycast 2.0
+
 ## [Add Detail View] - 2026-06-22
 
 - Add a detail panel to Documentation, Handbook, and Design System results that renders the full page content

--- a/extensions/gitlab-docs/CHANGELOG.md
+++ b/extensions/gitlab-docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GitLab Docs Changelog
 
-## [SVG grid view fix for Raycast 2.0] - 2026-08-24
+## [SVG grid view fix for Raycast 2.0] - {PR_MERGE_DATE}
 
 - Fixes the visual alignment of the SVG icons in the grid view for Raycast 2.0
 

--- a/extensions/gitlab-docs/CHANGELOG.md
+++ b/extensions/gitlab-docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GitLab Docs Changelog
 
-## [SVG grid view fix for Raycast 2.0] - {PR_MERGE_DATE}
+## [SVG grid view fix for Raycast 2.0] - 2026-08-24
 
 - Fixes the visual alignment of the SVG icons in the grid view for Raycast 2.0
 

--- a/extensions/gitlab-docs/src/svgs.tsx
+++ b/extensions/gitlab-docs/src/svgs.tsx
@@ -102,6 +102,33 @@ async function loadSprite(): Promise<string> {
   return sprite;
 }
 
+// Square canvas every icon is drawn onto.
+const CANVAS = 32;
+
+function renderIcon(viewBox: string, inner: string): string {
+  const header = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${CANVAS} ${CANVAS}" style="transform: translate(-12.5%, -12.5%);">`;
+
+  const [x, y, width, height] = viewBox
+    .trim()
+    .split(/[\s,]+/)
+    .map(Number);
+  if (![x, y, width, height].every((value) => Number.isFinite(value)) || width <= 0 || height <= 0) {
+    return `${header}${inner}</svg>`;
+  }
+
+  // Keep the icon at its natural size, only shrinking it if it would not fit.
+  const scale = Math.min(1, CANVAS / Math.max(width, height));
+  const translateX = round((CANVAS - width * scale) / 2 - x * scale);
+  const translateY = round((CANVAS - height * scale) / 2 - y * scale);
+  const resize = scale === 1 ? "" : ` scale(${round(scale)})`;
+
+  return `${header}<g transform="translate(${translateX} ${translateY})${resize}">${inner}</g></svg>`;
+}
+
+function round(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
 function parseSprite(sprite: string): Icon[] {
   const icons: Icon[] = [];
   const symbolRegex = /<symbol\b([^>]*)>([\s\S]*?)<\/symbol>/g;
@@ -118,9 +145,7 @@ function parseSprite(sprite: string): Icon[] {
     const name = idMatch[1];
 
     const viewBoxMatch = attributes.match(/viewBox="([^"]+)"/);
-    const viewBox = viewBoxMatch ? viewBoxMatch[1] : "0 0 16 16";
-
-    const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${viewBox}" fill="#000000">${inner}</svg>`;
+    const svg = renderIcon(viewBoxMatch ? viewBoxMatch[1] : "0 0 16 16", inner);
     const dataUri = `data:image/svg+xml;base64,${Buffer.from(svg).toString("base64")}`;
 
     // Allow searching with spaces (or no separator) for hyphenated names,


### PR DESCRIPTION
## Description

Fixes the visual alignment of the SVG icons in the grid view for Raycast 2.0

## Screencast

| Before | After |
| ------ | ------ |
|  <img width="1012" height="682" alt="before" src="https://github.com/user-attachments/assets/c0cdb4b9-6802-4e1c-b4b0-03f196e7e2a0" />  |  <img width="1012" height="682" alt="after" src="https://github.com/user-attachments/assets/c3a2cafa-ab70-4005-8bbb-0cacac739508" />  |

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
