### PR TITLE
[Todoist] Use background-safe menu bar notifications

### DIFF
--- a/extensions/todoist/CHANGELOG.md
+++ b/extensions/todoist/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Todoist Changelog
 
+## [Fix Menu Bar task actions in background] - {PR_MERGE_DATE}
+
+- Use background-safe HUD notifications for Menu Bar task actions instead of Toast APIs that can crash the command.
+
 ## [Fix menu bar out-of-memory crash] - 2026-07-18
 
 - Fixed the Menu Bar command crashing with "Worker terminated due to reaching memory limit" on larger accounts. Every command previously shared one cache key holding the entire sync state (all tasks, comments, and locations); the menu bar's background worker now uses its own cache key holding only the small slice of data it needs (user, projects, items, labels, collaborators), completing the sync scoping started in #28005.

--- a/extensions/todoist/CHANGELOG.md
+++ b/extensions/todoist/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Todoist Changelog
 
-## [Fix Menu Bar task actions in background] - {PR_MERGE_DATE}
+## [Fix Menu Bar task actions in background] - 2026-08-27
 
 - Use background-safe HUD notifications for Menu Bar task actions instead of Toast APIs that can crash the command.
 

--- a/extensions/todoist/src/components/MenubarTask.tsx
+++ b/extensions/todoist/src/components/MenubarTask.tsx
@@ -28,6 +28,10 @@ type MenuBarTaskProps = {
   setData: React.Dispatch<React.SetStateAction<SyncData | undefined>>;
 };
 
+function getFailureMessage(title: string, error: unknown) {
+  return error instanceof Error && error.message ? `${title}: ${error.message}` : title;
+}
+
 const MenuBarTask = ({ task, data, setData }: MenuBarTaskProps) => {
   const { focusedTask, unfocusTask, focusTask } = useFocusedTask();
   const { taskWidth } = getPreferenceValues<Preferences.MenuBar>();
@@ -50,8 +54,8 @@ const MenuBarTask = ({ task, data, setData }: MenuBarTaskProps) => {
       }
 
       await showHUD("Completed task");
-    } catch {
-      await showHUD("Unable to complete task");
+    } catch (error) {
+      await showHUD(getFailureMessage("Unable to complete task", error));
     }
     if (useConfetti) {
       try {
@@ -74,8 +78,8 @@ const MenuBarTask = ({ task, data, setData }: MenuBarTaskProps) => {
 
       await updateTask(updateData, { data, setData });
       await showHUD(`Updated task ${type}`);
-    } catch {
-      await showHUD(`Unable to update task ${type}`);
+    } catch (error) {
+      await showHUD(getFailureMessage(`Unable to update task ${type}`, error));
     }
   }
 
@@ -83,8 +87,8 @@ const MenuBarTask = ({ task, data, setData }: MenuBarTaskProps) => {
     try {
       await updateTask({ id: task.id, priority }, { data, setData });
       await showHUD("Updated task priority");
-    } catch {
-      await showHUD("Unable to update task priority");
+    } catch (error) {
+      await showHUD(getFailureMessage("Unable to update task priority", error));
     }
   }
 
@@ -92,8 +96,8 @@ const MenuBarTask = ({ task, data, setData }: MenuBarTaskProps) => {
     try {
       await updateTask({ id: task.id, responsible_uid: collaboratorId }, { data, setData });
       await showHUD("Updated task assignee");
-    } catch {
-      await showHUD("Unable to update task assignee");
+    } catch (error) {
+      await showHUD(getFailureMessage("Unable to update task assignee", error));
     }
   }
 
@@ -101,8 +105,8 @@ const MenuBarTask = ({ task, data, setData }: MenuBarTaskProps) => {
     try {
       await updateTask({ id: task.id, labels: [...task.labels, label] }, { data, setData });
       await showHUD("Added task label");
-    } catch {
-      await showHUD("Unable to add task label");
+    } catch (error) {
+      await showHUD(getFailureMessage("Unable to add task label", error));
     }
   }
 
@@ -117,8 +121,8 @@ const MenuBarTask = ({ task, data, setData }: MenuBarTaskProps) => {
       try {
         await apiDeleteTAsk(task.id, { data, setData });
         await showHUD("Deleted task");
-      } catch {
-        await showHUD("Unable to delete task");
+      } catch (error) {
+        await showHUD(getFailureMessage("Unable to delete task", error));
       }
     }
   }

