### PR TITLE
[Sonarr] Add a second instance with runtime switching

### DIFF
--- a/extensions/sonarr/.gitignore
+++ b/extensions/sonarr/.gitignore
@@ -17,6 +17,7 @@ compiled_raycast_rust
 # Claude Code
 .claude/
 CLAUDE.md
+.agents/
 
 # misc
 .DS_Store

--- a/extensions/sonarr/CHANGELOG.md
+++ b/extensions/sonarr/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Sonarr Changelog
 
-## [Second Instance and Windows Connection Fix] - {PR_MERGE_DATE}
+## [Second Instance and Windows Connection Fix] - 2026-08-25
 
 ### Added
 

--- a/extensions/sonarr/CHANGELOG.md
+++ b/extensions/sonarr/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Sonarr Changelog
 
+## [Second Instance and Windows Connection Fix] - {PR_MERGE_DATE}
+
+### Added
+
+- Support for a second Sonarr instance: enable it in the preferences, then switch between the two from the `Instance` section of any command's action panel (`⌘⇧I` / `Ctrl+Shift+I`). The selection is stored, so it applies to every command and survives closing Raycast
+- The second instance is configured with the same preferences as the first one — host, port, URL base, connection type and API key — so both accept exactly the same setups
+- `Instance Name` and `Second Instance Name` preferences, used to label the instance in the search bar and in the switch action
+- `Active Instance` preference, deciding which instance commands start on
+- `Instance Status` now reports every configured instance side by side — connection, version, and health checks per instance — and flags a second instance that is enabled but missing its host or API key
+
+### Changed
+
+- The `API Key` preference is now a password field, so the key is masked in the preferences instead of being displayed in clear text. Raycast stores password preferences separately from plain ones, so the key may need to be entered once more after updating
+
+### Fixed
+
+- Fixed the extension crashing on Windows with `Cannot read properties of undefined (reading 'trim')` when the optional `URL Base` preference was left empty: Raycast returns `undefined` rather than an empty string there, so every preference is now read through a helper that tolerates it
+
 ## [Windows Support] - 2026-08-22
 
 ### Added

--- a/extensions/sonarr/README.md
+++ b/extensions/sonarr/README.md
@@ -24,6 +24,18 @@ View your Sonarr instance, upcoming shows and much more
 - `Port` should be only the numeric port (`8989`) and is ignored if already included in `Host`.
 - `Connection Type` should match your Sonarr server (`HTTP` or `HTTPS`).
 - If Sonarr is served from a subpath, set `URL Base` (example: `sonarr` for `http://host:8989/sonarr`).
+- `Instance Name` is only a label: it names the instance in the search bar and in the switch action.
+
+### Two Sonarr Instances
+The extension can talk to a second Sonarr server and switch between the two from any command.
+
+1. Enable `Second Instance` in the extension preferences.
+2. Fill in `Second Instance Host`, `Second Instance Port`, `Second Instance Connection Type` and `Second Instance API Key` — the same four values as the first instance, with the same rules (`Second Instance URL Base` for a subpath, and a full URL in `Host` also works).
+3. Optionally name it with `Second Instance Name`.
+
+`Active Instance` decides which one commands start on, and changing it takes effect right away even if you had switched manually before. From any command, the `Instance` section of the action panel switches to the other one (`⌘⇧I` on macOS, `Ctrl+Shift+I` on Windows). The choice is remembered: it applies to every command and survives closing Raycast, until you switch back.
+
+`Instance Status` lists every configured instance, tests each connection, and reports a second instance that is enabled but still missing its host or API key.
 
 ### Extension Usage
 https://user-images.githubusercontent.com/43297314/179749726-0919e1d8-686f-4e45-8440-85fecdc35414.mp4

