### PR TITLE
[Google Calendar] Fix AI contact search caching

### DIFF
--- a/extensions/google-calendar/CHANGELOG.md
+++ b/extensions/google-calendar/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Google Calendar Changelog
 
+## [Fix AI contact search caching] - {PR_MERGE_DATE}
+
+- Key AI contact-search results by query and retry empty results so the tool matches the regular Search Contacts command.
+
 ## [Create All-Day Events] - 2026-08-14
 
 - Add all-day event creation to Create Event and Create Quick Event, including natural-language date-only phrases and “all day”

--- a/extensions/google-calendar/CHANGELOG.md
+++ b/extensions/google-calendar/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Calendar Changelog
 
-## [Fix AI contact search caching] - {PR_MERGE_DATE}
+## [Fix AI contact search caching] - 2026-08-27
 
 - Key AI contact-search results by query and retry empty results so the tool matches the regular Search Contacts command.
 

--- a/extensions/google-calendar/src/tools/search-contacts.ts
+++ b/extensions/google-calendar/src/tools/search-contacts.ts
@@ -24,24 +24,24 @@ type Input = {
   query: string;
 };
 
-const tool = async (input: Input) => {
-  const cachedSearchContacts = withCache(
-    async () => {
-      const contacts = await searchContacts(input.query);
-      return contacts.map((contact) => ({
-        name: contact.names?.[0]?.displayName,
-        email: contact.emailAddresses?.[0]?.value,
-      }));
+const cachedSearchContacts = withCache(
+  async (query: string) => {
+    const contacts = await searchContacts(query);
+    return contacts.map((contact) => ({
+      name: contact.names?.[0]?.displayName,
+      email: contact.emailAddresses?.[0]?.value,
+    }));
+  },
+  {
+    maxAge: 1000 * 60 * 60 * 24, // 24 hours
+    validate(data) {
+      return data.length > 0; // Retry empty results rather than treating them as valid cached data
     },
-    {
-      maxAge: 1000 * 60 * 60 * 24, // 24 hours
-      validate(data) {
-        return !data.length; // If no contacts are found, invalidate the cache
-      },
-    },
-  );
+  },
+);
 
-  return await cachedSearchContacts();
+const tool = async (input: Input) => {
+  return await cachedSearchContacts(input.query);
 };
 
 export default withGoogleAPIs(tool);


### PR DESCRIPTION
## Description

- include the contact query in the cached function arguments so each AI search gets its own cache key
- treat empty arrays as invalid cached data so transient empty results are retried
- keep non-empty results cached for the existing 24-hour window

Fixes #30521

## Screencast

Not included: the affected Google Workspace directory is not available locally. The fix is isolated to the AI tool cache wrapper; the shared People API search remains unchanged.

## Verification

- `npm test` — 25 tests passed
- targeted ESLint passed
- targeted Prettier check passed
- `git diff --check` passed
- full generated-preference/build validation will run in repository CI

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)