### PR TITLE
[Clean Keyboard] Fix Forever duration

### DIFF
--- a/extensions/clean-keyboard/CHANGELOG.md
+++ b/extensions/clean-keyboard/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Clean Keyboard Changelog
 
-## [Fix Forever Duration] - {PR_MERGE_DATE}
+## [Fix Forever Duration] - 2026-08-29
 
 - Fixed the Forever option unlocking the keyboard after 15 seconds and ensured manual unlock exits its native handler
 

--- a/extensions/clean-keyboard/CHANGELOG.md
+++ b/extensions/clean-keyboard/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Clean Keyboard Changelog
 
+## [Fix Forever Duration] - {PR_MERGE_DATE}
+
+- Fixed the Forever option unlocking the keyboard after 15 seconds
+
 ## [Lock Fn Keys] - 2026-05-07
 
 - Added opt-in preference to also block the function row while cleaning (macOS Tahoe 26+ only)

--- a/extensions/clean-keyboard/CHANGELOG.md
+++ b/extensions/clean-keyboard/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Fix Forever Duration] - {PR_MERGE_DATE}
 
-- Fixed the Forever option unlocking the keyboard after 15 seconds
+- Fixed the Forever option unlocking the keyboard after 15 seconds and ensured manual unlock exits its native handler
 
 ## [Lock Fn Keys] - 2026-05-07
 

--- a/extensions/clean-keyboard/src/clean-keyboard.tsx
+++ b/extensions/clean-keyboard/src/clean-keyboard.tsx
@@ -158,7 +158,7 @@ export default function Command() {
           title={`Cleaning keyboard${timeLeft ? ` for ${timeLeft} seconds…` : ""}`}
           actions={
             <ActionPanel>
-              <Action title={"Back"} onAction={timeLeft === null ? unlockAction : () => setIsRunning(false)} />
+              {timeLeft !== null && <Action title={"Back"} onAction={() => setIsRunning(false)} />}
               <Action
                 autoFocus={false}
                 title={"Unlock Keyboard"}

--- a/extensions/clean-keyboard/src/clean-keyboard.tsx
+++ b/extensions/clean-keyboard/src/clean-keyboard.tsx
@@ -158,7 +158,7 @@ export default function Command() {
           title={`Cleaning keyboard${timeLeft ? ` for ${timeLeft} seconds…` : ""}`}
           actions={
             <ActionPanel>
-              <Action title={"Back"} onAction={() => setIsRunning(false)} />
+              <Action title={"Back"} onAction={timeLeft === null ? unlockAction : () => setIsRunning(false)} />
               <Action
                 autoFocus={false}
                 title={"Unlock Keyboard"}

--- a/extensions/clean-keyboard/src/clean-keyboard.tsx
+++ b/extensions/clean-keyboard/src/clean-keyboard.tsx
@@ -85,7 +85,7 @@ export default function Command() {
   }, [isRunning]);
 
   const lockAction = async (duration: Duration) => {
-    let handler: (duration?: number) => void;
+    let handler: (duration: number | null) => Promise<void>;
     if (isMac) {
       const { handler: handlerSwift } = await import("swift:../swift/MyExecutable");
       handler = handlerSwift;
@@ -104,18 +104,21 @@ export default function Command() {
       }
     }
 
-    setTimeLeft(duration.seconds ?? null);
-    setIcon(duration.icon);
-    setIsRunning(true);
-    await showToast({ title: "Keyboard locked" });
+    const durationSeconds = duration.seconds ?? null;
+    const handlerPromise = handler(durationSeconds);
 
-    Promise.resolve(handler(duration.seconds)).catch(async (err) => {
+    handlerPromise.catch(async (err) => {
       // Roll back UI if hook installation failed
       setIsRunning(false);
       setTimeLeft(null);
       setIcon(null);
       await showToast({ title: "Failed to lock keyboard", message: String(err), style: Toast.Style.Failure });
     });
+
+    setTimeLeft(durationSeconds);
+    setIcon(duration.icon);
+    setIsRunning(true);
+    await showToast({ title: "Keyboard locked" });
   };
 
   const unlockAction = async () => {

--- a/extensions/clean-keyboard/src/clean-keyboard.tsx
+++ b/extensions/clean-keyboard/src/clean-keyboard.tsx
@@ -4,7 +4,7 @@ import { isMac, isTahoe, readFnState, setFnState } from "./lib/utils";
 
 interface Duration {
   display: string;
-  seconds: number;
+  seconds?: number;
   icon: string;
 }
 
@@ -46,7 +46,6 @@ const durations: Duration[] = [
   },
   {
     display: "Forever",
-    seconds: Infinity,
     icon: "🤯",
   },
 ];
@@ -86,7 +85,7 @@ export default function Command() {
   }, [isRunning]);
 
   const lockAction = async (duration: Duration) => {
-    let handler: (duration: number) => void;
+    let handler: (duration?: number) => void;
     if (isMac) {
       const { handler: handlerSwift } = await import("swift:../swift/MyExecutable");
       handler = handlerSwift;
@@ -105,7 +104,7 @@ export default function Command() {
       }
     }
 
-    setTimeLeft(duration.seconds);
+    setTimeLeft(duration.seconds ?? null);
     setIcon(duration.icon);
     setIsRunning(true);
     await showToast({ title: "Keyboard locked" });

--- a/extensions/clean-keyboard/swift/MyExecutable/Sources/SwiftAPIKeyboard.swift
+++ b/extensions/clean-keyboard/swift/MyExecutable/Sources/SwiftAPIKeyboard.swift
@@ -91,7 +91,7 @@ func globalKeyEventHandler(
 
 @raycast func handler(duration: Int?) {
   let handler = EventHandler()
-  handler.scheduleTimer(duration: duration ?? 15)
+  handler.scheduleTimer(duration: duration)
   handler.run()
 }
 

--- a/extensions/clean-keyboard/swift/MyExecutable/Sources/SwiftAPIKeyboard.swift
+++ b/extensions/clean-keyboard/swift/MyExecutable/Sources/SwiftAPIKeyboard.swift
@@ -71,6 +71,7 @@ class EventHandler {
 
     if controlFlag, keyCode == KeyCode.u.rawValue {
       isLocked = false
+      CFRunLoopStop(CFRunLoopGetCurrent())
       return Unmanaged.passRetained(event)
     }
 


### PR DESCRIPTION
## Description

Fixes #29403.

The Forever option previously passed `Infinity` into the native bridge. On macOS that arrives as a missing optional duration, which Swift replaced with 15 seconds. Forever now uses an omitted duration consistently, and Swift skips timer creation when no duration is supplied. Finite durations and manual Ctrl+U unlocking are unchanged.

## Screencast

Not included; this fixes the native duration passed by the existing Forever action without changing the UI.

## Checklist

- [x] I read the extension guidelines
- [x] I read the documentation about publishing
- [x] I ran `npm run lint` and `npm run build`
- [x] I checked that files in the assets folder are used by the extension itself
- [x] I checked that assets used in the README are located outside the metadata folder if they were not generated with the metadata tool

Validation: `npm run lint` and the macOS Swift-backed `npm run build` pass.