### PR TITLE
[Amphetamine] Restore Configure Session defaults

### DIFF
--- a/extensions/amphetamine/CHANGELOG.md
+++ b/extensions/amphetamine/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Restore Configure Session defaults] - {PR_MERGE_DATE}
+## [Restore Configure Session defaults] - 2026-08-27
 
 - Pre-fill the Configure Session duration and unit in Raycast v2 and remember the last entered values between launches.
 

--- a/extensions/amphetamine/CHANGELOG.md
+++ b/extensions/amphetamine/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Restore Configure Session defaults] - {PR_MERGE_DATE}
+
+- Pre-fill the Configure Session duration and unit in Raycast v2 and remember the last entered values between launches.
+
 ## [Quick Start Session command] - 2026-07-14
 
 - Add a Quick Start Session command: type hours, minutes, and seconds inline to start a session

--- a/extensions/amphetamine/src/amp-duration.tsx
+++ b/extensions/amphetamine/src/amp-duration.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import type { ComponentProps, ComponentType } from "react";
-import { Form, ActionPanel, Action, Toast, popToRoot, Icon } from "@raycast/api";
+import { Form, ActionPanel, Action, Toast, popToRoot, Icon, LocalStorage } from "@raycast/api";
 import ampStart from "./amp-start";
 import { formatDateTime, getSessionTime } from "./session-time";
 
@@ -30,6 +30,9 @@ enum SessionType {
   time = "time",
 }
 
+const DURATION_STORAGE_KEY = "configure-session-duration";
+const INTERVAL_STORAGE_KEY = "configure-session-interval";
+
 export default function SessionWithDuration() {
   const [sessionType, setSessionType] = useState<SessionType>(SessionType.duration);
   const [interval, setDurationUnit] = useState<keyof typeof Intervals>(Intervals.minutes);
@@ -37,6 +40,38 @@ export default function SessionWithDuration() {
   const [target, setTarget] = useState<Date | null>(null);
   const [targetError, setTargetError] = useState<string | undefined>();
   const [earliestTarget, setEarliestTarget] = useState(getMinimumUntilDate);
+  const [isLoadingDefaults, setIsLoadingDefaults] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadStoredDuration() {
+      try {
+        const [storedDuration, storedInterval] = await Promise.all([
+          LocalStorage.getItem<string>(DURATION_STORAGE_KEY),
+          LocalStorage.getItem<string>(INTERVAL_STORAGE_KEY),
+        ]);
+
+        if (!isMounted) return;
+
+        if (storedDuration !== undefined) {
+          setDuration(storedDuration);
+        }
+        if (storedInterval === Intervals.minutes || storedInterval === Intervals.hours) {
+          setDurationUnit(storedInterval);
+        }
+      } catch {
+        // Keep the built-in defaults when local storage is unavailable.
+      } finally {
+        if (isMounted) setIsLoadingDefaults(false);
+      }
+    }
+
+    void loadStoredDuration();
+    return () => {
+      isMounted = false;
+    };
+  }, []);
 
   useEffect(() => {
     if (sessionType !== SessionType.time) return;
@@ -100,11 +135,13 @@ export default function SessionWithDuration() {
   function handleChangeDuration(newInterval: keyof typeof Intervals) {
     if (interval !== newInterval) {
       setDurationUnit(newInterval);
+      void LocalStorage.setItem(INTERVAL_STORAGE_KEY, newInterval);
     }
   }
 
   return (
     <Form
+      isLoading={isLoadingDefaults}
       actions={
         <ActionPanel>
           <Action.SubmitForm title="Start Session" onSubmit={submit} icon={Icon.List} />
@@ -146,14 +183,17 @@ export default function SessionWithDuration() {
             info={`Sets the session duration based on the unit selected.\n\nCurrent: ${duration} ${
               duration === "1" ? interval.substring(0, interval.length - 1) : interval
             }`}
-            storeValue
-            onChange={(value) => setDuration(value)}
+            value={duration}
+            onChange={(value) => {
+              setDuration(value);
+              void LocalStorage.setItem(DURATION_STORAGE_KEY, value);
+            }}
           />
           <Form.Dropdown
             id="interval"
             title="Unit"
-            storeValue
-            info={`Select whether the duration should be in minutes or in hours.\n\n- Changing the duration to hours will set a default value of 1 hour.\n- Changing the duration to minutes will set a default value of 30 minutes`}
+            value={interval}
+            info="Select whether the duration should be in minutes or hours. The entered duration is preserved when switching units."
             onChange={(value) => handleChangeDuration(value as keyof typeof Intervals)}
           >
             <Form.Dropdown.Item value="minutes" title="minutes" />


### PR DESCRIPTION
## Description

- make the duration and unit controlled so displayed values match submitted values in Raycast v2
- restore the last entered duration and selected unit from LocalStorage before enabling the form
- keep the existing behavior that preserves the duration when switching units
- retain 30 minutes as the first-run default

Fixes #30502

## Screencast

Not included; this restores values in the existing Configure Session form without changing its layout.

## Verification

- `tsc -p tsconfig.json --noEmit`
- targeted ESLint
- targeted Prettier check
- `git diff --check`

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)