--- a/extensions/todoist/src/components/MenubarTask.tsx
+++ b/extensions/todoist/src/components/MenubarTask.tsx
@@ -7,10 +7,8 @@ import {
   open,
   launchCommand,
   LaunchType,
-  showToast,
-  Toast,
+  showHUD,
 } from "@raycast/api";
-import { showFailureToast } from "@raycast/utils";
 import { useMemo } from "react";
 import removeMarkdown from "remove-markdown";
 
@@ -51,15 +49,15 @@ const MenuBarTask = ({ task, data, setData }: MenuBarTaskProps) => {
         unfocusTask();
       }
 
-      await showToast({ style: Toast.Style.Success, title: "Completed task" });
-    } catch (error) {
-      await showFailureToast(error, { title: "Unable to complete task" });
+      await showHUD("Completed task");
+    } catch {
+      await showHUD("Unable to complete task");
     }
     if (useConfetti) {
       try {
         await open(`${process.env.RAYCAST_SCHEME ?? "raycast"}://extensions/raycast/raycast/confetti`);
-      } catch (error) {
-        await showFailureToast(error, { title: "Unable to show celebration" });
+      } catch {
+        await showHUD("Unable to show celebration");
       }
     }
   }
@@ -75,36 +73,36 @@ const MenuBarTask = ({ task, data, setData }: MenuBarTaskProps) => {
       };
 
       await updateTask(updateData, { data, setData });
-      await showToast({ style: Toast.Style.Success, title: `Updated task ${type}` });
-    } catch (error) {
-      await showFailureToast(error, { title: `Unable to update task ${type}` });
+      await showHUD(`Updated task ${type}`);
+    } catch {
+      await showHUD(`Unable to update task ${type}`);
     }
   }
 
   async function changePriority(task: Task, priority: number) {
     try {
       await updateTask({ id: task.id, priority }, { data, setData });
-      await showToast({ style: Toast.Style.Success, title: "Updated task priority" });
-    } catch (error) {
-      await showFailureToast(error, { title: "Unable to update task priority" });
+      await showHUD("Updated task priority");
+    } catch {
+      await showHUD("Unable to update task priority");
     }
   }
 
   async function changeAssignee(task: Task, collaboratorId: string) {
     try {
       await updateTask({ id: task.id, responsible_uid: collaboratorId }, { data, setData });
-      await showToast({ style: Toast.Style.Success, title: "Updated task assignee" });
-    } catch (error) {
-      await showFailureToast(error, { title: "Unable to update task assignee" });
+      await showHUD("Updated task assignee");
+    } catch {
+      await showHUD("Unable to update task assignee");
     }
   }
 
   async function addLabel(task: Task, label: string) {
     try {
       await updateTask({ id: task.id, labels: [...task.labels, label] }, { data, setData });
-      await showToast({ style: Toast.Style.Success, title: "Added task label" });
-    } catch (error) {
-      await showFailureToast(error, { title: "Unable to add task label" });
+      await showHUD("Added task label");
+    } catch {
+      await showHUD("Unable to add task label");
     }
   }
 
@@ -118,9 +116,9 @@ const MenuBarTask = ({ task, data, setData }: MenuBarTaskProps) => {
     ) {
       try {
         await apiDeleteTAsk(task.id, { data, setData });
-        await showToast({ style: Toast.Style.Success, title: "Deleted task" });
-      } catch (error) {
-        await showFailureToast(error, { title: "Unable to delete task" });
+        await showHUD("Deleted task");
+      } catch {
+        await showHUD("Unable to delete task");
       }
     }
   }


### PR DESCRIPTION
## Description

- replace Toast notifications in Menu Bar Tasks with background-safe HUD notifications
- cover completion, rescheduling, priority, assignee, labels, deletion, and confetti failures through the same menu-bar path
- leave foreground Todoist commands and their Toast behavior unchanged

Fixes #30494

## Screencast

Not included; the change affects notification delivery after existing menu-bar actions.

## Verification

- targeted ESLint passed
- targeted Prettier check passed
- `git diff --check` passed
- full generated-preference/build validation will run in repository CI

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)