### PR TITLE
feat(zotero): fuzzy search, BibTeX-key search, and group libraries

### DIFF
--- a/extensions/zotero/CHANGELOG.md
+++ b/extensions/zotero/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Added a "Search by BibTeX Citation Key" preference. With it on, typing a citation key like `smith2020quantum` returns that item.
 - Group libraries are now supported. By default only your personal library is searched, so a paper shared to a group no longer shows up twice. Use the new "Configure Group Libraries" action (`⌘L`) to pick which groups to include.
 - Items in group libraries now open in Zotero. The `zotero://` links use the `/groups/<groupID>/` path for group items, so pressing Enter opens them instead of doing nothing.
-- Selecting a collection now filters the whole library before the 100-item cap, and duplicate items are removed, so an entry in two collections shows once.
+- Selecting a collection now filters the whole library before the 100-item cap. Collections are matched by their key, so two collections that share a name stay separate, and the dropdown labels them so you can tell them apart.
 - Large libraries no longer run out of memory while searching. Matching long fields such as abstracts and notes no longer grows the heap on every keystroke.
 
 ## [Fixes] - 2026-07-17

--- a/extensions/zotero/CHANGELOG.md
+++ b/extensions/zotero/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Zotero Changelog
 
+## [Group libraries, fuzzy search, and BibTeX-key search] - {PR_MERGE_DATE}
+
+- Search now uses a subsequence fuzzy finder (fuzzysort) instead of near-exact matching, so typing `qsim` finds "Quantum Simulation". Results are ranked by how well they match, and the most recent items show for an empty query.
+- Added a "Search by BibTeX Citation Key" preference. With it on, typing a citation key like `smith2020quantum` returns that item.
+- Group libraries are now supported. By default only your personal library is searched, so a paper shared to a group no longer shows up twice. Use the new "Configure Group Libraries" action (`⌘L`) to pick which groups to include.
+- Items in group libraries now open in Zotero. The `zotero://` links use the `/groups/<groupID>/` path for group items, so pressing Enter opens them instead of doing nothing.
+- Selecting a collection now filters the whole library before the 100-item cap, and duplicate items are removed, so an entry in two collections shows once.
+- Large libraries no longer run out of memory while searching. Matching long fields such as abstracts and notes no longer grows the heap on every keystroke.
+
 ## [Fixes] - 2026-07-17
 
 - Fix "Worker terminated due to reaching memory limit: JS heap out of memory" crash on large libraries when browsing or running broad searches: the command rendered every matching item (the whole library on an empty query, or hundreds/thousands for a broad query), and Raycast's per-item detail + action list grows the command worker's memory until it is killed. Results are now capped at 100 rendered items (the section header shows "Top 100 — refine your search to see more" when capped), which keeps the render footprint bounded. Follow-up to #29478 / #29250

--- a/extensions/zotero/CHANGELOG.md
+++ b/extensions/zotero/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Zotero Changelog
 
-## [Group libraries, fuzzy search, and BibTeX-key search] - {PR_MERGE_DATE}
+## [Group libraries, fuzzy search, and BibTeX-key search] - 2026-08-30
 
 - Search now uses a subsequence fuzzy finder (fuzzysort) instead of near-exact matching, so typing `qsim` finds "Quantum Simulation". Results are ranked by how well they match, and the most recent items show for an empty query.
 - Added a "Search by BibTeX Citation Key" preference. With it on, typing a citation key like `smith2020quantum` returns that item.

--- a/extensions/zotero/CHANGELOG.md
+++ b/extensions/zotero/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Added a "Search by BibTeX Citation Key" preference. With it on, typing a citation key like `smith2020quantum` returns that item.
 - Group libraries are now supported. By default only your personal library is searched, so a paper shared to a group no longer shows up twice. Use the new "Configure Group Libraries" action (`⌘L`) to pick which groups to include.
 - Items in group libraries now open in Zotero. The `zotero://` links use the `/groups/<groupID>/` path for group items, so pressing Enter opens them instead of doing nothing.
-- Selecting a collection now filters the whole library before the 100-item cap. Collections are matched by their key, so two collections that share a name stay separate, and the dropdown labels them so you can tell them apart.
+- Selecting a collection now filters the whole library before the 100-item cap. Collections are matched by their library and key, so two collections that share a name (or a key across libraries) stay separate, and the dropdown labels them so you can tell them apart. The dropdown lists collections from your personal library and any group libraries you have included.
 - Large libraries no longer run out of memory while searching. Matching long fields such as abstracts and notes no longer grows the heap on every keystroke.
 
 ## [Fixes] - 2026-07-17

--- a/extensions/zotero/package-lock.json
+++ b/extensions/zotero/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@raycast/api": "^1.62.1",
         "citation-js": "^0.6.8",
-        "fuse.js": "^6.6.2",
+        "fuzzysort": "^3.1.0",
         "sql.js": "^1.8.0"
       },
       "devDependencies": {
@@ -23,7 +23,8 @@
         "eslint": "^8.45.0",
         "eslint-config-prettier": "^8.9.0",
         "prettier": "^3.0.0",
-        "typescript": "^5.1.6"
+        "typescript": "^5.1.6",
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1030,6 +1031,30 @@
         }
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1230,6 +1255,363 @@
       "dependencies": {
         "undici-types": "~5.26.4"
       }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.0.tgz",
+      "integrity": "sha512-70TeIFezKKy65LgAVyQh+w94/gjWhvPWaLaGGeMEgVrPkQhuj/M5bAYYZzIFUj9Y69oHyTm5Um/R6gcLh4A8JA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.0.tgz",
+      "integrity": "sha512-YC86tYIHK6M1IV+wbzO+Bxk8RCBr6ZyWYgWxUCzaZD8mc8rrFoIJDNzDrkHBYRc/wKdrsIXmm6/F7NzrAO+OrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.0.tgz",
+      "integrity": "sha512-oI+ECtUcli0y0fi4xpW82GdPIXdTkI8G8DSjG2LRuw09fPAGykaWYH/hXxiKuTxiAjiPSTIIuYUqof5Z2hShWw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.0.tgz",
+      "integrity": "sha512-NwV+1s7TiKrMe4owHyKB/dTLD7ZJD0YEBEhIz+hvav1Cu1GReJjF+rsdNwjzENQeIAbE/CoNiaAc5Vz2h5DPAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.0.tgz",
+      "integrity": "sha512-tWtHBTu5gOPK4u4Urtk4qAHW3zZ9rQAmbssO8gp7ELvGTGI3aCiq6NqyTQ0PCIg7KbHJF2UkGDDs77YZGxfjCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.0.tgz",
+      "integrity": "sha512-2qPoJiwTvtHQ27NnYvTnsgk8laXWYuVmNESG8WFZBcEPKLfZ3I27qBJarjVRQtwGeYyRfq5ZowHXih9lm2BItw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.0.tgz",
+      "integrity": "sha512-FQwsTRvLNuHoTdICABJQfbPUSEueISGmnpT06tXTMpfprf5NiKLSXKA0A+w45wJnCmZAnzgqBwbt6ARFuyOi5w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.0.tgz",
+      "integrity": "sha512-BBVTXziw8mY1a4ZbWME9tZyfzqXCDPqaC7Z3heQ29p5dkvXzwL0NwelO8zLa8c3RBKvl3YTuSnBgsBhYBtwjIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.0.tgz",
+      "integrity": "sha512-w2Iyy9+RqKwx3d9qWMKsJg0FfRBsY0/pXNv0mCQ3ueRvJI6+QAScfD4nrMlzFLs2HNVW6Ew+mtZfDl9b7Ew5/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.0.tgz",
+      "integrity": "sha512-YK++KtrFRHYE0P6/RtYEAy9t8F37znP+K03RrIuLPYOL6SVlObRumf/0OE4V/h63xL9DwkWbNssZfmA9hawuDA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.0.tgz",
+      "integrity": "sha512-aBfOG6fP7YkkPmTqPwufRJeFyz7WPpECv9XNbnsk9+vg7rxdih0lbtEel7jcRng4LZrrmU3FfitCFyEj4BWDWg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.0.tgz",
+      "integrity": "sha512-LGaHEOeHNAag9VuS1Crs5DFg4RrU9MPi2nVnNJk9DTePx/B6RRYKVmrIXt2h7YOJlwjaFJ6lwtFDliZxScTLrQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.0.tgz",
+      "integrity": "sha512-jClvk+J0FC3b7Udvegiw5/4hErbHtmsNsQgENnKXDWtNCJXsJYZH5WURvu7imDOO38xYml24eeh5x3A04ppwCw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.0.tgz",
+      "integrity": "sha512-0OJlaGK+8+B777Ql5okIpD7ua5Ro9+VB9Ve0OKa28OQJZ1RbuUBVNHK/e3pr4BROqsyPl1JrPO1ZxJseCNffcA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.0.tgz",
+      "integrity": "sha512-Ygsx+HoNH7afwi1bTIXbnTvVnsO+zurPLSYxybV1hHFVU72OWOCl6v05ql/z0hkpAPx+DK7Kn9Bi7MayCcjLTA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.0.tgz",
+      "integrity": "sha512-pDQxtMGb+OvG3fLwR2OkZlSd47hW+kWg4BYMG/++sR6RqorQccwPTDsxda5hPwiIeIErAnCF9ma3SAU06bdQtQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.0.tgz",
+      "integrity": "sha512-0BnUG9mS8I4SSHr3XsxVhuCMEiu+rX61xxZF5vujso4LaiAGFZFxvDjg6Xn6tLPNTUAfuCvQYas4LMQMVsKRSQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.0.tgz",
+      "integrity": "sha512-Adu/VttB1dpPNW+FEacrZ+xVm9tFty84+RrFzsqlFaPxoJB+9XXyDGtp5dCOoBwGBIEVH0To7lExFXEx0BIF4A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.0.tgz",
+      "integrity": "sha512-NQ3bDvjUbFKmP23671xUlXtKmqVsUBd6M4PQCvbmNtOy06hnQIdKHy8oG/6S3R/S6He1JgPk6A5VT+prAJMYEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.0.tgz",
+      "integrity": "sha512-u2eDAl4+0aFvA13GxlGBtTI3SS3sdgwgtV0HyjZ0QaQVCgNE+jqNGey+GtxWiq+wxr/UycAx/OnfJzApCFamvA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.0.tgz",
+      "integrity": "sha512-XvRb5vfW3wAZQ+ZUG21AnHHDKtNcw99eigzEhjr//NZ3u7SoBaPP0seSc7FgP7p1epAEdAoZckMW9WY/+4w70w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.0.tgz",
+      "integrity": "sha512-iZPmniy4kNBf5yo2RezbkYNNK5HPbXE9+g+twnbqSng7dtLEJy1SKoxiE/ni4FDacjyuZpEeb9U054N4EoKHYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.0.tgz",
+      "integrity": "sha512-mFBBd+LF37fnE8JnYUOH+imj0aPFPK30vpar4ehJkgnLj9sZn8ZxiRENmLtgIwxK7TC8klF6N57fxdNBwQoqOA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.0.tgz",
+      "integrity": "sha512-ujeqEY3B+zbGn3Z4Q03cUBG/LGWnBJncVT36WER31LcOsQk9+1dmINKKtvmmfChUvRbK1G0R8OhMWFgHgaZtAw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.0.tgz",
+      "integrity": "sha512-hncn90N4sOky0L2LKE5oESKLbxCPeVo4eLA2LSMoDzM+879ml4WSr+Rr4DWknNIVVvS1Hirkc9hx02W6YxS8rQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/he": {
       "version": "1.2.0",
@@ -1463,6 +1845,119 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
@@ -1574,6 +2069,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -1651,6 +2156,16 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1658,6 +2173,23 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -1681,6 +2213,16 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "license": "MIT"
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/citation-js": {
       "version": "0.6.8",
@@ -1814,6 +2356,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1863,6 +2415,13 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/esbuild": {
@@ -2070,6 +2629,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2077,6 +2646,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2248,13 +2827,26 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "node_modules/fuse.js": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
-      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
       "engines": {
-        "node": ">=10"
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/fuzzysort": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-3.1.0.tgz",
+      "integrity": "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==",
+      "license": "MIT"
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
@@ -2619,6 +3211,23 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2673,6 +3282,25 @@
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/natural-compare": {
@@ -2810,6 +3438,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2827,6 +3472,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -2928,6 +3602,52 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.0.tgz",
+      "integrity": "sha512-T5vnZ2y4QqC3/4P+w2+JO+Q/OVdnPsv4XcSYJYMEn0R9/jjl5AgLwO9LAZMzP2lN71O6pypn91rB7lDstUkfrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.0",
+        "@rollup/rollup-android-arm64": "4.63.0",
+        "@rollup/rollup-darwin-arm64": "4.63.0",
+        "@rollup/rollup-darwin-x64": "4.63.0",
+        "@rollup/rollup-freebsd-arm64": "4.63.0",
+        "@rollup/rollup-freebsd-x64": "4.63.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.0",
+        "@rollup/rollup-linux-arm64-musl": "4.63.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.0",
+        "@rollup/rollup-linux-loong64-musl": "4.63.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.0",
+        "@rollup/rollup-linux-x64-gnu": "4.63.0",
+        "@rollup/rollup-linux-x64-musl": "4.63.0",
+        "@rollup/rollup-openbsd-x64": "4.63.0",
+        "@rollup/rollup-openharmony-arm64": "4.63.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.0",
+        "@rollup/rollup-win32-x64-gnu": "4.63.0",
+        "@rollup/rollup-win32-x64-msvc": "4.63.0",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -2990,6 +3710,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -3011,10 +3738,34 @@
         "node": ">=8"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/sql.js": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.8.0.tgz",
       "integrity": "sha512-3HD8pSkZL+5YvYUI8nlvNILs61ALqq34xgmF+BHpqxe68yZIJ1H+sIVIODvni25+CcxHUxDyrTJUL0lE/m7afw=="
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -3083,6 +3834,20 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3126,6 +3891,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -3209,6 +4004,585 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -3236,6 +4610,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {
@@ -3810,6 +5201,19 @@
       "integrity": "sha512-QPaNt/nmE2bLGQa9b7wwyRJoLZ7pN6rcyXvzU0YCmivmJyq1BVo94G98tStRWkoD1RgDX5C+dPlhhHzNdu/W/w==",
       "requires": {}
     },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "dev": true,
+      "optional": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3951,6 +5355,187 @@
           }
         }
       }
