### PR TITLE
[In the Time Zone] Respect system time format

### DIFF
--- a/extensions/in-the-time-zone/CHANGELOG.md
+++ b/extensions/in-the-time-zone/CHANGELOG.md
@@ -1,6 +1,6 @@
 # In The Timezone Changelog
 
-## [System Time Format] - {PR_MERGE_DATE}
+## [System Time Format] - 2026-08-31
 
 - Respect the system 12/24-hour format, with preferences to override it
 

--- a/extensions/in-the-time-zone/CHANGELOG.md
+++ b/extensions/in-the-time-zone/CHANGELOG.md
@@ -1,5 +1,9 @@
 # In The Timezone Changelog
 
+## [System Time Format] - {PR_MERGE_DATE}
+
+- Respect the system 12/24-hour format, with preferences to override it
+
 ## [Initial Version] - 2026-04-08
 
 - Initial release

--- a/extensions/in-the-time-zone/package.json
+++ b/extensions/in-the-time-zone/package.json
@@ -23,6 +23,28 @@
   ],
   "preferences": [
     {
+      "name": "timeFormat",
+      "type": "dropdown",
+      "title": "Time Format",
+      "description": "Choose how times are displayed.",
+      "data": [
+        {
+          "title": "System Default",
+          "value": "system"
+        },
+        {
+          "title": "12-hour",
+          "value": "12-hour"
+        },
+        {
+          "title": "24-hour",
+          "value": "24-hour"
+        }
+      ],
+      "default": "system",
+      "required": false
+    },
+    {
       "name": "defaultScrubMinutes",
       "type": "dropdown",
       "title": "Arrow Key Scrub Minutes",

--- a/extensions/in-the-time-zone/src/in-the-time-zone.tsx
+++ b/extensions/in-the-time-zone/src/in-the-time-zone.tsx
@@ -12,7 +12,13 @@ import {
 import { DateTime } from "luxon";
 import { useEffect, useMemo, useState } from "react";
 import { searchCities } from "./citySearch";
-import { formatDelta, formatGmtOffset, getCurrentTimeISO } from "./time-utils";
+import {
+  ClockFormatPreference,
+  formatDelta,
+  formatGmtOffset,
+  getCurrentTimeISO,
+  resolveTimeFormat,
+} from "./time-utils";
 import { TimelineView } from "./timeline-view";
 import { DEFAULT_TIME_ZONES, getCityName, getTimezone } from "./timezones";
 
@@ -30,6 +36,7 @@ export default function Command() {
   const preferences = getPreferenceValues<Preferences>();
   const scrubMinutes = parseInt(preferences.defaultScrubMinutes, 10) || 60;
   const optionScrubMinutes = parseInt(preferences.optionScrubMinutes, 10) || 30;
+  const timeFormat = resolveTimeFormat(preferences.timeFormat as ClockFormatPreference);
 
   useEffect(() => {
     const load = async () => {
@@ -124,7 +131,7 @@ export default function Command() {
       const dt = DateTime.fromISO(baseISO).setZone(getTimezone(zoneId));
       const diffMinutes = dt.offset - base.offset;
       const cityName = getCityName(zoneId);
-      const paddedTime = padTime(dt.toFormat("h:mm a"));
+      const paddedTime = padTime(dt.toFormat(timeFormat));
       return {
         key: zoneId,
         title: `${paddedTime}  ${cityName}`,
@@ -134,11 +141,11 @@ export default function Command() {
         dateText: dt.toFormat("ccc, LLL d"),
       };
     });
-  }, [baseISO, base.offset, otherCities]);
+  }, [baseISO, base.offset, otherCities, timeFormat]);
 
   const baseRow = useMemo(() => {
     const cityName = baseCityId ? getCityName(baseCityId) : getCityName(baseZoneId);
-    const paddedTime = padTime(base.toFormat("h:mm a"));
+    const paddedTime = padTime(base.toFormat(timeFormat));
     const isSystemTz = !baseCityId;
     return {
       title: `${paddedTime}  ${cityName}`,
@@ -147,7 +154,7 @@ export default function Command() {
       timeColor: getTimeColor(base.hour),
       isSystemTz,
     };
-  }, [base, baseZoneId, baseCityId]);
+  }, [base, baseZoneId, baseCityId, timeFormat]);
 
   function shiftMinutes(delta: number) {
     setBaseISO((prev) => DateTime.fromISO(prev).plus({ minutes: delta }).toISO() || prev);
@@ -173,6 +180,7 @@ export default function Command() {
         onClearBase={clearBase}
         scrubMinutes={scrubMinutes}
         optionScrubMinutes={optionScrubMinutes}
+        timeFormat={timeFormat}
       />
     );
   }

--- a/extensions/in-the-time-zone/src/sun-times.ts
+++ b/extensions/in-the-time-zone/src/sun-times.ts
@@ -6,14 +6,14 @@ export interface SunTimes {
   sunset: string;
 }
 
-export function getSunTimes(lat: number, lng: number, date: Date, timezone: string): SunTimes {
+export function getSunTimes(lat: number, lng: number, date: Date, timezone: string, timeFormat: string): SunTimes {
   const times = SunCalc.getTimes(date, lat, lng);
 
   const sunrise = DateTime.fromJSDate(times.sunrise).setZone(timezone);
   const sunset = DateTime.fromJSDate(times.sunset).setZone(timezone);
 
   return {
-    sunrise: sunrise.isValid ? sunrise.toFormat("h:mm a") : "—",
-    sunset: sunset.isValid ? sunset.toFormat("h:mm a") : "—",
+    sunrise: sunrise.isValid ? sunrise.toFormat(timeFormat) : "—",
+    sunset: sunset.isValid ? sunset.toFormat(timeFormat) : "—",
   };
 }

--- a/extensions/in-the-time-zone/src/time-utils.ts
+++ b/extensions/in-the-time-zone/src/time-utils.ts
@@ -2,6 +2,16 @@ export function getCurrentTimeISO(): string {
   return new Date().toISOString();
 }
 
+export type ClockFormatPreference = "system" | "12-hour" | "24-hour";
+
+export function resolveTimeFormat(preference: ClockFormatPreference): string {
+  if (preference === "12-hour") return "h:mm a";
+  if (preference === "24-hour") return "HH:mm";
+
+  const systemFormat = new Intl.DateTimeFormat(undefined, { hour: "numeric" }).resolvedOptions();
+  return systemFormat.hour12 === false || systemFormat.hourCycle?.startsWith("h2") ? "HH:mm" : "h:mm a";
+}
+
 export function formatGmtOffset(offsetMinutes: number): string {
   const sign = offsetMinutes >= 0 ? "+" : "-";
   const abs = Math.abs(offsetMinutes);

--- a/extensions/in-the-time-zone/src/timeline-renderer.ts
+++ b/extensions/in-the-time-zone/src/timeline-renderer.ts
@@ -6,6 +6,7 @@ export interface TimelineConfig {
   baseISO: string;
   baseCityId: string | null;
   selectedZoneIds: string[];
+  timeFormat: string;
 }
 
 type HourType = "work" | "sleep" | "marginal";
@@ -39,7 +40,7 @@ function getDayDiff(localTime: DateTime, baseTime: DateTime): string {
 }
 
 export function generateCompactTimelineMarkdown(config: TimelineConfig): string {
-  const { baseISO, baseCityId, selectedZoneIds } = config;
+  const { baseISO, baseCityId, selectedZoneIds, timeFormat } = config;
 
   const baseZoneId = baseCityId ? getTimezone(baseCityId) : Intl.DateTimeFormat().resolvedOptions().timeZone;
   const baseTime = DateTime.fromISO(baseISO).setZone(baseZoneId);
@@ -54,7 +55,7 @@ export function generateCompactTimelineMarkdown(config: TimelineConfig): string 
     const offsetFromBase = localTime.offset - baseTime.offset;
 
     // Pad single-digit hours with a leading space so colons align
-    const rawTime = localTime.toFormat("h:mm a");
+    const rawTime = localTime.toFormat(timeFormat);
     const paddedTime = rawTime.padStart(8, " ");
 
     return {

--- a/extensions/in-the-time-zone/src/timeline-view.tsx
+++ b/extensions/in-the-time-zone/src/timeline-view.tsx
@@ -17,6 +17,7 @@ export interface TimelineViewProps {
   onClearBase: () => Promise<void>;
   scrubMinutes: number;
   optionScrubMinutes: number;
+  timeFormat: string;
 }
 
 export function TimelineView(props: TimelineViewProps) {
@@ -30,6 +31,7 @@ export function TimelineView(props: TimelineViewProps) {
     onClearBase,
     scrubMinutes,
     optionScrubMinutes,
+    timeFormat,
   } = props;
 
   function formatScrubTitle(minutes: number): string {
@@ -52,8 +54,9 @@ export function TimelineView(props: TimelineViewProps) {
       baseISO,
       baseCityId,
       selectedZoneIds,
+      timeFormat,
     });
-  }, [baseISO, baseCityId, selectedZoneIds]);
+  }, [baseISO, baseCityId, selectedZoneIds, timeFormat]);
 
   const citySunTimes = useMemo(() => {
     const date = new Date(baseISO);
@@ -63,12 +66,12 @@ export function TimelineView(props: TimelineViewProps) {
       const timezone = getTimezone(zoneId);
 
       if (city && city.lat && city.lng) {
-        const sunTimes = getSunTimes(city.lat, city.lng, date, timezone);
+        const sunTimes = getSunTimes(city.lat, city.lng, date, timezone, timeFormat);
         return { zoneId, cityName, sunrise: sunTimes.sunrise, sunset: sunTimes.sunset };
       }
       return { zoneId, cityName, sunrise: "—", sunset: "—" };
     });
-  }, [baseISO, selectedZoneIds]);
+  }, [baseISO, selectedZoneIds, timeFormat]);
 
   return (
     <Detail


### PR DESCRIPTION
## Description

Fixes #29829.

Adds a Time Format preference with System Default, 12-hour, and 24-hour choices. System Default resolves the runtime's system hour cycle. The selected Luxon format is shared across base/city rows, timeline rows, sunrise, and sunset so every displayed time stays consistent.

## Screencast

Not included; the change affects formatting throughout the existing views and is validated by the extension build/type-check.

## Checklist

- [x] I read the extension guidelines
- [x] I read the documentation about publishing
- [x] I ran `npm run lint` and `npm run build`
- [x] I checked that files in the assets folder are used by the extension itself
- [x] I checked that assets used in the README are located outside the metadata folder if they were not generated with the metadata tool

Validation: `npm run lint` and `npm run build` pass.