### PR TITLE
USB-C Inspector: shorter Store listing and overview

### DIFF
--- a/extensions/usb-c-inspector/CHANGELOG.md
+++ b/extensions/usb-c-inspector/CHANGELOG.md
@@ -1,6 +1,6 @@
 # USB-C Inspector Changelog
 
-## [1.0.1] - {PR_MERGE_DATE}
+## [1.0.1] - 2026-08-25
 
 - Shorten the Store listing and overview so they fit the Store card and read more naturally
 

--- a/extensions/usb-c-inspector/CHANGELOG.md
+++ b/extensions/usb-c-inspector/CHANGELOG.md
@@ -1,5 +1,9 @@
 # USB-C Inspector Changelog
 
+## [1.0.1] - {PR_MERGE_DATE}
+
+- Shorten the Store listing and overview so they fit the Store card and read more naturally
+
 ## [Initial Version] - 2026-08-25
 
 - Show All USB-C Ports with plain-English headlines from the official WhatCable CLI

--- a/extensions/usb-c-inspector/README.md
+++ b/extensions/usb-c-inspector/README.md
@@ -1,13 +1,13 @@
 # USB-C Inspector
 
-See exactly what your USB-C and MagSafe cables can do — charging watts, data speed, Thunderbolt, and connected devices — directly from Raycast.
+USB-C Inspector shows what each USB-C or MagSafe cable can do: charging watts, data speed, Thunderbolt, and the device on the other end.
+
+Plug a cable in, pick the port, and read the details. On first launch the extension downloads the official WhatCable CLI and verifies it. No separate install needed.
 
 ## Requirements
 
 - **Apple Silicon Mac** (M1 or later). USB-PD / e-marker data is not available on Intel Macs.
 - **macOS 14 (Sonoma)** or later.
-
-You do **not** need to install WhatCable separately. On first launch the extension downloads the notarized CLI from [GitHub Releases](https://github.com/darrylmorley/whatcable/releases) and verifies it with SHA-256.
 
 ## Commands
 

--- a/extensions/usb-c-inspector/package.json
+++ b/extensions/usb-c-inspector/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "usb-c-inspector",
   "title": "USB-C Inspector",
-  "description": "See exactly what your USB-C and MagSafe cables can do — charging watts, data speed, Thunderbolt, and connected devices on every port.",
+  "description": "See exactly what your plugged-in USB-C cables can do.",
   "icon": "extension-icon.png",
   "author": "thilip_lindseth",
   "platforms": [
@@ -67,7 +67,7 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
-    "prepublishOnly": "echo \"\\n\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t⚠️ MAKE SURE YOU RUN THIS FROM YOUR LOCAL MACHINE, NOT A CI ENVIRONMENT ⚠️\\n\\n\\n\"",
+    "prepublishOnly": "echo \"\\n\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\u26a0\ufe0f MAKE SURE YOU RUN THIS FROM YOUR LOCAL MACHINE, NOT A CI ENVIRONMENT \u26a0\ufe0f\\n\\n\\n\"",
     "publish": "npx @raycast/api@latest publish"
   }
 }


### PR DESCRIPTION
## Summary
- Shorten the Store listing description so it fits the extension card (no truncation, no em dashes)
- Rewrite the overview so it talks about checking a specific cable, not only ports

## Test plan
- [ ] Store listing shows: `See exactly what your plugged-in USB-C cables can do.`
- [ ] Extension detail overview uses the new two-paragraph intro
- [ ] Changelog has a `1.0.1` section


Made with [Cursor](https://cursor.com)