+    },
+    "@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.0.tgz",
+      "integrity": "sha512-70TeIFezKKy65LgAVyQh+w94/gjWhvPWaLaGGeMEgVrPkQhuj/M5bAYYZzIFUj9Y69oHyTm5Um/R6gcLh4A8JA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-android-arm64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.0.tgz",
+      "integrity": "sha512-YC86tYIHK6M1IV+wbzO+Bxk8RCBr6ZyWYgWxUCzaZD8mc8rrFoIJDNzDrkHBYRc/wKdrsIXmm6/F7NzrAO+OrA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-darwin-arm64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.0.tgz",
+      "integrity": "sha512-oI+ECtUcli0y0fi4xpW82GdPIXdTkI8G8DSjG2LRuw09fPAGykaWYH/hXxiKuTxiAjiPSTIIuYUqof5Z2hShWw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-darwin-x64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.0.tgz",
+      "integrity": "sha512-NwV+1s7TiKrMe4owHyKB/dTLD7ZJD0YEBEhIz+hvav1Cu1GReJjF+rsdNwjzENQeIAbE/CoNiaAc5Vz2h5DPAA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.0.tgz",
+      "integrity": "sha512-tWtHBTu5gOPK4u4Urtk4qAHW3zZ9rQAmbssO8gp7ELvGTGI3aCiq6NqyTQ0PCIg7KbHJF2UkGDDs77YZGxfjCA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-freebsd-x64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.0.tgz",
+      "integrity": "sha512-2qPoJiwTvtHQ27NnYvTnsgk8laXWYuVmNESG8WFZBcEPKLfZ3I27qBJarjVRQtwGeYyRfq5ZowHXih9lm2BItw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.0.tgz",
+      "integrity": "sha512-FQwsTRvLNuHoTdICABJQfbPUSEueISGmnpT06tXTMpfprf5NiKLSXKA0A+w45wJnCmZAnzgqBwbt6ARFuyOi5w==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.0.tgz",
+      "integrity": "sha512-BBVTXziw8mY1a4ZbWME9tZyfzqXCDPqaC7Z3heQ29p5dkvXzwL0NwelO8zLa8c3RBKvl3YTuSnBgsBhYBtwjIw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.0.tgz",
+      "integrity": "sha512-w2Iyy9+RqKwx3d9qWMKsJg0FfRBsY0/pXNv0mCQ3ueRvJI6+QAScfD4nrMlzFLs2HNVW6Ew+mtZfDl9b7Ew5/Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.0.tgz",
+      "integrity": "sha512-YK++KtrFRHYE0P6/RtYEAy9t8F37znP+K03RrIuLPYOL6SVlObRumf/0OE4V/h63xL9DwkWbNssZfmA9hawuDA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.0.tgz",
+      "integrity": "sha512-aBfOG6fP7YkkPmTqPwufRJeFyz7WPpECv9XNbnsk9+vg7rxdih0lbtEel7jcRng4LZrrmU3FfitCFyEj4BWDWg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.0.tgz",
+      "integrity": "sha512-LGaHEOeHNAag9VuS1Crs5DFg4RrU9MPi2nVnNJk9DTePx/B6RRYKVmrIXt2h7YOJlwjaFJ6lwtFDliZxScTLrQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.0.tgz",
+      "integrity": "sha512-jClvk+J0FC3b7Udvegiw5/4hErbHtmsNsQgENnKXDWtNCJXsJYZH5WURvu7imDOO38xYml24eeh5x3A04ppwCw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.0.tgz",
+      "integrity": "sha512-0OJlaGK+8+B777Ql5okIpD7ua5Ro9+VB9Ve0OKa28OQJZ1RbuUBVNHK/e3pr4BROqsyPl1JrPO1ZxJseCNffcA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.0.tgz",
+      "integrity": "sha512-Ygsx+HoNH7afwi1bTIXbnTvVnsO+zurPLSYxybV1hHFVU72OWOCl6v05ql/z0hkpAPx+DK7Kn9Bi7MayCcjLTA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.0.tgz",
+      "integrity": "sha512-pDQxtMGb+OvG3fLwR2OkZlSd47hW+kWg4BYMG/++sR6RqorQccwPTDsxda5hPwiIeIErAnCF9ma3SAU06bdQtQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.0.tgz",
+      "integrity": "sha512-0BnUG9mS8I4SSHr3XsxVhuCMEiu+rX61xxZF5vujso4LaiAGFZFxvDjg6Xn6tLPNTUAfuCvQYas4LMQMVsKRSQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.0.tgz",
+      "integrity": "sha512-Adu/VttB1dpPNW+FEacrZ+xVm9tFty84+RrFzsqlFaPxoJB+9XXyDGtp5dCOoBwGBIEVH0To7lExFXEx0BIF4A==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.0.tgz",
+      "integrity": "sha512-NQ3bDvjUbFKmP23671xUlXtKmqVsUBd6M4PQCvbmNtOy06hnQIdKHy8oG/6S3R/S6He1JgPk6A5VT+prAJMYEw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-openbsd-x64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.0.tgz",
+      "integrity": "sha512-u2eDAl4+0aFvA13GxlGBtTI3SS3sdgwgtV0HyjZ0QaQVCgNE+jqNGey+GtxWiq+wxr/UycAx/OnfJzApCFamvA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.0.tgz",
+      "integrity": "sha512-XvRb5vfW3wAZQ+ZUG21AnHHDKtNcw99eigzEhjr//NZ3u7SoBaPP0seSc7FgP7p1epAEdAoZckMW9WY/+4w70w==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.0.tgz",
+      "integrity": "sha512-iZPmniy4kNBf5yo2RezbkYNNK5HPbXE9+g+twnbqSng7dtLEJy1SKoxiE/ni4FDacjyuZpEeb9U054N4EoKHYw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.0.tgz",
+      "integrity": "sha512-mFBBd+LF37fnE8JnYUOH+imj0aPFPK30vpar4ehJkgnLj9sZn8ZxiRENmLtgIwxK7TC8klF6N57fxdNBwQoqOA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.0.tgz",
+      "integrity": "sha512-ujeqEY3B+zbGn3Z4Q03cUBG/LGWnBJncVT36WER31LcOsQk9+1dmINKKtvmmfChUvRbK1G0R8OhMWFgHgaZtAw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.0.tgz",
+      "integrity": "sha512-hncn90N4sOky0L2LKE5oESKLbxCPeVo4eLA2LSMoDzM+879ml4WSr+Rr4DWknNIVVvS1Hirkc9hx02W6YxS8rQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
     },
     "@types/he": {
       "version": "1.2.0",
@@ -4094,6 +5679,79 @@
         "eslint-visitor-keys": "^3.4.1"
       }
     },
+    "@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "requires": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      }
+    },
+    "@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "requires": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      }
+    },
+    "@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "requires": {
+        "tinyrainbow": "^1.2.0"
+      }
+    },
+    "@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "requires": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      }
+    },
+    "@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "requires": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      }
+    },
+    "@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "requires": {
+        "tinyspy": "^3.0.2"
+      }
+    },
+    "@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "requires": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      }
+    },
     "acorn": {
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
@@ -4164,6 +5822,12 @@
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
     },
+    "assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true
+    },
     "async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -4207,11 +5871,30 @@
         "ieee754": "^1.1.13"
       }
     },
+    "cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
+    },
+    "chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      }
     },
     "chalk": {
       "version": "4.1.2",
@@ -4227,6 +5910,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="
+    },
+    "check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true
     },
     "citation-js": {
       "version": "0.6.8",
@@ -4317,6 +6006,12 @@
         "ms": "^2.1.3"
       }
     },
+    "deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true
+    },
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -4353,6 +6048,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
     },
     "esbuild": {
       "version": "0.25.11",
@@ -4503,10 +6204,25 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true
     },
+    "estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
       "dev": true
     },
     "fast-deep-equal": {
@@ -4649,10 +6365,17 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fuse.js": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
-      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA=="
+    "fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "optional": true
+    },
+    "fuzzysort": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-3.1.0.tgz",
+      "integrity": "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ=="
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -4891,6 +6614,21 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4930,6 +6668,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
       "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="
+    },
+    "nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -5025,6 +6769,18 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
+    "pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true
+    },
     "picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5035,6 +6791,17 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true
+    },
+    "postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "requires": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      }
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -5089,6 +6856,42 @@
         "glob": "^7.1.3"
       }
     },
+    "rollup": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.0.tgz",
+      "integrity": "sha512-T5vnZ2y4QqC3/4P+w2+JO+Q/OVdnPsv4XcSYJYMEn0R9/jjl5AgLwO9LAZMzP2lN71O6pypn91rB7lDstUkfrQ==",
+      "dev": true,
+      "requires": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.0",
+        "@rollup/rollup-android-arm64": "4.63.0",
+        "@rollup/rollup-darwin-arm64": "4.63.0",
+        "@rollup/rollup-darwin-x64": "4.63.0",
+        "@rollup/rollup-freebsd-arm64": "4.63.0",
+        "@rollup/rollup-freebsd-x64": "4.63.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.0",
+        "@rollup/rollup-linux-arm64-musl": "4.63.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.0",
+        "@rollup/rollup-linux-loong64-musl": "4.63.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.0",
+        "@rollup/rollup-linux-x64-gnu": "4.63.0",
+        "@rollup/rollup-linux-x64-musl": "4.63.0",
+        "@rollup/rollup-openbsd-x64": "4.63.0",
+        "@rollup/rollup-openharmony-arm64": "4.63.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.0",
+        "@rollup/rollup-win32-x64-gnu": "4.63.0",
+        "@rollup/rollup-win32-x64-msvc": "4.63.0",
+        "@types/estree": "1.0.9",
+        "fsevents": "~2.3.2"
+      }
+    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5123,6 +6926,12 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -5134,10 +6943,28 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
+    "source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true
+    },
     "sql.js": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.8.0.tgz",
       "integrity": "sha512-3HD8pSkZL+5YvYUI8nlvNILs61ALqq34xgmF+BHpqxe68yZIJ1H+sIVIODvni25+CcxHUxDyrTJUL0lE/m7afw=="
+    },
+    "stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
     },
     "string-width": {
       "version": "4.2.3",
@@ -5187,6 +7014,18 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
     "tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -5208,6 +7047,24 @@
           "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="
         }
       }
+    },
+    "tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true
+    },
+    "tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true
+    },
+    "tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -5265,6 +7122,253 @@
         "punycode": "^2.1.0"
       }
     },
