### PR TITLE
Update apple-reminders extension

### DIFF
--- a/extensions/apple-reminders/CHANGELOG.md
+++ b/extensions/apple-reminders/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Apple Reminders Changelog
 
+## [Fix Menu Bar Reminders title truncation] - {PR_MERGE_DATE}
+
+- Truncate menu bar reminder titles by Unicode character instead of UTF-16 code units so emoji and other multi-byte characters are not split.
+
 ## [Fix natural-language due dates] - 2026-08-19
 
 - Restore relative due-date parsing in Create Reminder for `1h`, `1 hour`, `3 hours`, `in 10 minutes`, `3:45 pm`, `3 days`, and `1 year`.

--- a/extensions/apple-reminders/CHANGELOG.md
+++ b/extensions/apple-reminders/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Apple Reminders Changelog
 
-## [Fix Menu Bar Reminders title truncation] - {PR_MERGE_DATE}
+## [Fix Menu Bar Reminders title truncation] - 2026-08-27
 
 - Truncate menu bar reminder titles by Unicode character instead of UTF-16 code units so emoji and other multi-byte characters are not split.
 

--- a/extensions/apple-reminders/src/helpers.ts
+++ b/extensions/apple-reminders/src/helpers.ts
@@ -86,11 +86,13 @@ export function getLocationDescription(location: Location) {
 }
 
 export function truncate(str: string, maxLength = 45): string {
-  if (str.length <= maxLength) {
+  const characters = Array.from(str);
+
+  if (characters.length <= maxLength) {
     return str;
   }
 
-  return str.substring(0, maxLength) + "…";
+  return characters.slice(0, maxLength).join("") + "…";
 }
 
 export function getIntervalValidationError(interval?: string): string | undefined {


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used by the `README` are placed outside of the `metadata` folder
