### PR TITLE
Add List Applications AI tool to appfreezer

### DIFF
--- a/extensions/appfreezer/CHANGELOG.md
+++ b/extensions/appfreezer/CHANGELOG.md
@@ -1,6 +1,6 @@
 # App Freezer Changelog
 
-## [AI Tool Support] - {PR_MERGE_DATE}
+## [AI Tool Support] - 2026-08-25
 
 - Add a read-only "List Applications" AI tool for querying paused/running status and live CPU/memory usage.
 

--- a/extensions/appfreezer/CHANGELOG.md
+++ b/extensions/appfreezer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # App Freezer Changelog
 
+## [AI Tool Support] - {PR_MERGE_DATE}
+
+- Add a read-only "List Applications" AI tool for querying paused/running status and live CPU/memory usage.
+
 ## [Initial Release] - 2026-08-21
 
 - Pause or resume applications through the native App Freezer agent.

--- a/extensions/appfreezer/package.json
+++ b/extensions/appfreezer/package.json
@@ -54,6 +54,43 @@
       "mode": "view"
     }
   ],
+  "tools": [
+    {
+      "name": "list-applications",
+      "title": "List Applications",
+      "description": "List the applications App Freezer currently knows about, with their paused/running status and live CPU and memory usage. Read-only: never pauses, resumes, or quits anything."
+    }
+  ],
+  "ai": {
+    "instructions": "Use List Applications to answer questions about which applications are currently paused or running, and their CPU/memory usage, as reported by App Freezer. This tool is read-only and never pauses, resumes, or quits an application; if the user wants to change an application's state, tell them to use the Pause or Resume App, Quit App, Force Quit App, or Resume All Apps commands instead.",
+    "evals": [
+      {
+        "input": "@App Freezer Which apps are currently paused?",
+        "mocks": {
+          "list-applications": {
+            "generatedAt": "2026-07-30T12:00:00Z",
+            "count": 1,
+            "applications": [
+              {
+                "name": "Example",
+                "status": "paused",
+                "cpuPercent": 0,
+                "memoryPercent": 3.4
+              }
+            ]
+          }
+        },
+        "expected": [
+          {
+            "callsTool": "list-applications"
+          },
+          {
+            "includes": "Example"
+          }
+        ]
+      }
+    ]
+  },
   "scripts": {
     "build": "ray build -e dist",
     "dev": "ray develop",

--- a/extensions/appfreezer/src/tools/list-applications.ts
+++ b/extensions/appfreezer/src/tools/list-applications.ts
@@ -1,0 +1,41 @@
+import { loadSnapshot } from "../appfreezer";
+import { AppFreezerApplication } from "../protocol";
+
+type Input = {
+  /**
+   * Only return applications matching this status. Omit to return every known application.
+   */
+  status?: "running" | "paused";
+};
+
+type ApplicationSummary = {
+  name: string;
+  status: AppFreezerApplication["status"];
+  cpuPercent: number;
+  memoryPercent: number;
+};
+
+/**
+ * List the applications App Freezer currently knows about, with their paused/running status and live CPU and memory usage. Read-only: never pauses, resumes, or quits anything.
+ */
+export default async function listApplications(input: Input): Promise<{
+  generatedAt: string;
+  count: number;
+  applications: ApplicationSummary[];
+}> {
+  const snapshot = await loadSnapshot();
+  const applications = snapshot.applications
+    .filter((application) => !input.status || application.status === input.status)
+    .map((application) => ({
+      name: application.name,
+      status: application.status,
+      cpuPercent: application.cpuPercent,
+      memoryPercent: application.memoryPercent,
+    }));
+
+  return {
+    generatedAt: snapshot.generatedAt,
+    count: applications.length,
+    applications,
+  };
+}

--- a/extensions/appfreezer/tests/list-applications.test.ts
+++ b/extensions/appfreezer/tests/list-applications.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AgentSnapshot } from "../src/protocol";
+
+const loadSnapshot = vi.fn<() => Promise<AgentSnapshot>>();
+
+vi.mock("../src/appfreezer", () => ({
+  loadSnapshot: (...arguments_: []) => loadSnapshot(...arguments_),
+}));
+
+const { default: listApplications } = await import("../src/tools/list-applications");
+
+const snapshot: AgentSnapshot = {
+  protocolVersion: 4,
+  generatedAt: "2026-07-30T12:00:00Z",
+  applications: [
+    {
+      id: "running-id",
+      name: "Running App",
+      cpuPercent: 12.5,
+      memoryPercent: 8.25,
+      status: "running",
+      canPause: true,
+      canQuit: true,
+    },
+    {
+      id: "paused-id",
+      name: "Paused App",
+      cpuPercent: 0,
+      memoryPercent: 4.1,
+      status: "paused",
+      canPause: true,
+      canQuit: true,
+    },
+  ],
+};
+
+describe("listApplications tool", () => {
+  it("returns every known application when no status filter is given", async () => {
+    loadSnapshot.mockResolvedValueOnce(snapshot);
+    const result = await listApplications({});
+    expect(result.count).toBe(2);
+    expect(result.applications.map((application) => application.name)).toEqual(["Running App", "Paused App"]);
+  });
+
+  it("filters by status without exposing internal identifiers", async () => {
+    loadSnapshot.mockResolvedValueOnce(snapshot);
+    const result = await listApplications({ status: "paused" });
+    expect(result.count).toBe(1);
+    expect(result.applications[0]).toEqual({
+      name: "Paused App",
+      status: "paused",
+      cpuPercent: 0,
+      memoryPercent: 4.1,
+    });
+    expect(result.applications[0]).not.toHaveProperty("id");
+  });
+
+  it("propagates errors from the native agent instead of hiding them", async () => {
+    loadSnapshot.mockRejectedValueOnce(new Error("App Freezer is not installed."));
+    await expect(listApplications({})).rejects.toThrow("App Freezer is not installed.");
+  });
+});


### PR DESCRIPTION
## Description

Adds a read-only **List Applications** AI tool to the App Freezer extension, so Raycast AI can answer questions like "which apps are paused right now?" or "what's using the most CPU?" without needing to open a command.

This is a follow-up to #30000 (merged, live on the Store). It only adds new files plus the minimal `package.json`/`CHANGELOG.md` additions required to register the tool — no changes to existing commands' behavior.

### What's included

- `src/tools/list-applications.ts` — new AI tool. Reads the existing agent snapshot (`loadSnapshot`, already used by every command) and returns each application's name, paused/running status, CPU%, and memory%. Optional `status` filter (`"running" | "paused"`). Never pauses, resumes, or quits anything, and never exposes the internal opaque process id.
- `tests/list-applications.test.ts` — covers the unfiltered case, the status filter (and that internal ids aren't leaked), and that native-agent errors propagate instead of being swallowed.
- `package.json` — registers the tool under `tools`, and adds an `ai.instructions` string plus one `ai.evals` entry per the [AI Extensions guidelines](https://developers.raycast.com/ai-extensions).
- `CHANGELOG.md` — new "AI Tool Support" entry (date left as `{PR_MERGE_DATE}` per store convention, to be filled in on merge).

### Checklist

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run lint:store` (`ray lint --exit-on-error`)
- [x] `npm run build`

## Screenshots

N/A — this PR only adds a new AI tool (no view-mode UI) on top of the already-published extension; no new command screenshots are required.
