### PR TITLE
Brew: Clean-up upgrade and outdated views

### DIFF
--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Brew Changelog
 
-## [Upgrade View] - {PR_MERGE_DATE}
+## [Upgrade View] - 2026-08-27
 
 - The Upgrade command now lists the outdated formulae & casks, matching the Show Outdated command, instead of a list of progress steps.
 - Upgrade progress is reported via the toast/HUD, with the icon of each package reflecting its upgrade status.

--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - The Upgrade command now lists the outdated formulae & casks, matching the Show Outdated command, instead of a list of progress steps.
 - Upgrade progress is reported via the toast/HUD, with the icon of each package reflecting its upgrade status.
-- Outdated packages now use a grey check icon, matching the pending state in the Upgrade command.
+- "Upgrade All" now upgrades each package in turn, so its progress is reported per package.
+- Added a Refresh action to the outdated action panel.
 - Pinned formulae are skipped when upgrading.
 
 ## [Adopt] - 2026-08-19

--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Brew Changelog
 
+## [Upgrade View] - {PR_MERGE_DATE}
+
+- The Upgrade command now lists the outdated formulae & casks, matching the Show Outdated command, instead of a list of progress steps.
+- Upgrade progress is reported via the toast/HUD, with the icon of each package reflecting its upgrade status.
+- Outdated packages now use a grey check icon, matching the pending state in the Upgrade command.
+- Pinned formulae are skipped when upgrading.
+
 ## [Adopt] - 2026-08-19
 
 - Added "Copy Adopt Command" (⌘⇧⌥C) and "Run Adopt in <terminal>" (⌘⇧↵) actions in Search for packages not yet managed by Homebrew. They run `brew install --adopt` to reclaim an externally-installed package (e.g. installed via a .dmg or another package manager) into Homebrew so it is covered by `brew upgrade`.

--- a/extensions/brew/src/components/actionPanels.tsx
+++ b/extensions/brew/src/components/actionPanels.tsx
@@ -10,6 +10,7 @@ import {
   type Formula,
   type OutdatedCask,
   type OutdatedFormula,
+  type UpgradePackageStatus,
 } from "../utils";
 import { useTerminalApp } from "../utils/terminal";
 import * as Actions from "./actions";
