### PR TITLE
[GitHub] Split viewer stats GraphQL queries

### DIFF
--- a/extensions/github/CHANGELOG.md
+++ b/extensions/github/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GitHub Changelog
 
-## [Fix Stats for Large Accounts] - {PR_MERGE_DATE}
+## [Fix Stats for Large Accounts] - 2026-08-29
 
 - Split aggregate and list GraphQL requests so My GitHub Stats loads for accounts with large histories
 

--- a/extensions/github/CHANGELOG.md
+++ b/extensions/github/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GitHub Changelog
 
+## [Fix Stats for Large Accounts] - {PR_MERGE_DATE}
+
+- Split aggregate and list GraphQL requests so My GitHub Stats loads for accounts with large histories
+
 ## [Search Repositories UX and Performance Fixes] - 2026-08-22
 
 - Search Repositories: Show **Recent Visited Repositories** when the search field is empty instead of running a blank API search.

--- a/extensions/github/package.json
+++ b/extensions/github/package.json
@@ -1185,7 +1185,7 @@
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish",
     "generate": "graphql-codegen --config codegen.ts",
-    "test": "node --no-warnings --test --experimental-strip-types src/helpers/pull-request-checks.test.ts",
+    "test": "node --no-warnings --test --experimental-strip-types src/helpers/pull-request-checks.test.ts src/api/viewerStats.test.ts",
     "update-schema": "node scripts/update-graphql-schema.mjs"
   },
   "platforms": [

--- a/extensions/github/src/api/viewerStats.graphql
+++ b/extensions/github/src/api/viewerStats.graphql
@@ -1,4 +1,4 @@
-query getViewerStats($repositoriesCount: Int = 100) {
+query getViewerStats {
   viewer {
     ...UserFields
     bio
@@ -31,6 +31,26 @@ query getViewerStats($repositoriesCount: Int = 100) {
     issuesOpen: issues(states: [OPEN]) {
       totalCount
     }
+    contributionsCollection {
+      totalCommitContributions
+    }
+    publicRepos: repositories(ownerAffiliations: OWNER, privacy: PUBLIC) {
+      totalCount
+    }
+    ownedRepositories: repositories(ownerAffiliations: OWNER) {
+      totalCount
+    }
+  }
+  rateLimit {
+    remaining
+    limit
+    used
+    resetAt
+  }
+}
+
+query getViewerStatsDetails($repositoriesCount: Int = 100) {
+  viewer {
     recentPullRequests: pullRequests(first: 5, orderBy: { field: UPDATED_AT, direction: DESC }) {
       nodes {
         id
@@ -77,18 +97,11 @@ query getViewerStats($repositoriesCount: Int = 100) {
         }
       }
     }
-    contributionsCollection {
-      totalCommitContributions
-    }
-    publicRepos: repositories(ownerAffiliations: OWNER, privacy: PUBLIC) {
-      totalCount
-    }
     ownedRepositories: repositories(
       first: $repositoriesCount
       ownerAffiliations: OWNER
       orderBy: { field: STARGAZERS, direction: DESC }
     ) {
-      totalCount
       nodes {
         id
         nameWithOwner
@@ -98,7 +111,6 @@ query getViewerStats($repositoriesCount: Int = 100) {
       }
     }
     organizations(first: 20) {
-      totalCount
       nodes {
         id
         login
@@ -107,11 +119,5 @@ query getViewerStats($repositoriesCount: Int = 100) {
         url
       }
     }
-  }
-  rateLimit {
-    remaining
-    limit
-    used
-    resetAt
   }
 }

--- a/extensions/github/src/api/viewerStats.test.ts
+++ b/extensions/github/src/api/viewerStats.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const document = readFileSync(resolve("src/api/viewerStats.graphql"), "utf8");
+const operations = document.split(/\n(?=query )/);
+
+function getOperation(name: string): string {
+  const operation = operations.find((candidate) => candidate.startsWith(`query ${name}`));
+  assert.ok(operation, `missing ${name} operation`);
+  return operation;
+}
+
+test("keeps aggregate counts separate from viewer detail nodes", () => {
+  const summary = getOperation("getViewerStats");
+  const details = getOperation("getViewerStatsDetails");
+
+  assert.doesNotMatch(summary, /\bnodes\s*{/);
+  assert.doesNotMatch(details, /\btotalCount\b/);
+});

--- a/extensions/github/src/generated/graphql.ts
+++ b/extensions/github/src/generated/graphql.ts
@@ -1495,9 +1495,7 @@ export type GetViewerQuery = {
   };
 };
 
-export type GetViewerStatsQueryVariables = Exact<{
-  repositoriesCount?: number | null | undefined;
-}>;
+export type GetViewerStatsQueryVariables = Exact<{ [key: string]: never }>;
 
 export type GetViewerStatsQuery = {
   viewer: {
@@ -1520,6 +1518,19 @@ export type GetViewerStatsQuery = {
     pullRequestsOpen: { totalCount: number };
     issuesAuthored: { totalCount: number };
     issuesOpen: { totalCount: number };
+    contributionsCollection: { totalCommitContributions: number };
+    publicRepos: { totalCount: number };
+    ownedRepositories: { totalCount: number };
+  };
+  rateLimit: { remaining: number; limit: number; used: number; resetAt: any } | null;
+};
+
+export type GetViewerStatsDetailsQueryVariables = Exact<{
+  repositoriesCount?: number | null | undefined;
+}>;
+
+export type GetViewerStatsDetailsQuery = {
+  viewer: {
     recentPullRequests: {
       nodes: Array<{
         id: string;
@@ -1558,10 +1569,7 @@ export type GetViewerStatsQuery = {
         repository: { nameWithOwner: string };
       } | null> | null;
     };
-    contributionsCollection: { totalCommitContributions: number };
-    publicRepos: { totalCount: number };
     ownedRepositories: {
-      totalCount: number;
       nodes: Array<{
         id: string;
         nameWithOwner: string;
@@ -1571,11 +1579,9 @@ export type GetViewerStatsQuery = {
       } | null> | null;
     };
     organizations: {
-      totalCount: number;
       nodes: Array<{ id: string; login: string; name: string | null; avatarUrl: any; url: any } | null> | null;
     };
   };
-  rateLimit: { remaining: number; limit: number; used: number; resetAt: any } | null;
 };
 
 export const ShortRepositoryFieldsFragmentDoc = gql`
@@ -2785,7 +2791,7 @@ export const GetViewerDocument = gql`
   ${ProjectFieldsFragmentDoc}
 `;
 export const GetViewerStatsDocument = gql`
-  query getViewerStats($repositoriesCount: Int = 100) {
+  query getViewerStats {
     viewer {
       ...UserFields
       bio
@@ -2818,6 +2824,28 @@ export const GetViewerStatsDocument = gql`
       issuesOpen: issues(states: [OPEN]) {
         totalCount
       }
+      contributionsCollection {
+        totalCommitContributions
+      }
+      publicRepos: repositories(ownerAffiliations: OWNER, privacy: PUBLIC) {
+        totalCount
+      }
+      ownedRepositories: repositories(ownerAffiliations: OWNER) {
+        totalCount
+      }
+    }
+    rateLimit {
+      remaining
+      limit
+      used
+      resetAt
+    }
+  }
+  ${UserFieldsFragmentDoc}
+`;
+export const GetViewerStatsDetailsDocument = gql`
+  query getViewerStatsDetails($repositoriesCount: Int = 100) {
+    viewer {
       recentPullRequests: pullRequests(first: 5, orderBy: { field: UPDATED_AT, direction: DESC }) {
         nodes {
           id
@@ -2864,18 +2892,11 @@ export const GetViewerStatsDocument = gql`
           }
         }
       }
-      contributionsCollection {
-        totalCommitContributions
-      }
-      publicRepos: repositories(ownerAffiliations: OWNER, privacy: PUBLIC) {
-        totalCount
-      }
       ownedRepositories: repositories(
         first: $repositoriesCount
         ownerAffiliations: OWNER
         orderBy: { field: STARGAZERS, direction: DESC }
       ) {
-        totalCount
         nodes {
           id
           nameWithOwner
@@ -2885,7 +2906,6 @@ export const GetViewerStatsDocument = gql`
         }
       }
       organizations(first: 20) {
-        totalCount
         nodes {
           id
           login
@@ -2895,14 +2915,7 @@ export const GetViewerStatsDocument = gql`
         }
       }
     }
-    rateLimit {
-      remaining
-      limit
-      used
-      resetAt
-    }
   }
-  ${UserFieldsFragmentDoc}
 `;
 
 export type SdkFunctionWrapper = <T>(
@@ -3830,6 +3843,24 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
             signal,
           }),
         "getViewerStats",
+        "query",
+        variables,
+      );
+    },
+    getViewerStatsDetails(
+      variables?: GetViewerStatsDetailsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<GetViewerStatsDetailsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetViewerStatsDetailsQuery>({
+            document: GetViewerStatsDetailsDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "getViewerStatsDetails",
         "query",
         variables,
       );

--- a/extensions/github/src/hooks/useViewerStats.ts
+++ b/extensions/github/src/hooks/useViewerStats.ts
@@ -29,9 +29,12 @@ export function useViewerStats() {
   const cache = useMemo(() => new Cache({ namespace: getCacheNamespace(token) }), [token]);
 
   const fetchFresh = async () => {
-    const { viewer, rateLimit } = await github.getViewerStats({ repositoriesCount: 100 });
+    const [{ viewer, rateLimit }, { viewer: details }] = await Promise.all([
+      github.getViewerStats(),
+      github.getViewerStatsDetails({ repositoriesCount: 100 }),
+    ]);
 
-    const ownedRepos = viewer.ownedRepositories.nodes ?? [];
+    const ownedRepos = details.ownedRepositories.nodes ?? [];
     const starsReceived = ownedRepos.reduce((sum, repo) => sum + (repo?.stargazerCount ?? 0), 0);
     const forksReceived = ownedRepos.reduce((sum, repo) => sum + (repo?.forkCount ?? 0), 0);
     const hasMoreRepos = viewer.ownedRepositories.totalCount > ownedRepos.length;
@@ -83,15 +86,15 @@ export function useViewerStats() {
         publicRepos: viewer.publicRepos.totalCount,
         ownedRepos: viewer.ownedRepositories.totalCount,
       },
-      organizations: viewer.organizations.nodes?.filter((org) => org != null) ?? [],
+      organizations: details.organizations.nodes?.filter((org) => org != null) ?? [],
       ownedReposBreakdown,
       recent: {
-        pullRequests: (viewer.recentPullRequests.nodes ?? []).filter((pr): pr is NonNullable<typeof pr> => pr != null),
-        openPullRequests: (viewer.recentOpenPullRequests.nodes ?? []).filter(
+        pullRequests: (details.recentPullRequests.nodes ?? []).filter((pr): pr is NonNullable<typeof pr> => pr != null),
+        openPullRequests: (details.recentOpenPullRequests.nodes ?? []).filter(
           (pr): pr is NonNullable<typeof pr> => pr != null,
         ),
-        issues: (viewer.recentIssues.nodes ?? []).filter((iss): iss is NonNullable<typeof iss> => iss != null),
-        openIssues: (viewer.recentOpenIssues.nodes ?? []).filter((iss): iss is NonNullable<typeof iss> => iss != null),
+        issues: (details.recentIssues.nodes ?? []).filter((iss): iss is NonNullable<typeof iss> => iss != null),
+        openIssues: (details.recentOpenIssues.nodes ?? []).filter((iss): iss is NonNullable<typeof iss> => iss != null),
       },
       rateLimit: rateLimit
         ? {


### PR DESCRIPTION
## Description

Fixes #29578.

Splits My GitHub Stats into two parallel GraphQL operations:

- `getViewerStats` fetches profile and aggregate counts only.
- `getViewerStatsDetails` fetches recent PR/issue, repository, and organization nodes without aggregate counts.

This preserves the existing stats result while avoiding GitHub's per-query resource ceiling for accounts with large activity histories. The generated client is updated, and a regression test enforces that aggregate counts and detail nodes remain separated.

## Screencast

Not included; this changes the data-fetch boundary without changing the menu UI.

## Checklist

- [x] I read the extension guidelines
- [x] I read the documentation about publishing
- [x] I ran `npm run generate`, `npm test`, `npm run lint`, and `npm run build`
- [x] I checked that files in the assets folder are used by the extension itself
- [x] I checked that assets used in the README are located outside the metadata folder if they were not generated with the metadata tool

Validation: GraphQL generation, 3 tests, lint, and the full extension build pass.