### PR TITLE
Remove AeroSpace window switcher launcher argument

### DIFF
--- a/extensions/aerospace/CHANGELOG.md
+++ b/extensions/aerospace/CHANGELOG.md
@@ -1,5 +1,10 @@
 # aerospace Changelog
 
+## [Open Window Switcher Directly] - {PR_MERGE_DATE}
+
+- Open Switch Apps in Workspace immediately without showing a launcher argument form
+- Keep optional scope and search overrides available to integrations through `launchContext`
+
 ## [Runtime, Configuration, and UX Upgrade] - 2026-08-27
 
 - Trigger shortcuts with AeroSpace's native `trigger-binding` command instead of AppleScript keyboard events

--- a/extensions/aerospace/CHANGELOG.md
+++ b/extensions/aerospace/CHANGELOG.md
@@ -1,6 +1,6 @@
 # aerospace Changelog
 
-## [Open Window Switcher Directly] - {PR_MERGE_DATE}
+## [Open Window Switcher Directly] - 2026-08-28
 
 - Open Switch Apps in Workspace immediately without showing a launcher argument form
 - Keep optional scope and search overrides available to integrations through `launchContext`

--- a/extensions/aerospace/README.md
+++ b/extensions/aerospace/README.md
@@ -57,15 +57,15 @@ The extension supports programmatic access via Raycast deeplinks using `launchCo
 ### Deeplink Format
 
 ```bash
-raycast://extensions/limonkufu/aerospace/switchApps?arguments={\"workspace\":\"all\"}&context={\"searchText\":\"AppName\"}
+raycast://extensions/limonkufu/aerospace/switchApps?context={\"workspace\":\"all\",\"searchText\":\"AppName\"}
 ```
 
 **Parameters:**
 
-- `arguments` - UI parameters, such as workspace selection
-- `context` - launch context passed without showing UI prompts, such as search text for pre-filtering
+- `context.workspace` - optional `focused`, `visible`, or `all` scope override
+- `context.searchText` - optional initial search text
 
-This enables external tools to trigger the app switcher with pre-filtered search without displaying argument input prompts.
+This enables external tools to choose a scope or pre-filter the app switcher without displaying argument input prompts. Normal launches open the command immediately and use the last scope selected inside it.
 
 ## Contributing
 

--- a/extensions/aerospace/package.json
+++ b/extensions/aerospace/package.json
@@ -93,27 +93,6 @@
             }
           ]
         }
-      ],
-      "arguments": [
-        {
-          "name": "workspace",
-          "placeholder": "Focused, Visible, or All",
-          "type": "dropdown",
-          "data": [
-            {
-              "title": "Focused",
-              "value": "focused"
-            },
-            {
-              "title": "Visible",
-              "value": "visible"
-            },
-            {
-              "title": "All",
-              "value": "all"
-            }
-          ]
-        }
       ]
     }
   ],

--- a/extensions/aerospace/src/switchApps.tsx
+++ b/extensions/aerospace/src/switchApps.tsx
@@ -34,7 +34,7 @@ import { extractWorkspaceKeys, getConfigPath, loadConfig } from "./utils/config"
 import { createWindowRule } from "./utils/rules";
 import { resolveWindowScope, WINDOW_SCOPE_STORAGE_KEY } from "./utils/windowScope";
 
-type SwitchAppsLaunchContext = { searchText?: string };
+type SwitchAppsLaunchContext = { searchText?: string; workspace?: WindowScope };
 
 async function finishWindowAction(): Promise<void> {
   await popToRoot({ clearSearchBar: true });
@@ -188,11 +188,9 @@ function WindowActions({ window, onRefresh }: { window: WindowSnapshot; onRefres
   );
 }
 
-export default function Command(
-  props: LaunchProps<{ arguments: Arguments.SwitchApps; launchContext?: SwitchAppsLaunchContext }>,
-) {
+export default function Command(props: LaunchProps<{ launchContext?: SwitchAppsLaunchContext }>) {
   const { defaultWorkspace } = getPreferenceValues<Preferences.SwitchApps>();
-  const launchScope = props.arguments.workspace as WindowScope | undefined;
+  const launchScope = props.launchContext?.workspace;
   const { value: rememberedScope, setValue: rememberScope } = useLocalStorage<WindowScope>(WINDOW_SCOPE_STORAGE_KEY);
   const [sessionScope, setSessionScope] = useState<WindowScope>();
   const scope = resolveWindowScope(sessionScope, launchScope, rememberedScope, defaultWorkspace);

--- a/extensions/aerospace/src/utils/windowScope.test.ts
+++ b/extensions/aerospace/src/utils/windowScope.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { resolveWindowScope } from "./windowScope";
 
 describe("window scope selection", () => {
-  it("prefers the current session, explicit launch argument, remembered value, then preference", () => {
+  it("prefers the current session, launch context, remembered value, then preference", () => {
     expect(resolveWindowScope("all", "visible", "focused", "focused")).toBe("all");
     expect(resolveWindowScope(undefined, "visible", "all", "focused")).toBe("visible");
     expect(resolveWindowScope(undefined, undefined, "all", "focused")).toBe("all");


### PR DESCRIPTION
## Description

- Remove the optional workspace argument from Switch Apps in Workspace so the command opens immediately from Raycast
- Keep the Focused, Visible, and All scope picker inside the command and continue remembering the last selection
- Preserve non-interactive integrations through `launchContext.workspace` and `launchContext.searchText`
- Update the deeplink documentation and add a dedicated changelog entry

## Verification

- `npm run test` - 5 test files and 24 tests passed
- `npm run typecheck`
- `npm run lint:local`
- `npm run format:check`
- `npm run build`
- `npm run lint`
- Native Raycast smoke test confirmed the command opens directly into the window list with the remembered scope in its dropdown

## Screencast

Not included because this removes an intermediate launcher form; the native smoke test covered the resulting direct-open flow.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
