### PR TITLE
[Premier League] Fix stale fixtures, runaway scrolling and matchweek landing

### DIFF
--- a/extensions/premier-league/CHANGELOG.md
+++ b/extensions/premier-league/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Premier League Changelog
 
+## [Matchweek Navigation] - {PR_MERGE_DATE}
+
+- Fix Matches loading fixtures from the earliest seasons on record while the current season was still resolving.
+- Land on the upcoming matchweek instead of the one the gameweek config reports, and list the previous matchweek above it until the upcoming one kicks off.
+- Fetch a whole matchweek in one request. Scrolling no longer pulls in more matches or repeats fixtures already on screen.
+- Rename the matchweek actions to "Next Matchweek (n)" and "Previous Matchweek (n)", and bind them to `]` and `[`.
+
 ## [Fix Season Rollover] - 2026-08-21
 
 - Fix Matches, Table, Clubs and Squad showing the previous season once a new one kicks off. The season list the extension reads can trail the season it describes by months, so from July the active season is now read from the API and merged into that list.

--- a/extensions/premier-league/CHANGELOG.md
+++ b/extensions/premier-league/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Premier League Changelog
 
-## [Matchweek Navigation] - {PR_MERGE_DATE}
+## [Matchweek Navigation] - 2026-08-26
 
 - Fix Matches loading fixtures from the earliest seasons on record while the current season was still resolving.
 - Land on the upcoming matchweek instead of the one the gameweek config reports, and list the previous matchweek above it until the upcoming one kicks off.

--- a/extensions/premier-league/src/api/index.ts
+++ b/extensions/premier-league/src/api/index.ts
@@ -1,6 +1,5 @@
 import { showFailureToast } from "@raycast/utils";
 import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
