### PR TITLE
Update super-productivity extension

### DIFF
--- a/extensions/super-productivity/CHANGELOG.md
+++ b/extensions/super-productivity/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Make Access Token Optional] - {PR_MERGE_DATE}
+## [Make Access Token Optional] - 2026-08-29
 
 - Access token is no longer required — extensions works without authentication for local REST API connections that don't require a token
 

--- a/extensions/super-productivity/CHANGELOG.md
+++ b/extensions/super-productivity/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Make Access Token Optional] - {PR_MERGE_DATE}
+
+- Access token is no longer required — extensions works without authentication for local REST API connections that don't require a token
+
 ## [Require API Token] - 2026-08-13
 
 - Extension now requires API Token to use the local API (ref: [Issue #30157](https://github.com/raycast/extensions/issues/30157))

--- a/extensions/super-productivity/README.md
+++ b/extensions/super-productivity/README.md
@@ -37,7 +37,7 @@ npm run dev   # opens Raycast dev with the extension live-reloading
 
 The default preference `apiBaseUrl` is `http://127.0.0.1:3876`. Change it in Raycast preferences if your SP instance runs elsewhere.
 
-🔑 You will also need to enter the "Access Token" from local REST API settings.
+> **Access Token** — optional. Super Productivity v18.16.0+ no longer issues an access token. Leave the field blank for tokenless setups. If your SP version shows a token under `Settings → Misc → Local REST API`, paste it in the extension preferences and it will be sent as a Bearer token on every request.
 
 ---
 

--- a/extensions/super-productivity/package.json
+++ b/extensions/super-productivity/package.json
@@ -45,9 +45,9 @@
     {
       "name": "accessToken",
       "title": "Access Token",
-      "description": "Access Token for the Super Productivity Local REST API",
+      "description": "Access Token for the Super Productivity Local REST API (optional)",
       "type": "password",
-      "required": true,
+      "required": false,
       "placeholder": "xXX...XXX"
     }
   ],
@@ -191,7 +191,8 @@
   ],
   "title": "Super Productivity",
   "author": "pvnkmnk",
-  "contributors": ["xmok"],
+  "contributors": ["xmok",
+    "Man17"],
   "platforms": [
     "macOS",
     "Windows"

--- a/extensions/super-productivity/src/api.test.ts
+++ b/extensions/super-productivity/src/api.test.ts
@@ -92,7 +92,7 @@ beforeEach(() => {
 });
 
 describe("request authentication", () => {
-  it("sends Authorization Bearer header with the access token", async () => {
+  it("sends Authorization Bearer header when access token is set", async () => {
     mockFetch.mockResolvedValue(okResponse({ server: "SP", rendererReady: true }));
 
     await checkHealth();
@@ -100,12 +100,23 @@ describe("request authentication", () => {
     expect(mockFetch).toHaveBeenCalledWith(
       "http://test:3876/health",
       expect.objectContaining({
-        headers: {
+        headers: expect.objectContaining({
           Authorization: `Bearer ${mockPreferences.accessToken}`,
           "Content-Type": "application/json",
-        },
+        }),
       }),
     );
+  });
+
+  it("omits Authorization header when access token is empty", async () => {
+    mockPreferences.accessToken = "";
+    mockFetch.mockResolvedValue(okResponse({ server: "SP", rendererReady: true }));
+
+    await checkHealth();
+
+    const headers = mockFetch.mock.calls[0][1].headers as Record<string, string>;
+    expect(headers["Authorization"]).toBeUndefined();
+    expect(headers["Content-Type"]).toBe("application/json");
   });
 });
 

--- a/extensions/super-productivity/src/api.ts
+++ b/extensions/super-productivity/src/api.ts
@@ -25,12 +25,14 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
   const baseUrl = getBaseUrl();
   const url = `${baseUrl}${path}`;
 
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (accessToken) {
+    headers["Authorization"] = `Bearer ${accessToken}`;
+  }
+
   try {
     const res = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "Content-Type": "application/json",
-      },
+      headers,
       ...options,
     });
 


### PR DESCRIPTION
 ## Description

  Reverts the access token requirement introduced in #30163. Super Productivity v18.16.0 removed the access token from the local
  REST API, making the required field a breaking change. Users on this version cannot authenticate and the extension fails
  entirely.

  The token is now optional. When set, it is sent as a `Bearer` token in the `Authorization` header; when empty, requests are made
   without authentication.

  ## Screencast

  Straightforward preference change. No screencast needed.

  ## Checklist

  - [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
  - [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
  - [x] I ran `npm run build` and [tested this distribution build in
  Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
  - [x] I checked that files in the `assets` folder are used by the extension itself
  - [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
