### PR TITLE
[Agent Usage] Fix Amp usage parse

### DIFF
--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Agent Usage Changelog
 
-## [Fix Amp usage parse] - {PR_MERGE_DATE}
+## [Fix Amp usage parse] - 2026-08-27
 
 ### Bug Fixes
 

--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Agent Usage Changelog
 
+## [Fix Amp usage parse] - {PR_MERGE_DATE}
+
+### Bug Fixes
+
+- Parse `amp usage` when labels are markdown-bold (`**Amp Free:**`), which is what the CLI emits when it is not attached to a TTY (Raycast's fetch path)
+- Parse Amp Megawatt/Gigawatt subscription remaining (other usage + orb usage) in the detail view; the list and menu bar still show Amp Free
+
 ## [Add AIHubMix Usage] - 2026-08-22
 
 - Add AIHubMix balance monitoring to the main list and menu bar

--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Bug Fixes
 
 - Parse `amp usage` when labels are markdown-bold (`**Amp Free:**`), which is what the CLI emits when it is not attached to a TTY (Raycast's fetch path)
-- Parse Amp Megawatt/Gigawatt subscription remaining (other usage + orb usage) in the detail view; the list and menu bar still show Amp Free
+- Parse Amp Megawatt/Gigawatt subscription remaining (other usage + orb usage) in the detail view
+- List and menu bar still show Amp Free when present; if Amp Free is absent they use the tighter subscription pool instead of 0%
 
 ## [Add AIHubMix Usage] - 2026-08-22
 

--- a/extensions/agent-usage/package.json
+++ b/extensions/agent-usage/package.json
@@ -13,7 +13,7 @@
     "garrick_zhang",
     "EDM115",
     "chingweih",
-    "2f6ft9t7t6"
+    "jalenzz"
   ],
   "type": "module",
   "scripts": {

--- a/extensions/agent-usage/src/amp/effective-remaining.test.ts
+++ b/extensions/agent-usage/src/amp/effective-remaining.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { effectiveRemainingPercent } from "./effective-remaining.ts";
+import type { AmpUsage } from "./types.ts";
+
+function usage(overrides: Partial<AmpUsage> = {}): AmpUsage {
+  return {
+    email: "fixture@example.test",
+    nickname: "fixture",
+    individualCredits: { remaining: 1, unit: "$" },
+    ...overrides,
+  };
+}
+
+test("effectiveRemainingPercent uses Amp Free when it is present", () => {
+  assert.equal(
+    effectiveRemainingPercent(
+      usage({
+        ampFree: { percentRemaining: 98 },
+        subscription: { plan: "Megawatt", otherPercentRemaining: 0, orbPercentRemaining: 99 },
+      }),
+    ),
+    98,
+  );
+});
+
+test("effectiveRemainingPercent uses the tighter subscription pool when Amp Free is absent", () => {
+  assert.equal(
+    effectiveRemainingPercent(
+      usage({
+        subscription: { plan: "Gigawatt", otherPercentRemaining: 73, orbPercentRemaining: 91 },
+      }),
+    ),
+    73,
+  );
+});
+
+test("effectiveRemainingPercent returns null when no percentage pool is present", () => {
+  assert.equal(effectiveRemainingPercent(usage()), null);
+});

--- a/extensions/agent-usage/src/amp/effective-remaining.ts
+++ b/extensions/agent-usage/src/amp/effective-remaining.ts
@@ -1,0 +1,20 @@
+import type { AmpUsage } from "./types.ts";
+
+/**
+ * Remaining percent for the Amp list/menu-bar badge.
+ *
+ * Amp Free stays the primary badge when it is present, matching the previous
+ * single-pool UI. Subscription-only output has no Amp Free pool; using 0% for
+ * that absence would paint a red exhausted pie next to valid subscription
+ * remaining in the tooltip and details. Fall back to the tighter of the
+ * subscription other/orb windows instead.
+ */
+export function effectiveRemainingPercent(usage: AmpUsage): number | null {
+  if (usage.ampFree) {
+    return usage.ampFree.percentRemaining;
+  }
+  if (usage.subscription) {
+    return Math.min(usage.subscription.otherPercentRemaining, usage.subscription.orbPercentRemaining);
+  }
+  return null;
+}

--- a/extensions/agent-usage/src/amp/parser.test.ts
+++ b/extensions/agent-usage/src/amp/parser.test.ts
@@ -8,6 +8,12 @@ Amp Free: 100% remaining today (resets daily) - https://ampcode.com/settings#amp
 Individual credits: $10 remaining (set up automatic top-up to avoid running out) - https://ampcode.com/settings
 `;
 
+const MARKDOWN_SUBSCRIPTION_OUTPUT = `Signed in as zvq@live.com (spikezhang)
+**Amp Free:** 98% remaining today (resets daily) - https://ampcode.com/settings#amp-free
+**Amp Megawatt Subscription:** 0% other usage and 99% orb usage remaining - resets upon renewal in 24 days
+**Individual credits:** $16.75 remaining (set up auto-reload to avoid running out) - https://ampcode.com/settings
+`;
+
 test("parseAmpUsage parses percent-based Amp Free and individual credits", () => {
   const { usage, error } = parseAmpUsage(SAMPLE_OUTPUT);
 
@@ -15,10 +21,11 @@ test("parseAmpUsage parses percent-based Amp Free and individual credits", () =>
   assert.ok(usage);
   assert.equal(usage.email, "zvq@live.com");
   assert.equal(usage.nickname, "spikezhang");
-  assert.equal(usage.ampFree.percentRemaining, 100);
-  assert.equal(usage.ampFree.resetNote, "resets daily");
+  assert.equal(usage.ampFree?.percentRemaining, 100);
+  assert.equal(usage.ampFree?.resetNote, "resets daily");
   assert.equal(usage.individualCredits.remaining, 10);
   assert.equal(usage.individualCredits.unit, "$");
+  assert.equal(usage.subscription, undefined);
 });
 
 test("parseAmpUsage parses fractional percent remaining", () => {
@@ -30,8 +37,56 @@ Individual credits: $0 remaining
 
   assert.equal(error, null);
   assert.ok(usage);
-  assert.equal(usage.ampFree.percentRemaining, 37.5);
+  assert.equal(usage.ampFree?.percentRemaining, 37.5);
   assert.equal(usage.individualCredits.remaining, 0);
+});
+
+test("parseAmpUsage parses markdown-bold labels and Megawatt subscription remaining", () => {
+  const { usage, error } = parseAmpUsage(MARKDOWN_SUBSCRIPTION_OUTPUT);
+
+  assert.equal(error, null);
+  assert.ok(usage);
+  assert.equal(usage.email, "zvq@live.com");
+  assert.equal(usage.nickname, "spikezhang");
+  assert.equal(usage.ampFree?.percentRemaining, 98);
+  assert.equal(usage.ampFree?.resetNote, "resets daily");
+  assert.equal(usage.subscription?.plan, "Megawatt");
+  assert.equal(usage.subscription?.otherPercentRemaining, 0);
+  assert.equal(usage.subscription?.orbPercentRemaining, 99);
+  assert.equal(usage.subscription?.resetNote, "resets upon renewal in 24 days");
+  assert.equal(usage.individualCredits.remaining, 16.75);
+});
+
+test("parseAmpUsage parses TTY Amp Megawatt output without markdown", () => {
+  const output = `Signed in as zvq@live.com (spikezhang)
+Amp Free: 98% remaining today (resets daily) - https://ampcode.com/settings#amp-free
+Amp Megawatt Subscription: 0% other usage and 99% orb usage remaining - resets upon renewal in 24 days
+Individual credits: $16.75 remaining (set up auto-reload to avoid running out) - https://ampcode.com/settings
+`;
+  const { usage, error } = parseAmpUsage(output);
+
+  assert.equal(error, null);
+  assert.ok(usage);
+  assert.equal(usage.ampFree?.percentRemaining, 98);
+  assert.equal(usage.subscription?.plan, "Megawatt");
+  assert.equal(usage.subscription?.otherPercentRemaining, 0);
+  assert.equal(usage.subscription?.orbPercentRemaining, 99);
+  assert.equal(usage.individualCredits.remaining, 16.75);
+});
+
+test("parseAmpUsage parses subscription-only Amp CLI output", () => {
+  const output = `Signed in as fixture@example.test (example)
+Subscription Gigawatt: 73% other usage and 91% orb usage remaining - resets upon renewal in 1 month - https://ampcode.com/settings
+`;
+  const { usage, error } = parseAmpUsage(output);
+
+  assert.equal(error, null);
+  assert.ok(usage);
+  assert.equal(usage.ampFree, undefined);
+  assert.equal(usage.subscription?.plan, "Gigawatt");
+  assert.equal(usage.subscription?.otherPercentRemaining, 73);
+  assert.equal(usage.subscription?.orbPercentRemaining, 91);
+  assert.equal(usage.subscription?.resetNote, "resets upon renewal in 1 month");
 });
 
 test("parseAmpUsage returns an error when Amp Free uses the old dollar format", () => {

--- a/extensions/agent-usage/src/amp/parser.ts
+++ b/extensions/agent-usage/src/amp/parser.ts
@@ -1,6 +1,20 @@
-import type { AmpUsage, AmpError } from "./types.ts";
+import type { AmpError, AmpFreeUsage, AmpSubscriptionUsage, AmpUsage } from "./types.ts";
 
 const NOT_LOGGED_IN_SIGNALS = ["not logged in", "please sign in", "unauthenticated", "login required"];
+
+const PARSE_ERROR: AmpError = {
+  type: "unknown",
+  message: "Failed to parse Amp output. Please check if the format has changed.",
+};
+
+const AMP_FREE_PATTERN = /Amp Free:\s*([\d.]+)%\s*remaining(?:\s+today)?(?:\s+\(([^)]+)\))?/i;
+const SUBSCRIPTION_PATTERNS = [
+  /Amp\s+(.+?)\s+Subscription:\s*([\d.]+)%\s+other\s+usage\s+and\s+([\d.]+)%\s+orb\s+usage\s+remaining(?:\s+-\s+(.+))?/i,
+  /Subscription\s+(.+?):\s*([\d.]+)%\s+other\s+usage\s+and\s+([\d.]+)%\s+orb\s+usage\s+remaining(?:\s+-\s+(.+))?/i,
+];
+const TRAILING_URL_PATTERN = /\s+-\s+https?:\/\/\S+\s*$/i;
+const CREDITS_PATTERN = /Individual credits:\s*\$([\d.]+)/i;
+const SIGNED_IN_PATTERN = /Signed in as\s+(\S+)\s+\(([^)]+)\)/;
 
 // 检测错误类型
 export function detectAmpError(output: string): AmpError | null {
@@ -22,60 +36,65 @@ function clampPercent(value: number): number {
   return Math.min(100, Math.max(0, value));
 }
 
+function normalizeAmpOutput(output: string): string {
+  // Non-TTY `amp usage` wraps labels in markdown bold: **Amp Free:**
+  return output.replaceAll("**", "");
+}
+
+function parseAmpFree(text: string): AmpFreeUsage | undefined {
+  const match = text.match(AMP_FREE_PATTERN);
+  if (!match) return undefined;
+  return {
+    percentRemaining: clampPercent(parseFloat(match[1])),
+    resetNote: match[2]?.trim() || undefined,
+  };
+}
+
+function parseResetNote(value: string | undefined): string | undefined {
+  const note = value?.replace(TRAILING_URL_PATTERN, "").trim();
+  return note || undefined;
+}
+
+function parseSubscription(text: string): AmpSubscriptionUsage | undefined {
+  for (const pattern of SUBSCRIPTION_PATTERNS) {
+    const match = text.match(pattern);
+    if (!match) continue;
+    return {
+      plan: match[1].trim(),
+      otherPercentRemaining: clampPercent(parseFloat(match[2])),
+      orbPercentRemaining: clampPercent(parseFloat(match[3])),
+      resetNote: parseResetNote(match[4]),
+    };
+  }
+  return undefined;
+}
+
 export function parseAmpUsage(output: string): { usage: AmpUsage | null; error: AmpError | null } {
-  // 首先检测错误
   const detectedError = detectAmpError(output);
   if (detectedError) {
     return { usage: null, error: detectedError };
   }
 
-  const lines = output.trim().split("\n");
-
-  // Parse first line: Signed in as apple@example.com (nickname)
-  const firstLine = lines[0] || "";
-  const emailMatch = firstLine.match(/Signed in as\s+([^\s]+)\s+\(([^)]+)\)/);
-
+  const text = normalizeAmpOutput(output);
+  const emailMatch = text.match(SIGNED_IN_PATTERN);
   if (!emailMatch) {
-    return {
-      usage: null,
-      error: {
-        type: "unknown",
-        message: "Failed to parse Amp output. Please check if the format has changed.",
-      },
-    };
+    return { usage: null, error: PARSE_ERROR };
   }
 
-  const email = emailMatch[1];
-  const nickname = emailMatch[2] || "";
-
-  // Amp Free: 100% remaining today (resets daily) - https://...
-  const ampFreeLine = lines.find((line) => line.includes("Amp Free:")) || "";
-  const ampFreeMatch = ampFreeLine.match(/Amp Free:\s*([\d.]+)%\s*remaining(?:\s+today)?(?:\s+\(([^)]+)\))?/i);
-  if (!ampFreeMatch) {
-    return {
-      usage: null,
-      error: {
-        type: "unknown",
-        message: "Failed to parse Amp Free usage. Please check if the format has changed.",
-      },
-    };
+  const ampFree = parseAmpFree(text);
+  const subscription = parseSubscription(text);
+  if (!ampFree && !subscription) {
+    return { usage: null, error: PARSE_ERROR };
   }
 
-  const percentRemaining = clampPercent(parseFloat(ampFreeMatch[1]));
-  const resetNote = ampFreeMatch[2]?.trim() || undefined;
-
-  // Individual credits: $10 remaining ...
-  const creditsLine = lines.find((line) => line.includes("Individual credits:")) || "";
-  const creditsMatch = creditsLine.match(/Individual credits:\s*\$([\d.]+)/);
+  const creditsMatch = text.match(CREDITS_PATTERN);
   const creditsRemaining = creditsMatch?.[1] ? parseFloat(creditsMatch[1]) : 0;
 
   const usage: AmpUsage = {
-    email,
-    nickname,
-    ampFree: {
-      percentRemaining,
-      resetNote,
-    },
+    email: emailMatch[1],
+    nickname: emailMatch[2] || "",
+    ampFree,
+    subscription,
     individualCredits: {
       remaining: creditsRemaining,
       unit: "$",

--- a/extensions/agent-usage/src/amp/renderer.tsx
+++ b/extensions/agent-usage/src/amp/renderer.tsx
@@ -9,6 +9,7 @@ import {
   generatePieIcon,
   generateAsciiBar,
 } from "../agents/ui.tsx";
+import { effectiveRemainingPercent } from "./effective-remaining.ts";
 import type { AmpError, AmpFreeUsage, AmpSubscriptionUsage, AmpUsage } from "./types.ts";
 
 function formatPercent(value: number): string {
@@ -118,7 +119,11 @@ export function getAmpAccessory(usage: AmpUsage | null, error: AmpError | null, 
   }
   tooltipParts.push(`Credits: ${usage.individualCredits.unit}${usage.individualCredits.remaining.toFixed(2)}`);
 
-  const percent = usage.ampFree?.percentRemaining ?? 0;
+  const percent = effectiveRemainingPercent(usage);
+  if (percent === null) {
+    return getNoDataAccessory();
+  }
+
   return {
     icon: generatePieIcon(percent),
     text: formatPercent(percent),

--- a/extensions/agent-usage/src/amp/renderer.tsx
+++ b/extensions/agent-usage/src/amp/renderer.tsx
@@ -9,15 +9,24 @@ import {
   generatePieIcon,
   generateAsciiBar,
 } from "../agents/ui.tsx";
-import type { AmpUsage, AmpError } from "./types.ts";
+import type { AmpError, AmpFreeUsage, AmpSubscriptionUsage, AmpUsage } from "./types.ts";
 
 function formatPercent(value: number): string {
   return Number.isInteger(value) ? `${value}%` : `${value.toFixed(1)}%`;
 }
 
-function formatAmpFreeSummary(ampFree: AmpUsage["ampFree"]): string {
+function formatAmpFreeSummary(ampFree: AmpFreeUsage): string {
   const base = `${formatPercent(ampFree.percentRemaining)} remaining`;
   return ampFree.resetNote ? `${base} (${ampFree.resetNote})` : base;
+}
+
+function formatSubscriptionPools(subscription: AmpSubscriptionUsage): string {
+  return `Other ${formatPercent(subscription.otherPercentRemaining)}  Orb ${formatPercent(subscription.orbPercentRemaining)}`;
+}
+
+function formatSubscriptionSummary(subscription: AmpSubscriptionUsage): string {
+  const base = `${formatSubscriptionPools(subscription)} remaining`;
+  return subscription.resetNote ? `${base} (${subscription.resetNote})` : base;
 }
 
 export function formatAmpUsageText(usage: AmpUsage | null, error: AmpError | null): string {
@@ -25,12 +34,17 @@ export function formatAmpUsageText(usage: AmpUsage | null, error: AmpError | nul
   if (fallback !== null) return fallback;
   const u = usage as AmpUsage;
 
-  const { ampFree, individualCredits } = u;
-
   let text = `Amp Usage`;
-  text += `\n\nAmp Free: ${formatAmpFreeSummary(ampFree)}`;
-  text += `\n${generateAsciiBar(ampFree.percentRemaining)}`;
-  text += `\n\nIndividual Credits: ${individualCredits.unit}${individualCredits.remaining.toFixed(2)}`;
+  if (u.ampFree) {
+    text += `\n\nAmp Free: ${formatAmpFreeSummary(u.ampFree)}`;
+    text += `\n${generateAsciiBar(u.ampFree.percentRemaining)}`;
+  }
+  if (u.subscription) {
+    text += `\n\n${u.subscription.plan}: ${formatSubscriptionSummary(u.subscription)}`;
+    text += `\nOther ${generateAsciiBar(u.subscription.otherPercentRemaining)}`;
+    text += `\nOrb ${generateAsciiBar(u.subscription.orbPercentRemaining)}`;
+  }
+  text += `\n\nIndividual Credits: ${u.individualCredits.unit}${u.individualCredits.remaining.toFixed(2)}`;
 
   return text;
 }
@@ -40,20 +54,37 @@ export function renderAmpDetail(usage: AmpUsage | null, error: AmpError | null):
   if (fallback !== null) return fallback;
   const u = usage as AmpUsage;
 
-  const { ampFree, individualCredits } = u;
-
   return (
     <List.Item.Detail.Metadata>
-      <List.Item.Detail.Metadata.Label
-        title="Amp Free"
-        text={`${generateAsciiBar(ampFree.percentRemaining)} ${formatAmpFreeSummary(ampFree)}`}
-      />
+      {u.ampFree && (
+        <List.Item.Detail.Metadata.Label
+          title="Amp Free"
+          text={`${generateAsciiBar(u.ampFree.percentRemaining)} ${formatAmpFreeSummary(u.ampFree)}`}
+        />
+      )}
+
+      {u.subscription && (
+        <>
+          {u.ampFree && <List.Item.Detail.Metadata.Separator />}
+          <List.Item.Detail.Metadata.Label
+            title={`${u.subscription.plan} Other Usage`}
+            text={`${generateAsciiBar(u.subscription.otherPercentRemaining)} ${formatPercent(u.subscription.otherPercentRemaining)} remaining`}
+          />
+          <List.Item.Detail.Metadata.Label
+            title={`${u.subscription.plan} Orb`}
+            text={`${generateAsciiBar(u.subscription.orbPercentRemaining)} ${formatPercent(u.subscription.orbPercentRemaining)} remaining`}
+          />
+          {u.subscription.resetNote && (
+            <List.Item.Detail.Metadata.Label title="Renews" text={u.subscription.resetNote} />
+          )}
+        </>
+      )}
 
       <List.Item.Detail.Metadata.Separator />
 
       <List.Item.Detail.Metadata.Label
         title="Individual Credits"
-        text={`${individualCredits.unit}${individualCredits.remaining.toFixed(2)}`}
+        text={`${u.individualCredits.unit}${u.individualCredits.remaining.toFixed(2)}`}
       />
     </List.Item.Detail.Metadata>
   );
@@ -78,12 +109,19 @@ export function getAmpAccessory(usage: AmpUsage | null, error: AmpError | null, 
     return getNoDataAccessory();
   }
 
-  const percent = usage.ampFree.percentRemaining;
-  const summary = formatAmpFreeSummary(usage.ampFree);
+  const tooltipParts: string[] = [];
+  if (usage.ampFree) {
+    tooltipParts.push(`Amp Free: ${formatAmpFreeSummary(usage.ampFree)}`);
+  }
+  if (usage.subscription) {
+    tooltipParts.push(`${usage.subscription.plan}: ${formatSubscriptionSummary(usage.subscription)}`);
+  }
+  tooltipParts.push(`Credits: ${usage.individualCredits.unit}${usage.individualCredits.remaining.toFixed(2)}`);
 
+  const percent = usage.ampFree?.percentRemaining ?? 0;
   return {
     icon: generatePieIcon(percent),
     text: formatPercent(percent),
-    tooltip: `Amp Free: ${summary}`,
+    tooltip: tooltipParts.join(" | "),
   };
 }

--- a/extensions/agent-usage/src/amp/types.ts
+++ b/extensions/agent-usage/src/amp/types.ts
@@ -1,12 +1,24 @@
+export interface AmpFreeUsage {
+  /** Percentage of Amp Free remaining (0–100). */
+  percentRemaining: number;
+  /** e.g. "resets daily" when present in CLI output */
+  resetNote?: string;
+}
+
+export interface AmpSubscriptionUsage {
+  /** e.g. "Megawatt" or "Gigawatt" */
+  plan: string;
+  otherPercentRemaining: number;
+  orbPercentRemaining: number;
+  /** e.g. "resets upon renewal in 24 days" */
+  resetNote?: string;
+}
+
 export interface AmpUsage {
   email: string;
   nickname: string;
-  ampFree: {
-    /** Percentage of Amp Free remaining (0–100). */
-    percentRemaining: number;
-    /** e.g. "resets daily" when present in CLI output */
-    resetNote?: string;
-  };
+  ampFree?: AmpFreeUsage;
+  subscription?: AmpSubscriptionUsage;
   individualCredits: {
     remaining: number;
     unit: string;


### PR DESCRIPTION
## Description

Fix Amp usage parsing for the non-TTY output Raycast actually fetches.

- Strip markdown-bold wrappers (`**Amp Free:**`) that `amp usage` emits when it is not attached to a TTY
- Parse Amp Megawatt/Gigawatt subscription remaining (`other usage` + `orb usage`) and show those pools in the detail view
- List and menu bar still show Amp Free
- Replace invalid contributor handle `2f6ft9t7t6` with `jalenzz` so `package.json` validates

## Screencast

Parser-only change. Covered by unit tests against live Amp CLI captures (TTY, markdown-bold, subscription-only).

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder