### PR TITLE
[AeroSpace] Show focused workspace first

### DIFF
--- a/extensions/aerospace/CHANGELOG.md
+++ b/extensions/aerospace/CHANGELOG.md
@@ -1,6 +1,6 @@
 # aerospace Changelog
 
-## [Focused Workspace First] - {PR_MERGE_DATE}
+## [Focused Workspace First] - 2026-08-26
 
 - Show the focused workspace first when switching apps across all workspaces
 

--- a/extensions/aerospace/CHANGELOG.md
+++ b/extensions/aerospace/CHANGELOG.md
@@ -1,5 +1,9 @@
 # aerospace Changelog
 
+## [Focused Workspace First] - {PR_MERGE_DATE}
+
+- Show the focused workspace first when switching apps across all workspaces
+
 ## [Maintenance] - 2026-07-28
 
 - Eliminate 1-2s startup delay by removing `shell-env` (no longer spawns a login shell)

--- a/extensions/aerospace/src/switchApps.tsx
+++ b/extensions/aerospace/src/switchApps.tsx
@@ -36,14 +36,20 @@ async function getWindows(workspace: string): Promise<WindowWithPath[]> {
     "%{app-name} %{window-title} %{window-id} %{app-pid} %{workspace} %{app-bundle-id} %{monitor-name}",
   ];
 
-  const [output, apps] = await Promise.all([aerospace(...args), getApplications()]);
+  const [output, apps, focusedWorkspace] = await Promise.all([
+    aerospace(...args),
+    getApplications(),
+    workspace === "focused" ? undefined : aerospace("list-workspaces", "--focused"),
+  ]);
   const pathByBundleId = new Map(apps.map((a) => [a.bundleId, a.path]));
   const windows: Window[] = JSON.parse(output);
 
-  return windows.map((w) => ({
-    ...w,
-    "app-path": pathByBundleId.get(w["app-bundle-id"]) || "",
-  }));
+  return windows
+    .map((w) => ({
+      ...w,
+      "app-path": pathByBundleId.get(w["app-bundle-id"]) || "",
+    }))
+    .sort((a, b) => Number(b.workspace === focusedWorkspace) - Number(a.workspace === focusedWorkspace));
 }
 
 export default function Command(


### PR DESCRIPTION
## Description

Fixes #29850.

When switching apps across all workspaces, the extension now fetches AeroSpace's focused workspace in parallel with the existing window and application data. A stable ordering step promotes that workspace before the existing insertion-ordered grouping while preserving window order within every workspace. Focused-only mode is unchanged.

## Screencast

Not included because AeroSpace is not running in the validation environment; the extension compiles and type-checks against the existing command path.

## Checklist

- [x] I read the extension guidelines
- [x] I read the documentation about publishing
- [x] I ran `npm run lint` and `npm run build`
- [x] I checked that files in the assets folder are used by the extension itself
- [x] I checked that assets used in the README are located outside the metadata folder if they were not generated with the metadata tool

Validation: `npm run lint` and `npm run build` pass.