--- a/extensions/sonarr/package.json
+++ b/extensions/sonarr/package.json
@@ -81,6 +81,15 @@
   ],
   "preferences": [
     {
+      "name": "instanceName",
+      "title": "Instance Name",
+      "required": false,
+      "description": "A friendly name for your primary Sonarr instance",
+      "type": "textfield",
+      "placeholder": "Main",
+      "default": "Main"
+    },
+    {
       "name": "host",
       "title": "Host",
       "required": true,
@@ -127,8 +136,98 @@
       "title": "API Key",
       "required": true,
       "description": "The API key of the Sonarr server",
+      "type": "password",
+      "default": "",
+      "placeholder": "Enter your API key"
+    },
+    {
+      "name": "enableSecondaryInstance",
+      "title": "Second Instance",
+      "required": false,
+      "description": "Add a second Sonarr instance you can switch to from any command",
+      "type": "checkbox",
+      "label": "Enable second Sonarr instance",
+      "default": false
+    },
+    {
+      "name": "secondaryInstanceName",
+      "title": "Second Instance Name",
+      "required": false,
+      "description": "A friendly name for your second Sonarr instance",
+      "type": "textfield",
+      "placeholder": "Remote Server",
+      "default": ""
+    },
+    {
+      "name": "secondaryHost",
+      "title": "Second Instance Host",
+      "required": false,
+      "description": "Hostname or IP of the second Sonarr server, without the port (e.g. 192.168.0.30)",
+      "type": "textfield",
+      "placeholder": "sonarr.example.com",
+      "default": ""
+    },
+    {
+      "name": "secondaryPort",
+      "title": "Second Instance Port",
+      "required": false,
+      "description": "Port of the second Sonarr server (e.g. 8989)",
+      "type": "textfield",
+      "placeholder": "8989",
+      "default": "8989"
+    },
+    {
+      "name": "secondaryBase",
+      "title": "Second Instance URL Base (Optional)",
+      "required": false,
+      "description": "Optional URL base path of the second Sonarr server (e.g. sonarr if your URL is /sonarr)",
       "type": "textfield",
       "default": ""
+    },
+    {
+      "name": "secondaryHttp",
+      "title": "Second Instance Connection Type",
+      "required": false,
+      "description": "Change the connection type for the second Sonarr server",
+      "type": "dropdown",
+      "default": "http",
+      "data": [
+        {
+          "value": "http",
+          "title": "HTTP"
+        },
+        {
+          "value": "https",
+          "title": "HTTPS"
+        }
+      ]
+    },
+    {
+      "name": "secondaryApiKey",
+      "title": "Second Instance API Key",
+      "required": false,
+      "description": "The API key of the second Sonarr server",
+      "type": "password",
+      "placeholder": "Enter the second API key",
+      "default": ""
+    },
+    {
+      "name": "activeInstance",
+      "title": "Active Instance",
+      "required": false,
+      "description": "Which instance commands start on. Switching from a command overrides it until you change this preference again.",
+      "type": "dropdown",
+      "default": "primary",
+      "data": [
+        {
+          "value": "primary",
+          "title": "Primary Instance"
+        },
+        {
+          "value": "secondary",
+          "title": "Second Instance"
+        }
+      ]
     },
     {
       "name": "futureDays",

--- a/extensions/sonarr/src/blocklist.tsx
+++ b/extensions/sonarr/src/blocklist.tsx
@@ -1,8 +1,11 @@
 import { Action, ActionPanel, Color, Icon, Image, List, Keyboard } from "@raycast/api";
 import { useMemo, useState } from "react";
+import { InstanceActions } from "@/lib/components/InstanceActions";
+import { useInstance } from "@/lib/hooks/useInstance";
 import { useBlocklist } from "@/lib/hooks/useSonarrAPI";
 import type { BlocklistRecord } from "@/lib/types/blocklist";
-import { formatAirDate, formatQualityProfile, getSeriesPoster, getSonarrUrl } from "@/lib/utils/formatting";
+import type { InstanceState } from "@/lib/types/instance";
+import { formatAirDate, formatQualityProfile, getSearchPlaceholder, getSeriesPoster } from "@/lib/utils/formatting";
 
 function normalizeProtocol(protocol?: string): string {
   if (!protocol) return "Unknown";
@@ -25,7 +28,8 @@ function getProtocolColor(protocol?: string): Color {
 export default function Command() {
   const [searchText, setSearchText] = useState("");
   const [protocolFilter, setProtocolFilter] = useState("all");
-  const { data, isLoading, mutate } = useBlocklist(1, 100);
+  const instanceState = useInstance();
+  const { data, isLoading, mutate } = useBlocklist(instanceState.instance, 1, 100);
 
   const records = data?.records || [];
 
@@ -56,12 +60,21 @@ export default function Command() {
       .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
   }, [records, protocolFilter, searchText]);
 
+  // Also reachable with an empty list: without it, switching back out of an
+  // instance that returned nothing would mean quitting the command.
+  const instancePanel = (
+    <ActionPanel>
+      <InstanceActions state={instanceState} />
+    </ActionPanel>
+  );
+
   return (
     <List
-      isLoading={isLoading}
+      actions={instancePanel}
+      isLoading={isLoading || instanceState.isLoading}
       isShowingDetail
       filtering={false}
-      searchBarPlaceholder="Search blocked releases..."
+      searchBarPlaceholder={getSearchPlaceholder(instanceState, "Search blocked releases")}
       onSearchTextChange={setSearchText}
       searchBarAccessory={
         <List.Dropdown tooltip="Filter by Protocol" value={protocolFilter} onChange={setProtocolFilter}>
@@ -77,20 +90,29 @@ export default function Command() {
           title="Blocklist is Empty"
           description={searchText ? "No blocklist entries matched your search" : "No blocked releases found"}
           icon={Icon.CheckCircle}
+          actions={instancePanel}
         />
       )}
 
       <List.Section title="Blocked Releases" subtitle={`${filteredRecords.length} items`}>
         {filteredRecords.map((record) => (
-          <BlocklistItem key={record.id} record={record} onRefresh={mutate} />
+          <BlocklistItem key={record.id} record={record} onRefresh={mutate} instanceState={instanceState} />
         ))}
       </List.Section>
     </List>
   );
 }
 
-function BlocklistItem({ record, onRefresh }: { record: BlocklistRecord; onRefresh: () => void }) {
-  const sonarrUrl = getSonarrUrl();
+function BlocklistItem({
+  record,
+  onRefresh,
+  instanceState,
+}: {
+  record: BlocklistRecord;
+  onRefresh: () => void;
+  instanceState: InstanceState;
+}) {
+  const sonarrUrl = instanceState.instance?.url ?? "";
   const poster = record.series?.images ? getSeriesPoster(record.series.images) : undefined;
 
   const seriesTitle = record.series?.title || "Unknown Series";
@@ -197,6 +219,8 @@ function BlocklistItem({ record, onRefresh }: { record: BlocklistRecord; onRefre
               shortcut={Keyboard.Shortcut.Common.Refresh}
             />
           </ActionPanel.Section>
+
+          <InstanceActions state={instanceState} />
         </ActionPanel>
       }
     />

--- a/extensions/sonarr/src/download-queue.tsx
+++ b/extensions/sonarr/src/download-queue.tsx
@@ -1,4 +1,7 @@
+import { InstanceActions } from "@/lib/components/InstanceActions";
+import { useInstance } from "@/lib/hooks/useInstance";
 import { removeQueueItem, useQueue } from "@/lib/hooks/useSonarrAPI";
+import type { InstanceState } from "@/lib/types/instance";
 import type { QueueItem } from "@/lib/types/queue";
 import {
   formatAirDate,
@@ -6,6 +9,7 @@ import {
   formatEpisodeNumber,
   formatFileSize,
   formatTimeLeft,
+  getSearchPlaceholder,
   getSeriesPoster,
 } from "@/lib/utils/formatting";
 import { Shortcuts } from "@/lib/utils/shortcuts";
@@ -14,7 +18,8 @@ import { useEffect, useMemo, useState } from "react";
 
 export default function Command() {
   const [searchText, setSearchText] = useState("");
-  const { data, isLoading, mutate } = useQueue();
+  const instanceState = useInstance();
+  const { data, isLoading, mutate } = useQueue(instanceState.instance);
 
   const filteredData = useMemo<QueueItem[]>(() => {
     const queueItems = data?.records || [];
@@ -43,10 +48,19 @@ export default function Command() {
     return () => clearInterval(interval);
   }, [hasActiveDownloads, mutate]);
 
+  // Also reachable with an empty list: without it, switching back out of an
+  // instance that returned nothing would mean quitting the command.
+  const instancePanel = (
+    <ActionPanel>
+      <InstanceActions state={instanceState} />
+    </ActionPanel>
+  );
+
   return (
     <List
-      searchBarPlaceholder="Search downloads..."
-      isLoading={isLoading}
+      actions={instancePanel}
+      searchBarPlaceholder={getSearchPlaceholder(instanceState, "Search downloads")}
+      isLoading={isLoading || instanceState.isLoading}
       isShowingDetail
       filtering={false}
       onSearchTextChange={setSearchText}
@@ -56,18 +70,27 @@ export default function Command() {
           title={searchText ? "No Results" : "Queue is Empty"}
           description={searchText ? "No downloads match your search" : "No active downloads or queued episodes"}
           icon={Icon.Download}
+          actions={instancePanel}
         />
       )}
       <List.Section title="Download Queue" subtitle={`${filteredData.length} items`}>
         {filteredData.map((item) => (
-          <QueueListItem key={item.id} item={item} onRefresh={mutate} />
+          <QueueListItem key={item.id} item={item} onRefresh={mutate} instanceState={instanceState} />
         ))}
       </List.Section>
     </List>
   );
 }
 
-function QueueListItem({ item, onRefresh }: { item: QueueItem; onRefresh: () => void }) {
+function QueueListItem({
+  item,
+  onRefresh,
+  instanceState,
+}: {
+  item: QueueItem;
+  onRefresh: () => void;
+  instanceState: InstanceState;
+}) {
   const progress = formatDownloadProgress(item.sizeleft, item.size);
   const progressText = `${Math.round(progress)}%`;
   const poster = item.series ? getSeriesPoster(item.series.images) : undefined;
@@ -167,7 +190,7 @@ function QueueListItem({ item, onRefresh }: { item: QueueItem; onRefresh: () => 
 
     if (confirmed) {
       try {
-        await removeQueueItem(item.id, blocklist);
+        await removeQueueItem(instanceState.instance, item.id, blocklist);
         onRefresh();
       } catch {
         // Error toast already shown by removeQueueItem()
@@ -222,6 +245,8 @@ function QueueListItem({ item, onRefresh }: { item: QueueItem; onRefresh: () => 
               shortcut={Keyboard.Shortcut.Common.Refresh}
             />
           </ActionPanel.Section>
+
+          <InstanceActions state={instanceState} />
         </ActionPanel>
       }
     />

--- a/extensions/sonarr/src/history.tsx
+++ b/extensions/sonarr/src/history.tsx
@@ -1,13 +1,16 @@
 import { Action, ActionPanel, Color, Icon, Image, List, Keyboard } from "@raycast/api";
 import { useMemo, useState } from "react";
+import { InstanceActions } from "@/lib/components/InstanceActions";
+import { useInstance } from "@/lib/hooks/useInstance";
 import { useHistory } from "@/lib/hooks/useSonarrAPI";
 import type { HistoryRecord } from "@/lib/types/history";
+import type { InstanceState } from "@/lib/types/instance";
 import {
   formatAirDate,
   formatEpisodeNumber,
   formatQualityProfile,
+  getSearchPlaceholder,
   getSeriesPoster,
-  getSonarrUrl,
 } from "@/lib/utils/formatting";
 
 function getEventColor(eventType: string): Color {
@@ -43,7 +46,8 @@ function formatEventLabel(eventType: string): string {
 export default function Command() {
   const [searchText, setSearchText] = useState("");
   const [eventTypeFilter, setEventTypeFilter] = useState("all");
-  const { data, isLoading, mutate } = useHistory(1, 100);
+  const instanceState = useInstance();
+  const { data, isLoading, mutate } = useHistory(instanceState.instance, 1, 100);
 
   const records = data?.records || [];
 
@@ -72,12 +76,21 @@ export default function Command() {
       .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
   }, [records, eventTypeFilter, searchText]);
 
+  // Also reachable with an empty list: without it, switching back out of an
+  // instance that returned nothing would mean quitting the command.
+  const instancePanel = (
+    <ActionPanel>
+      <InstanceActions state={instanceState} />
+    </ActionPanel>
+  );
+
   return (
     <List
-      isLoading={isLoading}
+      actions={instancePanel}
+      isLoading={isLoading || instanceState.isLoading}
       isShowingDetail
       filtering={false}
-      searchBarPlaceholder="Search history by series, episode, or release title..."
+      searchBarPlaceholder={getSearchPlaceholder(instanceState, "Search history by series, episode, or release title")}
       onSearchTextChange={setSearchText}
       searchBarAccessory={
         <List.Dropdown tooltip="Filter by Event Type" value={eventTypeFilter} onChange={setEventTypeFilter}>
@@ -93,20 +106,29 @@ export default function Command() {
           title="No History Events"
           description={searchText ? "No events matched your search" : "No recent activity found"}
           icon={Icon.Clock}
+          actions={instancePanel}
         />
       )}
 
       <List.Section title="Recent History" subtitle={`${filteredRecords.length} events`}>
         {filteredRecords.map((record) => (
-          <HistoryListItem key={record.id} record={record} onRefresh={mutate} />
+          <HistoryListItem key={record.id} record={record} onRefresh={mutate} instanceState={instanceState} />
         ))}
       </List.Section>
     </List>
   );
 }
 
-function HistoryListItem({ record, onRefresh }: { record: HistoryRecord; onRefresh: () => void }) {
-  const sonarrUrl = getSonarrUrl();
+function HistoryListItem({
+  record,
+  onRefresh,
+  instanceState,
+}: {
+  record: HistoryRecord;
+  onRefresh: () => void;
+  instanceState: InstanceState;
+}) {
+  const sonarrUrl = instanceState.instance?.url ?? "";
   const poster = record.series?.images ? getSeriesPoster(record.series.images) : undefined;
 
   const seriesTitle = record.series?.title || "Unknown Series";
@@ -213,6 +235,8 @@ function HistoryListItem({ record, onRefresh }: { record: HistoryRecord; onRefre
               shortcut={Keyboard.Shortcut.Common.Refresh}
             />
           </ActionPanel.Section>
+
+          <InstanceActions state={instanceState} />
         </ActionPanel>
       }
     />

--- a/extensions/sonarr/src/index.tsx
+++ b/extensions/sonarr/src/index.tsx
@@ -13,7 +13,9 @@ import {
 import { showFailureToast } from "@raycast/utils";
 import { useMemo, useState } from "react";
 import type { SingleSeries } from "@/lib/types/episode";
+import type { InstanceState } from "@/lib/types/instance";
 import type { SonarrPreferences } from "@/lib/types/preferences";
+import { useInstance } from "@/lib/hooks/useInstance";
 import { useCalendar, searchEpisode, searchSeason, toggleEpisodeMonitoring } from "@/lib/hooks/useSonarrAPI";
 import {
   formatAirDate,
@@ -24,16 +26,18 @@ import {
   getEpisodeStatus,
   formatFileSize,
   formatQualityProfile,
-  getSonarrUrl,
+  getSearchPlaceholder,
 } from "@/lib/utils/formatting";
+import { InstanceActions } from "@/lib/components/InstanceActions";
 import { Shortcuts } from "@/lib/utils/shortcuts";
 
 export default function Command() {
   const preferences = getPreferenceValues<SonarrPreferences>();
   const futureDays = parseInt(preferences.futureDays || "14");
   const [searchText, setSearchText] = useState("");
+  const instanceState = useInstance();
 
-  const { data, isLoading, mutate } = useCalendar(futureDays);
+  const { data, isLoading, mutate } = useCalendar(instanceState.instance, futureDays);
 
   const filteredEpisodes = useMemo(() => {
     if (!data) return [];
@@ -47,25 +51,42 @@ export default function Command() {
     );
   }, [data, searchText]);
 
+  // Also reachable with an empty list: without it, switching back out of an
+  // instance that returned nothing would mean quitting the command.
+  const instancePanel = (
+    <ActionPanel>
+      <InstanceActions state={instanceState} />
+    </ActionPanel>
+  );
+
   return (
     <List
-      searchBarPlaceholder="Search upcoming episodes..."
-      isLoading={isLoading}
+      actions={instancePanel}
+      searchBarPlaceholder={getSearchPlaceholder(instanceState, "Search upcoming episodes")}
+      isLoading={isLoading || instanceState.isLoading}
       isShowingDetail
       filtering={false}
       onSearchTextChange={setSearchText}
     >
       <List.Section title="Upcoming Episodes" subtitle={`${filteredEpisodes.length} episodes`}>
         {filteredEpisodes.map((episode) => (
-          <EpisodeListItem key={episode.id} episode={episode} onRefresh={mutate} />
+          <EpisodeListItem key={episode.id} episode={episode} onRefresh={mutate} instanceState={instanceState} />
         ))}
       </List.Section>
     </List>
   );
 }
 
-function EpisodeListItem({ episode, onRefresh }: { episode: SingleSeries; onRefresh: () => void }) {
-  const sonarrUrl = getSonarrUrl();
+function EpisodeListItem({
+  episode,
+  onRefresh,
+  instanceState,
+}: {
+  episode: SingleSeries;
+  onRefresh: () => void;
+  instanceState: InstanceState;
+}) {
+  const sonarrUrl = instanceState.instance?.url ?? "";
 
   const status = getEpisodeStatus(episode.airDateUtc, episode.hasFile, episode.monitored);
   const poster = getSeriesPoster(episode.series.images);
@@ -124,7 +145,7 @@ function EpisodeListItem({ episode, onRefresh }: { episode: SingleSeries; onRefr
 
   const handleSearchEpisode = async () => {
     try {
-      await searchEpisode([episode.id]);
+      await searchEpisode(instanceState.instance, [episode.id]);
       await onRefresh();
     } catch (error) {
       showFailureToast(error, { title: "Failed to search episode" });
@@ -133,7 +154,7 @@ function EpisodeListItem({ episode, onRefresh }: { episode: SingleSeries; onRefr
 
   const handleSearchSeason = async () => {
     try {
-      await searchSeason(episode.seriesId, episode.seasonNumber);
+      await searchSeason(instanceState.instance, episode.seriesId, episode.seasonNumber);
       await onRefresh();
     } catch (error) {
       showFailureToast(error, { title: "Failed to search season" });
@@ -152,7 +173,7 @@ function EpisodeListItem({ episode, onRefresh }: { episode: SingleSeries; onRefr
 
     if (confirmed) {
       try {
-        await toggleEpisodeMonitoring(episode.id, !episode.monitored);
+        await toggleEpisodeMonitoring(instanceState.instance, episode.id, !episode.monitored);
         await onRefresh();
       } catch (error) {
         showFailureToast(error, { title: "Failed to update episode monitoring" });
@@ -235,6 +256,8 @@ function EpisodeListItem({ episode, onRefresh }: { episode: SingleSeries; onRefr
               shortcut={Keyboard.Shortcut.Common.Refresh}
             />
           </ActionPanel.Section>
+
+          <InstanceActions state={instanceState} />
         </ActionPanel>
       }
     />

--- a/extensions/sonarr/src/instance-status.tsx
+++ b/extensions/sonarr/src/instance-status.tsx
@@ -1,209 +1,257 @@
-import { Action, ActionPanel, Icon, List, Color, getPreferenceValues } from "@raycast/api";
-import { useState, useEffect } from "react";
-import { getSonarrUrl } from "@/lib/utils/formatting";
+import { Action, ActionPanel, Icon, List, Color, openExtensionPreferences } from "@raycast/api";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { InstanceActions } from "@/lib/components/InstanceActions";
+import { useInstance } from "@/lib/hooks/useInstance";
 import { testConnection, useSystemStatus, useHealth } from "@/lib/hooks/useSonarrAPI";
-import type { SonarrPreferences } from "@/lib/types/preferences";
+import type { InstanceState, SonarrInstance } from "@/lib/types/instance";
 import { HealthCheckType } from "@/lib/types/system";
+import { getSecondaryInstanceIssue } from "@/lib/utils/connection";
+
+interface ConnectionResult {
+  success: boolean;
+  message: string;
+  version?: string;
+}
 
 export default function Command() {
-  const preferences = getPreferenceValues<SonarrPreferences>();
-  const { http } = preferences;
-  const [isLoading, setIsLoading] = useState(false);
-  const [connectionStatus, setConnectionStatus] = useState<{
-    success: boolean;
-    message: string;
-    version?: string;
-  } | null>(null);
+  const instanceState = useInstance();
+  const { instances, instance: activeInstance, isLoading } = instanceState;
+  const secondaryIssue = getSecondaryInstanceIssue();
 
-  const { data: systemStatus } = useSystemStatus();
-  const { data: healthChecks } = useHealth();
+  return (
+    <List isLoading={isLoading} searchBarPlaceholder="Search Sonarr instances...">
+      {instances.map((instance) => (
+        <InstanceSection
+          key={instance.id}
+          instance={instance}
+          isActive={instance.id === activeInstance?.id}
+          instanceState={instanceState}
+        />
+      ))}
 
-  const sonarrUrl = getSonarrUrl();
+      {secondaryIssue && (
+        <List.Section title="Second Instance">
+          <List.Item
+            title="Second Instance Not Usable"
+            subtitle={secondaryIssue}
+            icon={{ source: Icon.Warning, tintColor: Color.Orange }}
+            accessories={[{ tag: { value: "Incomplete", color: Color.Orange } }]}
+            actions={
+              <ActionPanel>
+                <Action title="Open Extension Preferences" icon={Icon.Gear} onAction={openExtensionPreferences} />
+              </ActionPanel>
+            }
+          />
+        </List.Section>
+      )}
+    </List>
+  );
+}
+
+function InstanceSection({
+  instance,
+  isActive,
+  instanceState,
+}: {
+  instance: SonarrInstance;
+  isActive: boolean;
+  instanceState: InstanceState;
+}) {
+  const [manualResult, setManualResult] = useState<ConnectionResult | null>(null);
+  const [isTesting, setIsTesting] = useState(false);
+  const isMountedRef = useRef(true);
+
+  // Both instances are queried here, so a failing one must not raise a toast on
+  // top of the status it already reports in the list.
+  const {
+    data: systemStatus,
+    error: systemStatusError,
+    isLoading: isStatusLoading,
+  } = useSystemStatus(instance, {
+    showErrorToast: false,
+  });
+  const { data: healthChecks } = useHealth(instance, { showErrorToast: false });
 
   useEffect(() => {
-    handleTestConnection();
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+    };
   }, []);
 
-  const handleTestConnection = async () => {
-    setIsLoading(true);
+  // The initial verdict reuses the `/system/status` request this section
+  // already makes, instead of firing a second one with its own retry budget —
+  // an unreachable second instance would otherwise spin for the best part of a
+  // minute before saying so.
+  const connection: ConnectionResult | null =
+    manualResult ??
+    (systemStatus
+      ? { success: true, message: `Connected to Sonarr v${systemStatus.version}`, version: systemStatus.version }
+      : systemStatusError
+        ? { success: false, message: systemStatusError.message }
+        : null);
+
+  const handleTestConnection = useCallback(async () => {
+    setIsTesting(true);
+    setManualResult(null);
+
     try {
-      const result = await testConnection();
-      setConnectionStatus({
-        success: result.success,
-        message: result.message,
-        version: result.status?.version,
-      });
+      // An explicit test is interactive: report the first failure rather than
+      // retrying behind a spinner.
+      const result = await testConnection(instance, { retries: 0 });
+
+      if (isMountedRef.current) {
+        setManualResult({ success: result.success, message: result.message, version: result.status?.version });
+      }
     } catch (error) {
-      setConnectionStatus({
-        success: false,
-        message: error instanceof Error ? error.message : "Connection test failed",
-      });
+      if (isMountedRef.current) {
+        setManualResult({
+          success: false,
+          message: error instanceof Error ? error.message : "Connection test failed",
+        });
+      }
     } finally {
-      setIsLoading(false);
+      if (isMountedRef.current) {
+        setIsTesting(false);
+      }
     }
-  };
+  }, [instance]);
 
-  const statusIcon = connectionStatus?.success ? Icon.CheckCircle : Icon.XMarkCircle;
-  const statusColor = connectionStatus?.success ? Color.Green : Color.Red;
+  const isBusy = isTesting || (!manualResult && isStatusLoading);
+  const statusIcon = isBusy ? Icon.Clock : connection?.success ? Icon.CheckCircle : Icon.XMarkCircle;
+  const statusColor = isBusy ? Color.SecondaryText : connection?.success ? Color.Green : Color.Red;
+  const statusText = isBusy
+    ? "Testing…"
+    : connection
+      ? connection.success
+        ? `Connected (v${connection.version})`
+        : "Connection Failed"
+      : "Not Tested";
 
+  const isSecure = instance.url.startsWith("https://");
   const errors = healthChecks?.filter((check) => check.type === HealthCheckType.Error) || [];
   const warnings = healthChecks?.filter((check) => check.type === HealthCheckType.Warning) || [];
   const hasIssues = errors.length > 0 || warnings.length > 0;
 
-  const quickActions = (
-    <ActionPanel.Section title="Quick Actions">
-      <Action.OpenInBrowser title="Open Series Library" url={sonarrUrl} icon={Icon.List} />
-      <Action.OpenInBrowser title="Open Calendar" url={`${sonarrUrl}/calendar`} icon={Icon.Calendar} />
-      <Action.OpenInBrowser title="Open Queue" url={`${sonarrUrl}/queue`} icon={Icon.Download} />
-    </ActionPanel.Section>
+  const instanceActions = (
+    <>
+      <ActionPanel.Section title="Instance Actions">
+        <Action title="Test Connection" icon={Icon.Network} onAction={handleTestConnection} />
+      </ActionPanel.Section>
+
+      <ActionPanel.Section title="Quick Actions">
+        <Action.OpenInBrowser title="Open Sonarr" url={instance.url} icon={Icon.Globe} />
+        <Action.OpenInBrowser title="Open Calendar" url={`${instance.url}/calendar`} icon={Icon.Calendar} />
+        <Action.OpenInBrowser title="Open Queue" url={`${instance.url}/activity/queue`} icon={Icon.Download} />
+        <Action.CopyToClipboard title="Copy URL" content={instance.url} />
+      </ActionPanel.Section>
+
+      <InstanceActions state={instanceState} />
+    </>
   );
 
   return (
-    <List isLoading={isLoading}>
-      <List.Section title="Sonarr Instance">
+    <List.Section title={instance.name} subtitle={isActive ? "Active" : undefined}>
+      <List.Item
+        title="Connection Status"
+        icon={{ source: statusIcon, tintColor: statusColor }}
+        accessories={[{ text: statusText }]}
+        actions={<ActionPanel>{instanceActions}</ActionPanel>}
+      />
+
+      <List.Item
+        title="Instance URL"
+        subtitle={instance.url}
+        icon={Icon.Link}
+        accessories={[{ tag: { value: isSecure ? "HTTPS" : "HTTP", color: isSecure ? Color.Green : Color.Orange } }]}
+        actions={<ActionPanel>{instanceActions}</ActionPanel>}
+      />
+
+      {connection && !connection.success && (
         <List.Item
-          title="Connection Status"
-          icon={{ source: statusIcon, tintColor: statusColor }}
+          title="Status Message"
+          subtitle={connection.message}
+          icon={{ source: Icon.Info, tintColor: Color.Red }}
+          actions={<ActionPanel>{instanceActions}</ActionPanel>}
+        />
+      )}
+
+      {systemStatus && (
+        <List.Item
+          title="Sonarr Version"
+          subtitle={systemStatus.version}
+          icon={Icon.Info}
+          accessories={[{ text: systemStatus.osName }]}
+          actions={
+            <ActionPanel>
+              <Action.OpenInBrowser
+                title="Open System Status"
+                url={`${instance.url}/system/status`}
+                icon={Icon.Globe}
+              />
+              {instanceActions}
+            </ActionPanel>
+          }
+        />
+      )}
+
+      {healthChecks && (
+        <List.Item
+          title="Health Status"
+          subtitle={
+            hasIssues
+              ? `${errors.length} error${errors.length !== 1 ? "s" : ""}, ${warnings.length} warning${warnings.length !== 1 ? "s" : ""}`
+              : "All systems operational"
+          }
+          icon={hasIssues ? Icon.ExclamationMark : Icon.CheckCircle}
           accessories={[
             {
-              text: connectionStatus
-                ? connectionStatus.success
-                  ? `Connected (v${connectionStatus.version})`
-                  : "Connection Failed"
-                : "Not Tested",
+              tag: {
+                value: hasIssues ? "Issues Found" : "Healthy",
+                color: hasIssues ? (errors.length > 0 ? Color.Red : Color.Orange) : Color.Green,
+              },
             },
           ]}
           actions={
             <ActionPanel>
-              <Action title="Test Connection" icon={Icon.Network} onAction={handleTestConnection} />
-              <Action.OpenInBrowser title="Open Sonarr" url={sonarrUrl} icon={Icon.Globe} />
-              {quickActions}
+              <Action.OpenInBrowser
+                title="Open System Status"
+                url={`${instance.url}/system/status`}
+                icon={Icon.Globe}
+              />
+              {instanceActions}
             </ActionPanel>
           }
         />
-
-        <List.Item
-          title="Instance URL"
-          subtitle={sonarrUrl}
-          icon={Icon.Link}
-          actions={
-            <ActionPanel>
-              <Action.OpenInBrowser title="Open Sonarr" url={sonarrUrl} icon={Icon.Globe} />
-              <Action.CopyToClipboard title="Copy URL" content={sonarrUrl} />
-              {quickActions}
-            </ActionPanel>
-          }
-        />
-
-        <List.Item
-          title="Protocol"
-          subtitle={http.toUpperCase()}
-          icon={http === "https" ? Icon.Lock : Icon.LockUnlocked}
-          accessories={[{ text: http === "https" ? "Secure" : "Insecure" }]}
-          actions={
-            <ActionPanel>
-              <Action.OpenInBrowser title="Open Sonarr" url={sonarrUrl} icon={Icon.Globe} />
-              {quickActions}
-            </ActionPanel>
-          }
-        />
-
-        {connectionStatus && (
-          <List.Item
-            title="Status Message"
-            subtitle={connectionStatus.message}
-            icon={Icon.Info}
-            accessories={[{ text: connectionStatus.success ? "✅" : "❌" }]}
-            actions={
-              <ActionPanel>
-                <Action.OpenInBrowser title="Open Sonarr" url={sonarrUrl} icon={Icon.Globe} />
-                {quickActions}
-              </ActionPanel>
-            }
-          />
-        )}
-      </List.Section>
-
-      {systemStatus && (
-        <List.Section title="System Health">
-          <List.Item
-            title="Sonarr Version"
-            subtitle={systemStatus.version}
-            icon={Icon.Info}
-            accessories={[{ text: systemStatus.osName }]}
-            actions={
-              <ActionPanel>
-                <Action.OpenInBrowser title="Open System Status" url={`${sonarrUrl}/system/status`} icon={Icon.Globe} />
-                {quickActions}
-              </ActionPanel>
-            }
-          />
-
-          <List.Item
-            title="Health Status"
-            subtitle={
-              hasIssues
-                ? `${errors.length} error${errors.length !== 1 ? "s" : ""}, ${warnings.length} warning${warnings.length !== 1 ? "s" : ""}`
-                : "All systems operational"
-            }
-            icon={hasIssues ? Icon.ExclamationMark : Icon.CheckCircle}
-            accessories={[
-              {
-                tag: {
-                  value: hasIssues ? "Issues Found" : "Healthy",
-                  color: hasIssues ? (errors.length > 0 ? Color.Red : Color.Orange) : Color.Green,
-                },
-              },
-            ]}
-            actions={
-              <ActionPanel>
-                <Action.OpenInBrowser title="Open System Status" url={`${sonarrUrl}/system/status`} icon={Icon.Globe} />
-                {quickActions}
-              </ActionPanel>
-            }
-          />
-
-          {errors.map((error) => (
-            <List.Item
-              key={error.source}
-              title={error.message}
-              subtitle={error.source}
-              icon={{ source: Icon.XMarkCircle, tintColor: Color.Red }}
-              accessories={[{ tag: { value: "Error", color: Color.Red } }]}
-              actions={
-                <ActionPanel>
-                  <Action.OpenInBrowser
-                    title="Open System Status"
-                    url={`${sonarrUrl}/system/status`}
-                    icon={Icon.Globe}
-                  />
-                  {quickActions}
-                </ActionPanel>
-              }
-            />
-          ))}
-
-          {warnings.map((warning) => (
-            <List.Item
-              key={warning.source}
-              title={warning.message}
-              subtitle={warning.source}
-              icon={{ source: Icon.Warning, tintColor: Color.Orange }}
-              accessories={[{ tag: { value: "Warning", color: Color.Orange } }]}
-              actions={
-                <ActionPanel>
-                  <Action.OpenInBrowser
-                    title="Open System Status"
-                    url={`${sonarrUrl}/system/status`}
-                    icon={Icon.Globe}
-                  />
-                  {quickActions}
-                </ActionPanel>
-              }
-            />
-          ))}
-        </List.Section>
       )}
-    </List>
+
+      {[...errors, ...warnings].map((check) => {
+        const isError = check.type === HealthCheckType.Error;
+
+        return (
+          <List.Item
+            key={`${instance.id}-${check.source}-${check.message}`}
+            title={check.message}
+            subtitle={check.source}
+            icon={{
+              source: isError ? Icon.XMarkCircle : Icon.Warning,
+              tintColor: isError ? Color.Red : Color.Orange,
+            }}
+            accessories={[{ tag: { value: isError ? "Error" : "Warning", color: isError ? Color.Red : Color.Orange } }]}
+            actions={
+              <ActionPanel>
+                <Action.OpenInBrowser
+                  title="Open System Status"
+                  url={`${instance.url}/system/status`}
+                  icon={Icon.Globe}
+                />
+                {instanceActions}
+              </ActionPanel>
+            }
+          />
+        );
+      })}
+    </List.Section>
   );
 }

--- a/extensions/sonarr/src/lib/components/AddSeriesForm.tsx
+++ b/extensions/sonarr/src/lib/components/AddSeriesForm.tsx
@@ -1,4 +1,5 @@
 import { addSeries, getQualityProfiles, getRootFolders } from "@/lib/hooks/useSonarrAPI";
+import type { SonarrInstance } from "@/lib/types/instance";
 import type { AddSeriesOptions, QualityProfile, RootFolder, SeriesLookup } from "@/lib/types/series";
 import { Action, ActionPanel, Form, Icon, showToast, Toast, useNavigation } from "@raycast/api";
 import { useEffect, useState } from "react";
@@ -6,9 +7,10 @@ import { useEffect, useState } from "react";
 interface AddSeriesFormProps {
   series: SeriesLookup;
   onSeriesAdded: () => void;
+  instance: SonarrInstance | null;
 }
 
-export default function AddSeriesForm({ series, onSeriesAdded }: AddSeriesFormProps) {
+export default function AddSeriesForm({ series, onSeriesAdded, instance }: AddSeriesFormProps) {
   const { pop } = useNavigation();
   const [isLoading, setIsLoading] = useState(true);
   const [rootFolders, setRootFolders] = useState<RootFolder[]>([]);
@@ -18,7 +20,7 @@ export default function AddSeriesForm({ series, onSeriesAdded }: AddSeriesFormPr
     async function loadOptions() {
       setIsLoading(true);
       try {
-        const [folders, profiles] = await Promise.all([getRootFolders(), getQualityProfiles()]);
+        const [folders, profiles] = await Promise.all([getRootFolders(instance), getQualityProfiles(instance)]);
         setRootFolders(folders);
         setQualityProfiles(profiles);
       } catch (error) {
@@ -33,7 +35,7 @@ export default function AddSeriesForm({ series, onSeriesAdded }: AddSeriesFormPr
     }
 
     loadOptions();
-  }, []);
+  }, [instance]);
 
   async function handleSubmit(values: {
     rootFolderPath: string;
@@ -46,7 +48,7 @@ export default function AddSeriesForm({ series, onSeriesAdded }: AddSeriesFormPr
       showToast({
         style: Toast.Style.Failure,
         title: "Configuration Error",
-        message: "No root folders or quality profiles configured in Sonarr",
+        message: `No root folders or quality profiles configured in ${instance?.name ?? "Sonarr"}`,
       });
       return;
     }
@@ -74,7 +76,7 @@ export default function AddSeriesForm({ series, onSeriesAdded }: AddSeriesFormPr
     };
 
     try {
-      await addSeries(options);
+      await addSeries(instance, options);
       onSeriesAdded();
       pop();
     } catch {
@@ -105,7 +107,10 @@ export default function AddSeriesForm({ series, onSeriesAdded }: AddSeriesFormPr
         </ActionPanel>
       }
     >
-      <Form.Description title="Add Series to Sonarr" text={`Adding: ${series.title} (${series.year})`} />
+      <Form.Description
+        title={`Add Series to ${instance?.name ?? "Sonarr"}`}
+        text={`Adding: ${series.title} (${series.year})`}
+      />
 
       <Form.Dropdown id="rootFolderPath" title="Root Folder" defaultValue={rootFolders[0]?.path}>
         {rootFolders.map((folder) => (

--- a/extensions/sonarr/src/lib/components/InstanceActions.tsx
+++ b/extensions/sonarr/src/lib/components/InstanceActions.tsx
@@ -1,0 +1,33 @@
+import { Action, ActionPanel, Icon, openExtensionPreferences } from "@raycast/api";
+import type { InstanceState } from "@/lib/types/instance";
+import { Shortcuts } from "@/lib/utils/shortcuts";
+
+interface InstanceActionsProps {
+  state: InstanceState;
+}
+
+/**
+ * Instance section shared by every command: switching targets from here is what
+ * makes the choice stick across commands, since it writes the selection the
+ * `useInstance` hook reads back.
+ */
+export function InstanceActions({ state }: InstanceActionsProps) {
+  const inactiveInstances = state.instances.filter((candidate) => candidate.id !== state.instance?.id);
+
+  return (
+    <ActionPanel.Section title="Instance">
+      {inactiveInstances.map((instance, index) => (
+        <Action
+          key={instance.id}
+          title={`Switch to ${instance.name}`}
+          icon={Icon.Switch}
+          onAction={() => state.switchToInstance(instance)}
+          // Only the first alternative gets the shortcut: with the two
+          // instances the preferences allow, that is always the other one.
+          shortcut={index === 0 ? Shortcuts.switchInstance : undefined}
+        />
+      ))}
+      <Action title="Open Extension Preferences" icon={Icon.Gear} onAction={openExtensionPreferences} />
+    </ActionPanel.Section>
+  );
+}

--- a/extensions/sonarr/src/lib/hooks/useInstance.ts
+++ b/extensions/sonarr/src/lib/hooks/useInstance.ts
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useMemo } from "react";
+import { showFailureToast, useLocalStorage } from "@raycast/utils";
+import type { InstanceState, SonarrInstance, SonarrInstanceId } from "@/lib/types/instance";
+import { getPreferredInstanceId, getSonarrInstances } from "@/lib/utils/connection";
+
+const ACTIVE_INSTANCE_KEY = "sonarr-active-instance";
+
+interface StoredSelection {
+  instanceId: SonarrInstanceId;
+  /** The `Active Instance` preference this selection was recorded against. */
+  preferredInstanceId: SonarrInstanceId;
+}
+
+/**
+ * Resolves the instance every command talks to.
+ *
+ * The selection is stored rather than kept in component state, so switching
+ * instances in one command carries over to the others and survives closing
+ * Raycast. The `Active Instance` preference seeds it, and every change to that
+ * preference wins over an earlier manual switch — otherwise the preference
+ * would look broken to anyone who had ever used the switch action.
+ *
+ * Detecting "changed" is why the preference is stored alongside the selection
+ * and re-recorded on mount: comparing against the value the last selection was
+ * made under is what tells a real preference change apart from a preference
+ * that merely happens to name the other instance.
+ */
+export function useInstance(): InstanceState {
+  const instances = useMemo(() => getSonarrInstances(), []);
+  const preferredInstanceId = useMemo(() => getPreferredInstanceId(), []);
+  const {
+    value: storedSelection,
+    setValue: setStoredSelection,
+    isLoading,
+  } = useLocalStorage<StoredSelection>(ACTIVE_INSTANCE_KEY);
+
+  const isSelectionCurrent = storedSelection?.preferredInstanceId === preferredInstanceId;
+
+  useEffect(() => {
+    if (isLoading || isSelectionCurrent) {
+      return;
+    }
+
+    setStoredSelection({ instanceId: preferredInstanceId, preferredInstanceId }).catch((error) => {
+      showFailureToast(error, { title: "Failed to store the active Sonarr instance" });
+    });
+  }, [isLoading, isSelectionCurrent, preferredInstanceId, setStoredSelection]);
+
+  const instance = useMemo(() => {
+    // Stay on `null` until the stored selection is known, so no request is ever
+    // fired against the instance the user switched away from.
+    if (isLoading) {
+      return null;
+    }
+
+    const selectedId = isSelectionCurrent && storedSelection ? storedSelection.instanceId : preferredInstanceId;
+
+    return instances.find((candidate) => candidate.id === selectedId) ?? instances[0] ?? null;
+  }, [instances, storedSelection, isSelectionCurrent, preferredInstanceId, isLoading]);
+
+  const switchToInstance = useCallback(
+    (next: SonarrInstance) => {
+      setStoredSelection({ instanceId: next.id, preferredInstanceId }).catch((error) => {
+        showFailureToast(error, { title: `Failed to switch to ${next.name}` });
+      });
+    },
+    [setStoredSelection, preferredInstanceId],
+  );
+
+  return { instance, instances, isLoading, switchToInstance };
+}

--- a/extensions/sonarr/src/lib/hooks/useSonarrAPI.ts
+++ b/extensions/sonarr/src/lib/hooks/useSonarrAPI.ts
@@ -1,11 +1,11 @@
 import { useFetch, showFailureToast } from "@raycast/utils";
-import { getPreferenceValues, openExtensionPreferences, showToast, Toast } from "@raycast/api";
+import { openExtensionPreferences, showToast, Toast } from "@raycast/api";
 import { addDays, format } from "date-fns";
 import { z } from "zod";
 import type { SingleSeries } from "@/lib/types/episode";
 import type { BlocklistResponse } from "@/lib/types/blocklist";
 import type { HistoryResponse } from "@/lib/types/history";
-import type { SonarrPreferences } from "@/lib/types/preferences";
+import type { SonarrInstance } from "@/lib/types/instance";
 import type { QueueItem } from "@/lib/types/queue";
 import type { AddSeriesOptions, QualityProfile, RootFolder, SeriesFull, SeriesLookup } from "@/lib/types/series";
 import type { Command, HealthCheck, SystemStatus } from "@/lib/types/system";
@@ -19,15 +19,16 @@ import {
   SystemStatusSchema,
 } from "@/lib/types/schemas";
 import { fetchAndValidate, fetchWithTimeout } from "@/lib/utils/api-helpers";
-import { getSonarrBaseUrl } from "@/lib/utils/connection";
 
-function getApiConfig() {
-  const preferences = getPreferenceValues<SonarrPreferences>();
+function getApiConfig(instance: SonarrInstance | null) {
+  if (!instance?.url || !instance.apiKey) {
+    throw new Error("No Sonarr instance is configured. Check the extension preferences.");
+  }
 
   return {
-    url: getSonarrBaseUrl(),
+    url: instance.url,
     headers: {
-      "X-Api-Key": preferences.apiKey.trim(),
+      "X-Api-Key": instance.apiKey,
     },
   };
 }
@@ -73,14 +74,24 @@ function getApiError(status: number, payload: unknown): Error {
   return new Error(message ? `API returned ${status}: ${message}` : `API returned ${status}`);
 }
 
-export function useSonarrAPI<T>(endpoint: string, options?: { execute?: boolean }) {
-  const { url, headers } = getApiConfig();
-  const fullUrl = `${url}/api/v3${endpoint}`;
+export function useSonarrAPI<T>(
+  instance: SonarrInstance | null,
+  endpoint: string,
+  options?: { execute?: boolean; showErrorToast?: boolean },
+) {
+  const isInstanceReady = Boolean(instance?.url && instance.apiKey);
+  const fullUrl = isInstanceReady ? `${instance?.url}/api/v3${endpoint}` : "";
+  const showErrorToast = options?.showErrorToast ?? true;
 
   return useFetch<T>(fullUrl, {
-    headers,
-    execute: options?.execute ?? true,
-    keepPreviousData: true,
+    headers: { "X-Api-Key": instance?.apiKey ?? "" },
+    execute: isInstanceReady && (options?.execute ?? true),
+    // Deliberately off: keeping the previous payload would leave the list
+    // showing the instance the user just switched away from, and an action
+    // fired from one of those rows would send that instance's IDs to the new
+    // one. Same-URL revalidations after a `mutate()` are served from the cache,
+    // so this only resets the view when the instance actually changes.
+    keepPreviousData: false,
     parseResponse: async (response) => {
       const payload = await parseResponsePayload(response);
 
@@ -91,8 +102,12 @@ export function useSonarrAPI<T>(endpoint: string, options?: { execute?: boolean 
       return payload as T;
     },
     onError: (error) => {
+      if (!showErrorToast) {
+        return;
+      }
+
       showFailureToast(error, {
-        title: "Failed to fetch data from Sonarr",
+        title: `Failed to fetch data from ${instance?.name ?? "Sonarr"}`,
         primaryAction: {
           title: "Open Extension Preferences",
           onAction: openExtensionPreferences,
@@ -102,58 +117,62 @@ export function useSonarrAPI<T>(endpoint: string, options?: { execute?: boolean 
   });
 }
 
-export function useCalendar(futureDays: number = 14) {
+export function useCalendar(instance: SonarrInstance | null, futureDays: number = 14) {
   const currentDate = format(new Date(), "yyyy-MM-dd");
   const futureDate = format(addDays(new Date(), futureDays), "yyyy-MM-dd");
 
   return useSonarrAPI<SingleSeries[]>(
+    instance,
     `/calendar?start=${currentDate}&end=${futureDate}&includeSeries=true&includeEpisodeFile=true&includeEpisodeImages=true`,
   );
 }
 
-export function useSeries() {
-  return useSonarrAPI<SeriesFull[]>("/series");
+export function useSeries(instance: SonarrInstance | null) {
+  return useSonarrAPI<SeriesFull[]>(instance, "/series");
 }
 
-export function useQueue() {
-  return useSonarrAPI<{ records: QueueItem[] }>("/queue?includeEpisode=true&includeSeries=true");
+export function useQueue(instance: SonarrInstance | null) {
+  return useSonarrAPI<{ records: QueueItem[] }>(instance, "/queue?includeEpisode=true&includeSeries=true");
 }
 
-export function useWantedMissing(page: number = 1, pageSize: number = 50) {
+export function useWantedMissing(instance: SonarrInstance | null, page: number = 1, pageSize: number = 50) {
   return useSonarrAPI<WantedMissingResponse>(
+    instance,
     `/wanted/missing?page=${page}&pageSize=${pageSize}&sortKey=airDateUtc&sortDirection=descending&includeSeries=true`,
   );
 }
 
-export function useHistory(page: number = 1, pageSize: number = 100) {
+export function useHistory(instance: SonarrInstance | null, page: number = 1, pageSize: number = 100) {
   return useSonarrAPI<HistoryResponse>(
+    instance,
     `/history?page=${page}&pageSize=${pageSize}&sortKey=date&sortDirection=descending&includeSeries=true&includeEpisode=true`,
   );
 }
 
-export function useBlocklist(page: number = 1, pageSize: number = 100) {
+export function useBlocklist(instance: SonarrInstance | null, page: number = 1, pageSize: number = 100) {
   return useSonarrAPI<BlocklistResponse>(
+    instance,
     `/blocklist?page=${page}&pageSize=${pageSize}&sortKey=date&sortDirection=descending&includeSeries=true`,
   );
 }
 
-export function useCommands() {
-  return useSonarrAPI<Command[]>("/command");
+export function useCommands(instance: SonarrInstance | null) {
+  return useSonarrAPI<Command[]>(instance, "/command");
 }
 
-export function useSystemStatus() {
-  return useSonarrAPI<SystemStatus>("/system/status");
+export function useSystemStatus(instance: SonarrInstance | null, options?: { showErrorToast?: boolean }) {
+  return useSonarrAPI<SystemStatus>(instance, "/system/status", options);
 }
 
-export function useHealth() {
-  return useSonarrAPI<HealthCheck[]>("/health");
+export function useHealth(instance: SonarrInstance | null, options?: { showErrorToast?: boolean }) {
+  return useSonarrAPI<HealthCheck[]>(instance, "/health", options);
 }
 
-export async function searchSeries(searchTerm: string): Promise<SeriesLookup[]> {
-  const { url, headers } = getApiConfig();
-  const encodedTerm = encodeURIComponent(searchTerm);
-
+export async function searchSeries(instance: SonarrInstance | null, searchTerm: string): Promise<SeriesLookup[]> {
   try {
+    const { url, headers } = getApiConfig(instance);
+    const encodedTerm = encodeURIComponent(searchTerm);
+
     return await fetchAndValidate(`${url}/api/v3/series/lookup?term=${encodedTerm}`, z.array(SeriesLookupSchema), {
       headers,
     });
@@ -167,10 +186,10 @@ export async function searchSeries(searchTerm: string): Promise<SeriesLookup[]> 
   }
 }
 
-export async function addSeries(options: AddSeriesOptions): Promise<SeriesFull> {
-  const { url, headers } = getApiConfig();
-
+export async function addSeries(instance: SonarrInstance | null, options: AddSeriesOptions): Promise<SeriesFull> {
   try {
+    const { url, headers } = getApiConfig(instance);
+
     const result = await fetchAndValidate(`${url}/api/v3/series`, SeriesFullSchema, {
       method: "POST",
       headers: {
@@ -197,10 +216,14 @@ export async function addSeries(options: AddSeriesOptions): Promise<SeriesFull> 
   }
 }
 
-export async function removeQueueItem(id: number, blocklist: boolean = false): Promise<void> {
-  const { url, headers } = getApiConfig();
-
+export async function removeQueueItem(
+  instance: SonarrInstance | null,
+  id: number,
+  blocklist: boolean = false,
+): Promise<void> {
   try {
+    const { url, headers } = getApiConfig(instance);
+
     const response = await fetchWithTimeout(`${url}/api/v3/queue/${id}?blocklist=${blocklist}`, {
       method: "DELETE",
       headers,
@@ -225,8 +248,12 @@ export async function removeQueueItem(id: number, blocklist: boolean = false): P
   }
 }
 
-export async function executeCommand(command: string, body: Record<string, unknown> = {}): Promise<Command> {
-  const { url, headers } = getApiConfig();
+export async function executeCommand(
+  instance: SonarrInstance | null,
+  command: string,
+  body: Record<string, unknown> = {},
+): Promise<Command> {
+  const { url, headers } = getApiConfig(instance);
 
   const response = await fetchWithTimeout(`${url}/api/v3/command`, {
     method: "POST",
@@ -255,14 +282,14 @@ export async function executeCommand(command: string, body: Record<string, unkno
   return parsed.data;
 }
 
-export async function searchEpisode(episodeIds: number[]): Promise<Command> {
+export async function searchEpisode(instance: SonarrInstance | null, episodeIds: number[]): Promise<Command> {
   const toast = await showToast({
     style: Toast.Style.Animated,
     title: "Queueing episode search...",
   });
 
   try {
-    const result = await executeCommand("EpisodeSearch", { episodeIds });
+    const result = await executeCommand(instance, "EpisodeSearch", { episodeIds });
 
     toast.style = Toast.Style.Success;
     toast.title = "Episode search queued";
@@ -277,14 +304,18 @@ export async function searchEpisode(episodeIds: number[]): Promise<Command> {
   }
 }
 
-export async function searchSeason(seriesId: number, seasonNumber: number): Promise<Command> {
+export async function searchSeason(
+  instance: SonarrInstance | null,
+  seriesId: number,
+  seasonNumber: number,
+): Promise<Command> {
   const toast = await showToast({
     style: Toast.Style.Animated,
     title: "Queueing season search...",
   });
 
   try {
-    const result = await executeCommand("SeasonSearch", { seriesId, seasonNumber });
+    const result = await executeCommand(instance, "SeasonSearch", { seriesId, seasonNumber });
 
     toast.style = Toast.Style.Success;
     toast.title = "Season search queued";
@@ -299,10 +330,14 @@ export async function searchSeason(seriesId: number, seasonNumber: number): Prom
   }
 }
 
-export async function toggleEpisodeMonitoring(episodeId: number, monitored: boolean): Promise<void> {
-  const { url, headers } = getApiConfig();
-
+export async function toggleEpisodeMonitoring(
+  instance: SonarrInstance | null,
+  episodeId: number,
+  monitored: boolean,
+): Promise<void> {
   try {
+    const { url, headers } = getApiConfig(instance);
+
     const response = await fetchWithTimeout(`${url}/api/v3/episode/monitor`, {
       method: "PUT",
       headers: {
@@ -334,10 +369,10 @@ export async function toggleEpisodeMonitoring(episodeId: number, monitored: bool
   }
 }
 
-export async function getRootFolders(): Promise<RootFolder[]> {
-  const { url, headers } = getApiConfig();
-
+export async function getRootFolders(instance: SonarrInstance | null): Promise<RootFolder[]> {
   try {
+    const { url, headers } = getApiConfig(instance);
+
     return await fetchAndValidate(`${url}/api/v3/rootfolder`, z.array(RootFolderSchema), { headers });
   } catch (error) {
     showToast({
@@ -349,10 +384,10 @@ export async function getRootFolders(): Promise<RootFolder[]> {
   }
 }
 
-export async function getQualityProfiles(): Promise<QualityProfile[]> {
-  const { url, headers } = getApiConfig();
-
+export async function getQualityProfiles(instance: SonarrInstance | null): Promise<QualityProfile[]> {
   try {
+    const { url, headers } = getApiConfig(instance);
+
     const profiles = await fetchAndValidate(`${url}/api/v3/qualityprofile`, z.array(QualityProfileSchema), {
       headers,
     });
@@ -368,14 +403,17 @@ export async function getQualityProfiles(): Promise<QualityProfile[]> {
   }
 }
 
-export async function testConnection(): Promise<{ success: boolean; message: string; status?: SystemStatus }> {
-  const { url, headers } = getApiConfig();
-
+export async function testConnection(
+  instance: SonarrInstance | null,
+  options?: { timeout?: number; retries?: number },
+): Promise<{ success: boolean; message: string; status?: SystemStatus }> {
   try {
+    const { url, headers } = getApiConfig(instance);
+
     const status = await fetchAndValidate(`${url}/api/v3/system/status`, SystemStatusSchema, {
       headers,
-      timeout: 15000,
-      retries: 2,
+      timeout: options?.timeout ?? 15000,
+      retries: options?.retries ?? 2,
     });
 
     return {

--- a/extensions/sonarr/src/lib/types/instance.ts
+++ b/extensions/sonarr/src/lib/types/instance.ts
@@ -1,0 +1,20 @@
+export type SonarrInstanceId = "primary" | "secondary";
+
+export interface SonarrInstance {
+  id: SonarrInstanceId;
+  name: string;
+  url: string;
+  apiKey: string;
+}
+
+/**
+ * What `useInstance()` returns. Commands pass this straight down to their list
+ * items so a single prop carries both the instance to query and the actions
+ * needed to switch away from it.
+ */
+export interface InstanceState {
+  instance: SonarrInstance | null;
+  instances: SonarrInstance[];
+  isLoading: boolean;
+  switchToInstance: (instance: SonarrInstance) => void;
+}

--- a/extensions/sonarr/src/lib/types/preferences.ts
+++ b/extensions/sonarr/src/lib/types/preferences.ts
@@ -1,8 +1,25 @@
+import type { SonarrInstanceId } from "@/lib/types/instance";
+
+/**
+ * Optional preferences are typed as possibly `undefined` on purpose: Raycast
+ * hands back `undefined` (not an empty string) for an optional field that was
+ * never filled in, so reading them must always go through `readPreference()`
+ * in `@/lib/utils/connection`.
+ */
 export interface SonarrPreferences {
+  instanceName?: string;
   host: string;
   port: string;
-  base: string;
+  base?: string;
   http: "http" | "https";
   apiKey: string;
-  futureDays: string;
+  enableSecondaryInstance?: boolean;
+  secondaryInstanceName?: string;
+  secondaryHost?: string;
+  secondaryPort?: string;
+  secondaryBase?: string;
+  secondaryHttp?: "http" | "https";
+  secondaryApiKey?: string;
+  activeInstance?: SonarrInstanceId;
+  futureDays?: string;
 }

--- a/extensions/sonarr/src/lib/types/preferences.ts
+++ b/extensions/sonarr/src/lib/types/preferences.ts
@@ -1,25 +1,14 @@
-import type { SonarrInstanceId } from "@/lib/types/instance";
-
 /**
- * Optional preferences are typed as possibly `undefined` on purpose: Raycast
- * hands back `undefined` (not an empty string) for an optional field that was
- * never filled in, so reading them must always go through `readPreference()`
- * in `@/lib/utils/connection`.
+ * The extension preferences, derived from the manifest rather than restated.
+ *
+ * `Preferences` is generated from `package.json`, so adding, renaming or
+ * removing a preference there cannot drift from this type — a stale field name
+ * becomes a compile error instead of an `undefined` read at runtime.
+ *
+ * It is wrapped in `Partial` on purpose: the generated type declares every
+ * preference as always present, but Raycast hands back `undefined` for one that
+ * was never filled in — on Windows this crashed the extension on
+ * `preferences.base.trim()`. Marking them all optional forces every read
+ * through `readPreference()` in `@/lib/utils/connection`.
  */
-export interface SonarrPreferences {
-  instanceName?: string;
-  host: string;
-  port: string;
-  base?: string;
-  http: "http" | "https";
-  apiKey: string;
-  enableSecondaryInstance?: boolean;
-  secondaryInstanceName?: string;
-  secondaryHost?: string;
-  secondaryPort?: string;
-  secondaryBase?: string;
-  secondaryHttp?: "http" | "https";
-  secondaryApiKey?: string;
-  activeInstance?: SonarrInstanceId;
-  futureDays?: string;
-}
+export type SonarrPreferences = Partial<Preferences>;

--- a/extensions/sonarr/src/lib/utils/connection.ts
+++ b/extensions/sonarr/src/lib/utils/connection.ts
@@ -1,25 +1,49 @@
 import { getPreferenceValues } from "@raycast/api";
+import type { SonarrInstance, SonarrInstanceId } from "@/lib/types/instance";
 import type { SonarrPreferences } from "@/lib/types/preferences";
 
-/**
- * Resolves the Sonarr base URL from the connection preferences.
- *
- * `Host` is meant to hold a bare hostname or IP, with the port in its own
- * preference. Full URLs (`http://sonarr.example.com:8989`) and `host:port`
- * forms are still normalized here so configurations created while those were
- * advertised keep working.
- *
- * This is the single place that reads the connection preferences: API requests
- * and the "Open in Sonarr" browser links both build on it, so they cannot
- * disagree about which URL the instance lives at.
- */
-export function getSonarrBaseUrl(): string {
-  const preferences = getPreferenceValues<SonarrPreferences>();
-  const rawHost = preferences.host.trim();
-  const rawPort = preferences.port.trim();
-  const rawBase = preferences.base.trim();
+const DEFAULT_PRIMARY_NAME = "Main";
+const DEFAULT_SECONDARY_NAME = "Second Instance";
 
-  let protocol: string = preferences.http;
+/**
+ * Raycast returns `undefined` for an optional preference that was never filled
+ * in — observed on Windows, where macOS hands back an empty string. Reading a
+ * preference through this helper instead of calling `.trim()` on it directly is
+ * what keeps the extension from crashing on a fresh Windows setup.
+ */
+function readPreference(value: string | undefined | null): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/**
+ * Resolves a Sonarr base URL from the granular connection preferences.
+ *
+ * `host` is meant to hold a bare hostname or IP, with the port in its own
+ * value. Full URLs (`http://sonarr.example.com:8989`) and `host:port` forms are
+ * still normalized here so configurations created while those were advertised
+ * keep working.
+ *
+ * Both instances describe themselves with the same four preferences and are
+ * resolved through this one function, so neither can end up with URL handling
+ * the other does not have. It is also the single place that reads the
+ * connection preferences: API requests and the "Open in Sonarr" browser links
+ * both build on it, so they cannot disagree about where an instance lives.
+ */
+export function buildSonarrBaseUrl(parts: {
+  host: string | undefined;
+  port?: string | undefined;
+  base?: string | undefined;
+  protocol?: string | undefined;
+}): string {
+  const rawHost = readPreference(parts.host);
+  const rawPort = readPreference(parts.port);
+  const rawBase = readPreference(parts.base);
+
+  if (!rawHost) {
+    return "";
+  }
+
+  let protocol = readPreference(parts.protocol) || "http";
   let host = rawHost;
   let port = rawPort;
   let baseFromHost = "";
@@ -55,5 +79,96 @@ export function getSonarrBaseUrl(): string {
   host = host.replace(/\/+$/g, "");
   const basePath = (rawBase || baseFromHost).replace(/^\/|\/$/g, "");
 
+  if (!host) {
+    return "";
+  }
+
   return `${protocol}://${host}${port ? `:${port}` : ""}${basePath ? `/${basePath}` : ""}`;
+}
+
+function getPrimaryInstance(preferences: SonarrPreferences): SonarrInstance {
+  return {
+    id: "primary",
+    name: readPreference(preferences.instanceName) || DEFAULT_PRIMARY_NAME,
+    url: buildSonarrBaseUrl({
+      host: preferences.host,
+      port: preferences.port,
+      base: preferences.base,
+      protocol: preferences.http,
+    }),
+    apiKey: readPreference(preferences.apiKey),
+  };
+}
+
+function getSecondaryInstance(preferences: SonarrPreferences): SonarrInstance | null {
+  if (!preferences.enableSecondaryInstance) {
+    return null;
+  }
+
+  const url = buildSonarrBaseUrl({
+    host: preferences.secondaryHost,
+    port: preferences.secondaryPort,
+    base: preferences.secondaryBase,
+    protocol: preferences.secondaryHttp,
+  });
+  const apiKey = readPreference(preferences.secondaryApiKey);
+
+  if (!url || !apiKey) {
+    return null;
+  }
+
+  return {
+    id: "secondary",
+    name: readPreference(preferences.secondaryInstanceName) || DEFAULT_SECONDARY_NAME,
+    url,
+    apiKey,
+  };
+}
+
+/**
+ * Every configured and usable instance, primary first. The primary instance is
+ * always present: its preferences are required, so an incomplete one still
+ * surfaces here and fails with a real connection error instead of silently
+ * leaving the extension with nothing to talk to.
+ */
+export function getSonarrInstances(): SonarrInstance[] {
+  const preferences = getPreferenceValues<SonarrPreferences>();
+  const instances = [getPrimaryInstance(preferences)];
+  const secondary = getSecondaryInstance(preferences);
+
+  if (secondary) {
+    instances.push(secondary);
+  }
+
+  return instances;
+}
+
+/** The instance preferences point at, used until the user switches at runtime. */
+export function getPreferredInstanceId(): SonarrInstanceId {
+  const preferences = getPreferenceValues<SonarrPreferences>();
+  return readPreference(preferences.activeInstance) === "secondary" ? "secondary" : "primary";
+}
+
+/**
+ * Explains why an enabled second instance is not usable, so the Instance Status
+ * command can point at the missing preference instead of just not listing it.
+ */
+export function getSecondaryInstanceIssue(): string | null {
+  const preferences = getPreferenceValues<SonarrPreferences>();
+
+  if (!preferences.enableSecondaryInstance) {
+    return null;
+  }
+
+  const missing: string[] = [];
+
+  if (!readPreference(preferences.secondaryHost)) {
+    missing.push("Second Instance Host");
+  }
+
+  if (!readPreference(preferences.secondaryApiKey)) {
+    missing.push("Second Instance API Key");
+  }
+
+  return missing.length > 0 ? `Missing ${missing.join(" and ")}` : null;
 }

--- a/extensions/sonarr/src/lib/utils/formatting.ts
+++ b/extensions/sonarr/src/lib/utils/formatting.ts
@@ -1,10 +1,18 @@
 import { format, formatDistanceToNow, isPast, isFuture } from "date-fns";
 import type { Image, Ratings } from "@/lib/types/episode";
 import { CoverType } from "@/lib/types/episode";
-import { getSonarrBaseUrl } from "@/lib/utils/connection";
+import type { InstanceState } from "@/lib/types/instance";
 
-export function getSonarrUrl(): string {
-  return getSonarrBaseUrl();
+/**
+ * Names the instance being browsed in the search bar, but only when there is
+ * more than one to tell apart.
+ */
+export function getSearchPlaceholder(state: InstanceState, label: string = "Search series"): string {
+  if (state.instances.length > 1 && state.instance) {
+    return `${label} on ${state.instance.name}...`;
+  }
+
+  return `${label}...`;
 }
 
 export function formatSeriesTitle(title: string, year?: number): string {

--- a/extensions/sonarr/src/lib/utils/shortcuts.ts
+++ b/extensions/sonarr/src/lib/utils/shortcuts.ts
@@ -42,6 +42,10 @@ export const Shortcuts = {
     macOS: { modifiers: ["cmd", "shift"], key: "backspace" },
     Windows: { modifiers: ["ctrl", "shift"], key: "d" },
   },
+  switchInstance: {
+    macOS: { modifiers: ["cmd", "shift"], key: "i" },
+    Windows: { modifiers: ["ctrl", "shift"], key: "i" },
+  },
   configureAndAdd: {
     macOS: { modifiers: ["cmd", "shift"], key: "a" },
     Windows: { modifiers: ["ctrl", "shift"], key: "a" },

--- a/extensions/sonarr/src/missing-episodes.tsx
+++ b/extensions/sonarr/src/missing-episodes.tsx
@@ -2,17 +2,20 @@ import { Action, ActionPanel, Icon, List, Color, Image, Keyboard } from "@raycas
 import { showFailureToast } from "@raycast/utils";
 import { useState, useMemo } from "react";
 import { isFuture, isPast } from "date-fns";
+import type { InstanceState } from "@/lib/types/instance";
 import type { WantedMissingEpisode } from "@/lib/types/wanted";
+import { useInstance } from "@/lib/hooks/useInstance";
 import { useWantedMissing, searchEpisode } from "@/lib/hooks/useSonarrAPI";
 import {
   formatAirDate,
   formatEpisodeNumber,
   formatOverview,
+  getSearchPlaceholder,
   getSeriesPoster,
   getRatingDisplay,
   formatRelativeTime,
-  getSonarrUrl,
 } from "@/lib/utils/formatting";
+import { InstanceActions } from "@/lib/components/InstanceActions";
 import { Shortcuts } from "@/lib/utils/shortcuts";
 
 type FilterStatus = "all" | "missing" | "upcoming" | "unreleased";
@@ -20,7 +23,8 @@ type FilterStatus = "all" | "missing" | "upcoming" | "unreleased";
 export default function Command() {
   const [filterStatus, setFilterStatus] = useState<FilterStatus>("all");
   const [searchText, setSearchText] = useState("");
-  const { data, isLoading, mutate } = useWantedMissing(1, 100);
+  const instanceState = useInstance();
+  const { data, isLoading, mutate } = useWantedMissing(instanceState.instance, 1, 100);
 
   const filteredEpisodes = useMemo(() => {
     if (!data || !data.records) return [];
@@ -46,10 +50,19 @@ export default function Command() {
     });
   }, [data, filterStatus, searchText]);
 
+  // Also reachable with an empty list: without it, switching back out of an
+  // instance that returned nothing would mean quitting the command.
+  const instancePanel = (
+    <ActionPanel>
+      <InstanceActions state={instanceState} />
+    </ActionPanel>
+  );
+
   return (
     <List
-      searchBarPlaceholder="Search missing episodes..."
-      isLoading={isLoading}
+      actions={instancePanel}
+      searchBarPlaceholder={getSearchPlaceholder(instanceState, "Search missing episodes")}
+      isLoading={isLoading || instanceState.isLoading}
       isShowingDetail
       filtering={false}
       onSearchTextChange={setSearchText}
@@ -71,19 +84,28 @@ export default function Command() {
           title="No Missing Episodes"
           description={filterStatus === "all" ? "All monitored episodes have files" : "No episodes match this filter"}
           icon={Icon.Check}
+          actions={instancePanel}
         />
       )}
       <List.Section title="Missing Episodes" subtitle={`${filteredEpisodes.length} episodes`}>
         {filteredEpisodes.map((episode) => (
-          <MissingEpisodeListItem key={episode.id} episode={episode} onRefresh={mutate} />
+          <MissingEpisodeListItem key={episode.id} episode={episode} onRefresh={mutate} instanceState={instanceState} />
         ))}
       </List.Section>
     </List>
   );
 }
 
-function MissingEpisodeListItem({ episode, onRefresh }: { episode: WantedMissingEpisode; onRefresh: () => void }) {
-  const sonarrUrl = getSonarrUrl();
+function MissingEpisodeListItem({
+  episode,
+  onRefresh,
+  instanceState,
+}: {
+  episode: WantedMissingEpisode;
+  onRefresh: () => void;
+  instanceState: InstanceState;
+}) {
+  const sonarrUrl = instanceState.instance?.url ?? "";
 
   const poster = episode.series ? getSeriesPoster(episode.series.images) : undefined;
   const airDate = new Date(episode.airDateUtc);
@@ -147,7 +169,7 @@ function MissingEpisodeListItem({ episode, onRefresh }: { episode: WantedMissing
 
   const handleSearchEpisode = async () => {
     try {
-      await searchEpisode([episode.id]);
+      await searchEpisode(instanceState.instance, [episode.id]);
       onRefresh();
     } catch (error) {
       showFailureToast("Failed to search episode", {
@@ -223,6 +245,8 @@ function MissingEpisodeListItem({ episode, onRefresh }: { episode: WantedMissing
               shortcut={Keyboard.Shortcut.Common.Refresh}
             />
           </ActionPanel.Section>
+
+          <InstanceActions state={instanceState} />
         </ActionPanel>
       }
     />

--- a/extensions/sonarr/src/search-series.tsx
+++ b/extensions/sonarr/src/search-series.tsx
@@ -1,9 +1,12 @@
 import { Action, ActionPanel, Icon, List, Color, Image } from "@raycast/api";
 import { useState, useEffect, useMemo, useRef } from "react";
+import type { InstanceState } from "@/lib/types/instance";
 import type { SeriesLookup } from "@/lib/types/series";
+import { useInstance } from "@/lib/hooks/useInstance";
 import { searchSeries, useSeries } from "@/lib/hooks/useSonarrAPI";
-import { getSeriesPoster, getSeriesStatus } from "@/lib/utils/formatting";
+import { getSearchPlaceholder, getSeriesPoster, getSeriesStatus } from "@/lib/utils/formatting";
 import AddSeriesForm from "@/lib/components/AddSeriesForm";
+import { InstanceActions } from "@/lib/components/InstanceActions";
 import { Shortcuts } from "@/lib/utils/shortcuts";
 
 export default function Command() {
@@ -11,7 +14,9 @@ export default function Command() {
   const [searchResults, setSearchResults] = useState<SeriesLookup[]>([]);
   const [isSearching, setIsSearching] = useState(false);
   const searchRequestId = useRef(0);
-  const { data: existingSeries, mutate } = useSeries();
+  const instanceState = useInstance();
+  const { instance } = instanceState;
+  const { data: existingSeries, mutate } = useSeries(instance);
 
   const existingSeriesIds = useMemo(() => {
     return new Set((existingSeries || []).map((s) => s.tvdbId));
@@ -20,7 +25,7 @@ export default function Command() {
   useEffect(() => {
     const searchTerm = searchText.trim();
 
-    if (searchTerm.length < 3) {
+    if (searchTerm.length < 3 || !instance) {
       searchRequestId.current += 1;
       setSearchResults([]);
       setIsSearching(false);
@@ -34,7 +39,7 @@ export default function Command() {
 
     const timer = setTimeout(async () => {
       try {
-        const results = await searchSeries(searchTerm);
+        const results = await searchSeries(instance, searchTerm);
 
         if (requestId === searchRequestId.current) {
           setSearchResults(results);
@@ -47,23 +52,38 @@ export default function Command() {
     }, 350);
 
     return () => clearTimeout(timer);
-  }, [searchText]);
+  }, [searchText, instance]);
+
+  // Also reachable with an empty list: without it, switching back out of an
+  // instance that returned nothing would mean quitting the command.
+  const instancePanel = (
+    <ActionPanel>
+      <InstanceActions state={instanceState} />
+    </ActionPanel>
+  );
 
   return (
     <List
-      searchBarPlaceholder="Search for TV series..."
+      actions={instancePanel}
+      searchBarPlaceholder={getSearchPlaceholder(instanceState, "Search for TV series")}
       onSearchTextChange={setSearchText}
-      isLoading={isSearching}
+      isLoading={isSearching || instanceState.isLoading}
       throttle
     >
       {searchResults.length === 0 && searchText.trim().length >= 3 && !isSearching && (
-        <List.EmptyView title="No Series Found" description="Try a different search term" icon={Icon.MagnifyingGlass} />
+        <List.EmptyView
+          title="No Series Found"
+          description="Try a different search term"
+          icon={Icon.MagnifyingGlass}
+          actions={instancePanel}
+        />
       )}
       {searchResults.length === 0 && searchText.trim().length < 3 && (
         <List.EmptyView
           title="Search for TV Series"
           description="Enter at least 3 characters to start searching"
           icon={Icon.Video}
+          actions={instancePanel}
         />
       )}
       {searchResults.map((series) => (
@@ -72,6 +92,7 @@ export default function Command() {
           series={series}
           isInLibrary={existingSeriesIds.has(series.tvdbId)}
           onSeriesAdded={mutate}
+          instanceState={instanceState}
         />
       ))}
     </List>
@@ -82,10 +103,12 @@ function SeriesListItem({
   series,
   isInLibrary,
   onSeriesAdded,
+  instanceState,
 }: {
   series: SeriesLookup;
   isInLibrary: boolean;
   onSeriesAdded: () => void;
+  instanceState: InstanceState;
 }) {
   const poster = getSeriesPoster(series.images) || series.remotePoster;
   const status = getSeriesStatus(series.status);
@@ -129,7 +152,9 @@ function SeriesListItem({
               <Action.Push
                 title="Configure & Add"
                 icon={Icon.Plus}
-                target={<AddSeriesForm series={series} onSeriesAdded={onSeriesAdded} />}
+                target={
+                  <AddSeriesForm series={series} onSeriesAdded={onSeriesAdded} instance={instanceState.instance} />
+                }
                 shortcut={Shortcuts.configureAndAdd}
               />
             )}
@@ -151,6 +176,8 @@ function SeriesListItem({
               />
             )}
           </ActionPanel.Section>
+
+          <InstanceActions state={instanceState} />
         </ActionPanel>
       }
     />

--- a/extensions/sonarr/src/series-library.tsx
+++ b/extensions/sonarr/src/series-library.tsx
@@ -1,6 +1,8 @@
 import { Action, ActionPanel, Icon, Grid, Keyboard } from "@raycast/api";
 import { useState, useMemo } from "react";
+import type { InstanceState } from "@/lib/types/instance";
 import type { SeriesFull } from "@/lib/types/series";
+import { useInstance } from "@/lib/hooks/useInstance";
 import { useSeries } from "@/lib/hooks/useSonarrAPI";
 import {
   formatSeriesTitle,
@@ -9,8 +11,9 @@ import {
   getSeriesStatus,
   formatOverview,
   formatFileSize,
-  getSonarrUrl,
+  getSearchPlaceholder,
 } from "@/lib/utils/formatting";
+import { InstanceActions } from "@/lib/components/InstanceActions";
 import { SeriesDetail } from "@/lib/components/SeriesDetail";
 import { Shortcuts } from "@/lib/utils/shortcuts";
 
@@ -18,7 +21,8 @@ type FilterStatus = "all" | "available" | "missing";
 
 export default function Command() {
   const [filterStatus, setFilterStatus] = useState<FilterStatus>("all");
-  const { data, isLoading, mutate } = useSeries();
+  const instanceState = useInstance();
+  const { data, isLoading, mutate } = useSeries(instanceState.instance);
 
   const filteredSeries = useMemo(() => {
     if (!data) return [];
@@ -34,11 +38,20 @@ export default function Command() {
       .sort((a, b) => a.sortTitle.localeCompare(b.sortTitle));
   }, [data, filterStatus]);
 
+  // Also reachable with an empty list: without it, switching back out of an
+  // instance that returned nothing would mean quitting the command.
+  const instancePanel = (
+    <ActionPanel>
+      <InstanceActions state={instanceState} />
+    </ActionPanel>
+  );
+
   return (
     <Grid
+      actions={instancePanel}
       columns={5}
-      searchBarPlaceholder="Search series..."
-      isLoading={isLoading}
+      searchBarPlaceholder={getSearchPlaceholder(instanceState)}
+      isLoading={isLoading || instanceState.isLoading}
       searchBarAccessory={
         <Grid.Dropdown
           tooltip="Filter by Status"
@@ -56,17 +69,26 @@ export default function Command() {
           title="No Series Found"
           description={filterStatus === "all" ? "Your library is empty" : "No series match this filter"}
           icon={Icon.Video}
+          actions={instancePanel}
         />
       )}
       {filteredSeries.map((series) => (
-        <SeriesGridItem key={series.id} series={series} onRefresh={mutate} />
+        <SeriesGridItem key={series.id} series={series} onRefresh={mutate} instanceState={instanceState} />
       ))}
     </Grid>
   );
 }
 
-function SeriesGridItem({ series, onRefresh }: { series: SeriesFull; onRefresh: () => void }) {
-  const sonarrUrl = getSonarrUrl();
+function SeriesGridItem({
+  series,
+  onRefresh,
+  instanceState,
+}: {
+  series: SeriesFull;
+  onRefresh: () => void;
+  instanceState: InstanceState;
+}) {
+  const sonarrUrl = instanceState.instance?.url ?? "";
 
   const poster = getSeriesPoster(series.images);
 
@@ -176,6 +198,8 @@ function SeriesGridItem({ series, onRefresh }: { series: SeriesFull; onRefresh: 
               shortcut={Keyboard.Shortcut.Common.Refresh}
             />
           </ActionPanel.Section>
+
+          <InstanceActions state={instanceState} />
         </ActionPanel>
       }
     />

--- a/extensions/sonarr/src/unmonitored-series.tsx
+++ b/extensions/sonarr/src/unmonitored-series.tsx
@@ -1,6 +1,8 @@
 import { Action, ActionPanel, Icon, Grid, Keyboard } from "@raycast/api";
 import { useState, useMemo } from "react";
+import type { InstanceState } from "@/lib/types/instance";
 import type { SeriesFull } from "@/lib/types/series";
+import { useInstance } from "@/lib/hooks/useInstance";
 import { useSeries } from "@/lib/hooks/useSonarrAPI";
 import {
   formatSeriesTitle,
@@ -9,8 +11,9 @@ import {
   getSeriesStatus,
   formatOverview,
   formatFileSize,
-  getSonarrUrl,
+  getSearchPlaceholder,
 } from "@/lib/utils/formatting";
+import { InstanceActions } from "@/lib/components/InstanceActions";
 import { SeriesDetail } from "@/lib/components/SeriesDetail";
 import { Shortcuts } from "@/lib/utils/shortcuts";
 
@@ -18,7 +21,8 @@ type FilterStatus = "all" | "available" | "missing";
 
 export default function Command() {
   const [filterStatus, setFilterStatus] = useState<FilterStatus>("all");
-  const { data, isLoading, mutate } = useSeries();
+  const instanceState = useInstance();
+  const { data, isLoading, mutate } = useSeries(instanceState.instance);
 
   const filteredSeries = useMemo(() => {
     if (!data) return [];
@@ -34,11 +38,20 @@ export default function Command() {
       .sort((a, b) => a.sortTitle.localeCompare(b.sortTitle));
   }, [data, filterStatus]);
 
+  // Also reachable with an empty list: without it, switching back out of an
+  // instance that returned nothing would mean quitting the command.
+  const instancePanel = (
+    <ActionPanel>
+      <InstanceActions state={instanceState} />
+    </ActionPanel>
+  );
+
   return (
     <Grid
+      actions={instancePanel}
       columns={5}
-      searchBarPlaceholder="Search unmonitored series..."
-      isLoading={isLoading}
+      searchBarPlaceholder={getSearchPlaceholder(instanceState, "Search unmonitored series")}
+      isLoading={isLoading || instanceState.isLoading}
       searchBarAccessory={
         <Grid.Dropdown
           tooltip="Filter by Availability"
@@ -56,17 +69,26 @@ export default function Command() {
           title="No Unmonitored Series"
           description="All series in your library are being monitored"
           icon={Icon.Eye}
+          actions={instancePanel}
         />
       )}
       {filteredSeries.map((series) => (
-        <SeriesGridItem key={series.id} series={series} onRefresh={mutate} />
+        <SeriesGridItem key={series.id} series={series} onRefresh={mutate} instanceState={instanceState} />
       ))}
     </Grid>
   );
 }
 
-function SeriesGridItem({ series, onRefresh }: { series: SeriesFull; onRefresh: () => void }) {
-  const sonarrUrl = getSonarrUrl();
+function SeriesGridItem({
+  series,
+  onRefresh,
+  instanceState,
+}: {
+  series: SeriesFull;
+  onRefresh: () => void;
+  instanceState: InstanceState;
+}) {
+  const sonarrUrl = instanceState.instance?.url ?? "";
 
   const poster = getSeriesPoster(series.images);
 
@@ -170,6 +192,8 @@ function SeriesGridItem({ series, onRefresh }: { series: SeriesFull; onRefresh: 
               shortcut={Keyboard.Shortcut.Common.Refresh}
             />
           </ActionPanel.Section>
+
+          <InstanceActions state={instanceState} />
         </ActionPanel>
       }
     />


### PR DESCRIPTION
## Description

Closes #28428

Adds support for a second Sonarr instance, with switching between the two from any command — the setup people running separate instances (1080p / 4K / anime) asked for in that issue.

### Configuring the second instance

The second instance is described by the same preferences as the first one — host, port, URL base, connection type and API key — so both accept exactly the same setups (bare host, `host:port`, a full URL, a subpath behind a reverse proxy). Both resolve their URL through a single helper, so neither can end up with URL handling the other lacks.

Every second-instance preference is optional and gated behind an `Enable second Sonarr instance` checkbox: existing configurations keep working untouched, and nothing new has to be filled in. No existing preference was renamed or retyped, so no one has to reconfigure anything.

### Switching

The `Instance` section of every command's action panel switches instance (`⌘⇧I` / `Ctrl+Shift+I`). The selection is stored rather than kept in component state, so switching in one command carries over to the others and survives closing Raycast. The `Active Instance` preference seeds it, and every change to that preference wins over an earlier manual switch.

`Instance Status` was reworked to report every configured instance side by side, each with its own connection test, version and health checks. It also flags a second instance that is enabled but still missing its host or API key, instead of silently leaving it out of the list.

### Also in this PR

- **Fixes a crash on Windows.** Raycast returns `undefined` rather than an empty string for an optional preference that was never filled in, so reading `URL Base` threw `TypeError: Cannot read properties of undefined (reading 'trim')` and every command using it failed to open. Every preference is now read through a helper that tolerates it.
- **`API Key` becomes a password field**, so the key is masked in the preferences instead of being displayed in clear text. Raycast stores password preferences separately from plain ones, so the key may need to be entered once more after updating — this is called out in the changelog.

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used by the `README` are placed outside of the `metadata` folder
