### PR TITLE
fix(standing-desk-tracker): count in-progress session in today's stats

### DIFF
--- a/extensions/standing-desk-tracker/CHANGELOG.md
+++ b/extensions/standing-desk-tracker/CHANGELOG.md
@@ -25,4 +25,3 @@
 - Quick toggle command for switching states
 - Session history and statistics calculation
 - Configurable preferences for notifications and goals
-

--- a/extensions/standing-desk-tracker/CHANGELOG.md
+++ b/extensions/standing-desk-tracker/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Fix today's stats ignoring the in-progress session] - {PR_MERGE_DATE}
+## [Fix today's stats ignoring the in-progress session] - 2026-08-26
 
 ### Fixed
 

--- a/extensions/standing-desk-tracker/CHANGELOG.md
+++ b/extensions/standing-desk-tracker/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Fix today's stats ignoring the in-progress session] - {PR_MERGE_DATE}
+
+### Fixed
+
+- The menu bar command's "Today's Stats" no longer omits the session that is
+  currently running. `loadDailyStats` read the `currentState` React state
+  variable, but it is called from `loadData` immediately after
+  `setCurrentState`, so the closure still held the previous value (`null` on a
+  background refresh). Today's Standing/Sitting/Total therefore only ever
+  counted completed sessions and showed `0s` until the user toggled state. The
+  active state is now passed in explicitly, matching how
+  `checkAndShowMotivation` already receives it.
+
 ## [1.0.0] - 2026-02-05
 
 ### Added

--- a/extensions/standing-desk-tracker/README.md
+++ b/extensions/standing-desk-tracker/README.md
@@ -14,19 +14,25 @@ Track your standing and sitting time throughout the day to maintain a healthy wo
 ## Commands
 
 ### Standing Desk Tracker
+
 Main command to view and manage your standing/sitting state. Shows current status, elapsed time, and today's statistics.
 
 ### Standing Desk (Menubar)
+
 Displays your current status in the menubar with quick access to:
+
 - Current state (Standing/Sitting) and elapsed time
 - Today's statistics (standing, sitting, total time)
 - Quick toggle to switch states
 
 ### Toggle Standing/Sitting
+
 Quick command to toggle between standing and sitting states without opening a view.
 
 ### Standing Desk Stats
+
 View detailed statistics including:
+
 - Total time, standing time, and sitting time
 - Visual breakdown with progress bars
 - Session statistics (count, average duration, longest/shortest sessions)
@@ -76,4 +82,3 @@ npm run fix-lint
 ## License
 
 MIT
-

--- a/extensions/standing-desk-tracker/package.json
+++ b/extensions/standing-desk-tracker/package.json
@@ -84,4 +84,3 @@
     "publish": "npx @raycast/api@latest publish"
   }
 }
-

--- a/extensions/standing-desk-tracker/src/standing-desk-menubar.tsx
+++ b/extensions/standing-desk-tracker/src/standing-desk-menubar.tsx
@@ -15,6 +15,7 @@ import {
   calculateStats,
   formatDuration,
   getCurrentSessionElapsedTime,
+  getCurrentSessionElapsedTimeForPeriod,
   type DeskState,
 } from "./utils/standing-desk-utils";
 
