### PR TITLE
Tuple: Keep human transcript timestamps compact

### DIFF
--- a/extensions/tuple/CHANGELOG.md
+++ b/extensions/tuple/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Tuple Changelog
 
+## [Compact Transcript Timestamps] - {PR_MERGE_DATE}
+
+- Transcript views and AI summaries keep compact clock timestamps as Tuple shifts its CLI default to full RFC3339 instants.
+
 ## [Smarter Calls and Rooms] - 2026-08-20
 
 - **Contacts** now show only the call action that person can accept: start when they're online, join when their call has room, and neither when they're offline or the call is full. Favorites, search, and Copy Email still work for everyone.

--- a/extensions/tuple/CHANGELOG.md
+++ b/extensions/tuple/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Tuple Changelog
 
-## [Compact Transcript Timestamps] - {PR_MERGE_DATE}
+## [Compact Transcript Timestamps] - 2026-08-25
 
 - Transcript views and AI summaries keep compact clock timestamps as Tuple shifts its CLI default to full RFC3339 instants.
 

--- a/extensions/tuple/package.json
+++ b/extensions/tuple/package.json
@@ -178,7 +178,7 @@
               "text": "the migration is on track"
             }
           ],
-          "read-transcript": "[10:05:00] Jordan Alvarez: the migration is on track"
+          "read-transcript": "[2026-06-20T10:05:00.000Z] Jordan Alvarez: the migration is on track"
         },
         "expected": [
           {

--- a/extensions/tuple/src/lib/ai.ts
+++ b/extensions/tuple/src/lib/ai.ts
@@ -1,5 +1,5 @@
 import { AI, environment } from "@raycast/api";
-import { getTranscript } from "./tuple";
+import { getCompactTranscript } from "./tuple";
 
 /** Cap the transcript fed to the model so very long calls don't blow the context window. */
 const MAX_TRANSCRIPT_CHARS = 50_000;
@@ -22,7 +22,7 @@ export function aiAvailable(): boolean {
 
 /** Load and trim a transcript for use as model context, noting truncation when it happens. */
 export async function transcriptContext(callId: string): Promise<string> {
-  const transcript = (await getTranscript(callId)).trim();
+  const transcript = (await getCompactTranscript(callId)).trim();
   if (transcript.length <= MAX_TRANSCRIPT_CHARS) {
     return transcript;
   }

--- a/extensions/tuple/src/lib/tuple.ts
+++ b/extensions/tuple/src/lib/tuple.ts
@@ -267,16 +267,24 @@ function isUnsupportedFlag(error: unknown, flag: string): boolean {
   return `${classified.message}\n${classified.detail ?? ""}`.toLowerCase().includes(`unknown flag: ${flag}`);
 }
 
-async function runTupleActionWithFallback(args: string[], optionalArgs: string[]): Promise<void> {
+async function runWithOptionalArgs<T>(
+  run: (args: string[]) => Promise<T>,
+  args: string[],
+  optionalArgs: string[],
+): Promise<T> {
   try {
-    await runTupleAction([...args, ...optionalArgs]);
+    return await run([...args, ...optionalArgs]);
   } catch (error) {
     const unsupported = optionalArgs.find((arg) => arg.startsWith("--") && isUnsupportedFlag(error, arg));
     if (!unsupported) {
       throw error;
     }
-    await runTupleAction(args);
+    return run(args);
   }
+}
+
+async function runTupleActionWithFallback(args: string[], optionalArgs: string[]): Promise<void> {
+  await runWithOptionalArgs(runTupleAction, args, optionalArgs);
 }
 
 export function startCall(email: string): Promise<void> {
@@ -357,12 +365,22 @@ export function stripAnsi(text: string): string {
 }
 
 /**
- * Fetch a stored call's transcript as plain text (`transcription show`, default format). ANSI codes
- * are stripped defensively (see {@link stripAnsi}) so every consumer — including AI summarization
- * and the read-transcript tool — gets clean text even from an older CLI that colorized its output.
+ * Fetch a stored call's transcript using the CLI's default timestamp format.
+ * ANSI codes are stripped defensively (see {@link stripAnsi}) so agent tools get
+ * clean text even from an older CLI that colorized its output.
  */
 export async function getTranscript(callId: string): Promise<string> {
   return stripAnsi(await runTuple(["transcription", "show", callId]));
+}
+
+/**
+ * Fetch compact transcript text for human display and title/summary generation.
+ * Current CLIs honor `--timestamps clock`; older CLIs already default to clocks
+ * and reach the same result through the optional-flag fallback.
+ */
+export async function getCompactTranscript(callId: string): Promise<string> {
+  const transcript = await runWithOptionalArgs(runTuple, ["transcription", "show", callId], ["--timestamps", "clock"]);
+  return stripAnsi(transcript);
 }
 
 /**

--- a/extensions/tuple/src/search-calls.tsx
+++ b/extensions/tuple/src/search-calls.tsx
@@ -14,17 +14,17 @@ import {
   showToast,
   Toast,
 } from "@raycast/api";
-import { showFailureToast, useExec } from "@raycast/utils";
+import { showFailureToast, usePromise } from "@raycast/utils";
 import { useState } from "react";
 import { EditCallMetadata, SummarizeCall } from "./call-ai";
 import { CallDraft } from "./lib/ai";
 import { TupleErrorDetail, TupleErrorEmptyView } from "./lib/empty-state";
-import { tupleExecOptions, useTupleJson } from "./lib/hooks";
+import { useTupleJson } from "./lib/hooks";
 import {
   classifyError,
   deleteTranscript,
   exportTranscripts,
-  getBinaryPath,
+  getCompactTranscript,
   getConnectPrompt,
   stripAnsi,
   stripMatchMarkers,
@@ -310,9 +310,7 @@ function TranscriptDetail({ callId, call, onChange }: { callId: string; call?: S
     onChange?.();
   };
 
-  const { data, isLoading, error, revalidate } = useExec(getBinaryPath(), ["transcription", "show", callId], {
-    ...tupleExecOptions(),
-    keepPreviousData: true,
+  const { data, isLoading, error, revalidate } = usePromise(getCompactTranscript, [callId], {
     onError: async (error) => {
       if (classifyError(error).kind === TupleErrorKind.Unknown) {
         await showFailureToast(error, { title: "Could Not Load Transcript" });


### PR DESCRIPTION
## Description

Tuple CLI now defaults human-readable transcripts to RFC3339 timestamps so agents can pass an observed timestamp directly to screen capture. This extension keeps compact clock timestamps where people scan transcripts and where title/summary generation consumes them, while its agent-facing `read-transcript` tool inherits the new capture-ready default.

The compact-clock requests fall back to the previous command shape when an older Tuple CLI does not recognize `--timestamps`, so the extension remains compatible during rollout.

Paired CLI change: https://github.com/tupleapp/app/pull/3977

## Verification

- `npm run lint`
- `npm run build`
- Store publisher validation: package metadata, lockfile, icons, ESLint, and Prettier

## Screencast

Not included: this compatibility change preserves the existing visual transcript format and adds no new UI.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