+    "vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "requires": {
+        "esbuild": "^0.21.3",
+        "fsevents": "~2.3.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "dependencies": {
+        "@esbuild/aix-ppc64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+          "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+          "dev": true,
+          "optional": true
+        },
+        "@esbuild/android-arm": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+          "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+          "dev": true,
+          "optional": true
+        },
+        "@esbuild/android-arm64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+          "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+          "dev": true,
+          "optional": true
+        },
+        "@esbuild/android-x64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+          "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+          "dev": true,
+          "optional": true
+        },
+        "@esbuild/darwin-arm64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+          "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+          "dev": true,
+          "optional": true
+        },
+        "@esbuild/darwin-x64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+          "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+          "dev": true,
+          "optional": true
+        },
+        "@esbuild/freebsd-arm64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+          "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+          "dev": true,
+          "optional": true
+        },
+        "@esbuild/freebsd-x64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+          "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+          "dev": true,
+          "optional": true
+        },
+        "@esbuild/linux-arm": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+          "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+          "dev": true,
+          "optional": true
+        },
+        "@esbuild/linux-arm64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+          "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+          "dev": true,
+          "optional": true
+        },
+        "@esbuild/linux-ia32": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+          "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+          "dev": true,
+          "optional": true
+        },
+        "@esbuild/linux-loong64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+          "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+          "dev": true,
+          "optional": true
+        },
+        "@esbuild/linux-mips64el": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+          "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+          "dev": true,
+          "optional": true
+        },
+        "@esbuild/linux-ppc64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+          "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+          "dev": true,
+          "optional": true
+        },
+        "@esbuild/linux-riscv64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+          "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+          "dev": true,
+          "optional": true
+        },
+        "@esbuild/linux-s390x": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+          "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+          "dev": true,
+          "optional": true
+        },
+        "@esbuild/linux-x64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+          "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+          "dev": true,
+          "optional": true
+        },
+        "@esbuild/netbsd-x64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+          "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+          "dev": true,
+          "optional": true
+        },
+        "@esbuild/openbsd-x64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+          "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+          "dev": true,
+          "optional": true
+        },
+        "@esbuild/sunos-x64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+          "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+          "dev": true,
+          "optional": true
+        },
+        "@esbuild/win32-arm64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+          "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+          "dev": true,
+          "optional": true
+        },
+        "@esbuild/win32-ia32": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+          "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+          "dev": true,
+          "optional": true
+        },
+        "@esbuild/win32-x64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+          "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+          "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+          "dev": true,
+          "requires": {
+            "@esbuild/aix-ppc64": "0.21.5",
+            "@esbuild/android-arm": "0.21.5",
+            "@esbuild/android-arm64": "0.21.5",
+            "@esbuild/android-x64": "0.21.5",
+            "@esbuild/darwin-arm64": "0.21.5",
+            "@esbuild/darwin-x64": "0.21.5",
+            "@esbuild/freebsd-arm64": "0.21.5",
+            "@esbuild/freebsd-x64": "0.21.5",
+            "@esbuild/linux-arm": "0.21.5",
+            "@esbuild/linux-arm64": "0.21.5",
+            "@esbuild/linux-ia32": "0.21.5",
+            "@esbuild/linux-loong64": "0.21.5",
+            "@esbuild/linux-mips64el": "0.21.5",
+            "@esbuild/linux-ppc64": "0.21.5",
+            "@esbuild/linux-riscv64": "0.21.5",
+            "@esbuild/linux-s390x": "0.21.5",
+            "@esbuild/linux-x64": "0.21.5",
+            "@esbuild/netbsd-x64": "0.21.5",
+            "@esbuild/openbsd-x64": "0.21.5",
+            "@esbuild/sunos-x64": "0.21.5",
+            "@esbuild/win32-arm64": "0.21.5",
+            "@esbuild/win32-ia32": "0.21.5",
+            "@esbuild/win32-x64": "0.21.5"
+          }
+        }
+      }
+    },
+    "vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "requires": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      }
+    },
+    "vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "requires": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      }
+    },
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -5286,6 +7390,16 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
+      }
+    },
+    "why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "requires": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
       }
     },
     "widest-line": {

--- a/extensions/zotero/package.json
+++ b/extensions/zotero/package.json
@@ -54,6 +54,14 @@
       "description": "Whether to use BibTex or not?"
     },
     {
+      "name": "bibtex_search",
+      "type": "checkbox",
+      "required": false,
+      "default": false,
+      "label": "Search by BibTeX Citation Key",
+      "description": "Match the Better BibTeX citation key (e.g. smith2020quantum) when searching"
+    },
+    {
       "name": "bibtex_path",
       "type": "textfield",
       "required": false,
@@ -189,7 +197,7 @@
   "dependencies": {
     "@raycast/api": "^1.62.1",
     "citation-js": "^0.6.8",
-    "fuse.js": "^6.6.2",
+    "fuzzysort": "^3.1.0",
     "sql.js": "^1.8.0"
   },
   "devDependencies": {
@@ -199,14 +207,16 @@
     "@typescript-eslint/eslint-plugin": "^6.2.0",
     "@typescript-eslint/parser": "^6.2.0",
     "eslint": "^8.45.0",
-    "prettier": "^3.0.0",
     "eslint-config-prettier": "^8.9.0",
-    "typescript": "^5.1.6"
+    "prettier": "^3.0.0",
+    "typescript": "^5.1.6",
+    "vitest": "^2.1.9"
   },
   "scripts": {
     "build": "ray build -e dist",
     "dev": "ray develop",
     "lint": "ray lint --fix",
+    "test": "vitest run",
     "publish": "npx @raycast/api@latest publish"
   },
   "platforms": [

--- a/extensions/zotero/package.json
+++ b/extensions/zotero/package.json
@@ -215,7 +215,8 @@
   "scripts": {
     "build": "ray build -e dist",
     "dev": "ray develop",
-    "lint": "ray lint --fix",
+    "lint": "ray lint",
+    "fix-lint": "ray lint --fix",
     "test": "vitest run",
     "publish": "npx @raycast/api@latest publish"
   },

--- a/extensions/zotero/src/commandSearchZotero.tsx
+++ b/extensions/zotero/src/commandSearchZotero.tsx
@@ -6,10 +6,16 @@ import {
   setIncludedGroupLibraries,
 } from "./common/zoteroApi";
 import type { LibraryRef } from "./common/library";
-import { buildCollectionOptions, type CollectionOption } from "./common/collections";
+import { visibleCollectionOptions, type CollectionRef, type CollectionOption } from "./common/collections";
 import { useEffect, useRef, useState } from "react";
 import { useStore } from "./common/store";
 import { View } from "./common/View";
+
+// Libraries the search covers: the personal library plus any opted-in groups.
+function allowedLibraryIds(libraries: LibraryRef[], includedGroups: number[]): number[] {
+  const userIds = libraries.filter((l) => l.type === "user").map((l) => l.id);
+  return [...userIds, ...includedGroups];
+}
 
 export default function MyView() {
   // Keep the current search text and collection in refs so either one changing
@@ -18,10 +24,14 @@ export default function MyView() {
   const textRef = useRef("");
   const collectionRef = useRef("All");
   const store = useStore(["results"], (_, q) => searchResources(q as string, collectionRef.current), true);
-  const [collections, setCollections] = useState<CollectionOption[]>([]);
+  const [collectionOptions, setCollectionOptions] = useState<CollectionOption[]>([]);
   const [collection, setCollection] = useState("All");
   const [groupLibraries, setGroupLibraries] = useState<LibraryRef[]>([]);
   const [includedGroups, setIncludedGroups] = useState<number[]>([]);
+  // Raw inputs kept so the visible collection options can be recomputed when the
+  // set of included group libraries changes.
+  const allCollectionsRef = useRef<CollectionRef[]>([]);
+  const librariesRef = useRef<LibraryRef[]>([]);
   const sectionNames = ["Search Results"];
 
   useEffect(() => {
@@ -31,8 +41,10 @@ export default function MyView() {
         getLibraries(),
         getIncludedGroupLibraries(),
       ]);
-      const libraryNames = new Map(libraries.map((l) => [l.id, l.name]));
-      setCollections(buildCollectionOptions(cols, libraryNames));
+      allCollectionsRef.current = cols;
+      librariesRef.current = libraries;
+      const names = new Map(libraries.map((l) => [l.id, l.name]));
+      setCollectionOptions(visibleCollectionOptions(cols, allowedLibraryIds(libraries, included), names));
       setGroupLibraries(libraries.filter((l) => l.type === "group"));
       setIncludedGroups(included);
       await store.runQuery("");
@@ -46,7 +58,7 @@ export default function MyView() {
       sectionNames={sectionNames}
       queryResults={store.queryResults}
       isLoading={store.queryIsLoading}
-      collections={collections}
+      collections={collectionOptions}
       selectedCollection={collection}
       onCollectionChange={(value) => {
         collectionRef.current = value;
@@ -57,7 +69,17 @@ export default function MyView() {
       includedGroups={includedGroups}
       onSaveGroups={async (ids) => {
         await setIncludedGroupLibraries(ids);
+        const libraries = librariesRef.current;
+        const names = new Map(libraries.map((l) => [l.id, l.name]));
+        const options = visibleCollectionOptions(allCollectionsRef.current, allowedLibraryIds(libraries, ids), names);
+        // If the selected collection now falls outside the included libraries,
+        // reset to "All" so the user isn't left with a silently empty result set.
+        if (collectionRef.current !== "All" && !options.some((o) => o.key === collectionRef.current)) {
+          collectionRef.current = "All";
+          setCollection("All");
+        }
         setIncludedGroups(ids);
+        setCollectionOptions(options);
         store.runQuery(textRef.current);
       }}
       onSearchTextChange={(text) => {

--- a/extensions/zotero/src/commandSearchZotero.tsx
+++ b/extensions/zotero/src/commandSearchZotero.tsx
@@ -1,11 +1,12 @@
 import {
   searchResources,
   getCollections,
-  getGroupLibraries,
+  getLibraries,
   getIncludedGroupLibraries,
   setIncludedGroupLibraries,
 } from "./common/zoteroApi";
 import type { LibraryRef } from "./common/library";
+import { buildCollectionOptions, type CollectionOption } from "./common/collections";
 import { useEffect, useRef, useState } from "react";
 import { useStore } from "./common/store";
 import { View } from "./common/View";
@@ -17,7 +18,7 @@ export default function MyView() {
   const textRef = useRef("");
   const collectionRef = useRef("All");
   const store = useStore(["results"], (_, q) => searchResources(q as string, collectionRef.current), true);
-  const [collections, setCollections] = useState<string[]>([]);
+  const [collections, setCollections] = useState<CollectionOption[]>([]);
   const [collection, setCollection] = useState("All");
   const [groupLibraries, setGroupLibraries] = useState<LibraryRef[]>([]);
   const [includedGroups, setIncludedGroups] = useState<number[]>([]);
@@ -25,13 +26,14 @@ export default function MyView() {
 
   useEffect(() => {
     const init = async () => {
-      const [cols, groups, included] = await Promise.all([
+      const [cols, libraries, included] = await Promise.all([
         getCollections(),
-        getGroupLibraries(),
+        getLibraries(),
         getIncludedGroupLibraries(),
       ]);
-      setCollections(cols);
-      setGroupLibraries(groups);
+      const libraryNames = new Map(libraries.map((l) => [l.id, l.name]));
+      setCollections(buildCollectionOptions(cols, libraryNames));
+      setGroupLibraries(libraries.filter((l) => l.type === "group"));
       setIncludedGroups(included);
       await store.runQuery("");
     };

--- a/extensions/zotero/src/commandSearchZotero.tsx
+++ b/extensions/zotero/src/commandSearchZotero.tsx
@@ -1,17 +1,38 @@
-import { searchResources, getCollections } from "./common/zoteroApi";
-import { useEffect, useState } from "react";
+import {
+  searchResources,
+  getCollections,
+  getGroupLibraries,
+  getIncludedGroupLibraries,
+  setIncludedGroupLibraries,
+} from "./common/zoteroApi";
+import type { LibraryRef } from "./common/library";
+import { useEffect, useRef, useState } from "react";
 import { useStore } from "./common/store";
 import { View } from "./common/View";
 
 export default function MyView() {
-  const store = useStore(["results"], (_, q) => searchResources(q as string), true);
+  // Keep the current search text and collection in refs so either one changing
+  // re-runs the same combined query. Collection scoping is applied inside
+  // searchResources (before the render cap), not by post-filtering the results.
+  const textRef = useRef("");
+  const collectionRef = useRef("All");
+  const store = useStore(["results"], (_, q) => searchResources(q as string, collectionRef.current), true);
   const [collections, setCollections] = useState<string[]>([]);
+  const [collection, setCollection] = useState("All");
+  const [groupLibraries, setGroupLibraries] = useState<LibraryRef[]>([]);
+  const [includedGroups, setIncludedGroups] = useState<number[]>([]);
   const sectionNames = ["Search Results"];
 
   useEffect(() => {
     const init = async () => {
-      const cols = await getCollections();
+      const [cols, groups, included] = await Promise.all([
+        getCollections(),
+        getGroupLibraries(),
+        getIncludedGroupLibraries(),
+      ]);
       setCollections(cols);
+      setGroupLibraries(groups);
+      setIncludedGroups(included);
       await store.runQuery("");
     };
 
@@ -24,7 +45,21 @@ export default function MyView() {
       queryResults={store.queryResults}
       isLoading={store.queryIsLoading}
       collections={collections}
+      selectedCollection={collection}
+      onCollectionChange={(value) => {
+        collectionRef.current = value;
+        setCollection(value);
+        store.runQuery(textRef.current);
+      }}
+      groupLibraries={groupLibraries}
+      includedGroups={includedGroups}
+      onSaveGroups={async (ids) => {
+        await setIncludedGroupLibraries(ids);
+        setIncludedGroups(ids);
+        store.runQuery(textRef.current);
+      }}
       onSearchTextChange={(text) => {
+        textRef.current = text;
         store.runQuery(text);
       }}
       throttle

--- a/extensions/zotero/src/common/CollectionDropdown.tsx
+++ b/extensions/zotero/src/common/CollectionDropdown.tsx
@@ -1,10 +1,12 @@
 import { List } from "@raycast/api";
+import type { CollectionOption } from "./collections";
+
 export default function CollectionDropdown(props: {
-  collections: string[];
+  options: CollectionOption[];
   value: string;
   onSelection: (newValue: string) => void;
 }) {
-  const { onSelection, collections, value } = props;
+  const { onSelection, options, value } = props;
   return (
     <List.Dropdown
       tooltip="Select Collection"
@@ -14,8 +16,8 @@ export default function CollectionDropdown(props: {
       }}
     >
       <List.Dropdown.Item key="All" title="All" value="All" />
-      {collections.map((col) => (
-        <List.Dropdown.Item key={col} title={col} value={col} />
+      {options.map((opt) => (
+        <List.Dropdown.Item key={opt.key} title={opt.title} value={opt.key} />
       ))}
     </List.Dropdown>
   );

--- a/extensions/zotero/src/common/CollectionDropdown.tsx
+++ b/extensions/zotero/src/common/CollectionDropdown.tsx
@@ -1,10 +1,14 @@
 import { List } from "@raycast/api";
-export default function CollectionDropdown(props: { collections: string[]; onSelection: (newValue: string) => void }) {
-  const { onSelection, collections } = props;
+export default function CollectionDropdown(props: {
+  collections: string[];
+  value: string;
+  onSelection: (newValue: string) => void;
+}) {
+  const { onSelection, collections, value } = props;
   return (
     <List.Dropdown
       tooltip="Select Collection"
-      storeValue={true}
+      value={value}
       onChange={(newValue) => {
         onSelection(newValue);
       }}

--- a/extensions/zotero/src/common/View.tsx
+++ b/extensions/zotero/src/common/View.tsx
@@ -274,7 +274,7 @@ export const View = ({
             const attachmentFilePath = resolveAttachmentPath(item, preferences.zotero_path);
             return (
               <List.Item
-                key={item.key}
+                key={item.id ?? item.key}
                 id={`${item.id}`}
                 title={
                   item.title +

--- a/extensions/zotero/src/common/View.tsx
+++ b/extensions/zotero/src/common/View.tsx
@@ -4,14 +4,17 @@ import {
   Icon,
   Action,
   Keyboard,
+  Form,
   getPreferenceValues,
   Clipboard,
   closeMainWindow,
   showHUD,
   open,
+  useNavigation,
 } from "@raycast/api";
 import { dirname, join } from "path";
 import { RefData, Preferences, resolveHome, MAX_RENDER_RESULTS } from "./zoteroApi";
+import { LibraryRef, zoteroSelectUri, zoteroOpenPdfUri } from "./library";
 import { useVisitedUrls } from "./useVisitedUrls";
 import {
   exportRef,
@@ -21,12 +24,16 @@ import {
   exportPandocKey,
   exportPandocKeyPaste,
 } from "./clipboard";
-import { useState } from "react";
 import CollectionDropdown from "./CollectionDropdown";
 
 type Props = {
   sectionNames: string[];
   collections: string[];
+  selectedCollection: string;
+  onCollectionChange: (value: string) => void;
+  groupLibraries: LibraryRef[];
+  includedGroups: number[];
+  onSaveGroups: (ids: number[]) => void;
   queryResults: RefData[][];
   isLoading: boolean;
   onSearchTextChange?: (text: string) => void;
@@ -147,7 +154,7 @@ function getItemDoi(item: RefData): string {
 }
 
 function getItemZotUrl(item: RefData): string {
-  return `zotero://select/items/${item.library ? item.library : 0}_${item.key}`;
+  return zoteroSelectUri(item);
 }
 
 function getItemIcon(item: RefData): string {
@@ -182,10 +189,16 @@ function getItemDetail(item: RefData): string {
   const publicationDate = getItemPublicationDate(item);
   const pdfKey = item.attachment?.key;
 
-  return `## ${pdfKey ? `[${title}](zotero://open-pdf/library/items/${pdfKey})` : title}
+  return `## ${pdfKey ? `[${title}](${zoteroOpenPdfUri(item, pdfKey)})` : title}
 
   ---
-
+${
+  item.libraryType === "group" && item.libraryName
+    ? `
+**Library:** ${item.libraryName}
+`
+    : ""
+}
 ${creators ? formatAuthors(item) : ""}
 
 ${publicationTitle ? "**Publication:** " + publicationTitle : ""}
@@ -221,13 +234,17 @@ ${
 export const View = ({
   sectionNames,
   collections,
+  selectedCollection,
+  onCollectionChange,
+  groupLibraries,
+  includedGroups,
+  onSaveGroups,
   queryResults,
   isLoading,
   onSearchTextChange,
   throttle,
 }: Props): JSX.Element => {
   const [urls, onOpen] = useVisitedUrls();
-  const [collection, setCollection] = useState<string>("All");
   const preferences: Preferences = getPreferenceValues();
   return (
     <List
@@ -238,7 +255,9 @@ export const View = ({
       }}
       throttle={throttle}
       searchBarPlaceholder="Search Zotero..."
-      searchBarAccessory={<CollectionDropdown onSelection={setCollection} collections={collections} />}
+      searchBarAccessory={
+        <CollectionDropdown value={selectedCollection} onSelection={onCollectionChange} collections={collections} />
+      }
     >
       {sectionNames.map((sectionName, sectionIndex) => (
         <List.Section
@@ -250,97 +269,171 @@ export const View = ({
               : `${queryResults[sectionIndex].length}`
           }
         >
-          {queryResults[sectionIndex]
-            .filter((item) => item.collection?.includes(collection) || collection == "All")
-            .map((item) => {
-              const attachmentFilePath = resolveAttachmentPath(item, preferences.zotero_path);
-              return (
-                <List.Item
-                  key={item.key}
-                  id={`${item.id}`}
-                  title={item.title + (urls.includes(item.url) ? " (visited)" : "")}
-                  icon={getItemIcon(item)}
-                  detail={<List.Item.Detail markdown={getItemDetail(item)} />}
-                  actions={
-                    <ActionPanel>
-                      {item.attachment?.key && item.attachment.key !== `` && (
-                        <Action.OpenInBrowser
-                          icon={Icon.ArrowRightCircleFilled}
-                          title="Open PDF"
-                          url={`zotero://open-pdf/library/items/${item.attachment.key}`}
-                          onOpen={onOpen}
-                        />
-                      )}
-                      {item.attachment?.key && item.attachment.key !== `` && attachmentFilePath && (
-                        <Action
-                          icon={Icon.ArrowRightCircleFilled}
-                          title="Open PDF in System Viewer"
-                          onAction={async () => {
-                            try {
-                              await open(attachmentFilePath);
-                              closeMainWindow();
-                            } catch {
-                              await showHUD("Failed to open attachment");
-                            }
-                          }}
-                        />
-                      )}
+          {queryResults[sectionIndex].map((item) => {
+            const attachmentFilePath = resolveAttachmentPath(item, preferences.zotero_path);
+            return (
+              <List.Item
+                key={item.key}
+                id={`${item.id}`}
+                title={
+                  item.title +
+                  (item.libraryType === "group" && item.libraryName ? ` · ${item.libraryName}` : "") +
+                  (urls.includes(item.url) ? " (visited)" : "")
+                }
+                icon={getItemIcon(item)}
+                accessories={
+                  item.libraryType === "group" && item.libraryName
+                    ? [{ icon: Icon.TwoPeople, tooltip: item.libraryName }]
+                    : undefined
+                }
+                detail={<List.Item.Detail markdown={getItemDetail(item)} />}
+                actions={
+                  <ActionPanel>
+                    {item.attachment?.key && item.attachment.key !== `` && (
                       <Action.OpenInBrowser
-                        icon={Icon.Link}
-                        title="Open in Zotero"
-                        url={`zotero://select/items/${item.library ? item.library : 0}_${item.key}`}
+                        icon={Icon.ArrowRightCircleFilled}
+                        title="Open PDF"
+                        url={zoteroOpenPdfUri(item, item.attachment.key)}
                         onOpen={onOpen}
                       />
-                      {getURL(item) !== "" && (
-                        <Action.OpenInBrowser
-                          title="Open Original Link"
-                          url={getURL(item)}
-                          shortcut={openExtLinkCommandShortcut}
-                          onOpen={onOpen}
+                    )}
+                    {item.attachment?.key && item.attachment.key !== `` && attachmentFilePath && (
+                      <Action
+                        icon={Icon.ArrowRightCircleFilled}
+                        title="Open PDF in System Viewer"
+                        onAction={async () => {
+                          try {
+                            await open(attachmentFilePath);
+                            closeMainWindow();
+                          } catch {
+                            await showHUD("Failed to open attachment");
+                          }
+                        }}
+                      />
+                    )}
+                    <Action.OpenInBrowser
+                      icon={Icon.Link}
+                      title="Open in Zotero"
+                      url={zoteroSelectUri(item)}
+                      onOpen={onOpen}
+                    />
+                    {getURL(item) !== "" && (
+                      <Action.OpenInBrowser
+                        title="Open Original Link"
+                        url={getURL(item)}
+                        shortcut={openExtLinkCommandShortcut}
+                        onOpen={onOpen}
+                      />
+                    )}
+
+                    {preferences.use_bibtex && item.citekey && (
+                      <Action.CopyToClipboard
+                        title="Copy Bibtex Citation Key"
+                        content={item.citekey}
+                        shortcut={copyRefCommandShortcut}
+                      />
+                    )}
+                    {preferences.use_bibtex && item.citekey && <RefCopyToClipboardAction selected={item.citekey} />}
+                    {preferences.use_bibtex && item.citekey && <BibCopyToClipboardAction selected={item.citekey} />}
+                    {preferences.use_bibtex && item.citekey && <PandocCopyAction selected={item.citekey} />}
+                    {preferences.use_bibtex && item.citekey && <RefPasteAction selected={item.citekey} />}
+                    {preferences.use_bibtex && item.citekey && <BibPasteAction selected={item.citekey} />}
+                    {preferences.use_bibtex && item.citekey && <PandocPasteAction selected={item.citekey} />}
+
+                    <ActionPanel.Section>
+                      {item.attachment && item.attachment.key && item.attachment.key !== `` && (
+                        <PDFURLCopyToClipboardAction itemURL={zoteroOpenPdfUri(item, item.attachment.key)} />
+                      )}
+                      {getURL(item) !== "" && <URLCopyToClipboardAction itemURL={getURL(item)} />}
+                      {getItemTitle(item) !== "" && <TitleCopyToClipboardAction itemTitle={getItemTitle(item)} />}
+                      {getItemAuthors(item) !== "" && <AuthorsCopyToClipboardAction authors={getItemAuthors(item)} />}
+                      {getItemZotUrl(item) && <ZoteroUrlCopyToClipboard zotUrl={getItemZotUrl(item)} />}
+                      {getItemDoi(item) !== "" && <DoiCopyToClipboardAction itemDoi={getItemDoi(item)} />}
+                      {attachmentFilePath && (
+                        <PDFPathCopyToClipboardAction
+                          pdfPath={preferences.quote_pdf_path ? `"${attachmentFilePath}"` : attachmentFilePath}
                         />
                       )}
-
-                      {preferences.use_bibtex && item.citekey && (
-                        <Action.CopyToClipboard
-                          title="Copy Bibtex Citation Key"
-                          content={item.citekey}
-                          shortcut={copyRefCommandShortcut}
-                        />
-                      )}
-                      {preferences.use_bibtex && item.citekey && <RefCopyToClipboardAction selected={item.citekey} />}
-                      {preferences.use_bibtex && item.citekey && <BibCopyToClipboardAction selected={item.citekey} />}
-                      {preferences.use_bibtex && item.citekey && <PandocCopyAction selected={item.citekey} />}
-                      {preferences.use_bibtex && item.citekey && <RefPasteAction selected={item.citekey} />}
-                      {preferences.use_bibtex && item.citekey && <BibPasteAction selected={item.citekey} />}
-                      {preferences.use_bibtex && item.citekey && <PandocPasteAction selected={item.citekey} />}
-
-                      <ActionPanel.Section>
-                        {item.attachment && item.attachment.key && item.attachment.key !== `` && (
-                          <PDFURLCopyToClipboardAction
-                            itemURL={`zotero://open-pdf/library/items/${item.attachment.key}`}
-                          />
-                        )}
-                        {getURL(item) !== "" && <URLCopyToClipboardAction itemURL={getURL(item)} />}
-                        {getItemTitle(item) !== "" && <TitleCopyToClipboardAction itemTitle={getItemTitle(item)} />}
-                        {getItemAuthors(item) !== "" && <AuthorsCopyToClipboardAction authors={getItemAuthors(item)} />}
-                        {getItemZotUrl(item) && <ZoteroUrlCopyToClipboard zotUrl={getItemZotUrl(item)} />}
-                        {getItemDoi(item) !== "" && <DoiCopyToClipboardAction itemDoi={getItemDoi(item)} />}
-                        {attachmentFilePath && (
-                          <PDFPathCopyToClipboardAction
-                            pdfPath={preferences.quote_pdf_path ? `"${attachmentFilePath}"` : attachmentFilePath}
-                          />
-                        )}
-                      </ActionPanel.Section>
-                    </ActionPanel>
-                  }
-                />
-              );
-            })}
+                    </ActionPanel.Section>
+                    <ActionPanel.Section>
+                      <ConfigureGroupLibrariesAction
+                        groupLibraries={groupLibraries}
+                        includedGroups={includedGroups}
+                        onSave={onSaveGroups}
+                      />
+                    </ActionPanel.Section>
+                  </ActionPanel>
+                }
+              />
+            );
+          })}
         </List.Section>
       ))}
     </List>
   );
 };
+
+const configureGroupsShortcut: Keyboard.Shortcut = { modifiers: ["cmd"], key: "l" };
+
+function ConfigureGroupLibrariesAction({
+  groupLibraries,
+  includedGroups,
+  onSave,
+}: {
+  groupLibraries: LibraryRef[];
+  includedGroups: number[];
+  onSave: (ids: number[]) => void;
+}) {
+  const { push } = useNavigation();
+  if (groupLibraries.length === 0) {
+    return null;
+  }
+  return (
+    <Action
+      icon={Icon.TwoPeople}
+      title="Configure Group Libraries"
+      shortcut={configureGroupsShortcut}
+      onAction={() =>
+        push(<GroupLibrariesForm groupLibraries={groupLibraries} includedGroups={includedGroups} onSave={onSave} />)
+      }
+    />
+  );
+}
+
+function GroupLibrariesForm({
+  groupLibraries,
+  includedGroups,
+  onSave,
+}: {
+  groupLibraries: LibraryRef[];
+  includedGroups: number[];
+  onSave: (ids: number[]) => void;
+}) {
+  const { pop } = useNavigation();
+  return (
+    <Form
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm
+            title="Save"
+            icon={Icon.Check}
+            onSubmit={(values: { groups: string[] }) => {
+              onSave((values.groups ?? []).map(Number).filter((n) => !Number.isNaN(n)));
+              pop();
+            }}
+          />
+        </ActionPanel>
+      }
+    >
+      <Form.Description text="Choose which group libraries to include in search. Your personal library is always searched; group libraries are opt-in." />
+      <Form.TagPicker id="groups" title="Group Libraries" defaultValue={includedGroups.map(String)}>
+        {groupLibraries.map((l) => (
+          <Form.TagPicker.Item key={l.id} value={String(l.id)} title={l.name} icon={Icon.TwoPeople} />
+        ))}
+      </Form.TagPicker>
+    </Form>
+  );
+}
 
 function URLCopyToClipboardAction({ itemURL }: { itemURL: string }) {
   return (

--- a/extensions/zotero/src/common/View.tsx
+++ b/extensions/zotero/src/common/View.tsx
@@ -15,6 +15,7 @@ import {
 import { dirname, join } from "path";
 import { RefData, Preferences, resolveHome, MAX_RENDER_RESULTS } from "./zoteroApi";
 import { LibraryRef, zoteroSelectUri, zoteroOpenPdfUri } from "./library";
+import type { CollectionOption } from "./collections";
 import { useVisitedUrls } from "./useVisitedUrls";
 import {
   exportRef,
@@ -28,7 +29,7 @@ import CollectionDropdown from "./CollectionDropdown";
 
 type Props = {
   sectionNames: string[];
-  collections: string[];
+  collections: CollectionOption[];
   selectedCollection: string;
   onCollectionChange: (value: string) => void;
   groupLibraries: LibraryRef[];
@@ -256,7 +257,7 @@ export const View = ({
       throttle={throttle}
       searchBarPlaceholder="Search Zotero..."
       searchBarAccessory={
-        <CollectionDropdown value={selectedCollection} onSelection={onCollectionChange} collections={collections} />
+        <CollectionDropdown value={selectedCollection} onSelection={onCollectionChange} options={collections} />
       }
     >
       {sectionNames.map((sectionName, sectionIndex) => (

--- a/extensions/zotero/src/common/View.tsx
+++ b/extensions/zotero/src/common/View.tsx
@@ -14,7 +14,7 @@ import {
 } from "@raycast/api";
 import { dirname, join } from "path";
 import { RefData, Preferences, resolveHome, MAX_RENDER_RESULTS } from "./zoteroApi";
-import { LibraryRef, zoteroSelectUri, zoteroOpenPdfUri } from "./library";
+import { LibraryRef, itemIdentity, zoteroSelectUri, zoteroOpenPdfUri } from "./library";
 import type { CollectionOption } from "./collections";
 import { useVisitedUrls } from "./useVisitedUrls";
 import {
@@ -274,8 +274,8 @@ export const View = ({
             const attachmentFilePath = resolveAttachmentPath(item, preferences.zotero_path);
             return (
               <List.Item
-                key={item.id ?? item.key}
-                id={`${item.id}`}
+                key={itemIdentity(item)}
+                id={itemIdentity(item)}
                 title={
                   item.title +
                   (item.libraryType === "group" && item.libraryName ? ` · ${item.libraryName}` : "") +

--- a/extensions/zotero/src/common/collections.test.ts
+++ b/extensions/zotero/src/common/collections.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { buildCollectionOptions } from "./collections";
+import { buildCollectionOptions, visibleCollectionOptions, collectionId } from "./collections";
 
 describe("buildCollectionOptions", () => {
-  it("leaves unique names untouched", () => {
+  it("leaves unique names untouched but qualifies keys by library", () => {
     const opts = buildCollectionOptions(
       [
         { key: "K1", name: "Physics", library: 1 },
@@ -11,8 +11,8 @@ describe("buildCollectionOptions", () => {
       new Map([[1, "My Library"]]),
     );
     expect(opts).toEqual([
-      { key: "K1", title: "Physics" },
-      { key: "K2", title: "Cooking" },
+      { key: "1:K1", title: "Physics" },
+      { key: "1:K2", title: "Cooking" },
     ]);
   });
 
@@ -28,8 +28,8 @@ describe("buildCollectionOptions", () => {
       ]),
     );
     const byKey = Object.fromEntries(opts.map((o) => [o.key, o.title]));
-    expect(byKey["K1"]).toBe("Papers (My Library)");
-    expect(byKey["K2"]).toBe("Papers (Group A)");
+    expect(byKey["1:K1"]).toBe("Papers (My Library)");
+    expect(byKey["2:K2"]).toBe("Papers (Group A)");
   });
 
   it("keeps titles unique even when same-named collections live in the same library", () => {
@@ -42,8 +42,56 @@ describe("buildCollectionOptions", () => {
     );
     const titles = opts.map((o) => o.title);
     expect(new Set(titles).size).toBe(2); // no two options share a title
-    expect(opts.every((o) => o.key)).toBe(true);
-    // Same-library collisions should not carry a redundant library-name suffix.
     expect(titles.every((t) => !t.includes("(My Library)"))).toBe(true);
+  });
+
+  it("gives distinct ids to collections that share a key across libraries", () => {
+    const opts = buildCollectionOptions(
+      [
+        { key: "SAMEKEY", name: "Alpha", library: 1 },
+        { key: "SAMEKEY", name: "Beta", library: 2 },
+      ],
+      new Map([
+        [1, "My Library"],
+        [2, "Group A"],
+      ]),
+    );
+    const keys = opts.map((o) => o.key);
+    expect(keys).toEqual(["1:SAMEKEY", "2:SAMEKEY"]);
+    expect(new Set(keys).size).toBe(2);
+  });
+});
+
+describe("collectionId", () => {
+  it("qualifies a collection key with its library id", () => {
+    expect(collectionId(2, "ABCD")).toBe("2:ABCD");
+  });
+});
+
+describe("visibleCollectionOptions", () => {
+  const cols = [
+    { key: "P1", name: "Personal", library: 1 },
+    { key: "G1", name: "GroupOne", library: 2 },
+    { key: "G2", name: "GroupTwo", library: 3 },
+  ];
+  const names = new Map([
+    [1, "My Library"],
+    [2, "Group A"],
+    [3, "Group B"],
+  ]);
+
+  it("shows only personal collections when no groups are included", () => {
+    const opts = visibleCollectionOptions(cols, [1], names);
+    expect(opts.map((o) => o.key)).toEqual(["1:P1"]);
+  });
+
+  it("adds collections from an included group", () => {
+    const opts = visibleCollectionOptions(cols, [1, 2], names);
+    expect(opts.map((o) => o.key).sort()).toEqual(["1:P1", "2:G1"]);
+  });
+
+  it("omits collections from a group that is not included", () => {
+    const opts = visibleCollectionOptions(cols, [1, 2], names);
+    expect(opts.some((o) => o.key === "3:G2")).toBe(false);
   });
 });

--- a/extensions/zotero/src/common/collections.test.ts
+++ b/extensions/zotero/src/common/collections.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { buildCollectionOptions } from "./collections";
+
+describe("buildCollectionOptions", () => {
+  it("leaves unique names untouched", () => {
+    const opts = buildCollectionOptions(
+      [
+        { key: "K1", name: "Physics", library: 1 },
+        { key: "K2", name: "Cooking", library: 1 },
+      ],
+      new Map([[1, "My Library"]]),
+    );
+    expect(opts).toEqual([
+      { key: "K1", title: "Physics" },
+      { key: "K2", title: "Cooking" },
+    ]);
+  });
+
+  it("disambiguates same-named collections in different libraries by library name", () => {
+    const opts = buildCollectionOptions(
+      [
+        { key: "K1", name: "Papers", library: 1 },
+        { key: "K2", name: "Papers", library: 2 },
+      ],
+      new Map([
+        [1, "My Library"],
+        [2, "Group A"],
+      ]),
+    );
+    const byKey = Object.fromEntries(opts.map((o) => [o.key, o.title]));
+    expect(byKey["K1"]).toBe("Papers (My Library)");
+    expect(byKey["K2"]).toBe("Papers (Group A)");
+  });
+
+  it("keeps titles unique even when same-named collections live in the same library", () => {
+    const opts = buildCollectionOptions(
+      [
+        { key: "AAAA1111", name: "Notes", library: 1 },
+        { key: "BBBB2222", name: "Notes", library: 1 },
+      ],
+      new Map([[1, "My Library"]]),
+    );
+    const titles = opts.map((o) => o.title);
+    expect(new Set(titles).size).toBe(2); // no two options share a title
+    expect(opts.every((o) => o.key)).toBe(true);
+    // Same-library collisions should not carry a redundant library-name suffix.
+    expect(titles.every((t) => !t.includes("(My Library)"))).toBe(true);
+  });
+});

--- a/extensions/zotero/src/common/collections.ts
+++ b/extensions/zotero/src/common/collections.ts
@@ -6,12 +6,20 @@ export interface CollectionRef {
   library: number;
 }
 
-// A collection as offered in the dropdown: a stable key to filter by and a title
+// A collection as offered in the dropdown: a stable id to filter by and a title
 // to show. Titles are made unique so the user can tell same-named collections
-// apart, but filtering always uses the key.
+// apart, but filtering always uses the id.
 export interface CollectionOption {
   key: string;
   title: string;
+}
+
+// Globally-unique id for a collection. Zotero collection keys are unique only
+// within a library (like item keys), so a personal and a group collection can
+// share a key; qualifying with the libraryID keeps them distinct. getData tags
+// each item's collections with this same id so filtering never conflates them.
+export function collectionId(library: number, key: string): string {
+  return `${library}:${key}`;
 }
 
 // Build dropdown options from raw collections, disambiguating duplicate names.
@@ -38,7 +46,7 @@ export function buildCollectionOptions(
       const libName = libraryNames.get(c.library) ?? `Library ${c.library}`;
       title = `${c.name} (${libName})`;
     }
-    return { key: c.key, title };
+    return { key: collectionId(c.library, c.key), title };
   });
 
   // Second pass: any titles that still collide get a short key suffix.
@@ -48,9 +56,25 @@ export function buildCollectionOptions(
   }
   for (const o of options) {
     if ((titleCounts.get(o.title) ?? 0) > 1) {
-      o.title = `${o.title} [${o.key.slice(0, 4)}]`;
+      // o.key is "<library>:<key>"; use a fragment of the collection key part.
+      const rawKey = o.key.slice(o.key.indexOf(":") + 1);
+      o.title = `${o.title} [${rawKey.slice(0, 4)}]`;
     }
   }
 
   return options;
+}
+
+// Options for only the collections the user can currently search: those in the
+// personal library plus any opted-in group libraries. Collections from groups
+// the user has not included are omitted, so the dropdown never offers a
+// collection that would always return nothing.
+export function visibleCollectionOptions(
+  collections: CollectionRef[],
+  allowedLibraryIds: Iterable<number>,
+  libraryNames: Map<number, string>,
+): CollectionOption[] {
+  const allowed = new Set(allowedLibraryIds);
+  const inScope = collections.filter((c) => allowed.has(c.library));
+  return buildCollectionOptions(inScope, libraryNames);
 }

--- a/extensions/zotero/src/common/collections.ts
+++ b/extensions/zotero/src/common/collections.ts
@@ -1,0 +1,56 @@
+// A Zotero collection. Identified by its key (globally unique); the name is for
+// display only and is not necessarily unique.
+export interface CollectionRef {
+  key: string;
+  name: string;
+  library: number;
+}
+
+// A collection as offered in the dropdown: a stable key to filter by and a title
+// to show. Titles are made unique so the user can tell same-named collections
+// apart, but filtering always uses the key.
+export interface CollectionOption {
+  key: string;
+  title: string;
+}
+
+// Build dropdown options from raw collections, disambiguating duplicate names.
+// A name shared across libraries gets the library name appended; if that still
+// collides (same-named collections within one library, e.g. subcollections
+// under different parents), a short key fragment is appended so every title is
+// unique.
+export function buildCollectionOptions(
+  collections: CollectionRef[],
+  libraryNames: Map<number, string>,
+): CollectionOption[] {
+  // For each name, note how many libraries it spans. A name that collides only
+  // within one library gains nothing from a library-name suffix, so it goes
+  // straight to the key suffix below.
+  const librariesByName = new Map<string, Set<number>>();
+  for (const c of collections) {
+    if (!librariesByName.has(c.name)) librariesByName.set(c.name, new Set());
+    librariesByName.get(c.name)!.add(c.library);
+  }
+
+  const options: CollectionOption[] = collections.map((c) => {
+    let title = c.name;
+    if ((librariesByName.get(c.name)?.size ?? 0) > 1) {
+      const libName = libraryNames.get(c.library) ?? `Library ${c.library}`;
+      title = `${c.name} (${libName})`;
+    }
+    return { key: c.key, title };
+  });
+
+  // Second pass: any titles that still collide get a short key suffix.
+  const titleCounts = new Map<string, number>();
+  for (const o of options) {
+    titleCounts.set(o.title, (titleCounts.get(o.title) ?? 0) + 1);
+  }
+  for (const o of options) {
+    if ((titleCounts.get(o.title) ?? 0) > 1) {
+      o.title = `${o.title} [${o.key.slice(0, 4)}]`;
+    }
+  }
+
+  return options;
+}

--- a/extensions/zotero/src/common/library.test.ts
+++ b/extensions/zotero/src/common/library.test.ts
@@ -1,10 +1,30 @@
 import { describe, it, expect } from "vitest";
-import { zoteroSelectUri, zoteroOpenPdfUri } from "./library";
+import { itemIdentity, zoteroSelectUri, zoteroOpenPdfUri } from "./library";
 import type { RefData } from "./zoteroApi";
 
-const userItem: RefData = { key: "ABCD1234", library: 1, libraryType: "user" };
-const groupItem: RefData = { key: "WXYZ5678", library: 2, libraryType: "group", groupID: 6518241 };
+const userItem: RefData = { id: 10, key: "ABCD1234", library: 1, libraryType: "user" };
+const groupItem: RefData = { id: 20, key: "WXYZ5678", library: 2, libraryType: "group", groupID: 6518241 };
 const legacyItem: RefData = { key: "OLD0000", library: 1 }; // cache built before library fields existed
+
+describe("itemIdentity", () => {
+  it("prefers the globally unique database item id", () => {
+    expect(itemIdentity(userItem)).toBe("id:10");
+    expect(itemIdentity(groupItem)).toBe("id:20");
+  });
+
+  it("gives distinct ids to items that share a Zotero key across libraries", () => {
+    const personal: RefData = { id: 10, key: "SAMEKEY", library: 1 };
+    const group: RefData = { id: 20, key: "SAMEKEY", library: 2 };
+    expect(itemIdentity(personal)).not.toBe(itemIdentity(group));
+  });
+
+  it("falls back to library+key when the database id is missing", () => {
+    const personal: RefData = { key: "SAMEKEY", library: 1 };
+    const group: RefData = { key: "SAMEKEY", library: 2 };
+    expect(itemIdentity(personal)).toBe("1:SAMEKEY");
+    expect(itemIdentity(group)).toBe("2:SAMEKEY");
+  });
+});
 
 describe("zoteroSelectUri", () => {
   it("uses the /library/ path for personal-library items", () => {

--- a/extensions/zotero/src/common/library.test.ts
+++ b/extensions/zotero/src/common/library.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { zoteroSelectUri, zoteroOpenPdfUri } from "./library";
+import type { RefData } from "./zoteroApi";
+
+const userItem: RefData = { key: "ABCD1234", library: 1, libraryType: "user" };
+const groupItem: RefData = { key: "WXYZ5678", library: 2, libraryType: "group", groupID: 6518241 };
+const legacyItem: RefData = { key: "OLD0000", library: 1 }; // cache built before library fields existed
+
+describe("zoteroSelectUri", () => {
+  it("uses the /library/ path for personal-library items", () => {
+    expect(zoteroSelectUri(userItem)).toBe("zotero://select/library/items/ABCD1234");
+  });
+
+  it("uses the /groups/<groupID>/ path for group-library items", () => {
+    expect(zoteroSelectUri(groupItem)).toBe("zotero://select/groups/6518241/items/WXYZ5678");
+  });
+
+  it("falls back to the /library/ path when library metadata is missing", () => {
+    expect(zoteroSelectUri(legacyItem)).toBe("zotero://select/library/items/OLD0000");
+  });
+});
+
+describe("zoteroOpenPdfUri", () => {
+  it("opens a personal-library attachment via /library/", () => {
+    expect(zoteroOpenPdfUri(userItem, "PDFKEY1")).toBe("zotero://open-pdf/library/items/PDFKEY1");
+  });
+
+  it("opens a group-library attachment via /groups/<groupID>/", () => {
+    expect(zoteroOpenPdfUri(groupItem, "PDFKEY2")).toBe("zotero://open-pdf/groups/6518241/items/PDFKEY2");
+  });
+});

--- a/extensions/zotero/src/common/library.ts
+++ b/extensions/zotero/src/common/library.ts
@@ -14,6 +14,16 @@ export interface LibraryRef {
 
 export const USER_LIBRARY_NAME = "My Library";
 
+// Globally-unique identity for an item. Zotero item *keys* are unique only
+// within a library, so a personal item and a group item can share a key while
+// being different papers. Prefer the local items.itemID (unique in this
+// database); fall back to library+key for caches built before the id field
+// existed. Used for search dedupe and React row keys so the two cannot drift.
+export function itemIdentity(item: RefData): string {
+  if (item.id != null) return `id:${item.id}`;
+  return `${item.library ?? "?"}:${item.key}`;
+}
+
 // Build the zotero:// URI that selects an item in Zotero. Group items require
 // the /groups/<groupID>/ form; everything else (personal library, or a cache
 // built before group support) uses /library/. See Zotero's documented scheme:

--- a/extensions/zotero/src/common/library.ts
+++ b/extensions/zotero/src/common/library.ts
@@ -1,0 +1,39 @@
+import type { RefData } from "./zoteroApi";
+
+// A Zotero library: the personal ("user") library or a shared "group" library.
+export interface LibraryRef {
+  // Local libraryID (items.libraryID). Stable within this database only.
+  id: number;
+  type: "user" | "group";
+  // "My Library" for the personal library, else the group's name.
+  name: string;
+  // Online group id (groups.groupID); only set for group libraries. This — not
+  // the local libraryID — is what zotero:// URIs for group items must use.
+  groupID?: number;
+}
+
+export const USER_LIBRARY_NAME = "My Library";
+
+// Build the zotero:// URI that selects an item in Zotero. Group items require
+// the /groups/<groupID>/ form; everything else (personal library, or a cache
+// built before group support) uses /library/. See Zotero's documented scheme:
+//   zotero://select/library/items/<itemKey>
+//   zotero://select/groups/<groupID>/items/<itemKey>
+export function zoteroSelectUri(item: RefData): string {
+  if (item.libraryType === "group" && item.groupID) {
+    return `zotero://select/groups/${item.groupID}/items/${item.key}`;
+  }
+  return `zotero://select/library/items/${item.key}`;
+}
+
+// Build the zotero:// URI that opens an attachment PDF. open-pdf does not accept
+// the "<libraryID>_<key>" shorthand, so group attachments must use the explicit
+// /groups/<groupID>/ path — this is the bug that stopped group PDFs opening.
+//   zotero://open-pdf/library/items/<attachmentKey>
+//   zotero://open-pdf/groups/<groupID>/items/<attachmentKey>
+export function zoteroOpenPdfUri(item: RefData, attachmentKey: string): string {
+  if (item.libraryType === "group" && item.groupID) {
+    return `zotero://open-pdf/groups/${item.groupID}/items/${attachmentKey}`;
+  }
+  return `zotero://open-pdf/library/items/${attachmentKey}`;
+}

--- a/extensions/zotero/src/common/search.test.ts
+++ b/extensions/zotero/src/common/search.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import { parseQuery, rankResults } from "./search";
+import type { RefData } from "./zoteroApi";
+
+const item = (over: Partial<RefData>): RefData => ({
+  id: Math.floor(Math.random() * 1e9),
+  key: Math.random().toString(36).slice(2),
+  added: new Date("2020-01-01"),
+  ...over,
+});
+
+describe("parseQuery", () => {
+  it("splits plain terms", () => {
+    expect(parseQuery("quantum simulation")).toEqual({
+      terms: ["quantum", "simulation"],
+      tags: [],
+    });
+  });
+
+  it("extracts .tag tokens", () => {
+    expect(parseQuery("hello .physics world")).toEqual({
+      terms: ["hello", "world"],
+      tags: ["physics"],
+    });
+  });
+
+  it("treats + as space inside a term/tag", () => {
+    expect(parseQuery(".machine+learning")).toEqual({
+      terms: [],
+      tags: ["machine learning"],
+    });
+  });
+
+  it("ignores empty/whitespace", () => {
+    expect(parseQuery("   ")).toEqual({ terms: [], tags: [] });
+  });
+});
+
+describe("rankResults", () => {
+  it("empty query returns most-recent first, capped", () => {
+    const old = item({ title: "Old", added: new Date("2019-01-01") });
+    const mid = item({ title: "Mid", added: new Date("2020-06-01") });
+    const recent = item({ title: "Recent", added: new Date("2022-01-01") });
+    const out = rankResults([old, recent, mid], "", { limit: 2 });
+    expect(out.map((i) => i.title)).toEqual(["Recent", "Mid"]);
+  });
+
+  it("matches a subsequence in the title", () => {
+    const a = item({ title: "Quantum Simulation of Lattice Gauge Theories" });
+    const b = item({ title: "A Study of Marine Biology" });
+    const out = rankResults([a, b], "qsim", {});
+    expect(out[0].title).toBe("Quantum Simulation of Lattice Gauge Theories");
+  });
+
+  it("ranks a title hit above an abstract-only hit", () => {
+    const titleHit = item({ title: "Entanglement Entropy", abstractNote: "unrelated" });
+    const abstractHit = item({ title: "Unrelated", abstractNote: "we discuss entanglement entropy at length" });
+    const out = rankResults([abstractHit, titleHit], "entanglement", {});
+    expect(out[0].title).toBe("Entanglement Entropy");
+  });
+
+  it("requires every term to match (AND)", () => {
+    const both = item({ title: "Quantum Error Correction" });
+    const one = item({ title: "Quantum Computing" });
+    const out = rankResults([both, one], "quantum correction", {});
+    expect(out.map((i) => i.title)).toEqual(["Quantum Error Correction"]);
+  });
+
+  it("filters by .tag token", () => {
+    const tagged = item({ title: "Paper A", tags: ["topology"] });
+    const untagged = item({ title: "Paper B", tags: ["biology"] });
+    const out = rankResults([tagged, untagged], ".topology", {});
+    expect(out.map((i) => i.title)).toEqual(["Paper A"]);
+  });
+
+  it("matches a bibtex citekey when bibtexSearch is enabled", () => {
+    const target = item({ title: "Some Paper", citekey: "smith2020quantum" });
+    const other = item({ title: "Another Paper", citekey: "jones2019bio" });
+    const out = rankResults([target, other], "smith2020quantum", { bibtexSearch: true });
+    expect(out[0].title).toBe("Some Paper");
+  });
+
+  it("does not match citekey when bibtexSearch is disabled", () => {
+    const target = item({ title: "Some Paper", citekey: "smith2020quantum" });
+    const out = rankResults([target], "smith2020quantum", { bibtexSearch: false });
+    expect(out).toHaveLength(0);
+  });
+
+  it("matches a citekey case-insensitively", () => {
+    // Real keys look like "Omran2015"; users often type lowercase.
+    const target = item({ title: "Pauli Blocking", citekey: "Omran2015" });
+    const out = rankResults([target], "omran2015", { bibtexSearch: true });
+    expect(out[0].title).toBe("Pauli Blocking");
+  });
+
+  it("matches a partial/fuzzy citekey subsequence", () => {
+    const target = item({ title: "Tangent-space methods", citekey: "Vanderstraeten2019" });
+    const other = item({ title: "Something else", citekey: "Haegeman2013" });
+    const out = rankResults([target, other], "vander2019", { bibtexSearch: true });
+    expect(out[0].title).toBe("Tangent-space methods");
+  });
+
+  it("ranks a citekey hit above a paper that merely mentions the key text in its title", () => {
+    const keyHit = item({ title: "Unrelated Title", citekey: "Peotta2015" });
+    const titleMention = item({ title: "A comment on Peotta2015 and flat bands", citekey: "other1999" });
+    const out = rankResults([titleMention, keyHit], "Peotta2015", { bibtexSearch: true });
+    expect(out[0].title).toBe("Unrelated Title");
+  });
+
+  it("dedupes items sharing a key (no doubles)", () => {
+    const a = item({ key: "SAMEKEY", title: "Dup", collection: ["A", "B"] });
+    const b = { ...a };
+    const out = rankResults([a, b], "", {});
+    expect(out.filter((i) => i.key === "SAMEKEY")).toHaveLength(1);
+  });
+
+  it("matches a whole-word term inside a long abstract (substring, not subsequence)", () => {
+    const hit = item({ title: "Unrelated", abstractNote: "a long discussion of superconductivity and more" });
+    const out = rankResults([hit], "superconductivity", {});
+    expect(out).toHaveLength(1);
+  });
+
+  it("does not fuzzy-subsequence-match scattered letters across a long abstract", () => {
+    // 'xzqj' appears only as scattered letters; must NOT match (would be noise
+    // and, when run over every item's abstract, the source of the OOM).
+    const noise = item({ title: "Plain Title", abstractNote: "the quick brown fox jumps over the lazy zebra" });
+    const out = rankResults([noise], "xzqj", {});
+    expect(out).toHaveLength(0);
+  });
+
+  it("restricts to an allowed-collections set when provided", () => {
+    const inScope = item({ title: "Keep", collection: ["Physics"] });
+    const outScope = item({ title: "Drop", collection: ["Cooking"] });
+    const out = rankResults([inScope, outScope], "", { collections: ["Physics"] });
+    expect(out.map((i) => i.title)).toEqual(["Keep"]);
+  });
+
+  it("restricts to an allowed-libraries set when provided (personal-only default)", () => {
+    const personal = item({ title: "Mine", library: 1 });
+    const group = item({ title: "Group", library: 2 });
+    const out = rankResults([personal, group], "", { libraries: [1] });
+    expect(out.map((i) => i.title)).toEqual(["Mine"]);
+  });
+
+  it("includes a selected group library alongside the personal one", () => {
+    const personal = item({ title: "Mine", library: 1 });
+    const group = item({ title: "Group", library: 2 });
+    const other = item({ title: "OtherGroup", library: 3 });
+    const out = rankResults([personal, group, other], "", { libraries: [1, 2] });
+    expect(out.map((i) => i.title).sort()).toEqual(["Group", "Mine"]);
+  });
+});

--- a/extensions/zotero/src/common/search.test.ts
+++ b/extensions/zotero/src/common/search.test.ts
@@ -123,6 +123,13 @@ describe("rankResults", () => {
     expect(out.map((i) => i.title).sort()).toEqual(["Group", "Personal"]);
   });
 
+  it("keeps two items that share a key when the database id is missing", () => {
+    const personal = item({ id: undefined, key: "SAMEKEY", library: 1, title: "Personal" });
+    const group = item({ id: undefined, key: "SAMEKEY", library: 2, title: "Group" });
+    const out = rankResults([personal, group], "", {});
+    expect(out.map((i) => i.title).sort()).toEqual(["Group", "Personal"]);
+  });
+
   it("matches a whole-word term inside a long abstract (substring, not subsequence)", () => {
     const hit = item({ title: "Unrelated", abstractNote: "a long discussion of superconductivity and more" });
     const out = rankResults([hit], "superconductivity", {});
@@ -149,6 +156,13 @@ describe("rankResults", () => {
     const a = item({ title: "A", collectionKeys: ["PAPERS_A"] });
     const b = item({ title: "B", collectionKeys: ["PAPERS_B"] });
     const out = rankResults([a, b], "", { collections: ["PAPERS_A"] });
+    expect(out.map((i) => i.title)).toEqual(["A"]);
+  });
+
+  it("does not conflate collections that share a key across libraries", () => {
+    const a = item({ title: "A", collectionKeys: ["1:SAMEKEY"] });
+    const b = item({ title: "B", collectionKeys: ["2:SAMEKEY"] });
+    const out = rankResults([a, b], "", { collections: ["1:SAMEKEY"] });
     expect(out.map((i) => i.title)).toEqual(["A"]);
   });
 

--- a/extensions/zotero/src/common/search.test.ts
+++ b/extensions/zotero/src/common/search.test.ts
@@ -107,11 +107,20 @@ describe("rankResults", () => {
     expect(out[0].title).toBe("Unrelated Title");
   });
 
-  it("dedupes items sharing a key (no doubles)", () => {
-    const a = item({ key: "SAMEKEY", title: "Dup", collection: ["A", "B"] });
+  it("dedupes the same item (same id) appearing twice", () => {
+    const a = item({ id: 42, key: "SAMEKEY", title: "Dup" });
     const b = { ...a };
     const out = rankResults([a, b], "", {});
-    expect(out.filter((i) => i.key === "SAMEKEY")).toHaveLength(1);
+    expect(out.filter((i) => i.id === 42)).toHaveLength(1);
+  });
+
+  it("keeps two distinct items that share a Zotero key across libraries", () => {
+    // Zotero item keys are unique only within a library, so a personal item and
+    // a group item can share a key while being different papers.
+    const personal = item({ id: 10, key: "SAMEKEY", library: 1, title: "Personal" });
+    const group = item({ id: 20, key: "SAMEKEY", library: 2, title: "Group" });
+    const out = rankResults([personal, group], "", {});
+    expect(out.map((i) => i.title).sort()).toEqual(["Group", "Personal"]);
   });
 
   it("matches a whole-word term inside a long abstract (substring, not subsequence)", () => {
@@ -128,11 +137,19 @@ describe("rankResults", () => {
     expect(out).toHaveLength(0);
   });
 
-  it("restricts to an allowed-collections set when provided", () => {
-    const inScope = item({ title: "Keep", collection: ["Physics"] });
-    const outScope = item({ title: "Drop", collection: ["Cooking"] });
-    const out = rankResults([inScope, outScope], "", { collections: ["Physics"] });
+  it("restricts to an allowed-collections set by collection key", () => {
+    const inScope = item({ title: "Keep", collectionKeys: ["PHYSKEY"] });
+    const outScope = item({ title: "Drop", collectionKeys: ["COOKKEY"] });
+    const out = rankResults([inScope, outScope], "", { collections: ["PHYSKEY"] });
     expect(out.map((i) => i.title)).toEqual(["Keep"]);
+  });
+
+  it("does not conflate distinct collections that share a name (filters by key)", () => {
+    // Two collections named "Papers" in different libraries have different keys.
+    const a = item({ title: "A", collectionKeys: ["PAPERS_A"] });
+    const b = item({ title: "B", collectionKeys: ["PAPERS_B"] });
+    const out = rankResults([a, b], "", { collections: ["PAPERS_A"] });
+    expect(out.map((i) => i.title)).toEqual(["A"]);
   });
 
   it("restricts to an allowed-libraries set when provided (personal-only default)", () => {

--- a/extensions/zotero/src/common/search.ts
+++ b/extensions/zotero/src/common/search.ts
@@ -28,7 +28,8 @@ export function parseQuery(q: string): ParsedQuery {
 export interface RankOptions {
   // Include the Better BibTeX citekey as a (highest-weight) search field.
   bibtexSearch?: boolean;
-  // If provided, keep only items belonging to at least one of these collections.
+  // If provided, keep only items belonging to at least one of these collections,
+  // identified by collection key.
   collections?: string[];
   // If provided, keep only items whose libraryID is in this set. Used to scope
   // search to the personal library (default) plus any opted-in group libraries.
@@ -113,8 +114,10 @@ function recency(item: RefData): number {
 }
 
 function inCollections(item: RefData, allowed: Set<string>): boolean {
-  if (!item.collection || item.collection.length === 0) return false;
-  return item.collection.some((c) => allowed.has(c));
+  // Filter on collection keys, not names: distinct collections can share a name
+  // but never a key, so this never conflates same-named collections.
+  if (!item.collectionKeys || item.collectionKeys.length === 0) return false;
+  return item.collectionKeys.some((k) => allowed.has(k));
 }
 
 // Rank items against a query. Pure: no Raycast / DB access, so it is the tested
@@ -124,10 +127,12 @@ export function rankResults(items: RefData[], query: string, opts: RankOptions =
   const limit = opts.limit ?? DEFAULT_LIMIT;
   const threshold = opts.threshold ?? DEFAULT_THRESHOLD;
 
-  // Dedupe by key up front so a doubled row can never reach the UI.
+  // Dedupe by the globally-unique item id (items.itemID). Zotero item *keys* are
+  // unique only within a library, so a personal item and a group item can share
+  // a key while being different papers; keying dedupe on the id keeps both.
   const seen = new Set<string>();
   let pool = items.filter((it) => {
-    const k = it.key ?? String(it.id);
+    const k = it.id != null ? `id:${it.id}` : `${it.library ?? "?"}:${it.key}`;
     if (seen.has(k)) return false;
     seen.add(k);
     return true;

--- a/extensions/zotero/src/common/search.ts
+++ b/extensions/zotero/src/common/search.ts
@@ -1,4 +1,5 @@
 import fuzzysort from "fuzzysort";
+import { itemIdentity } from "./library";
 import type { RefData } from "./zoteroApi";
 
 export interface ParsedQuery {
@@ -29,7 +30,7 @@ export interface RankOptions {
   // Include the Better BibTeX citekey as a (highest-weight) search field.
   bibtexSearch?: boolean;
   // If provided, keep only items belonging to at least one of these collections,
-  // identified by collection key.
+  // identified by library-qualified collection id (`collectionId`).
   collections?: string[];
   // If provided, keep only items whose libraryID is in this set. Used to scope
   // search to the personal library (default) plus any opted-in group libraries.
@@ -114,25 +115,25 @@ function recency(item: RefData): number {
 }
 
 function inCollections(item: RefData, allowed: Set<string>): boolean {
-  // Filter on collection keys, not names: distinct collections can share a name
-  // but never a key, so this never conflates same-named collections.
+  // Filter on library-qualified collection ids, not names or bare keys: distinct
+  // collections can share a name or a key across libraries, so only
+  // `collectionId(library, key)` keeps them independent.
   if (!item.collectionKeys || item.collectionKeys.length === 0) return false;
   return item.collectionKeys.some((k) => allowed.has(k));
 }
 
 // Rank items against a query. Pure: no Raycast / DB access, so it is the tested
 // seam. Empty query -> most-recent first. Non-empty -> relevance-ranked with
-// AND semantics across terms and exact-ish tag filters. Always deduped by key.
+// AND semantics across terms and exact-ish tag filters. Always deduped by the
+// globally unique item identity so personal and group items that share a
+// Zotero key both survive.
 export function rankResults(items: RefData[], query: string, opts: RankOptions = {}): RefData[] {
   const limit = opts.limit ?? DEFAULT_LIMIT;
   const threshold = opts.threshold ?? DEFAULT_THRESHOLD;
 
-  // Dedupe by the globally-unique item id (items.itemID). Zotero item *keys* are
-  // unique only within a library, so a personal item and a group item can share
-  // a key while being different papers; keying dedupe on the id keeps both.
   const seen = new Set<string>();
   let pool = items.filter((it) => {
-    const k = it.id != null ? `id:${it.id}` : `${it.library ?? "?"}:${it.key}`;
+    const k = itemIdentity(it);
     if (seen.has(k)) return false;
     seen.add(k);
     return true;

--- a/extensions/zotero/src/common/search.ts
+++ b/extensions/zotero/src/common/search.ts
@@ -1,0 +1,182 @@
+import fuzzysort from "fuzzysort";
+import type { RefData } from "./zoteroApi";
+
+export interface ParsedQuery {
+  terms: string[];
+  tags: string[];
+}
+
+// A query is a space-separated list of terms. A token starting with "." is a
+// tag filter (".topology"); everything else is a fuzzy term. "+" stands in for a
+// space inside a single token so multi-word tags/terms survive the split.
+export function parseQuery(q: string): ParsedQuery {
+  const tokens = q.split(/\s+/).filter(Boolean);
+  const terms: string[] = [];
+  const tags: string[] = [];
+  for (const tok of tokens) {
+    if (tok.startsWith(".")) {
+      const t = tok.slice(1).replace(/\+/g, " ").trim();
+      if (t) tags.push(t);
+    } else {
+      const t = tok.replace(/\+/g, " ").trim();
+      if (t) terms.push(t);
+    }
+  }
+  return { terms, tags };
+}
+
+export interface RankOptions {
+  // Include the Better BibTeX citekey as a (highest-weight) search field.
+  bibtexSearch?: boolean;
+  // If provided, keep only items belonging to at least one of these collections.
+  collections?: string[];
+  // If provided, keep only items whose libraryID is in this set. Used to scope
+  // search to the personal library (default) plus any opted-in group libraries.
+  libraries?: number[];
+  // Max results to return (default 100).
+  limit?: number;
+  // Per-term score floor; a term scoring below this against every field is
+  // treated as "no match" so scattered-subsequence noise doesn't leak in.
+  threshold?: number;
+}
+
+const DEFAULT_LIMIT = 100;
+// fuzzysort score: 1 = perfect, 0 = none. Require at least a weak real match.
+const DEFAULT_THRESHOLD = 0.2;
+
+interface Field {
+  key: string;
+  weight: number;
+  array?: boolean;
+  bibtexOnly?: boolean;
+  // Long free-text fields are matched with a cheap case-insensitive substring
+  // test instead of fuzzysort. fuzzysort.single() caches every target string it
+  // sees in a module-level Map that is never cleared, and allocates typed
+  // arrays proportional to the target length; running it over every item's
+  // abstract/notes on each keystroke grows the heap until the Raycast worker is
+  // killed ("Worker terminated due to reaching memory limit"). Substring
+  // matching allocates nothing persistent and is the right semantics for long
+  // prose anyway (scattered-letter subsequence hits in an abstract are noise).
+  substring?: boolean;
+}
+
+// Weights are relative; higher wins ties across fields. citekey is highest so a
+// typed bibtex key beats an incidental substring elsewhere.
+const FIELDS: Field[] = [
+  { key: "citekey", weight: 1.0, bibtexOnly: true },
+  { key: "title", weight: 0.9 },
+  { key: "tags", weight: 0.7, array: true },
+  { key: "creators", weight: 0.6, array: true },
+  { key: "DOI", weight: 0.6 },
+  { key: "collection", weight: 0.5, array: true },
+  { key: "abstractNote", weight: 0.35, substring: true },
+  { key: "date", weight: 0.3 },
+  { key: "notes", weight: 0.3, array: true, substring: true },
+];
+
+function fieldText(item: RefData, f: Field): string {
+  const v = item[f.key];
+  if (v == null) return "";
+  if (f.array) return Array.isArray(v) ? v.join(" ") : String(v);
+  return String(v);
+}
+
+// A contiguous substring hit in a long field is a strong signal, so score it as
+// a (near) perfect match before weighting.
+const SUBSTRING_MATCH_SCORE = 1.0;
+
+// Best weighted score of a single term across all searchable fields (0 = no
+// field matched above threshold).
+function termScore(item: RefData, term: string, opts: RankOptions): number {
+  let best = 0;
+  const lowerTerm = term.toLowerCase();
+  for (const f of FIELDS) {
+    if (f.bibtexOnly && !opts.bibtexSearch) continue;
+    const text = fieldText(item, f);
+    if (!text) continue;
+    if (f.substring) {
+      if (text.toLowerCase().includes(lowerTerm)) {
+        best = Math.max(best, SUBSTRING_MATCH_SCORE * f.weight);
+      }
+      continue;
+    }
+    const r = fuzzysort.single(term, text);
+    if (!r || r.score <= 0) continue;
+    best = Math.max(best, r.score * f.weight);
+  }
+  return best;
+}
+
+function recency(item: RefData): number {
+  const t = item.added ? new Date(item.added as unknown as string).getTime() : 0;
+  return Number.isNaN(t) ? 0 : t;
+}
+
+function inCollections(item: RefData, allowed: Set<string>): boolean {
+  if (!item.collection || item.collection.length === 0) return false;
+  return item.collection.some((c) => allowed.has(c));
+}
+
+// Rank items against a query. Pure: no Raycast / DB access, so it is the tested
+// seam. Empty query -> most-recent first. Non-empty -> relevance-ranked with
+// AND semantics across terms and exact-ish tag filters. Always deduped by key.
+export function rankResults(items: RefData[], query: string, opts: RankOptions = {}): RefData[] {
+  const limit = opts.limit ?? DEFAULT_LIMIT;
+  const threshold = opts.threshold ?? DEFAULT_THRESHOLD;
+
+  // Dedupe by key up front so a doubled row can never reach the UI.
+  const seen = new Set<string>();
+  let pool = items.filter((it) => {
+    const k = it.key ?? String(it.id);
+    if (seen.has(k)) return false;
+    seen.add(k);
+    return true;
+  });
+
+  if (opts.collections && opts.collections.length > 0) {
+    const allowed = new Set(opts.collections);
+    pool = pool.filter((it) => inCollections(it, allowed));
+  }
+
+  if (opts.libraries) {
+    const allowed = new Set(opts.libraries);
+    pool = pool.filter((it) => it.library != null && allowed.has(it.library));
+  }
+
+  const { terms, tags } = parseQuery(query);
+
+  // Tag tokens are substring filters (matches Zotero's own tag semantics).
+  if (tags.length > 0) {
+    const lowered = tags.map((t) => t.toLowerCase());
+    pool = pool.filter((it) => {
+      const itemTags = (it.tags ?? []).map((t) => t.toLowerCase());
+      return lowered.every((needle) => itemTags.some((t) => t.includes(needle)));
+    });
+  }
+
+  if (terms.length === 0) {
+    return pool.sort((a, b) => recency(b) - recency(a)).slice(0, limit);
+  }
+
+  const scored: { item: RefData; score: number }[] = [];
+  for (const it of pool) {
+    let total = 0;
+    let matchedAll = true;
+    for (const term of terms) {
+      const s = termScore(it, term, opts);
+      if (s < threshold) {
+        matchedAll = false;
+        break;
+      }
+      total += s;
+    }
+    if (matchedAll) scored.push({ item: it, score: total });
+  }
+
+  // Drop fuzzysort's prepared-target cache so the short-field targets prepared
+  // during this search don't accumulate across keystrokes.
+  fuzzysort.cleanup();
+
+  scored.sort((a, b) => b.score - a.score || recency(b.item) - recency(a.item));
+  return scored.slice(0, limit).map((s) => s.item);
+}

--- a/extensions/zotero/src/common/store.ts
+++ b/extensions/zotero/src/common/store.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { showToast, Toast } from "@raycast/api";
 import { RefData } from "./zoteroApi";
 
@@ -14,6 +14,12 @@ export const useStore = (
   queryFunc: (section: string, q?: string) => Promise<RefData[]>,
   initialLoading?: boolean,
 ): Store => {
+  // Monotonic id of the most recently started query. Searches are async and can
+  // overlap (fast typing, a collection change, or a group-libraries change all
+  // trigger runQuery), so an older search may resolve after a newer one. Only
+  // the latest query is allowed to commit its results or clear the loading
+  // flag; stale responses are dropped.
+  const latestRef = useRef(0);
   const [store, setStore] = useState(() => ({
     queryResults: Array(sections.length).fill([]),
     queryIsLoading: !!initialLoading,
@@ -21,11 +27,14 @@ export const useStore = (
       setStore((prev) => ({ ...prev, queryResults: Array(sections.length).fill([]) }));
     },
     runQuery: async (q?: string) => {
+      const queryId = ++latestRef.current;
       setStore((prev) => ({ ...prev, queryIsLoading: true }));
       try {
         const queryResults = await Promise.all(sections.map((section) => queryFunc(section, q)));
+        if (queryId !== latestRef.current) return; // a newer query superseded this one
         setStore((prev) => ({ ...prev, queryResults }));
       } catch (e) {
+        if (queryId !== latestRef.current) return;
         console.log("runQuery error", e);
         showToast({
           style: Toast.Style.Failure,
@@ -33,7 +42,11 @@ export const useStore = (
           message: String(e),
         });
       } finally {
-        setStore((prev) => ({ ...prev, queryIsLoading: false }));
+        // Only the latest query owns the loading flag; a stale one finishing must
+        // not turn the spinner off while a newer query is still in flight.
+        if (queryId === latestRef.current) {
+          setStore((prev) => ({ ...prev, queryIsLoading: false }));
+        }
       }
     },
   }));

--- a/extensions/zotero/src/common/zoteroApi.ts
+++ b/extensions/zotero/src/common/zoteroApi.ts
@@ -48,9 +48,9 @@ export interface RefData {
   attachment?: Attachment;
   // Human-readable collection names (for display).
   collection?: string[];
-  // Collection keys (globally unique), used for filtering. Distinct collections
-  // that happen to share a name have different keys, so filtering by key never
-  // conflates them.
+  // Library-qualified collection ids (`collectionId(library, key)`), used for
+  // filtering. Distinct collections that share a name or a bare key across
+  // libraries stay independent.
   collectionKeys?: string[];
   [key: string]: any;
 }

--- a/extensions/zotero/src/common/zoteroApi.ts
+++ b/extensions/zotero/src/common/zoteroApi.ts
@@ -3,6 +3,7 @@ import { getPreferenceValues, environment, showToast, Toast, LocalStorage } from
 import type { LibraryRef } from "./library";
 import { USER_LIBRARY_NAME } from "./library";
 import type { CollectionRef } from "./collections";
+import { collectionId } from "./collections";
 import * as utils from "./utils";
 import { existsSync, readFileSync, rmSync } from "fs";
 import { execFileSync } from "child_process";
@@ -179,7 +180,8 @@ SELECT  libraries.libraryID AS id,
 
 const COLLECTIONS_SQL = `
 SELECT  collections.collectionName AS name,
-        collections.key AS key
+        collections.key AS key,
+        collections.libraryID AS library
     FROM collections
     LEFT JOIN collectionItems
         ON collections.collectionID = collectionItems.collectionID
@@ -193,7 +195,7 @@ WHERE itemNotes.parentItemID = :id
 `;
 
 const cachePath = utils.cachePath("zotero.json");
-const CACHE_VERSION = 6;
+const CACHE_VERSION = 7;
 
 // LocalStorage key holding the JSON array of group libraryIDs the user opted
 // into searching. The personal library is always searched; group libraries are
@@ -563,7 +565,9 @@ async function getDataImpl(): Promise<RefData[]> {
     while (st6.step()) {
       const o = st6.getAsObject();
       cltNames.push(o.name);
-      cltKeys.push(o.key);
+      // Qualify by libraryID so collections sharing a key across libraries stay
+      // distinct (see collectionId).
+      cltKeys.push(collectionId(o.library as number, o.key as string));
     }
 
     st6.free();

--- a/extensions/zotero/src/common/zoteroApi.ts
+++ b/extensions/zotero/src/common/zoteroApi.ts
@@ -1,19 +1,28 @@
 import { stat, readFile, writeFile, copyFile, rename } from "fs/promises";
-import { getPreferenceValues, environment, showToast, Toast } from "@raycast/api";
+import { getPreferenceValues, environment, showToast, Toast, LocalStorage } from "@raycast/api";
+import type { LibraryRef } from "./library";
+import { USER_LIBRARY_NAME } from "./library";
 import * as utils from "./utils";
 import { existsSync, readFileSync, rmSync } from "fs";
 import { execFileSync } from "child_process";
-import Fuse from "fuse.js";
+import { rankResults } from "./search";
 import initSqlJs, { Database as SqlJsDatabase } from "sql.js";
 import path = require("path");
 
 export interface Preferences {
   zotero_path: string;
   use_bibtex?: boolean;
+  bibtex_search?: boolean;
   bibtex_path?: string;
   csl_style?: string;
   cache_period?: string;
   quote_pdf_path?: boolean;
+}
+
+// citekey is populated (and thus searchable) when the user either exports
+// BibTeX or explicitly opts into bibtex-key search.
+function bibtexEnabled(p: Preferences): boolean {
+  return !!(p.use_bibtex || p.bibtex_search);
 }
 
 export interface RefData {
@@ -22,6 +31,14 @@ export interface RefData {
   modified?: Date;
   key?: string;
   library?: number;
+  // "user" for the personal library, "group" for a group library. Absent in
+  // caches built before group-library support (treated as personal).
+  libraryType?: "user" | "group";
+  // Online group id (groups.groupID), used to build zotero:// URIs for group
+  // items. Only present for group-library items.
+  groupID?: number;
+  // Human-readable library name ("My Library" or the group's name).
+  libraryName?: string;
   type?: string;
   citekey?: string;
   tags?: string[];
@@ -142,6 +159,16 @@ SELECT DISTINCT collections.collectionName AS name
     FROM collections
 `;
 
+const LIBRARIES_SQL = `
+SELECT  libraries.libraryID AS id,
+        libraries.type AS type,
+        groups.groupID AS groupID,
+        groups.name AS name
+    FROM libraries
+    LEFT JOIN groups
+        ON libraries.libraryID = groups.libraryID
+`;
+
 const COLLECTIONS_SQL = `
 SELECT  collections.collectionName AS name,
         collections.key AS key
@@ -158,7 +185,12 @@ WHERE itemNotes.parentItemID = :id
 `;
 
 const cachePath = utils.cachePath("zotero.json");
-const CACHE_VERSION = 3;
+const CACHE_VERSION = 5;
+
+// LocalStorage key holding the JSON array of group libraryIDs the user opted
+// into searching. The personal library is always searched; group libraries are
+// opt-in (default none) so a paper shared to a group no longer double-lists.
+const INCLUDED_GROUPS_KEY = "included_group_libraries";
 
 export function resolveHome(filepath: string): string {
   if (filepath[0] === "~") {
@@ -203,6 +235,8 @@ const SLIM_TABLES = [
   "collections",
   "collectionItems",
   "itemNotes",
+  "libraries",
+  "groups",
 ];
 
 // CREATE TABLE ... AS SELECT copies rows but not indexes, so re-create the
@@ -343,6 +377,56 @@ async function openBibtexDb(): Promise<[SqlJsDatabase, boolean] | null> {
   return [new SQL.Database(db), isBBTUpdated];
 }
 
+// Read every library (personal + groups) from an open database into a map keyed
+// by local libraryID.
+function readLibraries(db: SqlJsDatabase): Map<number, LibraryRef> {
+  const map = new Map<number, LibraryRef>();
+  const st = db.prepare(LIBRARIES_SQL);
+  while (st.step()) {
+    const row = st.getAsObject();
+    const id = row.id as number;
+    const isGroup = row.type === "group";
+    map.set(id, {
+      id,
+      type: isGroup ? "group" : "user",
+      name: isGroup ? (row.name as string) ?? `Group ${row.groupID ?? id}` : USER_LIBRARY_NAME,
+      groupID: isGroup ? (row.groupID as number) : undefined,
+    });
+  }
+  st.free();
+  return map;
+}
+
+// All libraries (personal + groups) in the database. Used by the UI to offer the
+// group libraries the user can opt into searching.
+export const getLibraries = async (): Promise<LibraryRef[]> => {
+  const db = await openDb();
+  const libs = [...readLibraries(db).values()];
+  db.close();
+  return libs;
+};
+
+export const getGroupLibraries = async (): Promise<LibraryRef[]> => {
+  return (await getLibraries()).filter((l) => l.type === "group");
+};
+
+// The set of group libraryIDs the user opted into searching (personal library is
+// always included; groups default to none).
+export const getIncludedGroupLibraries = async (): Promise<number[]> => {
+  const raw = await LocalStorage.getItem<string>(INCLUDED_GROUPS_KEY);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.map(Number).filter((n) => !Number.isNaN(n)) : [];
+  } catch {
+    return [];
+  }
+};
+
+export const setIncludedGroupLibraries = async (ids: number[]): Promise<void> => {
+  await LocalStorage.setItem(INCLUDED_GROUPS_KEY, JSON.stringify(ids));
+};
+
 export const getCollections = async (): Promise<string[]> => {
   const db = await openDb();
   const st = db.prepare(ALL_COLLECTIONS_SQL);
@@ -378,6 +462,7 @@ function getData(): Promise<RefData[]> {
 async function getDataImpl(): Promise<RefData[]> {
   const db = await openDb();
   const preferences: Preferences = getPreferenceValues();
+  const libraries = readLibraries(db);
 
   const st = db.prepare(INVALID_TYPES_SQL);
   const invalid_ids = [];
@@ -475,8 +560,17 @@ async function getDataImpl(): Promise<RefData[]> {
       row.collection = clt;
     }
 
-    if (preferences.use_bibtex) {
+    if (bibtexEnabled(preferences)) {
       row.citekey = row.citationKey || (await getBibtexKey(row.key, row.library));
+    }
+
+    const lib = libraries.get(row.library as number);
+    if (lib) {
+      row.libraryType = lib.type;
+      row.libraryName = lib.name;
+      if (lib.groupID != null) {
+        row.groupID = lib.groupID;
+      }
     }
 
     rows.push(row);
@@ -488,24 +582,6 @@ async function getDataImpl(): Promise<RefData[]> {
   return rows;
 }
 
-const parseQuery = (q: string) => {
-  const queryItems = q.split(" ");
-  const qs = queryItems.filter((c) => !c.startsWith("."));
-  const ts = queryItems.filter((c) => c.startsWith("."));
-
-  let qss = "";
-  if (qs.length > 0) {
-    qss = qs.join(" ");
-  }
-
-  let tss = [];
-  if (ts.length > 0) {
-    tss = ts.map((x) => x.substring(1));
-  }
-
-  return { qss, tss };
-};
-
 // Cap how many results are rendered at once. Raycast renders every List item
 // with a full detail markdown and ~15-20 actions; rendering the whole library
 // (empty query) or a broad-query result of hundreds/thousands grows the
@@ -514,7 +590,7 @@ const parseQuery = (q: string) => {
 // 100 is far more than a user scans and keeps the render footprint bounded.
 export const MAX_RENDER_RESULTS = 100;
 
-export const searchResources = async (q: string): Promise<RefData[]> => {
+export const searchResources = async (q: string, collection?: string): Promise<RefData[]> => {
   const preferences: Preferences = getPreferenceValues();
 
   async function updateCache(): Promise<RefData[]> {
@@ -531,6 +607,7 @@ export const searchResources = async (q: string): Promise<RefData[]> => {
         version: CACHE_VERSION,
         zotero_path: preferences.zotero_path,
         use_bibtex: preferences.use_bibtex,
+        bibtex_search: preferences.bibtex_search,
         data: data,
       };
       try {
@@ -570,7 +647,8 @@ export const searchResources = async (q: string): Promise<RefData[]> => {
         if (
           fData.version === CACHE_VERSION &&
           fData.zotero_path === preferences.zotero_path &&
-          fData.use_bibtex === preferences.use_bibtex
+          fData.use_bibtex === preferences.use_bibtex &&
+          fData.bibtex_search === preferences.bibtex_search
         ) {
           return fData.data;
         } else {
@@ -608,73 +686,27 @@ export const searchResources = async (q: string): Promise<RefData[]> => {
     return ret;
   }
 
-  ret.sort(function (a, b) {
-    return +new Date(b.added) - +new Date(a.added);
+  // Collection scoping happens here (before the render cap) so choosing a
+  // collection narrows the whole library, not just the first MAX_RENDER_RESULTS
+  // rows a broad query already surfaced.
+  const collections = collection && collection !== "All" ? [collection] : undefined;
+
+  // Library scoping: always search the personal library; add only the group
+  // libraries the user opted into. This is what keeps a paper shared to a group
+  // from double-listing by default.
+  const includedGroups = new Set(await getIncludedGroupLibraries());
+  const allowedLibraries = new Set<number>();
+  for (const it of ret) {
+    if (it.library == null) continue;
+    if (it.libraryType !== "group" || includedGroups.has(it.library)) {
+      allowedLibraries.add(it.library);
+    }
+  }
+
+  return rankResults(ret, q, {
+    bibtexSearch: !!preferences.bibtex_search,
+    collections,
+    libraries: [...allowedLibraries],
+    limit: MAX_RENDER_RESULTS,
   });
-
-  const { qss, tss } = parseQuery(q);
-
-  if (!qss.trim() && tss.length < 1) {
-    return ret.slice(0, MAX_RENDER_RESULTS);
-  }
-
-  const options = {
-    isCaseSensitive: false,
-    includeScore: false,
-    shouldSort: true,
-    includeMatches: false,
-    findAllMatches: true,
-    minMatchCharLength: 3,
-    threshold: 0.1,
-    ignoreLocation: true,
-    keys: [
-      {
-        name: "title",
-        weight: 10,
-      },
-      {
-        name: "abstractNote",
-        weight: 5,
-      },
-      {
-        name: "notes",
-        weight: 6,
-      },
-      {
-        name: "tags",
-        weight: 15,
-      },
-      {
-        name: "date",
-        weight: 3,
-      },
-      {
-        name: "creators",
-        weight: 4,
-      },
-      {
-        name: "DOI",
-        weight: 10,
-      },
-    ],
-  };
-
-  const query: Fuse.Expression = {
-    $and: qss
-      .split(" ")
-      .map((k) => k.trim())
-      .filter(Boolean)
-      .map((z) => ({
-        $or: options.keys.map((x) => Object.fromEntries(new Map([[x.name, z.replace(/\+/gi, " ")]]))),
-      })),
-  };
-
-  if (tss.length > 0) {
-    query["$and"].push({ $and: tss.map((x) => ({ tags: x.replace(/\+/gi, " ") })) });
-  }
-
-  return new Fuse(ret, options)
-    .search(query)
-    .slice(0, MAX_RENDER_RESULTS)
-    .map((x) => x.item);
 };

--- a/extensions/zotero/src/common/zoteroApi.ts
+++ b/extensions/zotero/src/common/zoteroApi.ts
@@ -2,6 +2,7 @@ import { stat, readFile, writeFile, copyFile, rename } from "fs/promises";
 import { getPreferenceValues, environment, showToast, Toast, LocalStorage } from "@raycast/api";
 import type { LibraryRef } from "./library";
 import { USER_LIBRARY_NAME } from "./library";
+import type { CollectionRef } from "./collections";
 import * as utils from "./utils";
 import { existsSync, readFileSync, rmSync } from "fs";
 import { execFileSync } from "child_process";
@@ -44,7 +45,12 @@ export interface RefData {
   tags?: string[];
   notes?: string[];
   attachment?: Attachment;
+  // Human-readable collection names (for display).
   collection?: string[];
+  // Collection keys (globally unique), used for filtering. Distinct collections
+  // that happen to share a name have different keys, so filtering by key never
+  // conflates them.
+  collectionKeys?: string[];
   [key: string]: any;
 }
 
@@ -155,7 +161,9 @@ ORDER BY "index" ASC
 `;
 
 const ALL_COLLECTIONS_SQL = `
-SELECT DISTINCT collections.collectionName AS name
+SELECT  collections.collectionName AS name,
+        collections.key AS key,
+        collections.libraryID AS library
     FROM collections
 `;
 
@@ -185,7 +193,7 @@ WHERE itemNotes.parentItemID = :id
 `;
 
 const cachePath = utils.cachePath("zotero.json");
-const CACHE_VERSION = 5;
+const CACHE_VERSION = 6;
 
 // LocalStorage key holding the JSON array of group libraryIDs the user opted
 // into searching. The personal library is always searched; group libraries are
@@ -427,12 +435,13 @@ export const setIncludedGroupLibraries = async (ids: number[]): Promise<void> =>
   await LocalStorage.setItem(INCLUDED_GROUPS_KEY, JSON.stringify(ids));
 };
 
-export const getCollections = async (): Promise<string[]> => {
+export const getCollections = async (): Promise<CollectionRef[]> => {
   const db = await openDb();
   const st = db.prepare(ALL_COLLECTIONS_SQL);
-  const cols = [];
+  const cols: CollectionRef[] = [];
   while (st.step()) {
-    cols.push(st.getAsObject().name);
+    const r = st.getAsObject();
+    cols.push({ key: r.key as string, name: r.name as string, library: r.library as number });
   }
   st.free();
   db.close();
@@ -549,15 +558,19 @@ async function getDataImpl(): Promise<RefData[]> {
     const st6 = db.prepare(COLLECTIONS_SQL);
     st6.bind({ ":id": row.id });
 
-    const clt = [];
+    const cltNames = [];
+    const cltKeys = [];
     while (st6.step()) {
-      clt.push(st6.getAsObject().name);
+      const o = st6.getAsObject();
+      cltNames.push(o.name);
+      cltKeys.push(o.key);
     }
 
     st6.free();
 
-    if (clt.length > 0) {
-      row.collection = clt;
+    if (cltNames.length > 0) {
+      row.collection = cltNames;
+      row.collectionKeys = cltKeys;
     }
 
     if (bibtexEnabled(preferences)) {


### PR DESCRIPTION
## Description

This updates the existing **Zotero** extension (`extensions/zotero`) with a better search experience and support for group libraries.

**Fuzzy search.** The old matcher used Fuse.js tuned to near-exact matching, so partial or out-of-order queries returned nothing. Search now uses a subsequence fuzzy finder (fuzzysort): typing `qsim` finds "Quantum Simulation". Results are ranked by how well they match, and an empty query shows the most recent items. The ranking logic lives in a small pure module (`src/common/search.ts`) so it can be tested directly.

**Memory.** Matching every item's abstract and notes with fuzzysort on each keystroke grew the heap until the Raycast worker was killed on large libraries ("Worker terminated due to reaching memory limit"). Long free-text fields now use a substring test instead, and fuzzysort's cache is cleared after each search. A load test over 20k items and hundreds of searches shows no heap growth.

**BibTeX-key search.** A new "Search by BibTeX Citation Key" preference lets you type a citation key (for example `smith2020quantum`) and get its item.

**Collections.** Selecting a collection now filters the whole library before the 100-item render cap, instead of filtering only the first 100 results. Items are also deduped, so an entry in two collections shows once.

**Group libraries.** Only the personal library is searched by default, so a paper shared to a group no longer appears twice. A new "Configure Group Libraries" action (`⌘L`) lets you pick which groups to include. Group items also open correctly now: the `zotero://` select and open-PDF links use the `/groups/<groupID>/` path for group items, so pressing Enter opens them instead of doing nothing.

## Testing

Added vitest with 25 tests covering ranking, BibTeX-key matching, collection and library filtering, dedupe, and the `zotero://` URI builders. Run with `npm test`. `ray build` and `ray lint` both pass.

### Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that assets used by the extension are updated in `metadata`
- [x] I updated the `CHANGELOG.md` with a new entry using the `{PR_MERGE_DATE}` placeholder
