### PR TITLE
[Quit Applications] Quit the selected application bundle

### DIFF
--- a/extensions/quit-applications/CHANGELOG.md
+++ b/extensions/quit-applications/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Quit Applications Changelog
 
+## [Quit exact application bundle] - {PR_MERGE_DATE}
+
+- Target the selected bundle path when quitting or restarting and only report success after the exact application exits.
+
 ## [Show menu bar apps] - 2026-07-01
 
 - Switched running-app discovery to NSWorkspace so menu bar / accessory (LSUIElement) apps now appear in the list, while system agents and helper processes stay hidden.

--- a/extensions/quit-applications/CHANGELOG.md
+++ b/extensions/quit-applications/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Quit Applications Changelog
 
-## [Quit exact application bundle] - {PR_MERGE_DATE}
+## [Quit exact application bundle] - 2026-08-27
 
 - Target the selected bundle path when quitting or restarting and only report success after the exact application exits.
 

--- a/extensions/quit-applications/src/index.tsx
+++ b/extensions/quit-applications/src/index.tsx
@@ -15,6 +15,16 @@ import { execSync } from "child_process";
 
 const APPLESCRIPT_TIMEOUT_MS = 5000;
 const RESTART_APPLESCRIPT_TIMEOUT_MS = 15000;
+const QUIT_POLL_INTERVAL_MS = 200;
+
+type RunningApp = {
+  name: string;
+  path?: string;
+};
+
+function escapeAppleScriptString(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
 
 function applicationNameFromPath(path: string): string {
   /* Example:
@@ -97,24 +107,48 @@ async function getRunningAppsPaths(): Promise<string[]> {
   }
 }
 
-function quitApp(app: string) {
+function isAppRunning(appPath: string): Promise<boolean> {
   return runAppleScript(
-    `try
-  tell application "${app}" to quit
-  on error error_message number error_number
-      if error_number is equal to -128 then
-      -- the user cancelled the action. no need to error
-      else
-          display dialog error_message
-      end if
-end try`,
-    { timeout: APPLESCRIPT_TIMEOUT_MS },
-  );
+    `ObjC.import('AppKit');
+    const targetPath = ${JSON.stringify(appPath)};
+    const apps = $.NSWorkspace.sharedWorkspace.runningApplications;
+    let running = false;
+    for (let i = 0; i < apps.count; i++) {
+      const url = apps.objectAtIndex(i).bundleURL;
+      if (url && !url.isNil() && ObjC.unwrap(url.path) === targetPath) {
+        running = true;
+        break;
+      }
+    }
+    JSON.stringify(running);`,
+    { language: "JavaScript", timeout: APPLESCRIPT_TIMEOUT_MS },
+  ).then((result) => JSON.parse(result) as boolean);
 }
 
-function restartApp(app: string) {
+async function waitForAppToQuit(appPath: string): Promise<void> {
+  const deadline = Date.now() + APPLESCRIPT_TIMEOUT_MS;
+
+  while (await isAppRunning(appPath)) {
+    if (Date.now() >= deadline) {
+      throw new Error("Application did not quit before the timeout");
+    }
+    await new Promise((resolve) => setTimeout(resolve, QUIT_POLL_INTERVAL_MS));
+  }
+}
+
+async function quitApp(app: RunningApp) {
+  const target = escapeAppleScriptString(app.path ?? app.name);
+  await runAppleScript(`tell application "${target}" to quit`, { timeout: APPLESCRIPT_TIMEOUT_MS });
+
+  if (app.path) {
+    await waitForAppToQuit(app.path);
+  }
+}
+
+function restartApp(app: RunningApp) {
+  const target = escapeAppleScriptString(app.path ?? app.name);
   return runAppleScript(
-    `tell application "${app}"
+    `tell application "${target}"
                             repeat while its running
                               quit
                               delay 0.5
@@ -125,50 +159,50 @@ function restartApp(app: string) {
   );
 }
 
-async function quitAppWithToast(app: string): Promise<boolean> {
+async function quitAppWithToast(app: RunningApp): Promise<boolean> {
   try {
     await quitApp(app);
     showToast({
       style: Toast.Style.Success,
-      title: `Quit ${app}`,
+      title: `Quit ${app.name}`,
     });
     return true;
   } catch {
     showToast({
       style: Toast.Style.Failure,
-      title: `Unable to quit ${app}`,
+      title: `Unable to quit ${app.name}`,
     });
     return false;
   }
 }
 
-async function restartAppWithToast(app: string): Promise<boolean> {
+async function restartAppWithToast(app: RunningApp): Promise<boolean> {
   try {
     await restartApp(app);
     showToast({
       style: Toast.Style.Success,
-      title: `Restarted ${app}`,
+      title: `Restarted ${app.name}`,
     });
     return true;
   } catch {
     showToast({
       style: Toast.Style.Failure,
-      title: `Unable to restart ${app}`,
+      title: `Unable to restart ${app.name}`,
     });
     return false;
   }
 }
 
-function getQuickLinkForApp(appName: string, action: string): string {
+function getQuickLinkForApp(app: Required<RunningApp>, action: string): string {
   return createDeeplink({
     type: DeeplinkType.Extension,
     command: "index",
-    context: { appName, action },
+    context: { appName: app.name, appPath: app.path, action },
   });
 }
 
 type CommandProps = {
-  launchContext?: { appName: string; action: string /* quit | restart */ };
+  launchContext?: { appName: string; appPath?: string; action: string /* quit | restart */ };
 };
 
 export default function Command({ launchContext }: CommandProps) {
@@ -184,12 +218,13 @@ export default function Command({ launchContext }: CommandProps) {
   const [searchText, setSearchText] = useState("");
   useEffect(() => {
     if (launchContext && launchContext.appName && launchContext.action) {
-      const { appName, action } = launchContext;
+      const { appName, appPath, action } = launchContext;
+      const app = { name: appName, path: appPath };
 
       if (action === "quit") {
-        void quitAppWithToast(appName);
+        void quitAppWithToast(app);
       } else if (action === "restart") {
-        void restartAppWithToast(appName);
+        void restartAppWithToast(app);
       }
       return;
     }
@@ -257,10 +292,10 @@ export default function Command({ launchContext }: CommandProps) {
                   // Excluded apps were already removed from `apps` at load time (loadApps),
                   // so every entry here is safe to quit.
                   for (const app of apps) {
-                    const success = await quitAppWithToast(app.name);
+                    const success = await quitAppWithToast(app);
 
                     if (success) {
-                      remainingApps = remainingApps.filter((a) => a.name !== app.name);
+                      remainingApps = remainingApps.filter((a) => a.path !== app.path);
                     }
                   }
 
@@ -290,7 +325,7 @@ export default function Command({ launchContext }: CommandProps) {
               <Action
                 title="Quit"
                 onAction={async () => {
-                  const success = await quitAppWithToast(app.name);
+                  const success = await quitAppWithToast(app);
 
                   if (success) {
                     setApps((prev) => prev.filter((a) => a.path !== app.path));
@@ -304,16 +339,16 @@ export default function Command({ launchContext }: CommandProps) {
               <Action
                 title="Restart"
                 onAction={async () => {
-                  await restartAppWithToast(app.name);
+                  await restartAppWithToast(app);
                 }}
               />
               <Action.CreateQuicklink
                 title="Create Quit Quicklink"
-                quicklink={{ link: getQuickLinkForApp(app.name, "quit"), name: `Quit ${app.name}` }}
+                quicklink={{ link: getQuickLinkForApp(app, "quit"), name: `Quit ${app.name}` }}
               />
               <Action.CreateQuicklink
                 title="Create Restart Quicklink"
-                quicklink={{ link: getQuickLinkForApp(app.name, "restart"), name: `Restart ${app.name}` }}
+                quicklink={{ link: getQuickLinkForApp(app, "restart"), name: `Restart ${app.name}` }}
               />
             </ActionPanel>
           }


### PR DESCRIPTION
## Description

- preserve the selected bundle path through quit, restart, and generated Quicklinks
- target that exact bundle instead of re-resolving a shared display name
- wait for the selected process to exit before showing success or removing its row
- propagate AppleScript failures instead of swallowing them

Fixes #29648

## Screencast

Not included: the affected Wispr Flow setup is not available locally. The path targeting and TypeScript build were verified against the current extension source.

## Verification

- `npm run lint`
- `npm run build`

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)