-import { formatISO } from "date-fns";
 import {
   Club,
   Content,
@@ -26,6 +25,7 @@ import {
   TeamForm,
 } from "../types";
 import { competitions } from "../components/searchbar_competition";
+import { getCompetitionTimestamp } from "../utils";
 
 const epl = competitions[0].value;
 
@@ -144,7 +144,7 @@ export const getUpcomingMatchweek = async (
   season: string,
   comp: string = "8",
 ): Promise<number | undefined> => {
-  const today = formatISO(new Date(), { representation: "date" });
+  const now = getCompetitionTimestamp(new Date());
 
   const config: AxiosRequestConfig = {
     method: "get",
@@ -154,7 +154,7 @@ export const getUpcomingMatchweek = async (
       season,
       _sort: "kickoff:asc",
       _limit: 1,
-      [`kickoff>${today}`]: "",
+      [`kickoff>${now}`]: "",
     },
   };
 

--- a/extensions/premier-league/src/api/index.ts
+++ b/extensions/premier-league/src/api/index.ts
@@ -1,5 +1,6 @@
 import { showFailureToast } from "@raycast/utils";
 import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
+import { formatISO } from "date-fns";
 import {
   Club,
   Content,
@@ -136,6 +137,33 @@ export const getMatchweek = async (): Promise<number> => {
     showFailureToast(e);
 
     return 0;
+  }
+};
+
+export const getUpcomingMatchweek = async (
+  season: string,
+  comp: string = "8",
+): Promise<number | undefined> => {
+  const today = formatISO(new Date(), { representation: "date" });
+
+  const config: AxiosRequestConfig = {
+    method: "get",
+    url: `${endpoint}/v2/matches`,
+    params: {
+      competition: comp,
+      season,
+      _sort: "kickoff:asc",
+      _limit: 1,
+      [`kickoff>${today}`]: "",
+    },
+  };
+
+  try {
+    const { data }: AxiosResponse<EPLPagination<Fixture>> = await axios(config);
+
+    return data.data[0]?.matchWeek;
+  } catch {
+    return undefined;
   }
 };
 

--- a/extensions/premier-league/src/components/searchbar_competition.tsx
+++ b/extensions/premier-league/src/components/searchbar_competition.tsx
@@ -34,7 +34,7 @@ export const competitions = [
 export default function SearchBarCompetition(props: {
   type: string;
   selected: string;
-  onSelect: React.Dispatch<React.SetStateAction<string>>;
+  onSelect: (value: string) => void;
   data: { title: string; value: string }[];
 }) {
   return (

--- a/extensions/premier-league/src/match.tsx
+++ b/extensions/premier-league/src/match.tsx
@@ -6,124 +6,225 @@ import {
   List,
 } from "@raycast/api";
 import { usePromise } from "@raycast/utils";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { format, formatISO, getMonth, startOfMonth } from "date-fns";
 import groupBy from "lodash.groupby";
-import { getMatches, getSeasons, getClubs, getMatchweek } from "./api";
+import {
+  getClubs,
+  getMatches,
+  getMatchweek,
+  getSeasons,
+  getUpcomingMatchweek,
+} from "./api";
 import Matchday from "./components/matchday";
 import SearchBarCompetition, {
   competitions,
 } from "./components/searchbar_competition";
-import { convertISOToLocalTime } from "./utils";
+import { Fixture } from "./types";
+import { convertISOToLocalTime, getKickoffDate } from "./utils";
 
 const { filter } = getPreferenceValues();
 
 const epl = competitions[0].value;
+
+const TOTAL_MATCHWEEKS = 38;
+const MATCHES_LIMIT = 100;
+
+const year = new Date().getFullYear();
 
 const getMonthName = (monthIndex: number): string => {
   const date = new Date(year, monthIndex, 1);
   return format(date, "MMMM");
 };
 
-const year = new Date().getFullYear();
+type MatchRequest =
+  | {
+      kind: "matchweek";
+      competition: string;
+      season: string;
+      team: string;
+      matchweek: number;
+      withPrevious: boolean;
+    }
+  | {
+      kind: "month";
+      competition: string;
+      season: string;
+      start: string;
+      end: string;
+    };
+
+const emptyResult = { current: [] as Fixture[], previous: [] as Fixture[] };
+
+const fetchMatches = async (request?: MatchRequest) => {
+  if (!request) {
+    return emptyResult;
+  }
+
+  if (request.kind === "month") {
+    const { data } = await getMatches({
+      competition: request.competition,
+      season: request.season,
+      [`kickoff>${request.start}`]: "",
+      [`kickoff<${request.end}`]: "",
+      _limit: MATCHES_LIMIT,
+    });
+
+    return { current: data, previous: [] as Fixture[] };
+  }
+
+  const { data: current } = await getMatches({
+    competition: request.competition,
+    season: request.season,
+    team: request.team,
+    matchweek: request.matchweek,
+    _limit: MATCHES_LIMIT,
+  });
+
+  if (!request.withPrevious || request.matchweek <= 1) {
+    return { current, previous: [] as Fixture[] };
+  }
+
+  const { data: previous } = await getMatches({
+    competition: request.competition,
+    season: request.season,
+    team: request.team,
+    matchweek: request.matchweek - 1,
+    _limit: MATCHES_LIMIT,
+  });
+
+  return { current, previous };
+};
 
 export default function EPLMatchday() {
   const [competition, setCompetition] = useState<string>(epl);
   const isEPL = useMemo(() => competition === epl, [competition]);
 
   const [team, setTeam] = useState<string>("");
-
-  const [matchweek, setMatchweek] = useState<number>(0);
+  const [selectedMatchweek, setSelectedMatchweek] = useState<number>();
+  const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
   const [month, setMonth] = useState<number>(getMonth(new Date()));
 
-  useEffect(() => {
-    getMatchweek().then(setMatchweek);
-  }, []);
-
   const { data: seasons = [] } = usePromise(getSeasons);
-
   const season = useMemo(() => seasons[0]?.seasonId, [seasons]);
 
-  const { data: clubs } = usePromise(getClubs, [season]);
-
-  const props = useMemo(() => {
-    if (isEPL) {
-      return {
-        competition,
-        team,
-        season,
-        matchweek,
-      };
-    }
-
-    const start = formatISO(startOfMonth(new Date(year, month, 1)), {
-      representation: "date",
-    });
-    const end = formatISO(startOfMonth(new Date(year, month + 1, 1)), {
-      representation: "date",
-    });
-
-    return {
-      competition,
-      season,
-      [`kickoff>${start}`]: "",
-      [`kickoff<${end}`]: "",
-      _limit: 20,
-    };
-  }, [competition, team, season, matchweek, month]);
-
-  const { isLoading, data, pagination } = usePromise(
-    (props) =>
-      async ({ cursor: _next }) => {
-        return await getMatches({
-          ...props,
-          _next,
-        });
-      },
-    [props],
+  const { data: clubs } = usePromise(
+    async (id?: string) => (id ? await getClubs(id) : []),
+    [season],
   );
 
-  const matchday = groupBy(data, (f) =>
+  const { data: upcomingMatchweek } = usePromise(
+    async (id?: string) =>
+      id
+        ? ((await getUpcomingMatchweek(id)) ?? (await getMatchweek()))
+        : undefined,
+    [season],
+  );
+
+  const matchweek = selectedMatchweek ?? upcomingMatchweek;
+  const isLandingView = selectedMatchweek === undefined;
+
+  const request = useMemo<MatchRequest | undefined>(() => {
+    if (!season) {
+      return undefined;
+    }
+
+    if (isEPL) {
+      return matchweek
+        ? {
+            kind: "matchweek",
+            competition,
+            season,
+            team,
+            matchweek,
+            withPrevious: isLandingView,
+          }
+        : undefined;
+    }
+
+    return {
+      kind: "month",
+      competition,
+      season,
+      start: formatISO(startOfMonth(new Date(year, month, 1)), {
+        representation: "date",
+      }),
+      end: formatISO(startOfMonth(new Date(year, month + 1, 1)), {
+        representation: "date",
+      }),
+    };
+  }, [competition, isEPL, isLandingView, matchweek, month, season, team]);
+
+  const { isLoading, data } = usePromise(fetchMatches, [request]);
+
+  const { current, previous } = data ?? emptyResult;
+
+  const firstKickoff = current.find((match) => match.kickoff);
+  const hasCommenced = firstKickoff
+    ? getKickoffDate(firstKickoff.kickoff, firstKickoff.kickoffTimezone) <=
+      new Date()
+    : false;
+
+  const showPrevious = previous.length > 0 && !hasCommenced;
+  const fixtures = showPrevious ? [...previous, ...current] : current;
+
+  const matchday = groupBy(fixtures, (f) =>
     f.kickoff
       ? convertISOToLocalTime(f.kickoff, f.kickoffTimezone, "EEE d MMM yyyy")
       : "Date To Be Confirmed",
   );
 
+  const goToMatchweek = (next: number) => {
+    setSelectedMatchweek(next);
+    setSelectedItemId(null);
+  };
+
+  const onSearchBarSelect = (value: string) => {
+    setSelectedItemId(null);
+    if (filter === "competition") {
+      setCompetition(value);
+    } else {
+      setTeam(value);
+    }
+  };
+
   const actions = isEPL ? (
     <ActionPanel.Section title="Matchweek">
-      {matchweek > 1 && (
+      {matchweek && matchweek < TOTAL_MATCHWEEKS && (
         <Action
-          title={`Matchweek ${matchweek - 1}`}
-          icon={Icon.ArrowLeftCircle}
-          onAction={() => {
-            setMatchweek(matchweek - 1);
-          }}
+          title={`Next Matchweek (${matchweek + 1})`}
+          icon={Icon.ArrowRightCircle}
+          shortcut={{ modifiers: [], key: "]" }}
+          onAction={() => goToMatchweek(matchweek + 1)}
         />
       )}
-      {matchweek < 38 && (
+      {matchweek && matchweek > 1 && (
         <Action
-          title={`Matchweek ${matchweek + 1}`}
-          icon={Icon.ArrowRightCircle}
-          onAction={() => {
-            setMatchweek(matchweek + 1);
-          }}
+          title={`Previous Matchweek (${matchweek - 1})`}
+          icon={Icon.ArrowLeftCircle}
+          shortcut={{ modifiers: [], key: "[" }}
+          onAction={() => goToMatchweek(matchweek - 1)}
         />
       )}
     </ActionPanel.Section>
   ) : (
     <ActionPanel.Section title="Matchweek">
       <Action
-        title={getMonthName(month - 1)}
-        icon={Icon.ArrowLeftCircle}
+        title={getMonthName(month + 1)}
+        icon={Icon.ArrowRightCircle}
+        shortcut={{ modifiers: [], key: "]" }}
         onAction={() => {
-          setMonth(month - 1);
+          setSelectedItemId(null);
+          setMonth(month + 1);
         }}
       />
       <Action
-        title={getMonthName(month + 1)}
-        icon={Icon.ArrowRightCircle}
+        title={getMonthName(month - 1)}
+        icon={Icon.ArrowLeftCircle}
+        shortcut={{ modifiers: [], key: "[" }}
         onAction={() => {
-          setMonth(month + 1);
+          setSelectedItemId(null);
+          setMonth(month - 1);
         }}
       />
     </ActionPanel.Section>
@@ -132,18 +233,19 @@ export default function EPLMatchday() {
   return (
     <List
       throttle
-      isLoading={isLoading}
+      isLoading={isLoading || !request}
       navigationTitle={
         isEPL
-          ? `Matchweek ${matchweek} | Fixtures & Live Matches`
+          ? `Matchweek ${matchweek ?? ""} | Fixtures & Live Matches`
           : `${getMonthName(month)} | Fixtures & Live Matches`
       }
-      pagination={pagination}
+      selectedItemId={selectedItemId ?? current[0]?.matchId}
+      onSelectionChange={setSelectedItemId}
       searchBarAccessory={
         <SearchBarCompetition
           type={filter}
           selected={team}
-          onSelect={filter === "competition" ? setCompetition : setTeam}
+          onSelect={onSearchBarSelect}
           data={
             filter === "competition"
               ? competitions

--- a/extensions/premier-league/src/utils/index.ts
+++ b/extensions/premier-league/src/utils/index.ts
@@ -46,14 +46,16 @@ export const getFlagEmoji = (isoCode?: string) => {
     .replace(/./g, (char) => String.fromCodePoint(127397 + char.charCodeAt(0)));
 };
 
+export const getKickoffDate = (str: string, tz: string = "GMT"): Date =>
+  new Date(`${str}${tz === "BST" ? "+01:00" : "+00:00"}`);
+
 export const convertISOToLocalTime = (
   str: string,
   tz: string = "GMT",
   output: string = "EEE d MMM yyyy, HH:mm",
 ) => {
   try {
-    const stringWithTZ = tz === "BST" ? `${str}+01:00` : `${str}+00:00`;
-    return format(new Date(stringWithTZ), output);
+    return format(getKickoffDate(str, tz), output);
   } catch (error) {
     showFailureToast(error, { message: `Invalid ISO date value: ${str}` });
 

--- a/extensions/premier-league/src/utils/index.ts
+++ b/extensions/premier-league/src/utils/index.ts
@@ -46,6 +46,24 @@ export const getFlagEmoji = (isoCode?: string) => {
     .replace(/./g, (char) => String.fromCodePoint(127397 + char.charCodeAt(0)));
 };
 
+export const getCompetitionTimestamp = (date: Date): string => {
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    timeZone: "Europe/London",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(date);
+
+  const part = (type: string) =>
+    parts.find((p) => p.type === type)?.value ?? "00";
+
+  return `${part("year")}-${part("month")}-${part("day")} ${part("hour")}:${part("minute")}:${part("second")}`;
+};
+
 export const getKickoffDate = (str: string, tz: string = "GMT"): Date =>
   new Date(`${str}${tz === "BST" ? "+01:00" : "+00:00"}`);
 


### PR DESCRIPTION
## Description

- Matches sometimes opened on fixtures from 2006. It now waits until it knows which season and matchweek to show before loading anything.
- Scrolling a matchweek kept loading more games past the (usually) ten that exist, and eventually showed some fixtures twice as a result of fetch-scrolling. A matchweek now loads once, in full, and scrolling just scrolls. Pagination is explicitly and exclusively done via quick options.
- The **Matches** command would open on a matchweek that had already finished. Now, it opens on the next one to be played.
- When you _first_ open Matches, the previous matchweek sits above the upcoming one so last weekend's results are still there, and it drops away once the new matchweek kicks off. Focus **always** lands on the first upcoming fixture.
- The matchweek actions name where they take you, so "Next Matchweek (3)" and "Previous Matchweek (1)" instead of a "Matchweek (n)". "Next" comes before "previous" in the list, and they're on `]` and `[`. Both commands now show up at the top of the list.

## Screencast

N/A

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)