@@ -354,6 +355,10 @@ export function FormulaActionPanel(props: {
 
 export function OutdatedActionPanel(props: {
   outdated: OutdatedCask | OutdatedFormula;
+  /** Called when the upgrade starts or finishes, e.g. to show its status in a list */
+  onUpgrade?: (status: UpgradePackageStatus) => void;
+  /** Overrides the default "Upgrade All", e.g. to report progress per package */
+  onUpgradeAll?: () => void;
   onAction: (result: boolean) => void;
 }) {
   const { outdated } = props;
@@ -363,12 +368,32 @@ export function OutdatedActionPanel(props: {
     return (o as OutdatedFormula).pinned != undefined;
   }
 
+  // When the caller shows the upgrade status itself, leave the list as-is:
+  // an upgraded package remains visible, with its status
+  function onUpgradeAction(result: boolean) {
+    if (props.onUpgrade) {
+      props.onUpgrade(result ? "upgraded" : "failed");
+    } else {
+      props.onAction(result);
+    }
+  }
+
   return (
     <ActionPanel>
       <ActionPanel.Section>
-        <Actions.FormulaUpgradeAction formula={outdated} onAction={props.onAction} />
-        <Actions.FormulaUpgradeAllAction onAction={props.onAction} />
+        <Actions.FormulaUpgradeAction
+          formula={outdated}
+          onStart={() => props.onUpgrade?.("upgrading")}
+          onAction={onUpgradeAction}
+        />
+        <Actions.FormulaUpgradeAllAction onUpgradeAll={props.onUpgradeAll} onAction={props.onAction} />
         {isPinable(outdated) && <Actions.FormulaPinAction formula={outdated} onAction={props.onAction} />}
+        <Action
+          title="Refresh"
+          icon={Icon.ArrowClockwise}
+          shortcut={Keyboard.Shortcut.Common.Refresh}
+          onAction={() => props.onAction(true)}
+        />
       </ActionPanel.Section>
       <ActionPanel.Section>
         <Action.CopyToClipboard
@@ -398,6 +423,29 @@ export function OutdatedActionPanel(props: {
           onAction={() => runCommandInTerminal(brewUninstallCommand(outdated))}
         />
       </ActionPanel.Section>
+    </ActionPanel>
+  );
+}
+
+/**
+ * Actions available while an upgrade is running.
+ *
+ * Other brew actions are omitted, since Homebrew does not support concurrent processes.
+ */
+export function UpgradingActionPanel(props: { outdated: OutdatedCask | OutdatedFormula; onCancel: () => void }) {
+  return (
+    <ActionPanel>
+      <Action
+        title="Cancel Upgrade"
+        icon={Icon.XMarkCircle}
+        style={Action.Style.Destructive}
+        onAction={props.onCancel}
+      />
+      <Action.CopyToClipboard
+        title="Copy Upgrade Command"
+        content={brewUpgradeCommand(props.outdated)}
+        shortcut={{ modifiers: ["cmd", "opt"], key: "c" }}
+      />
     </ActionPanel>
   );
 }

--- a/extensions/brew/src/components/actions.tsx
+++ b/extensions/brew/src/components/actions.tsx
@@ -48,13 +48,19 @@ export function FormulaUninstallAction(props: { formula: Cask | Nameable; onActi
   );
 }
 
-export function FormulaUpgradeAction(props: { formula: Cask | Nameable; onAction: (result: boolean) => void }) {
+export function FormulaUpgradeAction(props: {
+  formula: Cask | Nameable;
+  /** Called when the upgrade starts, e.g. to show progress */
+  onStart?: () => void;
+  onAction: (result: boolean) => void;
+}) {
   return (
     <Action
       title="Upgrade"
       icon={Icon.Hammer}
       shortcut={{ modifiers: ["cmd", "shift"], key: "u" }}
       onAction={async () => {
+        props.onStart?.();
         const result = await upgrade(props.formula);
         props.onAction(result);
       }}
@@ -62,13 +68,21 @@ export function FormulaUpgradeAction(props: { formula: Cask | Nameable; onAction
   );
 }
 
-export function FormulaUpgradeAllAction(props: { onAction: (result: boolean) => void }) {
+export function FormulaUpgradeAllAction(props: {
+  /** Overrides the default upgrade, e.g. to report progress per package */
+  onUpgradeAll?: () => void;
+  onAction: (result: boolean) => void;
+}) {
   return (
     <Action
       title="Upgrade All"
       icon={Icon.Hammer}
       shortcut={{ modifiers: ["cmd", "opt"], key: "u" }}
       onAction={async () => {
+        if (props.onUpgradeAll) {
+          props.onUpgradeAll();
+          return;
+        }
         const result = await upgradeAll();
         props.onAction(result);
       }}

--- a/extensions/brew/src/components/outdatedList.tsx
+++ b/extensions/brew/src/components/outdatedList.tsx
@@ -1,0 +1,146 @@
+/**
+ * Shared list of outdated formulae & casks.
+ *
+ * Used by both the outdated & upgrade commands.
+ */
+
+import React from "react";
+import { Color, Icon, List } from "@raycast/api";
+import { getProgressIcon } from "@raycast/utils";
+import { OutdatedCask, OutdatedFormula, OutdatedResults } from "../utils";
+import { OutdatedActionPanel } from "./actionPanels";
+import { InstallableFilterType, placeholder } from "./filter";
+
+/** Icon for a list item, e.g. an upgrade status indicator. Defaults to `PENDING_ICON`. */
+export type OutdatedIcon = (
+  outdated: OutdatedCask | OutdatedFormula,
+  isCask: boolean,
+) => React.ComponentProps<typeof List.Item>["icon"];
+
+/** Actions for a list item. Defaults to the standard OutdatedActionPanel. */
+export type OutdatedActions = (
+  outdated: OutdatedCask | OutdatedFormula,
+  isCask: boolean,
+) => React.ComponentProps<typeof List.Item>["actions"];
+
+export interface OutdatedListProps {
+  outdated?: OutdatedResults;
+  isLoading: boolean;
+  filterType: InstallableFilterType;
+  searchBarAccessory?: React.ComponentProps<typeof List>["searchBarAccessory"];
+  navigationTitle?: string;
+  /** Overrides the default (filter based) search bar placeholder */
+  searchBarPlaceholder?: string;
+  icon?: OutdatedIcon;
+  actions?: OutdatedActions;
+  onAction: () => void;
+}
+
+/** Icon for a package which is outdated, but not (yet) upgraded. */
+export const PENDING_ICON = { source: Icon.CheckCircle, tintColor: Color.SecondaryText };
+
+export function OutdatedList(props: OutdatedListProps) {
+  const formulae = props.filterType != InstallableFilterType.casks ? (props.outdated?.formulae ?? []) : [];
+  const casks = props.filterType != InstallableFilterType.formulae ? (props.outdated?.casks ?? []) : [];
+  const hasResults = formulae.length > 0 || casks.length > 0;
+
+  // Determine search bar placeholder based on loading state
+  const searchBarPlaceholder =
+    props.searchBarPlaceholder ?? (props.isLoading ? "Checking for outdated packages…" : placeholder(props.filterType));
+
+  return (
+    <List
+      navigationTitle={props.navigationTitle}
+      searchBarPlaceholder={searchBarPlaceholder}
+      searchBarAccessory={props.searchBarAccessory}
+      isLoading={props.isLoading}
+    >
+      {/* Loading state */}
+      {props.isLoading && !props.outdated && (
+        <List.EmptyView
+          icon={getProgressIcon(0.5)}
+          title="Checking for outdated packages..."
+          description="Running brew outdated"
+        />
+      )}
+
+      {/* Empty state when no outdated packages */}
+      {!props.isLoading && !hasResults && props.outdated !== undefined && (
+        <List.EmptyView
+          icon={{ source: Icon.CheckCircle, tintColor: Color.Green }}
+          title="All your packages are up to date"
+        />
+      )}
+
+      {/* Results */}
+      {hasResults && (
+        <>
+          <List.Section title="Formulae">
+            {formulae.map((formula) => (
+              <OutdatedFormulaeListItem
+                key={formula.name}
+                outdated={formula}
+                icon={props.icon}
+                actions={props.actions}
+                onAction={props.onAction}
+              />
+            ))}
+          </List.Section>
+          <List.Section title="Casks">
+            {casks.map((cask) => (
+              <OutdatedCaskListItem
+                key={cask.name}
+                outdated={cask}
+                icon={props.icon}
+                actions={props.actions}
+                onAction={props.onAction}
+              />
+            ))}
+          </List.Section>
+        </>
+      )}
+    </List>
+  );
+}
+
+interface OutdatedListItemProps {
+  icon?: OutdatedIcon;
+  actions?: OutdatedActions;
+  onAction: () => void;
+}
+
+function OutdatedCaskListItem(props: OutdatedListItemProps & { outdated: OutdatedCask }) {
+  const outdated = props.outdated;
+  const version = `${outdated.installed_versions} -> ${outdated.current_version}`;
+
+  return (
+    <List.Item
+      id={outdated.name}
+      title={outdated.name}
+      accessories={[{ text: version }]}
+      icon={props.icon?.(outdated, true) ?? PENDING_ICON}
+      actions={props.actions?.(outdated, true) ?? <OutdatedActionPanel outdated={outdated} onAction={props.onAction} />}
+    />
+  );
+}
+
+function OutdatedFormulaeListItem(props: OutdatedListItemProps & { outdated: OutdatedFormula }) {
+  const outdated = props.outdated;
+  let version = "";
+  if (outdated.installed_versions.length > 0) {
+    version = `${outdated.installed_versions[0]} -> ${outdated.current_version}`;
+  }
+
+  return (
+    <List.Item
+      id={outdated.name}
+      title={outdated.name}
+      subtitle={outdated.pinned ? "Pinned" : ""}
+      accessories={[{ text: version }]}
+      icon={props.icon?.(outdated, false) ?? PENDING_ICON}
+      actions={
+        props.actions?.(outdated, false) ?? <OutdatedActionPanel outdated={outdated} onAction={props.onAction} />
+      }
+    />
+  );
+}

--- a/extensions/brew/src/components/outdatedList.tsx
+++ b/extensions/brew/src/components/outdatedList.tsx
@@ -7,7 +7,8 @@
 import React from "react";
 import { Color, Icon, List } from "@raycast/api";
 import { getProgressIcon } from "@raycast/utils";
-import { OutdatedCask, OutdatedFormula, OutdatedResults } from "../utils";
+import { OutdatedCask, OutdatedFormula, OutdatedResults, type UpgradePackageStatus } from "../utils";
+import type { PackageState } from "../hooks/useBrewUpgrade";
 import { OutdatedActionPanel } from "./actionPanels";
 import { InstallableFilterType, placeholder } from "./filter";
 
@@ -16,6 +17,13 @@ export type OutdatedIcon = (
   outdated: OutdatedCask | OutdatedFormula,
   isCask: boolean,
 ) => React.ComponentProps<typeof List.Item>["icon"];
+
+/** Called when a package upgrade starts or finishes, e.g. to update its icon. */
+export type OutdatedUpgradeCallback = (
+  outdated: OutdatedCask | OutdatedFormula,
+  isCask: boolean,
+  status: UpgradePackageStatus,
+) => void;
 
 /** Actions for a list item. Defaults to the standard OutdatedActionPanel. */
 export type OutdatedActions = (
@@ -33,11 +41,35 @@ export interface OutdatedListProps {
   searchBarPlaceholder?: string;
   icon?: OutdatedIcon;
   actions?: OutdatedActions;
+  onUpgrade?: OutdatedUpgradeCallback;
+  /** Overrides the default "Upgrade All", e.g. to report progress per package */
+  onUpgradeAll?: () => void;
   onAction: () => void;
 }
 
 /** Icon for a package which is outdated, but not (yet) upgraded. */
 export const PENDING_ICON = { source: Icon.CheckCircle, tintColor: Color.SecondaryText };
+
+/**
+ * The list item icon, indicating the upgrade status of a package.
+ */
+export function statusIcon(state?: PackageState): React.ComponentProps<typeof List.Item>["icon"] {
+  if (!state) return { value: PENDING_ICON, tooltip: "Pending" };
+
+  switch (state.status) {
+    case "upgrading":
+      return { value: { source: Icon.ArrowDownCircle, tintColor: Color.Blue }, tooltip: "Upgrading…" };
+    case "upgraded":
+      return { value: { source: Icon.CheckCircle, tintColor: Color.Green }, tooltip: "Upgraded" };
+    case "failed":
+      return { value: { source: Icon.XMarkCircle, tintColor: Color.Red }, tooltip: state.message ?? "Upgrade failed" };
+    case "skipped":
+      return {
+        value: { source: Icon.MinusCircle, tintColor: Color.SecondaryText },
+        tooltip: state.message ?? "Skipped",
+      };
+  }
+}
 
 export function OutdatedList(props: OutdatedListProps) {
   const formulae = props.filterType != InstallableFilterType.casks ? (props.outdated?.formulae ?? []) : [];
@@ -82,6 +114,8 @@ export function OutdatedList(props: OutdatedListProps) {
                 outdated={formula}
                 icon={props.icon}
                 actions={props.actions}
+                onUpgrade={props.onUpgrade}
+                onUpgradeAll={props.onUpgradeAll}
                 onAction={props.onAction}
               />
             ))}
@@ -93,6 +127,8 @@ export function OutdatedList(props: OutdatedListProps) {
                 outdated={cask}
                 icon={props.icon}
                 actions={props.actions}
+                onUpgrade={props.onUpgrade}
+                onUpgradeAll={props.onUpgradeAll}
                 onAction={props.onAction}
               />
             ))}
@@ -106,6 +142,8 @@ export function OutdatedList(props: OutdatedListProps) {
 interface OutdatedListItemProps {
   icon?: OutdatedIcon;
   actions?: OutdatedActions;
+  onUpgrade?: OutdatedUpgradeCallback;
+  onUpgradeAll?: () => void;
   onAction: () => void;
 }
 
@@ -119,7 +157,16 @@ function OutdatedCaskListItem(props: OutdatedListItemProps & { outdated: Outdate
       title={outdated.name}
       accessories={[{ text: version }]}
       icon={props.icon?.(outdated, true) ?? PENDING_ICON}
-      actions={props.actions?.(outdated, true) ?? <OutdatedActionPanel outdated={outdated} onAction={props.onAction} />}
+      actions={
+        props.actions?.(outdated, true) ?? (
+          <OutdatedActionPanel
+            outdated={outdated}
+            onUpgrade={(status) => props.onUpgrade?.(outdated, true, status)}
+            onUpgradeAll={props.onUpgradeAll}
+            onAction={props.onAction}
+          />
+        )
+      }
     />
   );
 }
@@ -139,7 +186,14 @@ function OutdatedFormulaeListItem(props: OutdatedListItemProps & { outdated: Out
       accessories={[{ text: version }]}
       icon={props.icon?.(outdated, false) ?? PENDING_ICON}
       actions={
-        props.actions?.(outdated, false) ?? <OutdatedActionPanel outdated={outdated} onAction={props.onAction} />
+        props.actions?.(outdated, false) ?? (
+          <OutdatedActionPanel
+            outdated={outdated}
+            onUpgrade={(status) => props.onUpgrade?.(outdated, false, status)}
+            onUpgradeAll={props.onUpgradeAll}
+            onAction={props.onAction}
+          />
+        )
       }
     />
   );

--- a/extensions/brew/src/hooks/useBrewOutdated.ts
+++ b/extensions/brew/src/hooks/useBrewOutdated.ts
@@ -17,9 +17,13 @@ import { preferences } from "../utils";
  *
  * This shows potentially stale data immediately, then updates with fresh data.
  *
+ * @param options.backgroundRefresh - Run brew update & refresh in the background (default: true).
+ *   Disable this when the caller runs its own brew command, since brew does not
+ *   support concurrent processes.
  * @returns Object containing loading state, data, isRefreshing flag, and revalidate function
  */
-export function useBrewOutdated() {
+export function useBrewOutdated(options?: { backgroundRefresh?: boolean }) {
+  const backgroundRefresh = options?.backgroundRefresh ?? true;
   const [isRefreshing, setIsRefreshing] = useState(false);
   const hasRefreshedRef = useRef(false);
 
@@ -98,10 +102,10 @@ export function useBrewOutdated() {
 
   // Start background refresh after initial data loads
   useEffect(() => {
-    if (!result.isLoading && result.data && !hasRefreshedRef.current) {
+    if (backgroundRefresh && !result.isLoading && result.data && !hasRefreshedRef.current) {
       refreshInBackground();
     }
-  }, [result.isLoading, result.data, refreshInBackground]);
+  }, [backgroundRefresh, result.isLoading, result.data, refreshInBackground]);
 
   return {
     ...result,

--- a/extensions/brew/src/hooks/useBrewUpgrade.ts
+++ b/extensions/brew/src/hooks/useBrewUpgrade.ts
@@ -1,0 +1,176 @@
+/**
+ * Hook for upgrading all outdated packages.
+ *
+ * Progress is reported via the toast/HUD. The per-package status is exposed so
+ * that a list can show it, e.g. as the icon of each item.
+ */
+
+import { useCallback, useRef, useState } from "react";
+import { showToast, Toast } from "@raycast/api";
+import {
+  actionsLogger,
+  brewUpgradeOutdated,
+  ensureError,
+  formatCount,
+  preferences,
+  showActionToast,
+  showBrewFailureToast,
+  upgradeKey,
+  type ActionToastHandle,
+  type OutdatedResults,
+  type UpgradePackage,
+  type UpgradePackageStatus,
+} from "../utils";
+
+/** Upgrade status of a package. */
+export interface PackageState {
+  status: UpgradePackageStatus;
+  message?: string;
+}
+
+export interface BrewUpgrade {
+  /** Upgrade status of each package, keyed by `upgradeKey` */
+  states: Map<string, PackageState>;
+  /** Outdated packages, as fetched when the upgrade started */
+  outdated?: OutdatedResults;
+  isUpgrading: boolean;
+  /** Upgrade all outdated packages. Does nothing if an upgrade is already running. */
+  upgradeAll: () => Promise<void>;
+  /** Set the status of a single package, e.g. when upgraded individually */
+  setPackageState: (pkg: UpgradePackage, state: PackageState) => void;
+  /** Cancel the running upgrade */
+  cancel: () => void;
+  /** Clear the upgrade status of all packages */
+  reset: () => void;
+}
+
+export function useBrewUpgrade(): BrewUpgrade {
+  const [states, setStates] = useState<Map<string, PackageState>>(new Map());
+  const [outdated, setOutdated] = useState<OutdatedResults | undefined>();
+  const [isUpgrading, setIsUpgrading] = useState(false);
+  const toastRef = useRef<ActionToastHandle | undefined>(undefined);
+  const isUpgradingRef = useRef(false);
+
+  const setState = useCallback((key: string, state: PackageState) => {
+    setStates((previous) => {
+      const existing = previous.get(key);
+      if (existing?.status === state.status && existing?.message === state.message) {
+        return previous;
+      }
+      const next = new Map(previous);
+      next.set(key, state);
+      return next;
+    });
+  }, []);
+
+  const setPackageState = useCallback(
+    (pkg: UpgradePackage, state: PackageState) => setState(upgradeKey(pkg), state),
+    [setState],
+  );
+
+  const upgradeAll = useCallback(async () => {
+    // Homebrew does not support concurrent upgrades
+    if (isUpgradingRef.current) {
+      actionsLogger.log("Upgrade already running, skipping duplicate call");
+      return;
+    }
+    isUpgradingRef.current = true;
+    setIsUpgrading(true);
+
+    actionsLogger.log("Starting upgrade process");
+
+    const toast = showActionToast({ title: "Upgrading", message: "Updating Homebrew…", cancelable: true });
+    toastRef.current = toast;
+
+    // Progress is reported via the toast: only the package status is reflected in the list
+    let total = 0;
+    let finished = 0;
+
+    try {
+      const summary = await brewUpgradeOutdated({
+        greedy: preferences.greedyUpgrades,
+        cancel: toast.abort?.signal,
+        onEvent: (event) => {
+          switch (event.type) {
+            case "update":
+              toast.updateTitle("Upgrading");
+              toast.updateMessage("Updating Homebrew…");
+              break;
+            case "check":
+              toast.updateMessage("Checking for outdated packages…");
+              break;
+            case "start":
+              total = event.packages.length;
+              setOutdated(event.outdated);
+              break;
+            case "prefetch":
+              toast.updateTitle(`Downloading ${formatCount(total, "package")}`);
+              toast.updateMessage(event.progress?.message ?? "");
+              break;
+            case "package":
+              if (event.status === "upgrading" && event.progress) {
+                // Download/install progress is shown in the toast only, to avoid
+                // re-rendering the list for every line of brew output
+                toast.updateMessage(event.progress.message);
+              } else {
+                if (event.status === "upgrading") {
+                  toast.updateTitle(`Upgrading ${event.package.name} (${finished + 1}/${total})`);
+                  toast.updateMessage("");
+                } else if (event.status !== "skipped") {
+                  finished += 1;
+                }
+                setState(upgradeKey(event.package), { status: event.status, message: event.message });
+              }
+              break;
+          }
+        },
+      });
+
+      if (summary.cancelled) {
+        toast.hide();
+        await showToast({
+          style: Toast.Style.Failure,
+          title: "Upgrade Cancelled",
+          message: `${formatCount(summary.upgraded.length, "package")} upgraded`,
+        });
+      } else if (summary.failed.length > 0) {
+        // Keep the window open so the failed packages remain visible
+        toast.hide();
+        await showToast({
+          style: Toast.Style.Failure,
+          title: `Failed to upgrade ${formatCount(summary.failed.length, "package")}`,
+          message: summary.failed.map((pkg) => pkg.name).join(", "),
+        });
+      } else if (summary.upgraded.length === 0) {
+        await toast.showSuccessHUD("Nothing to upgrade");
+      } else {
+        await toast.showSuccessHUD(`Upgraded ${formatCount(summary.upgraded.length, "package")}`);
+      }
+    } catch (err) {
+      const error = ensureError(err);
+      toast.hide();
+
+      if (error.name === "AbortError") {
+        actionsLogger.log("Upgrade cancelled by user");
+        await showToast({ style: Toast.Style.Failure, title: "Upgrade Cancelled" });
+      } else {
+        actionsLogger.error("Upgrade failed", { name: error.name, message: error.message });
+        await showBrewFailureToast("Upgrade failed", error);
+      }
+    } finally {
+      isUpgradingRef.current = false;
+      setIsUpgrading(false);
+    }
+  }, [setState]);
+
+  const cancel = useCallback(() => {
+    toastRef.current?.abort?.abort();
+  }, []);
+
+  const reset = useCallback(() => {
+    setStates(new Map());
+    setOutdated(undefined);
+  }, []);
+
+  return { states, outdated, isUpgrading, upgradeAll, setPackageState, cancel, reset };
+}

--- a/extensions/brew/src/outdated.tsx
+++ b/extensions/brew/src/outdated.tsx
@@ -1,24 +1,43 @@
 /**
  * Outdated view for displaying outdated brew packages.
+ *
+ * Upgrades are reported via the toast/HUD, with the icon of each item
+ * reflecting its upgrade status.
  */
 
-import React, { useState } from "react";
+import React, { useCallback, useState } from "react";
+import { upgradeKey } from "./utils";
 import { useBrewOutdated } from "./hooks/useBrewOutdated";
+import { useBrewUpgrade } from "./hooks/useBrewUpgrade";
 import { InstallableFilterDropdown, InstallableFilterType } from "./components/filter";
 import { ErrorBoundary } from "./components/ErrorBoundary";
-import { OutdatedList } from "./components/outdatedList";
+import { UpgradingActionPanel } from "./components/actionPanels";
+import { OutdatedList, statusIcon } from "./components/outdatedList";
 
 function OutdatedContent() {
   const [filter, setFilter] = useState(InstallableFilterType.all);
   const { isLoading, isRefreshing, data, revalidate } = useBrewOutdated();
+  const upgrade = useBrewUpgrade();
+
+  const handleAction = useCallback(() => {
+    upgrade.reset();
+    revalidate();
+  }, [upgrade, revalidate]);
 
   return (
     <OutdatedList
-      outdated={data}
-      isLoading={isLoading || isRefreshing}
+      outdated={upgrade.outdated ?? data}
+      isLoading={isLoading || isRefreshing || upgrade.isUpgrading}
       filterType={filter}
+      searchBarPlaceholder={upgrade.isUpgrading ? "Upgrading…" : undefined}
       searchBarAccessory={<InstallableFilterDropdown onSelect={setFilter} />}
-      onAction={() => revalidate()}
+      icon={(item, isCask) => statusIcon(upgrade.states.get(upgradeKey({ name: item.name, isCask })))}
+      onUpgrade={(item, isCask, status) => upgrade.setPackageState({ name: item.name, isCask }, { status })}
+      onUpgradeAll={upgrade.upgradeAll}
+      actions={
+        upgrade.isUpgrading ? (item) => <UpgradingActionPanel outdated={item} onCancel={upgrade.cancel} /> : undefined
+      }
+      onAction={handleAction}
     />
   );
 }

--- a/extensions/brew/src/outdated.tsx
+++ b/extensions/brew/src/outdated.tsx
@@ -3,13 +3,10 @@
  */
 
 import React, { useState } from "react";
-import { Color, Icon, List } from "@raycast/api";
-import { getProgressIcon } from "@raycast/utils";
-import { OutdatedCask, OutdatedFormula, OutdatedResults } from "./utils";
 import { useBrewOutdated } from "./hooks/useBrewOutdated";
-import { OutdatedActionPanel } from "./components/actionPanels";
-import { InstallableFilterDropdown, InstallableFilterType, placeholder } from "./components/filter";
+import { InstallableFilterDropdown, InstallableFilterType } from "./components/filter";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import { OutdatedList } from "./components/outdatedList";
 
 function OutdatedContent() {
   const [filter, setFilter] = useState(InstallableFilterType.all);
@@ -31,97 +28,5 @@ export default function Main() {
     <ErrorBoundary>
       <OutdatedContent />
     </ErrorBoundary>
-  );
-}
-
-function OutdatedCaskListItem(props: { outdated: OutdatedCask; onAction: () => void }) {
-  const outdated = props.outdated;
-  const version = `${outdated.installed_versions} -> ${outdated.current_version}`;
-
-  return (
-    <List.Item
-      id={outdated.name}
-      title={outdated.name}
-      accessories={[{ text: version }]}
-      icon={{ source: Icon.CheckCircle, tintColor: Color.Red }}
-      actions={<OutdatedActionPanel outdated={outdated} onAction={props.onAction} />}
-    />
-  );
-}
-
-function OutdatedFormulaeListItem(props: { outdated: OutdatedFormula; onAction: () => void }) {
-  const outdated = props.outdated;
-  let version = "";
-  if (outdated.installed_versions.length > 0) {
-    version = `${outdated.installed_versions[0]} -> ${outdated.current_version}`;
-  }
-
-  return (
-    <List.Item
-      id={outdated.name}
-      title={outdated.name}
-      subtitle={outdated.pinned ? "Pinned" : ""}
-      accessories={[{ text: version }]}
-      icon={{ source: Icon.CheckCircle, tintColor: Color.Red }}
-      actions={<OutdatedActionPanel outdated={outdated} onAction={props.onAction} />}
-    />
-  );
-}
-
-interface OutdatedListProps {
-  outdated?: OutdatedResults;
-  isLoading: boolean;
-  searchBarAccessory?: React.ComponentProps<typeof List>["searchBarAccessory"];
-  filterType: InstallableFilterType;
-  onAction: () => void;
-}
-
-function OutdatedList(props: OutdatedListProps) {
-  const formulae = props.filterType != InstallableFilterType.casks ? (props.outdated?.formulae ?? []) : [];
-  const casks = props.filterType != InstallableFilterType.formulae ? (props.outdated?.casks ?? []) : [];
-  const hasResults = formulae.length > 0 || casks.length > 0;
-
-  // Determine search bar placeholder based on loading state
-  const searchBarPlaceholder = props.isLoading ? "Checking for outdated packages…" : placeholder(props.filterType);
-
-  return (
-    <List
-      searchBarPlaceholder={searchBarPlaceholder}
-      searchBarAccessory={props.searchBarAccessory}
-      isLoading={props.isLoading}
-    >
-      {/* Loading state */}
-      {props.isLoading && !props.outdated && (
-        <List.EmptyView
-          icon={getProgressIcon(0.5)}
-          title="Checking for outdated packages..."
-          description="Running brew outdated"
-        />
-      )}
-
-      {/* Empty state when no outdated packages */}
-      {!props.isLoading && !hasResults && props.outdated !== undefined && (
-        <List.EmptyView
-          icon={{ source: Icon.CheckCircle, tintColor: Color.Green }}
-          title="All your packages are up to date"
-        />
-      )}
-
-      {/* Results */}
-      {hasResults && (
-        <>
-          <List.Section title="Formulae">
-            {formulae.map((formula) => (
-              <OutdatedFormulaeListItem key={formula.name} outdated={formula} onAction={props.onAction} />
-            ))}
-          </List.Section>
-          <List.Section title="Casks">
-            {casks.map((cask) => (
-              <OutdatedCaskListItem key={cask.name} outdated={cask} onAction={props.onAction} />
-            ))}
-          </List.Section>
-        </>
-      )}
-    </List>
   );
 }

--- a/extensions/brew/src/upgrade.tsx
+++ b/extensions/brew/src/upgrade.tsx
@@ -1,388 +1,221 @@
 /**
- * Upgrade command for upgrading all brew packages with progress display.
+ * Upgrade command: upgrades all outdated packages.
+ *
+ * Shows the outdated formulae & casks, with progress reported via the toast/HUD.
+ * The icon of each item reflects its upgrade status.
  */
 
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { Action, ActionPanel, Color, Icon, List, showToast, Toast, popToRoot } from "@raycast/api";
-import { getProgressIcon } from "@raycast/utils";
-import { brewUpgradeWithProgress, preferences, showBrewFailureToast, actionsLogger, ensureError } from "./utils";
+import { Action, ActionPanel, Color, Icon, List, showToast, Toast } from "@raycast/api";
+import {
+  actionsLogger,
+  brewUpgradeCommand,
+  brewUpgradeOutdated,
+  ensureError,
+  formatCount,
+  type OutdatedCask,
+  type OutdatedFormula,
+  type OutdatedResults,
+  preferences,
+  showActionToast,
+  showBrewFailureToast,
+  upgradeKey,
+  type ActionToastHandle,
+  type UpgradePackageStatus,
+} from "./utils";
+import { useBrewOutdated } from "./hooks/useBrewOutdated";
+import { InstallableFilterDropdown, InstallableFilterType } from "./components/filter";
 import { ErrorBoundary } from "./components/ErrorBoundary";
-import type { UpgradeStep } from "./utils/brew/upgrade";
+import { OutdatedList, PENDING_ICON } from "./components/outdatedList";
 
-/// Status Messages
-
-const STATUS_MESSAGES = {
-  UPGRADING: "Upgrading...",
-  NOTHING_TO_UPGRADE: "Nothing to upgrade!",
-  UPGRADE_CANCELLED: "Upgrade Cancelled",
-  UPGRADE_FAILED: "Upgrade Failed",
-} as const;
+interface PackageState {
+  status: UpgradePackageStatus;
+  message?: string;
+}
 
 /**
- * Get the icon for a step based on its status.
+ * The list item icon, indicating the upgrade status of a package.
  */
-function getStepIcon(step: UpgradeStep): { source: Icon; tintColor?: Color } | ReturnType<typeof getProgressIcon> {
-  switch (step.status) {
-    case "pending":
-      return { source: Icon.Circle, tintColor: Color.SecondaryText };
-    case "running":
-      return getProgressIcon(0.5);
-    case "completed":
-      return { source: Icon.CheckCircle, tintColor: Color.Green };
+function statusIcon(state?: PackageState): React.ComponentProps<typeof List.Item>["icon"] {
+  if (!state) return { value: PENDING_ICON, tooltip: "Pending" };
+
+  switch (state.status) {
+    case "upgrading":
+      return { value: { source: Icon.ArrowDownCircle, tintColor: Color.Blue }, tooltip: "Upgrading…" };
+    case "upgraded":
+      return { value: { source: Icon.CheckCircle, tintColor: Color.Green }, tooltip: "Upgraded" };
     case "failed":
-      // Use warning icon for recoverable errors
-      if (step.isRecoverable) {
-        return { source: Icon.ExclamationMark, tintColor: Color.Orange };
-      }
-      return { source: Icon.XMarkCircle, tintColor: Color.Red };
+      return { value: { source: Icon.XMarkCircle, tintColor: Color.Red }, tooltip: state.message ?? "Upgrade failed" };
     case "skipped":
-      return { source: Icon.MinusCircle, tintColor: Color.SecondaryText };
+      return {
+        value: { source: Icon.MinusCircle, tintColor: Color.SecondaryText },
+        tooltip: state.message ?? "Skipped",
+      };
   }
 }
 
-/**
- * Format duration in a human-readable way.
- */
-function formatDuration(startTime?: number, endTime?: number): string | undefined {
-  if (!startTime) return undefined;
-  const end = endTime || Date.now();
-  const durationMs = end - startTime;
-  if (durationMs < 1000) return `${durationMs}ms`;
-  const seconds = Math.floor(durationMs / 1000);
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  const remainingSeconds = seconds % 60;
-  return `${minutes}m ${remainingSeconds}s`;
-}
-
-/**
- * Calculate overall progress percentage.
- */
-function calculateProgress(steps: UpgradeStep[]): number {
-  if (steps.length === 0) return 0;
-  const completed = steps.filter(
-    (s) => s.status === "completed" || s.status === "skipped" || s.status === "failed",
-  ).length;
-  return completed / steps.length;
+function UpgradingActionPanel(props: { outdated: OutdatedCask | OutdatedFormula; onCancel: () => void }) {
+  return (
+    <ActionPanel>
+      <Action
+        title="Cancel Upgrade"
+        icon={Icon.XMarkCircle}
+        style={Action.Style.Destructive}
+        onAction={props.onCancel}
+      />
+      <Action.CopyToClipboard
+        title="Copy Upgrade Command"
+        content={brewUpgradeCommand(props.outdated)}
+        shortcut={{ modifiers: ["cmd", "opt"], key: "c" }}
+      />
+    </ActionPanel>
+  );
 }
 
 function UpgradeContent() {
-  const [steps, setSteps] = useState<UpgradeStep[]>([]);
-  const [isRunning, setIsRunning] = useState(true);
-  const [currentOutput, setCurrentOutput] = useState<string>("");
-  const [error, setError] = useState<Error | undefined>();
-  const [wasCancelled, setWasCancelled] = useState(false);
-  const abortControllerRef = useRef<AbortController | null>(null);
+  const [filter, setFilter] = useState(InstallableFilterType.all);
+  // The upgrade runs its own brew update, so skip the hook's background refresh:
+  // brew does not support concurrent processes.
+  const { isLoading, data, revalidate } = useBrewOutdated({ backgroundRefresh: false });
+  // Fresh results, fetched by the upgrade after running brew update
+  const [outdated, setOutdated] = useState<OutdatedResults | undefined>();
+  const [states, setStates] = useState<Map<string, PackageState>>(new Map());
+  const [isUpgrading, setIsUpgrading] = useState(true);
+  const toastRef = useRef<ActionToastHandle | undefined>(undefined);
   const hasStartedRef = useRef(false);
-  const isMountedRef = useRef(true);
 
-  const handleProgress = useCallback((newSteps: UpgradeStep[], output?: string) => {
-    if (!isMountedRef.current) return;
-    setSteps([...newSteps]);
-    if (output) {
-      setCurrentOutput(output);
-    }
-    actionsLogger.log("Upgrade progress", {
-      completedSteps: newSteps.filter((s) => s.status === "completed").length,
-      totalSteps: newSteps.length,
+  const setPackageState = useCallback((key: string, state: PackageState) => {
+    setStates((previous) => {
+      const existing = previous.get(key);
+      if (existing?.status === state.status && existing?.message === state.message) {
+        return previous;
+      }
+      const next = new Map(previous);
+      next.set(key, state);
+      return next;
     });
   }, []);
 
   const runUpgrade = useCallback(async () => {
-    if (hasStartedRef.current) {
-      actionsLogger.log("Upgrade already started, skipping duplicate call");
-      return;
-    }
+    if (hasStartedRef.current) return;
     hasStartedRef.current = true;
+
     actionsLogger.log("Starting upgrade process");
 
-    const controller = new AbortController();
-    abortControllerRef.current = controller;
+    const toast = showActionToast({ title: "Upgrading", message: "Updating Homebrew…", cancelable: true });
+    toastRef.current = toast;
 
-    const toast = await showToast({
-      style: Toast.Style.Animated,
-      title: "Upgrading packages...",
-    });
+    // Progress is reported via the toast: only the package status is reflected in the list
+    let total = 0;
+    let finished = 0;
 
     try {
-      const result = await brewUpgradeWithProgress(preferences.greedyUpgrades, handleProgress, controller.signal);
-
-      if (result.success) {
-        const completedCount = result.steps.filter((s) => s.status === "completed").length;
-        const skippedCount = result.steps.filter((s) => s.status === "skipped").length;
-
-        if (completedCount <= 2) {
-          toast.style = Toast.Style.Success;
-          toast.title = STATUS_MESSAGES.NOTHING_TO_UPGRADE;
-        } else {
-          const upgradedCount = completedCount - 2;
-          toast.style = Toast.Style.Success;
-          toast.title = `${upgradedCount} package${upgradedCount === 1 ? "" : "s"} upgraded.`;
-          if (skippedCount > 0) {
-            toast.title += ` ${skippedCount} skipped.`;
+      const summary = await brewUpgradeOutdated({
+        greedy: preferences.greedyUpgrades,
+        cancel: toast.abort?.signal,
+        onEvent: (event) => {
+          switch (event.type) {
+            case "update":
+              toast.updateTitle("Upgrading");
+              toast.updateMessage("Updating Homebrew…");
+              break;
+            case "check":
+              toast.updateMessage("Checking for outdated packages…");
+              break;
+            case "start":
+              total = event.packages.length;
+              setOutdated(event.outdated);
+              break;
+            case "prefetch":
+              toast.updateTitle(`Downloading ${formatCount(total, "package")}`);
+              toast.updateMessage(event.progress?.message ?? "");
+              break;
+            case "package":
+              if (event.status === "upgrading" && event.progress) {
+                // Download/install progress is shown in the toast only, to avoid
+                // re-rendering the list for every line of brew output
+                toast.updateMessage(event.progress.message);
+              } else {
+                if (event.status === "upgrading") {
+                  toast.updateTitle(`Upgrading ${event.package.name} (${finished + 1}/${total})`);
+                  toast.updateMessage("");
+                } else if (event.status !== "skipped") {
+                  finished += 1;
+                }
+                setPackageState(upgradeKey(event.package), { status: event.status, message: event.message });
+              }
+              break;
           }
-        }
+        },
+      });
+
+      if (summary.cancelled) {
+        toast.hide();
+        await showToast({
+          style: Toast.Style.Failure,
+          title: "Upgrade Cancelled",
+          message: `${formatCount(summary.upgraded.length, "package")} upgraded`,
+        });
+      } else if (summary.failed.length > 0) {
+        // Keep the window open so the failed packages remain visible
+        toast.hide();
+        await showToast({
+          style: Toast.Style.Failure,
+          title: `Failed to upgrade ${formatCount(summary.failed.length, "package")}`,
+          message: summary.failed.map((pkg) => pkg.name).join(", "),
+        });
+      } else if (summary.upgraded.length === 0) {
+        await toast.showSuccessHUD("Nothing to upgrade");
       } else {
-        toast.style = Toast.Style.Failure;
-        toast.title = "Upgrade failed";
-        toast.message = result.error?.message;
-        setError(result.error);
+        await toast.showSuccessHUD(`Upgraded ${formatCount(summary.upgraded.length, "package")}`);
       }
     } catch (err) {
       const error = ensureError(err);
-      actionsLogger.error("Upgrade caught exception", {
-        name: error.name,
-        message: error.message,
-        stack: error.stack,
-      });
+      toast.hide();
 
       if (error.name === "AbortError") {
-        toast.style = Toast.Style.Failure;
-        toast.title = "Upgrade cancelled";
-        setWasCancelled(true);
-        // Log cancellation with current state (steps is captured in closure)
-        actionsLogger.log("Upgrade cancelled by user", {
-          completedSteps: steps.filter((s) => s.status === "completed").length,
-          runningStep: steps.find((s) => s.status === "running")?.title,
-          pendingSteps: steps.filter((s) => s.status === "pending").length,
-          totalSteps: steps.length,
-        });
+        actionsLogger.log("Upgrade cancelled by user");
+        await showToast({ style: Toast.Style.Failure, title: "Upgrade Cancelled" });
       } else {
-        toast.style = Toast.Style.Failure;
-        toast.title = "Upgrade failed";
-        toast.message = error.message;
-        setError(error);
+        actionsLogger.error("Upgrade failed", { name: error.name, message: error.message });
         await showBrewFailureToast("Upgrade failed", error);
       }
     } finally {
-      setIsRunning(false);
-      abortControllerRef.current = null;
+      setIsUpgrading(false);
     }
-  }, [handleProgress]);
+  }, [setPackageState]);
 
+  // Start once the (cached) outdated packages are listed, so the upgrade
+  // doesn't run concurrently with the initial brew outdated fetch.
   useEffect(() => {
-    isMountedRef.current = true;
-    actionsLogger.log("UpgradeView mounted");
-    runUpgrade();
-
-    return () => {
-      actionsLogger.log("UpgradeView cleanup called");
-      isMountedRef.current = false;
-      // Don't abort on cleanup - let the process complete
-      // User can manually cancel if needed
-    };
-  }, [runUpgrade]);
+    if (!isLoading) {
+      runUpgrade();
+    }
+  }, [isLoading, runUpgrade]);
 
   const handleCancel = useCallback(() => {
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort();
-    }
+    toastRef.current?.abort?.abort();
   }, []);
 
-  const progress = calculateProgress(steps);
-  const runningStep = steps.find((s) => s.status === "running");
-  const completedCount = steps.filter((s) => s.status === "completed").length;
-  const failedCount = steps.filter((s) => s.status === "failed").length;
-  const recoverableCount = steps.filter((s) => s.status === "failed" && s.isRecoverable).length;
-
-  // Count skipped steps (for cancelled detection)
-  const skippedCount = steps.filter((s) => s.status === "skipped").length;
-  const cancelledStepCount = steps.filter((s) => s.message === "Cancelled by user" || s.message === "Cancelled").length;
-  const isCancelledState = wasCancelled || cancelledStepCount > 0;
-
-  // Determine navigation title based on state
-  let navigationTitle: string = STATUS_MESSAGES.UPGRADING;
-  if (!isRunning) {
-    if (isCancelledState) {
-      navigationTitle = STATUS_MESSAGES.UPGRADE_CANCELLED;
-    } else if (error || failedCount > 0) {
-      navigationTitle = STATUS_MESSAGES.UPGRADE_FAILED;
-    } else if (completedCount <= 2) {
-      // No packages were actually upgraded (only update + check steps)
-      navigationTitle = STATUS_MESSAGES.NOTHING_TO_UPGRADE;
-    } else {
-      navigationTitle = `Upgraded ${completedCount - 2} package${completedCount - 2 === 1 ? "" : "s"}`;
-    }
-  } else if (runningStep) {
-    navigationTitle = `Upgrading ${runningStep.title}...`;
-  }
-
-  // Determine search bar placeholder based on state
-  let searchBarPlaceholder: string = STATUS_MESSAGES.UPGRADING;
-  if (!isRunning) {
-    if (isCancelledState) {
-      searchBarPlaceholder = STATUS_MESSAGES.UPGRADE_CANCELLED;
-    } else if (error || failedCount > 0) {
-      searchBarPlaceholder = STATUS_MESSAGES.UPGRADE_FAILED;
-    } else if (completedCount <= 2) {
-      searchBarPlaceholder = STATUS_MESSAGES.NOTHING_TO_UPGRADE;
-    } else {
-      searchBarPlaceholder = "Upgrade Complete";
-    }
-  }
+  const handleAction = useCallback(() => {
+    // Show the refreshed results, rather than those fetched by the upgrade
+    setOutdated(undefined);
+    setStates(new Map());
+    revalidate();
+  }, [revalidate]);
 
   return (
-    <List
-      isLoading={isRunning && steps.length === 0}
-      navigationTitle={navigationTitle}
-      searchBarPlaceholder={searchBarPlaceholder}
-    >
-      {steps.length === 0 && isRunning && (
-        <List.EmptyView
-          icon={getProgressIcon(0.1)}
-          title="Preparing upgrade..."
-          description="Checking for outdated packages"
-        />
-      )}
-
-      {steps.length > 0 && (
-        <>
-          <List.Section title="Progress" subtitle={`${Math.round(progress * 100)}% complete`}>
-            {steps.map((step) => (
-              <List.Item
-                key={step.id}
-                icon={getStepIcon(step)}
-                title={step.title}
-                subtitle={step.subtitle}
-                accessories={[
-                  // Show current phase for running steps
-                  ...(step.status === "running" && step.currentPhase
-                    ? [
-                        {
-                          tag: { value: step.currentPhase, color: Color.Blue },
-                          tooltip: `Current phase: ${step.currentPhase}`,
-                        },
-                      ]
-                    : []),
-                  // Show message (use "Cancelled" instead of "Aborted" for abort errors)
-                  ...(step.message
-                    ? [
-                        {
-                          text: step.message === "Aborted" ? "Cancelled" : step.message,
-                          tooltip: step.message === "Aborted" ? "Cancelled by user" : step.message,
-                        },
-                      ]
-                    : []),
-                  // Show recoverable indicator for failed steps
-                  ...(step.status === "failed" && step.isRecoverable
-                    ? [
-                        {
-                          tag: { value: "Retry", color: Color.Orange },
-                          tooltip: "This error may be resolved by retrying",
-                        },
-                      ]
-                    : []),
-                  // Show duration
-                  ...(step.status === "running" || step.status === "completed" || step.status === "failed"
-                    ? [{ text: formatDuration(step.startTime, step.endTime), tooltip: "Duration" }]
-                    : []),
-                ]}
-                actions={
-                  <ActionPanel>
-                    {isRunning && (
-                      <Action
-                        title="Cancel Upgrade"
-                        icon={Icon.XMarkCircle}
-                        style={Action.Style.Destructive}
-                        onAction={handleCancel}
-                      />
-                    )}
-                    {!isRunning && <Action title="Close" icon={Icon.ArrowLeft} onAction={() => popToRoot()} />}
-                    {currentOutput && (
-                      <Action.CopyToClipboard
-                        title="Copy Output Log"
-                        content={currentOutput}
-                        shortcut={{ modifiers: ["cmd"], key: "l" }}
-                      />
-                    )}
-                  </ActionPanel>
-                }
-              />
-            ))}
-          </List.Section>
-
-          {!isRunning && (
-            <List.Section title="Summary">
-              {/* Show upgraded packages */}
-              {steps
-                .filter((s) => s.status === "completed" && (s.id.startsWith("formula-") || s.id.startsWith("cask-")))
-                .map((step) => (
-                  <List.Item
-                    key={`summary-${step.id}`}
-                    icon={{ source: Icon.CheckCircle, tintColor: Color.Green }}
-                    title={step.title}
-                    accessories={[
-                      ...(step.subtitle ? [{ text: step.subtitle, tooltip: "Version change" }] : []),
-                      { text: "Upgraded", tooltip: `Upgraded in ${formatDuration(step.startTime, step.endTime)}` },
-                    ]}
-                  />
-                ))}
-              {/* Show failed packages */}
-              {steps
-                .filter((s) => s.status === "failed" && (s.id.startsWith("formula-") || s.id.startsWith("cask-")))
-                .map((step) => (
-                  <List.Item
-                    key={`summary-${step.id}`}
-                    icon={{ source: Icon.XMarkCircle, tintColor: Color.Red }}
-                    title={step.title}
-                    accessories={[
-                      ...(step.subtitle ? [{ text: step.subtitle, tooltip: "Version change" }] : []),
-                      { text: step.message || "Failed", tooltip: step.message },
-                    ]}
-                  />
-                ))}
-              {/* Show totals if there were packages */}
-              {(completedCount > 2 || failedCount > 0 || isCancelledState) && (
-                <List.Item
-                  icon={{
-                    source: isCancelledState ? Icon.XMarkCircle : Icon.Document,
-                    tintColor: isCancelledState ? Color.Orange : Color.SecondaryText,
-                  }}
-                  title="Total"
-                  accessories={[
-                    // Show upgraded count only if we actually upgraded packages (completedCount > 2 means more than just update+check)
-                    ...(completedCount > 2
-                      ? [{ text: `${completedCount - 2} upgraded`, tooltip: "Packages upgraded" }]
-                      : []),
-                    // Show cancelled info if cancelled
-                    ...(isCancelledState
-                      ? [
-                          {
-                            text:
-                              cancelledStepCount > 0
-                                ? `${cancelledStepCount} cancelled`
-                                : skippedCount > 0
-                                  ? `${skippedCount} skipped`
-                                  : "Cancelled",
-                            tooltip: "Upgrade was cancelled by user",
-                          },
-                        ]
-                      : []),
-                    // Show failed count (excluding cancellation-related failures)
-                    ...(failedCount > 0 && !isCancelledState
-                      ? [
-                          {
-                            text: `${failedCount} failed${recoverableCount > 0 ? ` (${recoverableCount} retryable)` : ""}`,
-                            tooltip:
-                              recoverableCount > 0 ? "Some failures may be resolved by retrying" : "Packages failed",
-                          },
-                        ]
-                      : []),
-                  ]}
-                />
-              )}
-              {/* Show message when nothing to upgrade (only if not cancelled) */}
-              {completedCount <= 2 && failedCount === 0 && !isCancelledState && (
-                <List.Item
-                  icon={{ source: Icon.CheckCircle, tintColor: Color.Green }}
-                  title="All packages are up to date"
-                />
-              )}
-            </List.Section>
-          )}
-        </>
-      )}
-    </List>
+    <OutdatedList
+      outdated={outdated ?? data}
+      isLoading={isLoading || isUpgrading}
+      filterType={filter}
+      navigationTitle="Upgrade"
+      searchBarPlaceholder={isUpgrading ? "Upgrading…" : undefined}
+      searchBarAccessory={<InstallableFilterDropdown onSelect={setFilter} />}
+      icon={(item, isCask) => statusIcon(states.get(upgradeKey({ name: item.name, isCask })))}
+      actions={isUpgrading ? (item) => <UpgradingActionPanel outdated={item} onCancel={handleCancel} /> : undefined}
+      onAction={handleAction}
+    />
   );
 }
 

--- a/extensions/brew/src/upgrade.tsx
+++ b/extensions/brew/src/upgrade.tsx
@@ -6,214 +6,52 @@
  */
 
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { Action, ActionPanel, Color, Icon, List, showToast, Toast } from "@raycast/api";
-import {
-  actionsLogger,
-  brewUpgradeCommand,
-  brewUpgradeOutdated,
-  ensureError,
-  formatCount,
-  type OutdatedCask,
-  type OutdatedFormula,
-  type OutdatedResults,
-  preferences,
-  showActionToast,
-  showBrewFailureToast,
-  upgradeKey,
-  type ActionToastHandle,
-  type UpgradePackageStatus,
-} from "./utils";
+import { upgradeKey } from "./utils";
 import { useBrewOutdated } from "./hooks/useBrewOutdated";
+import { useBrewUpgrade } from "./hooks/useBrewUpgrade";
 import { InstallableFilterDropdown, InstallableFilterType } from "./components/filter";
 import { ErrorBoundary } from "./components/ErrorBoundary";
-import { OutdatedList, PENDING_ICON } from "./components/outdatedList";
-
-interface PackageState {
-  status: UpgradePackageStatus;
-  message?: string;
-}
-
-/**
- * The list item icon, indicating the upgrade status of a package.
- */
-function statusIcon(state?: PackageState): React.ComponentProps<typeof List.Item>["icon"] {
-  if (!state) return { value: PENDING_ICON, tooltip: "Pending" };
-
-  switch (state.status) {
-    case "upgrading":
-      return { value: { source: Icon.ArrowDownCircle, tintColor: Color.Blue }, tooltip: "Upgrading…" };
-    case "upgraded":
-      return { value: { source: Icon.CheckCircle, tintColor: Color.Green }, tooltip: "Upgraded" };
-    case "failed":
-      return { value: { source: Icon.XMarkCircle, tintColor: Color.Red }, tooltip: state.message ?? "Upgrade failed" };
-    case "skipped":
-      return {
-        value: { source: Icon.MinusCircle, tintColor: Color.SecondaryText },
-        tooltip: state.message ?? "Skipped",
-      };
-  }
-}
-
-function UpgradingActionPanel(props: { outdated: OutdatedCask | OutdatedFormula; onCancel: () => void }) {
-  return (
-    <ActionPanel>
-      <Action
-        title="Cancel Upgrade"
-        icon={Icon.XMarkCircle}
-        style={Action.Style.Destructive}
-        onAction={props.onCancel}
-      />
-      <Action.CopyToClipboard
-        title="Copy Upgrade Command"
-        content={brewUpgradeCommand(props.outdated)}
-        shortcut={{ modifiers: ["cmd", "opt"], key: "c" }}
-      />
-    </ActionPanel>
-  );
-}
+import { UpgradingActionPanel } from "./components/actionPanels";
+import { OutdatedList, statusIcon } from "./components/outdatedList";
 
 function UpgradeContent() {
   const [filter, setFilter] = useState(InstallableFilterType.all);
   // The upgrade runs its own brew update, so skip the hook's background refresh:
   // brew does not support concurrent processes.
   const { isLoading, data, revalidate } = useBrewOutdated({ backgroundRefresh: false });
-  // Fresh results, fetched by the upgrade after running brew update
-  const [outdated, setOutdated] = useState<OutdatedResults | undefined>();
-  const [states, setStates] = useState<Map<string, PackageState>>(new Map());
-  const [isUpgrading, setIsUpgrading] = useState(true);
-  const toastRef = useRef<ActionToastHandle | undefined>(undefined);
+  const upgrade = useBrewUpgrade();
+  const { upgradeAll } = upgrade;
   const hasStartedRef = useRef(false);
-
-  const setPackageState = useCallback((key: string, state: PackageState) => {
-    setStates((previous) => {
-      const existing = previous.get(key);
-      if (existing?.status === state.status && existing?.message === state.message) {
-        return previous;
-      }
-      const next = new Map(previous);
-      next.set(key, state);
-      return next;
-    });
-  }, []);
-
-  const runUpgrade = useCallback(async () => {
-    if (hasStartedRef.current) return;
-    hasStartedRef.current = true;
-
-    actionsLogger.log("Starting upgrade process");
-
-    const toast = showActionToast({ title: "Upgrading", message: "Updating Homebrew…", cancelable: true });
-    toastRef.current = toast;
-
-    // Progress is reported via the toast: only the package status is reflected in the list
-    let total = 0;
-    let finished = 0;
-
-    try {
-      const summary = await brewUpgradeOutdated({
-        greedy: preferences.greedyUpgrades,
-        cancel: toast.abort?.signal,
-        onEvent: (event) => {
-          switch (event.type) {
-            case "update":
-              toast.updateTitle("Upgrading");
-              toast.updateMessage("Updating Homebrew…");
-              break;
-            case "check":
-              toast.updateMessage("Checking for outdated packages…");
-              break;
-            case "start":
-              total = event.packages.length;
-              setOutdated(event.outdated);
-              break;
-            case "prefetch":
-              toast.updateTitle(`Downloading ${formatCount(total, "package")}`);
-              toast.updateMessage(event.progress?.message ?? "");
-              break;
-            case "package":
-              if (event.status === "upgrading" && event.progress) {
-                // Download/install progress is shown in the toast only, to avoid
-                // re-rendering the list for every line of brew output
-                toast.updateMessage(event.progress.message);
-              } else {
-                if (event.status === "upgrading") {
-                  toast.updateTitle(`Upgrading ${event.package.name} (${finished + 1}/${total})`);
-                  toast.updateMessage("");
-                } else if (event.status !== "skipped") {
-                  finished += 1;
-                }
-                setPackageState(upgradeKey(event.package), { status: event.status, message: event.message });
-              }
-              break;
-          }
-        },
-      });
-
-      if (summary.cancelled) {
-        toast.hide();
-        await showToast({
-          style: Toast.Style.Failure,
-          title: "Upgrade Cancelled",
-          message: `${formatCount(summary.upgraded.length, "package")} upgraded`,
-        });
-      } else if (summary.failed.length > 0) {
-        // Keep the window open so the failed packages remain visible
-        toast.hide();
-        await showToast({
-          style: Toast.Style.Failure,
-          title: `Failed to upgrade ${formatCount(summary.failed.length, "package")}`,
-          message: summary.failed.map((pkg) => pkg.name).join(", "),
-        });
-      } else if (summary.upgraded.length === 0) {
-        await toast.showSuccessHUD("Nothing to upgrade");
-      } else {
-        await toast.showSuccessHUD(`Upgraded ${formatCount(summary.upgraded.length, "package")}`);
-      }
-    } catch (err) {
-      const error = ensureError(err);
-      toast.hide();
-
-      if (error.name === "AbortError") {
-        actionsLogger.log("Upgrade cancelled by user");
-        await showToast({ style: Toast.Style.Failure, title: "Upgrade Cancelled" });
-      } else {
-        actionsLogger.error("Upgrade failed", { name: error.name, message: error.message });
-        await showBrewFailureToast("Upgrade failed", error);
-      }
-    } finally {
-      setIsUpgrading(false);
-    }
-  }, [setPackageState]);
 
   // Start once the (cached) outdated packages are listed, so the upgrade
   // doesn't run concurrently with the initial brew outdated fetch.
   useEffect(() => {
-    if (!isLoading) {
-      runUpgrade();
+    if (!isLoading && !hasStartedRef.current) {
+      hasStartedRef.current = true;
+      upgradeAll();
     }
-  }, [isLoading, runUpgrade]);
-
-  const handleCancel = useCallback(() => {
-    toastRef.current?.abort?.abort();
-  }, []);
+  }, [isLoading, upgradeAll]);
 
   const handleAction = useCallback(() => {
     // Show the refreshed results, rather than those fetched by the upgrade
-    setOutdated(undefined);
-    setStates(new Map());
+    upgrade.reset();
     revalidate();
-  }, [revalidate]);
+  }, [upgrade, revalidate]);
 
   return (
     <OutdatedList
-      outdated={outdated ?? data}
-      isLoading={isLoading || isUpgrading}
+      outdated={upgrade.outdated ?? data}
+      isLoading={isLoading || upgrade.isUpgrading}
       filterType={filter}
       navigationTitle="Upgrade"
-      searchBarPlaceholder={isUpgrading ? "Upgrading…" : undefined}
+      searchBarPlaceholder={upgrade.isUpgrading ? "Upgrading…" : undefined}
       searchBarAccessory={<InstallableFilterDropdown onSelect={setFilter} />}
-      icon={(item, isCask) => statusIcon(states.get(upgradeKey({ name: item.name, isCask })))}
-      actions={isUpgrading ? (item) => <UpgradingActionPanel outdated={item} onCancel={handleCancel} /> : undefined}
+      icon={(item, isCask) => statusIcon(upgrade.states.get(upgradeKey({ name: item.name, isCask })))}
+      onUpgrade={(item, isCask, status) => upgrade.setPackageState({ name: item.name, isCask }, { status })}
+      onUpgradeAll={upgradeAll}
+      actions={
+        upgrade.isUpgrading ? (item) => <UpgradingActionPanel outdated={item} onCancel={upgrade.cancel} /> : undefined
+      }
       onAction={handleAction}
     />
   );

--- a/extensions/brew/src/utils/brew/index.ts
+++ b/extensions/brew/src/utils/brew/index.ts
@@ -66,8 +66,14 @@ export {
 } from "./actions";
 
 // Upgrade with progress
-export { brewUpgradeWithProgress } from "./upgrade";
-export type { UpgradeStep, UpgradeStepStatus, UpgradeProgressCallback, UpgradeResult } from "./upgrade";
+export { brewUpgradeOutdated, upgradeKey } from "./upgrade";
+export type {
+  UpgradePackage,
+  UpgradePackageStatus,
+  UpgradeEvent,
+  UpgradeEventCallback,
+  UpgradeSummary,
+} from "./upgrade";
 
 // Services
 export {

--- a/extensions/brew/src/utils/brew/upgrade.ts
+++ b/extensions/brew/src/utils/brew/upgrade.ts
@@ -13,53 +13,66 @@
  * 3. Continue with remaining packages when one fails
  */
 
-import { Cask, Nameable, OutdatedCask, OutdatedFormula } from "../types";
+import { OutdatedResults } from "../types";
 import { actionsLogger } from "../logger";
-import { execBrewWithProgress, ProgressCallback, BrewProgress, DEFAULT_STALE_TIMEOUT_MS } from "./progress";
-import { brewIdentifier, brewCaskOption, isCask } from "./helpers";
-import { formatCount } from "../text";
-import { isRecoverableError, getErrorMessage, StaleProcessError, BrewLockError } from "../errors";
+import { execBrewWithProgress, BrewProgress, DEFAULT_STALE_TIMEOUT_MS } from "./progress";
+import { getErrorMessage, ensureError, StaleProcessError, BrewLockError } from "../errors";
 import { preferences } from "../preferences";
 
 /// Upgrade Types
 
 /**
- * Status of an upgrade step.
+ * A package included in an upgrade run.
  */
-export type UpgradeStepStatus = "pending" | "running" | "completed" | "failed" | "skipped";
-
-/**
- * Information about a single upgrade step.
- */
-export interface UpgradeStep {
-  id: string;
-  title: string;
-  subtitle?: string;
-  status: UpgradeStepStatus;
-  message?: string;
-  startTime?: number;
-  endTime?: number;
-  progress?: BrewProgress;
-  /** Error that caused the step to fail */
-  error?: Error;
-  /** Whether the error is recoverable (can be retried) */
-  isRecoverable?: boolean;
-  /** Current phase within the step (for detailed progress) */
-  currentPhase?: string;
+export interface UpgradePackage {
+  name: string;
+  isCask: boolean;
 }
 
 /**
- * Callback for upgrade progress updates.
+ * Status of a single package during an upgrade run.
  */
-export type UpgradeProgressCallback = (steps: UpgradeStep[], output?: string) => void;
+export type UpgradePackageStatus = "upgrading" | "upgraded" | "failed" | "skipped";
 
 /**
- * Result of an upgrade operation.
+ * Events emitted while upgrading outdated packages.
+ *
+ * Consumers can use these to drive a toast/HUD and, optionally, a minimal
+ * per-package indicator.
  */
-export interface UpgradeResult {
-  success: boolean;
-  steps: UpgradeStep[];
-  error?: Error;
+export type UpgradeEvent =
+  /** Running `brew update` */
+  | { type: "update" }
+  /** Checking which packages are outdated */
+  | { type: "check" }
+  /** Outdated packages resolved: the run is about to start */
+  | { type: "start"; outdated: OutdatedResults; packages: UpgradePackage[]; skipped: UpgradePackage[] }
+  /** Pre-fetching downloads for all packages */
+  | { type: "prefetch"; progress?: BrewProgress }
+  /** Progress for a single package */
+  | {
+      type: "package";
+      package: UpgradePackage;
+      status: UpgradePackageStatus;
+      progress?: BrewProgress;
+      message?: string;
+      error?: Error;
+    };
+
+/**
+ * Callback for upgrade events.
+ */
+export type UpgradeEventCallback = (event: UpgradeEvent) => void;
+
+/**
+ * Summary of an upgrade run.
+ */
+export interface UpgradeSummary {
+  upgraded: UpgradePackage[];
+  failed: UpgradePackage[];
+  skipped: UpgradePackage[];
+  /** True if the run was cancelled before all packages were upgraded */
+  cancelled: boolean;
 }
 
 /**
@@ -74,351 +87,193 @@ export interface UpgradeOptions {
   continueOnError?: boolean;
   /** Timeout for stale process detection (ms) */
   staleTimeoutMs?: number;
+  /** Callback for progress events */
+  onEvent?: UpgradeEventCallback;
+  /** AbortSignal for cancellation */
+  cancel?: AbortSignal;
 }
 
 /**
- * Upgrade all outdated packages with progress tracking.
+ * Stable key for a package, suitable for use in a status map.
+ */
+export function upgradeKey(pkg: UpgradePackage): string {
+  return `${pkg.isCask ? "cask" : "formula"}-${pkg.name}`;
+}
+
+/// Upgrade
+
+/**
+ * Upgrade all outdated packages, reporting progress via events.
  *
  * Features:
  * - Optional pre-fetching with Homebrew 5.0 concurrent downloads
- * - Detailed per-phase progress tracking
- * - Stale process detection and timeout handling
+ * - Pinned formulae are skipped
  * - Continue upgrading remaining packages when one fails
- * - Recoverable error detection for retry suggestions
+ * - Cancellation via AbortSignal
  *
- * @param greedy - Include auto-updating casks (legacy parameter)
- * @param onProgress - Callback for progress updates
- * @param cancel - AbortSignal for cancellation
- * @param options - Additional upgrade options
- * @returns Result of the upgrade operation
+ * Throws if `brew update` or `brew outdated` fail, since neither leaves
+ * anything to upgrade.
+ *
+ * @param options - Upgrade options, including the event callback & cancellation signal
+ * @returns Summary of the upgrade run
  */
-export async function brewUpgradeWithProgress(
-  greedy: boolean,
-  onProgress?: UpgradeProgressCallback,
-  cancel?: AbortSignal,
-  options?: Omit<UpgradeOptions, "greedy">,
-): Promise<UpgradeResult> {
-  const steps: UpgradeStep[] = [];
-  let outputLog = "";
+export async function brewUpgradeOutdated(options?: UpgradeOptions): Promise<UpgradeSummary> {
+  const onEvent = options?.onEvent;
+  const cancel = options?.cancel;
   const prefetch = options?.prefetch ?? true; // Default to pre-fetching
   const continueOnError = options?.continueOnError ?? true; // Default to continuing
   const staleTimeoutMs = options?.staleTimeoutMs ?? DEFAULT_STALE_TIMEOUT_MS;
   const verboseLogging = preferences.verboseLogging ?? false;
+  const execOptions = { staleTimeoutMs, verboseLogging };
 
-  // Step 1: Update brew
-  const updateStep: UpgradeStep = {
-    id: "update",
-    title: "Updating Homebrew",
-    status: "running",
-    startTime: Date.now(),
-  };
-  steps.push(updateStep);
-  onProgress?.(steps, outputLog);
-
-  try {
-    await execBrewWithProgress(
-      "update",
-      (progress) => {
-        updateStep.message = progress.message;
-        updateStep.currentPhase = progress.phase;
-        onProgress?.(steps, outputLog);
-      },
-      cancel,
-      { staleTimeoutMs, verboseLogging },
-    );
-    updateStep.status = "completed";
-    updateStep.endTime = Date.now();
-    onProgress?.(steps, outputLog);
-  } catch (error) {
-    updateStep.status = "failed";
-    updateStep.endTime = Date.now();
-    updateStep.error = error instanceof Error ? error : new Error(String(error));
-    updateStep.message = getErrorMessage(error);
-    updateStep.isRecoverable = isRecoverableError(error);
-    actionsLogger.error("Homebrew update failed", {
-      error: updateStep.message,
-      isRecoverable: updateStep.isRecoverable,
-    });
-    return { success: false, steps, error: updateStep.error };
-  }
+  // Step 1: Update brew - 'outdated' is only reliable after a 'brew update'
+  onEvent?.({ type: "update" });
+  await execBrewWithProgress("update", undefined, cancel, execOptions);
 
   // Step 2: Check for outdated packages
-  const checkStep: UpgradeStep = {
-    id: "check",
-    title: "Checking for outdated packages",
-    status: "running",
-    startTime: Date.now(),
-  };
-  steps.push(checkStep);
-  onProgress?.(steps, outputLog);
-
-  let outdated: { formulae: OutdatedFormula[]; casks: OutdatedCask[] };
-  try {
-    // Skip the update since we just did it - call outdated directly
-    let cmd = "outdated --json=v2";
-    if (greedy) {
-      cmd += " --greedy";
-    }
-    const result = await execBrewWithProgress(cmd, undefined, cancel, { staleTimeoutMs, verboseLogging });
-    outdated = JSON.parse(result.stdout);
-    checkStep.status = "completed";
-    checkStep.endTime = Date.now();
-    checkStep.message = `Found ${formatCount(outdated.formulae.length, "formula", "formulae")} and ${formatCount(outdated.casks.length, "cask")}`;
-    onProgress?.(steps, outputLog);
-  } catch (error) {
-    checkStep.status = "failed";
-    checkStep.endTime = Date.now();
-    checkStep.error = error instanceof Error ? error : new Error(String(error));
-    checkStep.message = getErrorMessage(error);
-    checkStep.isRecoverable = isRecoverableError(error);
-    return { success: false, steps, error: checkStep.error };
+  onEvent?.({ type: "check" });
+  let cmd = "outdated --json=v2";
+  if (options?.greedy) {
+    cmd += " --greedy";
   }
+  const result = await execBrewWithProgress(cmd, undefined, cancel, execOptions);
+  const outdated = JSON.parse(result.stdout) as OutdatedResults;
 
-  // If nothing to upgrade, we're done
-  if (outdated.formulae.length === 0 && outdated.casks.length === 0) {
-    actionsLogger.log("No packages to upgrade");
-    return { success: true, steps };
-  }
-
-  // Create steps for each package
-  const packageSteps: UpgradeStep[] = [
-    ...outdated.formulae.map((f) => ({
-      id: `formula-${f.name}`,
-      title: f.name,
-      subtitle: `${f.installed_versions[0] || "?"} → ${f.current_version}`,
-      status: "pending" as UpgradeStepStatus,
-    })),
-    ...outdated.casks.map((c) => ({
-      id: `cask-${c.name}`,
-      title: c.name,
-      subtitle: `${c.installed_versions} → ${c.current_version}`,
-      status: "pending" as UpgradeStepStatus,
-    })),
+  // Pinned formulae cannot be upgraded, so exclude them from the run
+  const packages: UpgradePackage[] = [
+    ...outdated.formulae.filter((formula) => !formula.pinned).map((formula) => ({ name: formula.name, isCask: false })),
+    ...outdated.casks.map((cask) => ({ name: cask.name, isCask: true })),
   ];
-  steps.push(...packageSteps);
-  onProgress?.(steps, outputLog);
+  const pinned: UpgradePackage[] = outdated.formulae
+    .filter((formula) => formula.pinned)
+    .map((formula) => ({ name: formula.name, isCask: false }));
+
+  onEvent?.({ type: "start", outdated, packages, skipped: pinned });
+  for (const pkg of pinned) {
+    onEvent?.({ type: "package", package: pkg, status: "skipped", message: "Pinned" });
+  }
+
+  const summary: UpgradeSummary = { upgraded: [], failed: [], skipped: [...pinned], cancelled: false };
+
+  if (packages.length === 0) {
+    actionsLogger.log("No packages to upgrade");
+    return summary;
+  }
 
   actionsLogger.log("Starting batch upgrade", {
-    totalPackages: packageSteps.length,
+    totalPackages: packages.length,
     formulae: outdated.formulae.length,
     casks: outdated.casks.length,
+    pinned: pinned.length,
     prefetch,
     continueOnError,
   });
 
   // Step 3 (optional): Pre-fetch all packages concurrently
   // This leverages Homebrew 5.0's HOMEBREW_DOWNLOAD_CONCURRENCY for parallel downloads
-  if (prefetch && packageSteps.length > 1) {
-    const fetchStep: UpgradeStep = {
-      id: "fetch",
-      title: "Pre-fetching downloads",
-      subtitle: `${packageSteps.length} packages`,
-      status: "running",
-      startTime: Date.now(),
-    };
-    // Insert after check step, before package steps
-    const insertIndex = steps.indexOf(checkStep) + 1;
-    steps.splice(insertIndex, 0, fetchStep);
-    onProgress?.(steps, outputLog);
+  if (prefetch && packages.length > 1) {
+    onEvent?.({ type: "prefetch" });
+    const onFetchProgress = (progress: BrewProgress) => onEvent?.({ type: "prefetch", progress });
+
+    // Fetch formulae and casks separately (brew fetch syntax)
+    const formulaNames = packages.filter((pkg) => !pkg.isCask).map((pkg) => pkg.name);
+    const caskNames = packages.filter((pkg) => pkg.isCask).map((pkg) => pkg.name);
 
     try {
-      // Build fetch command with all packages
-      const formulaNames = outdated.formulae.map((f) => f.name);
-      const caskNames = outdated.casks.map((c) => `--cask ${c.name}`);
-      const allPackages = [...formulaNames, ...caskNames.map((c) => c.split(" ")[1])];
-
-      // Fetch formulae and casks separately (brew fetch syntax)
       if (formulaNames.length > 0) {
-        fetchStep.message = `Fetching ${formulaNames.length} formulae...`;
-        fetchStep.currentPhase = "downloading";
-        onProgress?.(steps, outputLog);
-
-        await execBrewWithProgress(
-          `fetch ${formulaNames.join(" ")}`,
-          (progress) => {
-            fetchStep.message = progress.message;
-            fetchStep.currentPhase = progress.phase;
-            outputLog += progress.message + "\n";
-            onProgress?.(steps, outputLog);
-          },
-          cancel,
-          { staleTimeoutMs, verboseLogging },
-        );
+        await execBrewWithProgress(`fetch ${formulaNames.join(" ")}`, onFetchProgress, cancel, execOptions);
       }
-
-      if (outdated.casks.length > 0) {
-        fetchStep.message = `Fetching ${outdated.casks.length} casks...`;
-        fetchStep.currentPhase = "downloading";
-        onProgress?.(steps, outputLog);
-
-        await execBrewWithProgress(
-          `fetch --cask ${outdated.casks.map((c) => c.name).join(" ")}`,
-          (progress) => {
-            fetchStep.message = progress.message;
-            fetchStep.currentPhase = progress.phase;
-            outputLog += progress.message + "\n";
-            onProgress?.(steps, outputLog);
-          },
-          cancel,
-          { staleTimeoutMs, verboseLogging },
-        );
+      if (caskNames.length > 0) {
+        await execBrewWithProgress(`fetch --cask ${caskNames.join(" ")}`, onFetchProgress, cancel, execOptions);
       }
-
-      fetchStep.status = "completed";
-      fetchStep.endTime = Date.now();
-      fetchStep.message = `Pre-fetched ${allPackages.length} packages`;
-      actionsLogger.log("Pre-fetch completed", { packages: allPackages.length });
+      actionsLogger.log("Pre-fetch completed", { packages: packages.length });
     } catch (error) {
       // Pre-fetch failure is not fatal - we can still try to upgrade
-      fetchStep.status = "failed";
-      fetchStep.endTime = Date.now();
-      fetchStep.error = error instanceof Error ? error : new Error(String(error));
-      fetchStep.message = `Pre-fetch failed: ${getErrorMessage(error)}`;
-      fetchStep.isRecoverable = true; // Always recoverable since we can still upgrade
-      actionsLogger.warn("Pre-fetch failed, continuing with upgrades", {
-        error: fetchStep.message,
-      });
+      // A cancellation is handled by the upgrade loop below
+      actionsLogger.warn("Pre-fetch failed, continuing with upgrades", { error: getErrorMessage(error) });
     }
-    onProgress?.(steps, outputLog);
   }
 
   // Step 4: Upgrade each package sequentially
   // Note: We MUST upgrade sequentially because Homebrew doesn't support concurrent upgrades
-  let hasLockError = false;
+  let stop = false;
 
-  for (let i = 0; i < packageSteps.length; i++) {
-    // Check for cancellation
+  for (const pkg of packages) {
     if (cancel?.aborted) {
-      const remainingCount = packageSteps.length - i;
-      actionsLogger.log("Upgrade cancelled by user", {
-        completedPackages: i,
-        remainingPackages: remainingCount,
-        totalPackages: packageSteps.length,
-      });
-      // Mark remaining as skipped
-      for (let j = i; j < packageSteps.length; j++) {
-        packageSteps[j].status = "skipped";
-        packageSteps[j].message = "Cancelled by user";
-      }
-      onProgress?.(steps, outputLog);
-      break;
+      summary.cancelled = true;
     }
 
-    // If we hit a lock error, skip remaining packages
-    if (hasLockError) {
-      packageSteps[i].status = "skipped";
-      packageSteps[i].message = "Skipped due to brew lock error";
-      onProgress?.(steps, outputLog);
+    // Skip the remaining packages once cancelled, locked out or stopped by an error
+    if (summary.cancelled || stop) {
+      summary.skipped.push(pkg);
+      onEvent?.({
+        type: "package",
+        package: pkg,
+        status: "skipped",
+        message: summary.cancelled ? "Cancelled" : "Skipped",
+      });
       continue;
     }
 
-    const step = packageSteps[i];
-    step.status = "running";
-    step.startTime = Date.now();
-    step.currentPhase = "starting";
-    onProgress?.(steps, outputLog);
-
-    const isCaskPackage = step.id.startsWith("cask-");
-    const packageName = step.id.replace(/^(formula|cask)-/, "");
+    onEvent?.({ type: "package", package: pkg, status: "upgrading" });
 
     try {
-      const caskOption = isCaskPackage ? "--cask" : "";
-      const cmd = `upgrade ${caskOption} ${packageName}`.trim();
-
+      const cmd = `upgrade ${pkg.isCask ? "--cask " : ""}${pkg.name}`;
       await execBrewWithProgress(
         cmd,
-        (progress) => {
-          step.message = progress.message;
-          step.progress = progress;
-          step.currentPhase = progress.phase;
-          outputLog += progress.message + "\n";
-          onProgress?.(steps, outputLog);
-        },
+        (progress) => onEvent?.({ type: "package", package: pkg, status: "upgrading", progress }),
         cancel,
-        { staleTimeoutMs, packageName, verboseLogging },
+        { ...execOptions, packageName: pkg.name },
       );
 
-      step.status = "completed";
-      step.endTime = Date.now();
-      step.message = "Upgraded successfully";
-      actionsLogger.log("Package upgraded", { identifier: packageName });
-    } catch (error) {
-      step.status = "failed";
-      step.endTime = Date.now();
-      step.error = error instanceof Error ? error : new Error(String(error));
-      step.message = getErrorMessage(error);
-      step.isRecoverable = isRecoverableError(error);
+      summary.upgraded.push(pkg);
+      onEvent?.({ type: "package", package: pkg, status: "upgraded" });
+      actionsLogger.log("Package upgraded", { identifier: pkg.name });
+    } catch (err) {
+      const error = ensureError(err);
 
-      actionsLogger.error("Package upgrade failed", {
-        identifier: packageName,
-        error: step.message,
-        errorType: error instanceof Error ? error.name : "unknown",
-        isRecoverable: step.isRecoverable,
-        currentPhase: step.currentPhase,
-      });
-
-      // Check if this is a lock error - if so, we should stop
-      if (error instanceof BrewLockError) {
-        hasLockError = true;
-        actionsLogger.warn("Lock error detected, skipping remaining packages");
+      // Cancellation aborts the running brew process: treat it as skipped
+      if (cancel?.aborted || error.name === "AbortError") {
+        summary.cancelled = true;
+        summary.skipped.push(pkg);
+        onEvent?.({ type: "package", package: pkg, status: "skipped", message: "Cancelled" });
+        continue;
       }
 
-      // Check if this is a stale process error
+      const message = getErrorMessage(error);
+      summary.failed.push(pkg);
+      onEvent?.({ type: "package", package: pkg, status: "failed", message, error });
+
+      actionsLogger.error("Package upgrade failed", {
+        identifier: pkg.name,
+        error: message,
+        errorType: error.name,
+      });
+
       if (error instanceof StaleProcessError) {
         actionsLogger.warn("Stale process detected", {
-          packageName,
-          lastPhase: (error as StaleProcessError).lastPhase,
-          staleDurationMs: (error as StaleProcessError).staleDurationMs,
+          packageName: pkg.name,
+          lastPhase: error.lastPhase,
+          staleDurationMs: error.staleDurationMs,
         });
       }
 
-      // If continueOnError is false, stop here
-      if (!continueOnError) {
-        // Mark remaining as skipped
-        for (let j = i + 1; j < packageSteps.length; j++) {
-          packageSteps[j].status = "skipped";
-          packageSteps[j].message = "Skipped due to previous error";
-        }
-        onProgress?.(steps, outputLog);
-        break;
+      // A lock error affects every subsequent upgrade, so stop here
+      if (error instanceof BrewLockError) {
+        actionsLogger.warn("Lock error detected, skipping remaining packages");
+        stop = true;
+      } else if (!continueOnError) {
+        stop = true;
       }
     }
-
-    onProgress?.(steps, outputLog);
   }
 
-  const failedSteps = steps.filter((s) => s.status === "failed");
-  const recoverableFailures = failedSteps.filter((s) => s.isRecoverable);
-  const result: UpgradeResult = {
-    success: failedSteps.length === 0,
-    steps,
-    error: failedSteps.length > 0 ? new Error(`${failedSteps.length} package(s) failed to upgrade`) : undefined,
-  };
-
   actionsLogger.log("Batch upgrade completed", {
-    success: result.success,
-    completed: steps.filter((s) => s.status === "completed").length,
-    failed: failedSteps.length,
-    recoverableFailures: recoverableFailures.length,
-    skipped: steps.filter((s) => s.status === "skipped").length,
+    upgraded: summary.upgraded.length,
+    failed: summary.failed.length,
+    skipped: summary.skipped.length,
+    cancelled: summary.cancelled,
   });
 
-  return result;
-}
-
-/**
- * Upgrade a single package with progress tracking.
- */
-export async function brewUpgradeSingleWithProgress(
-  upgradable: Cask | Nameable,
-  onProgress?: ProgressCallback,
-  cancel?: AbortSignal,
-): Promise<void> {
-  const identifier = brewIdentifier(upgradable);
-  actionsLogger.log("Upgrading package with progress", {
-    identifier,
-    type: isCask(upgradable) ? "cask" : "formula",
-  });
-  await execBrewWithProgress(`upgrade ${brewCaskOption(upgradable)} ${identifier}`, onProgress, cancel);
-  actionsLogger.log("Package upgraded successfully", { identifier });
+  return summary;
 }

--- a/extensions/brew/src/utils/index.ts
+++ b/extensions/brew/src/utils/index.ts
@@ -93,7 +93,13 @@ export type { MemorySnapshot, MemoryDelta, MemoryTrackingResult, CallerInfo } fr
 export * from "./brew";
 
 // Re-export upgrade types for convenience
-export type { UpgradeStep, UpgradeStepStatus, UpgradeProgressCallback, UpgradeResult } from "./brew/upgrade";
+export type {
+  UpgradePackage,
+  UpgradePackageStatus,
+  UpgradeEvent,
+  UpgradeEventCallback,
+  UpgradeSummary,
+} from "./brew/upgrade";
 
 // Re-export progress types and constants for convenience
 export type { BrewPhase, BrewProgress, ProgressCallback, ExecBrewWithProgressOptions } from "./brew/progress";


### PR DESCRIPTION
## Description

- The Upgrade command now lists the outdated formulae & casks, matching the _Show Outdated_ command, instead of a list of progress steps.
- Upgrade progress is reported via the toast/HUD, with the icon of each package reflecting its upgrade status.
- _Upgrade All_ now upgrades each package in turn, so its progress is reported per package.
- Added a _Refresh_ action to the outdated action panel.
- Pinned formulae are skipped when upgrading.

## Screencast

<img width="862" height="587" alt="Screenshot 2026-08-27 at 12 27 31" src="https://github.com/user-attachments/assets/211c0b15-8578-4771-982f-07018991cf6d" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
