### PR TITLE
[Search npm] Add Aube package manager support

### DIFF
--- a/extensions/search-npm/CHANGELOG.md
+++ b/extensions/search-npm/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Search npm Changelog
 
-## [Add Aube support] - {PR_MERGE_DATE}
+## [Add Aube support] - 2026-08-27
 
 - Add Aube as a package manager option for copying install commands
 

--- a/extensions/search-npm/CHANGELOG.md
+++ b/extensions/search-npm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Search npm Changelog
 
+## [Add Aube support] - {PR_MERGE_DATE}
+
+- Add Aube as a package manager option for copying install commands
+
 ## [Add search results provider] - 2026-08-06
 
 - Add an npmx.dev option for external package search results

--- a/extensions/search-npm/package.json
+++ b/extensions/search-npm/package.json
@@ -75,6 +75,10 @@
         {
           "title": "bun",
           "value": "bun"
+        },
+        {
+          "title": "Aube",
+          "value": "aube"
         }
       ],
       "title": "Default Package Manager",
@@ -102,6 +106,10 @@
         {
           "title": "bun",
           "value": "bun"
+        },
+        {
+          "title": "Aube",
+          "value": "aube"
         }
       ],
       "title": "Secondary Package Manager",

--- a/extensions/search-npm/src/components/CopyInstallCommandActions.tsx
+++ b/extensions/search-npm/src/components/CopyInstallCommandActions.tsx
@@ -1,7 +1,7 @@
 import type { Keyboard } from "@raycast/api";
 import { Action, getPreferenceValues } from "@raycast/api";
 
-type Registries = "yarn" | "npm" | "pnpm" | "bun";
+type Registries = "yarn" | "npm" | "pnpm" | "bun" | "aube";
 interface RegistryItem {
   name: string;
   registry: Registries;
@@ -26,6 +26,11 @@ const registries: RegistryItem[] = [
   {
     name: "bun",
     registry: "bun",
+    installCommand: "add",
+  },
+  {
+    name: "Aube",
+    registry: "aube",
     installCommand: "add",
   },
 ];


### PR DESCRIPTION
## Description

Fixes #29691.

Adds Aube to the extension's shared package-manager registry and to both package-manager preferences. Selecting it now copies `aube add <package>` using the same existing action path as Yarn, npm, pnpm, and Bun.

## Screencast

Not included; this adds one option to the existing package-manager dropdowns and copy action.

## Checklist

- [x] I read the extension guidelines
- [x] I read the documentation about publishing
- [x] I ran `npm run lint` and `npm run build`
- [x] I checked that files in the assets folder are used by the extension itself
- [x] I checked that assets used in the README are located outside the metadata folder if they were not generated with the metadata tool

Validation: `npm run lint` and `npm run build` pass.