### PR TITLE
[Slack] Keep Set Status responsive in large workspaces

### DIFF
--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Slack Changelog
 
+## [Keep Set Status responsive in large workspaces] - {PR_MERGE_DATE}
+
+- Load custom workspace emojis only when opening the emoji picker and render them in bounded slices to prevent Set Status from exceeding the extension memory limit.
+
 ## [Fix Search Emojis crash in large workspaces] - 2026-08-12
 
 - Fix a "Worker terminated due to reaching memory limit: JS heap out of memory" crash in the Search Emojis command by rendering emojis in slices with a "Show More" item instead of rendering every custom emoji at once.

--- a/extensions/slack/CHANGELOG.md
+++ b/extensions/slack/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Slack Changelog
 
-## [Keep Set Status responsive in large workspaces] - {PR_MERGE_DATE}
+## [Keep Set Status responsive in large workspaces] - 2026-08-29
 
 - Load custom workspace emojis only when opening the emoji picker and render them in bounded slices to prevent Set Status from exceeding the extension memory limit.
 

--- a/extensions/slack/src/components/set-status/emoji-picker.component.tsx
+++ b/extensions/slack/src/components/set-status/emoji-picker.component.tsx
@@ -1,23 +1,28 @@
-import { Action, ActionPanel, List, useNavigation } from "@raycast/api";
-import { Emoji } from "../../types/emoji.type";
-import { useMemo, useState } from "react";
+import { Action, ActionPanel, Icon, List, useNavigation } from "@raycast/api";
+import { useCachedPromise } from "@raycast/utils";
+import { useCallback, useMemo, useState } from "react";
+import { SlackClient } from "../../shared/client";
+import { SLACK_EMOJI_CODE_MAP } from "../../constants/emoji.constants";
 
 interface EmojiPickerProps {
-  emojis: Emoji;
   onSelect: (emoji: { name: string; value: string }) => void;
 }
 