@@ -149,7 +150,8 @@ export default function Command() {
 
       let totalStanding = stats.totalStanding;
       if (currentState === "standing") {
-        const currentElapsed = await getCurrentSessionElapsedTime();
+        const currentElapsed =
+          await getCurrentSessionElapsedTimeForPeriod("day");
         totalStanding += currentElapsed;
       }
 
@@ -212,7 +214,8 @@ export default function Command() {
       let totalSitting = stats.totalSitting;
 
       if (activeState) {
-        const currentElapsed = await getCurrentSessionElapsedTime();
+        const currentElapsed =
+          await getCurrentSessionElapsedTimeForPeriod("day");
         if (activeState === "standing") {
           totalStanding += currentElapsed;
         } else {

--- a/extensions/standing-desk-tracker/src/standing-desk-menubar.tsx
+++ b/extensions/standing-desk-tracker/src/standing-desk-menubar.tsx
@@ -80,7 +80,7 @@ export default function Command() {
       setElapsedTime(0);
     }
 
-    await loadDailyStats();
+    await loadDailyStats(state);
     // Check motivation after stats are loaded
     await checkAndShowMotivation(state);
     setIsLoading(false);
@@ -201,7 +201,7 @@ export default function Command() {
     }
   }
 
-  async function loadDailyStats() {
+  async function loadDailyStats(activeState: DeskState | null) {
     try {
       const allSessions = await getSessions();
       const daySessions = getSessionsForPeriod(allSessions, "day");
@@ -211,9 +211,9 @@ export default function Command() {
       let totalStanding = stats.totalStanding;
       let totalSitting = stats.totalSitting;
 
-      if (currentState) {
+      if (activeState) {
         const currentElapsed = await getCurrentSessionElapsedTime();
-        if (currentState === "standing") {
+        if (activeState === "standing") {
           totalStanding += currentElapsed;
         } else {
           totalSitting += currentElapsed;
@@ -241,7 +241,7 @@ export default function Command() {
       await setState(newState, now);
       setCurrentState(newState);
       setElapsedTime(0);
-      await loadDailyStats();
+      await loadDailyStats(newState);
       await showHUD(
         `Started ${newState === "standing" ? "Standing" : "Sitting"}`,
       );

--- a/extensions/standing-desk-tracker/src/standing-desk-tracker.tsx
+++ b/extensions/standing-desk-tracker/src/standing-desk-tracker.tsx
@@ -9,6 +9,7 @@ import {
   calculateStats,
   formatDuration,
   getCurrentSessionElapsedTime,
+  getCurrentSessionElapsedTimeForPeriod,
   type DeskState,
 } from "./utils/standing-desk-utils";
 
@@ -62,7 +63,8 @@ export default function Command() {
       let totalSitting = stats.totalSitting;
 
       if (currentState) {
-        const currentElapsed = await getCurrentSessionElapsedTime();
+        const currentElapsed =
+          await getCurrentSessionElapsedTimeForPeriod("day");
         if (currentState === "standing") {
           totalStanding += currentElapsed;
         } else {

--- a/extensions/standing-desk-tracker/src/utils/standing-desk-utils.ts
+++ b/extensions/standing-desk-tracker/src/utils/standing-desk-utils.ts
@@ -96,10 +96,7 @@ export async function getSessions(): Promise<Session[]> {
   }
 }
 
-export function getSessionsForPeriod(
-  sessions: Session[],
-  period: "day" | "week" | "month",
-): Session[] {
+export function getPeriodCutoffTime(period: "day" | "week" | "month"): number {
   const now = new Date();
   const cutoff = new Date();
 
@@ -118,9 +115,20 @@ export function getSessionsForPeriod(
       cutoff.setDate(1);
       cutoff.setHours(0, 0, 0, 0);
       break;
+    default: {
+      const exhaustiveCheck: never = period;
+      return exhaustiveCheck;
+    }
   }
 
-  const cutoffTime = cutoff.getTime();
+  return cutoff.getTime();
+}
+
+export function getSessionsForPeriod(
+  sessions: Session[],
+  period: "day" | "week" | "month",
+): Session[] {
+  const cutoffTime = getPeriodCutoffTime(period);
 
   return sessions.filter((session) => {
     const sessionDate = new Date(session.startTime);
@@ -208,4 +216,23 @@ export async function getCurrentSessionElapsedTime(): Promise<number> {
 
   const now = Date.now();
   return Math.floor((now - startTime) / 1000);
+}
+
+export async function getCurrentSessionElapsedTimeForPeriod(
+  period: "day" | "week" | "month",
+): Promise<number> {
+  const { startTime } = await getCurrentState();
+  if (!startTime) {
+    return 0;
+  }
+
+  const cutoffTime = getPeriodCutoffTime(period);
+  const effectiveStart = Math.max(startTime, cutoffTime);
+  const now = Date.now();
+
+  if (now <= effectiveStart) {
+    return 0;
+  }
+
+  return Math.floor((now - effectiveStart) / 1000);
 }

--- a/extensions/standing-desk-tracker/tsconfig.json
+++ b/extensions/standing-desk-tracker/tsconfig.json
@@ -14,4 +14,3 @@
     "resolveJsonModule": true
   }
 }
-


### PR DESCRIPTION
## Description

Fixes the `Standing Desk` menu bar command showing `0s` for **Today's Stats** while a session is in progress.

`loadDailyStats()` read the `currentState` React state variable, but it is called from `loadData()` on the line right after `setCurrentState(state)`:

```ts
async function loadData() {
  const { state } = await getCurrentState();
  setCurrentState(state);          // state setters don't mutate the existing closure
  ...
  await loadDailyStats();          // still sees the previous render's currentState
  await checkAndShowMotivation(state);
}
```

State setters don't mutate the closure that `loadDailyStats` captured, and the mount effect has an empty dependency list so it never re-runs. On every background refresh `currentState` is therefore still `null`, the `if (currentState)` guard is never taken, and the in-progress session is never added. Today's Standing / Sitting / Total only ever counted *completed* sessions — so a fresh install that has toggled once shows `0s` indefinitely.

The fix passes the resolved state in explicitly, the same way `checkAndShowMotivation(state)` already receives it, plus `newState` from `handleToggleState`. No behaviour change beyond the in-progress session now being counted.

Note `standing-desk-tracker.tsx` has the same shape, but it self-heals there because its effect re-runs on `[currentState]`, so I left it alone to keep this focused.

## Screencast

Straightforward logic fix with no UI change — the affected rows are the existing `Standing` / `Sitting` / `Total` items in the menu bar's "Today's Stats" section, which now include the running session instead of omitting it.

Reported from a fresh store install where "Today's Stats" read `Standing 0s / Sitting 0s / Total 0s` during an active sitting session.

To be precise about what I verified: `ray build` + `ray lint` pass, and I installed the distribution bundle and confirmed the command runs on its background interval. I have not captured a before/after screenshot of the menu bar itself, so the fix rests on the control-flow argument above rather than a visual diff. Happy to add a screencast if that's wanted for review.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