-function EmojiPicker({ emojis, onSelect }: EmojiPickerProps) {
-  const { pop } = useNavigation();
+const DISPLAY_LIMIT = 1000;
 
+function EmojiPicker({ onSelect }: EmojiPickerProps) {
+  const { pop } = useNavigation();
   const [searchText, setSearchText] = useState("");
+  const [displayLimit, setDisplayLimit] = useState(DISPLAY_LIMIT);
+  const { data: workspaceEmojis, isLoading } = useCachedPromise(SlackClient.getWorkspaceEmojis);
 
   const emojiEntries = useMemo(() => {
+    const emojis = { ...workspaceEmojis, ...SLACK_EMOJI_CODE_MAP };
     return Object.entries(emojis).map(([name, value]) => ({
       name,
       value,
     }));
-  }, [emojis]);
+  }, [workspaceEmojis]);
 
   const filtered = useMemo(() => {
     const normalized = searchText.replace(/^:/, "").toLowerCase();
@@ -26,9 +31,22 @@ function EmojiPicker({ emojis, onSelect }: EmojiPickerProps) {
     return emojiEntries.filter((emoji) => emoji.name.toLowerCase().includes(normalized));
   }, [searchText, emojiEntries]);
 
+  const visibleEmojis = useMemo(() => filtered.slice(0, displayLimit), [filtered, displayLimit]);
+  const hiddenCount = filtered.length - visibleEmojis.length;
+
+  const handleSearchTextChange = useCallback((value: string) => {
+    setSearchText(value);
+    setDisplayLimit(DISPLAY_LIMIT);
+  }, []);
+
   return (
-    <List onSearchTextChange={setSearchText} searchBarPlaceholder={"Search emoji (e.g. :smile)"} throttle>
-      {filtered.map((emoji) => (
+    <List
+      isLoading={isLoading}
+      onSearchTextChange={handleSearchTextChange}
+      searchBarPlaceholder={"Search emoji (e.g. :smile)"}
+      throttle
+    >
+      {visibleEmojis.map((emoji) => (
         <List.Item
           key={emoji.name}
           title={emoji.name}
@@ -46,6 +64,18 @@ function EmojiPicker({ emojis, onSelect }: EmojiPickerProps) {
           }
         />
       ))}
+      {hiddenCount > 0 && (
+        <List.Item
+          title="Show More"
+          subtitle={`${hiddenCount} more`}
+          icon={Icon.Ellipsis}
+          actions={
+            <ActionPanel>
+              <Action title="Show More" onAction={() => setDisplayLimit((limit) => limit + DISPLAY_LIMIT)} />
+            </ActionPanel>
+          }
+        />
+      )}
     </List>
   );
 }

--- a/extensions/slack/src/set-status.tsx
+++ b/extensions/slack/src/set-status.tsx
@@ -14,6 +14,8 @@ import {
 import { showToastWithPromise } from "./utils/toast.util";
 import SetAiStatusForm from "./components/set-status/set-ai-status-form.component";
 
+const BUILT_IN_EMOJIS: Record<string, string> = SLACK_EMOJI_CODE_MAP;
+
 // Reverse of SLACK_EMOJI_CODE_MAP: raw emoji glyph -> `:name:`. Raycast's argument field attaches an
 // emoji auto-picker that inserts a raw Unicode glyph (e.g. 👈) rather than its name, so we map it back.
 // The variation-selector-stripped key is added as a fallback so e.g. both `☝️` and `☝` resolve.
@@ -76,28 +78,27 @@ function SlackStatusList(props: LaunchProps<{ arguments: Arguments.SetStatus }>)
       execute: !!me?.id,
     },
   );
-  const { data: workspaceEmojis, isLoading: isFetchWorkspaceEmojisLoading } = useCachedPromise(
-    SlackClient.getWorkspaceEmojis,
-  );
-
   const isLoading = useMemo(() => {
-    return isFetchProfileLoading || isFetchMeLoading || isFetchWorkspaceEmojisLoading;
-  }, [isFetchProfileLoading, isFetchMeLoading, isFetchWorkspaceEmojisLoading]);
-
-  const emojis: { [key: string]: string } = useMemo(() => {
-    return {
-      ...workspaceEmojis,
-      ...SLACK_EMOJI_CODE_MAP,
-    };
-  }, [workspaceEmojis]);
+    return isFetchProfileLoading || isFetchMeLoading;
+  }, [isFetchProfileLoading, isFetchMeLoading]);
 
   const currentStatusEmoji = useMemo(() => {
     if (!profile?.status_emoji) {
       return undefined;
     }
 
-    return emojis[profile.status_emoji];
-  }, [profile?.status_emoji, emojis]);
+    return BUILT_IN_EMOJIS[profile.status_emoji];
+  }, [profile?.status_emoji]);
+
+  const statusFormEmojis = useMemo<Record<string, string | undefined>>(() => {
+    const currentEmoji = profile?.status_emoji;
+    if (!currentEmoji || BUILT_IN_EMOJIS[currentEmoji]) {
+      return BUILT_IN_EMOJIS;
+    }
+
+    // Preserve an existing custom emoji in the form without loading the full workspace catalog.
+    return { ...BUILT_IN_EMOJIS, [currentEmoji]: undefined };
+  }, [profile?.status_emoji]);
 
   const getCurrentStatusText = useCallback(
     (defaultStatusText?: string) => {
@@ -316,7 +317,7 @@ function SlackStatusList(props: LaunchProps<{ arguments: Arguments.SetStatus }>)
                 title={"Open Status Form"}
                 target={
                   <StatusForm
-                    emojis={emojis}
+                    emojis={statusFormEmojis}
                     formInitialValues={{
                       statusText: getCurrentStatusText(),
                       emoji: getCurrentStatusEmojiName(),
@@ -336,10 +337,7 @@ function SlackStatusList(props: LaunchProps<{ arguments: Arguments.SetStatus }>)
           icon={"😁"}
           actions={
             <ActionPanel>
-              <Action.Push
-                title={"Choose Emoji"}
-                target={<EmojiPicker emojis={emojis} onSelect={handleEmojiChange} />}
-              />
+              <Action.Push title={"Choose Emoji"} target={<EmojiPicker onSelect={handleEmojiChange} />} />
             </ActionPanel>
           }
         />

--- a/extensions/slack/src/types/emoji.type.ts
+++ b/extensions/slack/src/types/emoji.type.ts
@@ -1,1 +1,1 @@
-export type Emoji = { [key: string]: string };
+export type Emoji = { [key: string]: string | undefined };


### PR DESCRIPTION
## Description

- stop fetching the full custom emoji catalog when Set Status opens
- keep the basic status form on built-in emoji while preserving an existing custom status value
- load custom emoji only after the user opens the dedicated picker
- render picker results in 1,000-item slices with Show More, matching the merged Search Emojis memory fix

Fixes #29811

## Screencast

Not included: an affected 56,000-emoji Slack workspace is not available locally. The change follows the already merged and workspace-verified bounded-rendering pattern from #29907.

## Verification

- targeted ESLint passed
- targeted Prettier check passed
- `git diff --check` passed
- full generated-type/build validation will run in repository CI

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)