### PR TITLE
Update agent-usage extension

### DIFF
--- a/extensions/agent-usage/.gitignore
+++ b/extensions/agent-usage/.gitignore
@@ -4,6 +4,7 @@
 /node_modules
 
 # Raycast specific files
+/dist
 raycast-env.d.ts
 .raycast-swift-build
 .swiftpm

--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Agent Usage Changelog
 
-## [Copilot multi-account and AI credits] - {PR_MERGE_DATE}
+## [Copilot multi-account and AI credits] - 2026-08-29
 
 ### New Features
 

--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Agent Usage Changelog
 
+## [Copilot multi-account and AI credits] - {PR_MERGE_DATE}
+
+### New Features
+
+- Support unlimited named GitHub Copilot accounts, with separate rows in the main list and menu bar
+- Add Copilot accounts through the existing **Manage Accounts** action
+- Show `GITHUB_TOKEN` and `GH_TOKEN` as separate auto-detected accounts while retaining the legacy preference token
+
+### Improvements
+
+- Rename Copilot's Premium Interactions quota to AI Credits
+- Show the remaining AI Credits as both a percentage and a credit balance, such as `24 / 300 credits`
+- Support GitHub token discovery from Windows command shells as well as Unix login shells
+
 ## [Fix Amp usage parse] - 2026-08-27
 
 ### Bug Fixes

--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Support unlimited named GitHub Copilot accounts, with separate rows in the main list and menu bar
 - Add Copilot accounts through the existing **Manage Accounts** action
-- Show `GITHUB_TOKEN` and `GH_TOKEN` as separate auto-detected accounts while retaining the legacy preference token
+- Prefer the active GitHub CLI token from `gh auth token`, then fall back to `GITHUB_TOKEN` and `GH_TOKEN` as separate auto-detected accounts while retaining the legacy preference token
 
 ### Improvements
 

--- a/extensions/agent-usage/README.md
+++ b/extensions/agent-usage/README.md
@@ -21,12 +21,12 @@ Track usage across your AI coding agents in one place.
 
 | Agent           | Data Source                 | Manual Key | OpenCode | Env Var | Multi-Account | Setup                                                                                            |
 | --------------- | --------------------------- | :--------: | :------: | :-----: | :-----------: | ------------------------------------------------------------------------------------------------ |
-| **AIHubMix**    | AIHubMix user self API      |     ✓      |    —     |    ✓    |       —       | Paste the Access Key from https://console.aihubmix.com/setting, or set `AIHUBMIX_ACCESS_KEY`      |
+| **AIHubMix**    | AIHubMix user self API      |     ✓      |    —     |    ✓    |       —       | Paste the Access Key from https://console.aihubmix.com/setting, or set `AIHUBMIX_ACCESS_KEY`     |
 | **Amp**         | Local SQLite database       |     —      |    —     |    —    |       —       | Auto-detected from local database                                                                |
 | **Claude**      | Anthropic OAuth Usage API   |     —      |    ✓     |    —    |       —       | Auto-detected after `claude` login                                                               |
 | **ClinePass**   | Cline API                   |     ✓      |    —     |    —    |       ✓       | Auto-detected from the local Cline login, or add a user ID and API key via Manage Accounts       |
 | **Codex**       | OpenAI API                  |     ✓      |    —     |    —    |       ✓       | Run `codex login`, add additional `CODEX_HOME` paths in preferences, or paste a token manually   |
-| **Copilot**     | GitHub Copilot internal API |     ✓      |    —     |    ✓    |       ✓       | Add named accounts via Manage Accounts, or use `GH_TOKEN`/`GITHUB_TOKEN`                         |
+| **Copilot**     | GitHub Copilot internal API |     ✓      |    —     |    ✓    |       ✓       | Add named accounts, sign in with GitHub CLI, or use `GH_TOKEN`/`GITHUB_TOKEN`                    |
 | **Cursor**      | Cursor API                  |     ✓      |    —     |    —    |       —       | Auto-detected from Cursor app login, or paste cookie header in preferences                       |
 | **DeepSeek**    | DeepSeek balance API        |     ✓      |    ✓     |    ✓    |       —       | Use OpenCode `deepseek`, set `DEEPSEEK_API_KEY`/`DEEPSEEK_KEY`, or paste an API key              |
 | **Droid**       | Factory AI API              |     —      |    —     |    —    |       —       | Run `droid` command to login                                                                     |
@@ -36,7 +36,7 @@ Track usage across your AI coding agents in one place.
 | **Antigravity** | Google API                  |     —      |    —     |    —    |       —       | Auto-detected from local API                                                                     |
 | **Synthetic**   | Synthetic API               |     ✓      |    ✓     |    —    |       ✓       | Use OpenCode `synthetic`, or paste API key from https://synthetic.new/billing                    |
 | **MiniMax**     | MiniMax API                 |     ✓      |    ✓     |    ✓    |       —       | Use OpenCode `minimax-coding-plan`, set `MINIMAX_API_KEY` env var, or paste token in preferences |
-| **MinimaxCN**   | MinimaxCN API (国内版)        |     ✓      |    —     |    ✓    |       —       | Set `MINIMAX_CN_API_KEY` env var, or paste token in preferences |
+| **MinimaxCN**   | MinimaxCN API (国内版)      |     ✓      |    —     |    ✓    |       —       | Set `MINIMAX_CN_API_KEY` env var, or paste token in preferences                                  |
 | **OpenCode Go** | OpenCode API                |     ✓      |    —     |    —    |       —       | Set workspace ID and auth cookie in preferences                                                  |
 | **z.ai (GLM)**  | Zhipu API                   |     ✓      |    ✓     |    ✓    |       ✓       | Paste token, use OpenCode `zai-coding-plan`, or set `ZAI_API_KEY`/`GLM_API_KEY` env var          |
 
@@ -81,9 +81,10 @@ This works by comparing your stored account tokens with the keys configured in `
 ### Copilot Token
 
 1. Use a GitHub OAuth token that the Copilot internal API accepts, such as the token from `gh auth token`
-2. Add each token as a named account with the in-view **Manage Accounts** action
-3. `GH_TOKEN` and `GITHUB_TOKEN` are also shown as separate auto-detected accounts; Agent Usage resolves them from your login shell when Raycast doesn't inherit the shell environment
-4. Standard personal access tokens may not work with `https://api.github.com/copilot_internal/user`
+2. Agent Usage first reads the active GitHub CLI login with `gh auth token`
+3. If GitHub CLI has no token, `GH_TOKEN` and `GITHUB_TOKEN` are shown as separate auto-detected accounts; Agent Usage resolves them from your login shell when Raycast doesn't inherit the shell environment
+4. Add additional tokens as named accounts with the in-view **Manage Accounts** action
+5. Standard personal access tokens may not work with `https://api.github.com/copilot_internal/user`
 
 The legacy `Copilot Authorization Token` preference remains supported as a `Preference` account.
 

--- a/extensions/agent-usage/README.md
+++ b/extensions/agent-usage/README.md
@@ -26,7 +26,7 @@ Track usage across your AI coding agents in one place.
 | **Claude**      | Anthropic OAuth Usage API   |     —      |    ✓     |    —    |       —       | Auto-detected after `claude` login                                                               |
 | **ClinePass**   | Cline API                   |     ✓      |    —     |    —    |       ✓       | Auto-detected from the local Cline login, or add a user ID and API key via Manage Accounts       |
 | **Codex**       | OpenAI API                  |     ✓      |    —     |    —    |       ✓       | Run `codex login`, add additional `CODEX_HOME` paths in preferences, or paste a token manually   |
-| **Copilot**     | GitHub Copilot internal API |     —      |    —     |    ✓    |       —       | Auto-detected from `GH_TOKEN`/`GITHUB_TOKEN`, or paste token in preferences                      |
+| **Copilot**     | GitHub Copilot internal API |     ✓      |    —     |    ✓    |       ✓       | Add named accounts via Manage Accounts, or use `GH_TOKEN`/`GITHUB_TOKEN`                         |
 | **Cursor**      | Cursor API                  |     ✓      |    —     |    —    |       —       | Auto-detected from Cursor app login, or paste cookie header in preferences                       |
 | **DeepSeek**    | DeepSeek balance API        |     ✓      |    ✓     |    ✓    |       —       | Use OpenCode `deepseek`, set `DEEPSEEK_API_KEY`/`DEEPSEEK_KEY`, or paste an API key              |
 | **Droid**       | Factory AI API              |     —      |    —     |    —    |       —       | Run `droid` command to login                                                                     |
@@ -81,9 +81,11 @@ This works by comparing your stored account tokens with the keys configured in `
 ### Copilot Token
 
 1. Use a GitHub OAuth token that the Copilot internal API accepts, such as the token from `gh auth token`
-2. Standard personal access tokens may not work with `https://api.github.com/copilot_internal/user`
-3. Set that token in `GH_TOKEN` or `GITHUB_TOKEN`; if Raycast doesn't inherit shell env, Agent Usage will resolve it from your login shell
-4. Optional fallback: paste the same OAuth token in extension preferences (`Copilot Authorization Token`)
+2. Add each token as a named account with the in-view **Manage Accounts** action
+3. `GH_TOKEN` and `GITHUB_TOKEN` are also shown as separate auto-detected accounts; Agent Usage resolves them from your login shell when Raycast doesn't inherit the shell environment
+4. Standard personal access tokens may not work with `https://api.github.com/copilot_internal/user`
+
+The legacy `Copilot Authorization Token` preference remains supported as a `Preference` account.
 
 ## Preferences
 

--- a/extensions/agent-usage/package.json
+++ b/extensions/agent-usage/package.json
@@ -25,7 +25,7 @@
     "lint": "ray lint",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish",
-    "test": "node --test --experimental-strip-types 'src/**/*.test.ts'",
+    "test": "node --test --experimental-strip-types \"src/**/*.test.ts\"",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -143,7 +143,7 @@
       "name": "copilotAuthToken",
       "type": "password",
       "title": "Legacy Copilot Token (Optional)",
-      "description": "Existing single-account token. Add new named Copilot accounts with the Manage Accounts action. GH_TOKEN and GITHUB_TOKEN are also auto-detected. Standard PATs may not work.",
+      "description": "Existing single-account token. Add named accounts with Manage Accounts. Authentication is auto-detected from GitHub CLI first, then GH_TOKEN or GITHUB_TOKEN. Standard PATs may not work.",
       "required": false
     },
     {

--- a/extensions/agent-usage/package.json
+++ b/extensions/agent-usage/package.json
@@ -13,7 +13,8 @@
     "garrick_zhang",
     "EDM115",
     "chingweih",
-    "jalenzz"
+    "jalenzz",
+    "Jakoss"
   ],
   "type": "module",
   "scripts": {
@@ -141,8 +142,8 @@
     {
       "name": "copilotAuthToken",
       "type": "password",
-      "title": "Copilot Authorization Token (Optional)",
-      "description": "Optional fallback OAuth token for Copilot usage. Usually auto-detected from GH_TOKEN or GITHUB_TOKEN (for example from 'gh auth token'). Standard PATs may not work.",
+      "title": "Legacy Copilot Token (Optional)",
+      "description": "Existing single-account token. Add new named Copilot accounts with the Manage Accounts action. GH_TOKEN and GITHUB_TOKEN are also auto-detected. Standard PATs may not work.",
       "required": false
     },
     {

--- a/extensions/agent-usage/src/accounts/storage.test.ts
+++ b/extensions/agent-usage/src/accounts/storage.test.ts
@@ -163,6 +163,20 @@ test("addAccount uses separate storage per provider", async () => {
   assert.equal(zaiAccounts[0].label, "Zai Account");
 });
 
+test("Copilot accounts use separate storage", async () => {
+  const { addAccount, loadAccounts } = await loadStorageModule();
+
+  await addAccount("copilot", "Work", "copilot-token");
+  await addAccount("kimi", "Personal", "kimi-token");
+
+  const copilotAccounts = await loadAccounts("copilot");
+  const kimiAccounts = await loadAccounts("kimi");
+  assert.equal(copilotAccounts.length, 1);
+  assert.equal(copilotAccounts[0].label, "Work");
+  assert.equal(copilotAccounts[0].token, "copilot-token");
+  assert.equal(kimiAccounts[0].token, "kimi-token");
+});
+
 test("updateAccount returns true and modifies existing account", async () => {
   const { addAccount, updateAccount, loadAccounts } = await loadStorageModule();
 

--- a/extensions/agent-usage/src/accounts/types.ts
+++ b/extensions/agent-usage/src/accounts/types.ts
@@ -19,6 +19,7 @@ export const ACCOUNTS_STORAGE_KEYS = {
   kimi: "kimi-accounts",
   zai: "zai-accounts",
   codex: "codex-accounts",
+  copilot: "copilot-accounts",
   clinepass: "clinepass-accounts",
   synthetic: "synthetic-accounts",
 } as const;

--- a/extensions/agent-usage/src/agent-usage-menubar.tsx
+++ b/extensions/agent-usage/src/agent-usage-menubar.tsx
@@ -20,7 +20,7 @@ import {
   useClaudeUsage,
   useClinePassAccounts,
   useCodexAccounts,
-  useCopilotUsage,
+  useCopilotAccounts,
   useCursorUsage,
   useDeepSeekUsage,
   useDroidUsage,
@@ -107,7 +107,7 @@ export default function MenuBarCommand() {
   const claudeState = useClaudeUsage(isClaudeVisible);
   const clinePassState = useClinePassAccounts(isClinePassVisible);
   const codexState = useCodexAccounts(isCodexVisible);
-  const copilotState = useCopilotUsage(isCopilotVisible);
+  const copilotState = useCopilotAccounts(isCopilotVisible);
   const cursorState = useCursorUsage(isCursorVisible);
   const deepseekState = useDeepSeekUsage(isDeepSeekVisible);
   const droidState = useDroidUsage(isDroidVisible);
@@ -153,16 +153,6 @@ export default function MenuBarCommand() {
         accessory: getClaudeAccessory(claudeState.usage, claudeState.error, claudeState.isLoading),
         revalidate: claudeState.revalidate,
         lastFetchedAt: claudeState.lastFetchedAt,
-      },
-      {
-        id: "copilot",
-        name: "Copilot",
-        icon: getThemeIcon("copilot-icon.svg"),
-        visible: isCopilotVisible,
-        isLoading: copilotState.isLoading,
-        accessory: getCopilotAccessory(copilotState.usage, copilotState.error, copilotState.isLoading),
-        revalidate: copilotState.revalidate,
-        lastFetchedAt: copilotState.lastFetchedAt,
       },
       {
         id: "cursor",
@@ -259,7 +249,6 @@ export default function MenuBarCommand() {
       isAihubmixVisible,
       isAmpVisible,
       isClaudeVisible,
-      isCopilotVisible,
       isCursorVisible,
       isDeepSeekVisible,
       isDroidVisible,
@@ -281,11 +270,6 @@ export default function MenuBarCommand() {
       claudeState.error,
       claudeState.revalidate,
       claudeState.lastFetchedAt,
-      copilotState.isLoading,
-      copilotState.usage,
-      copilotState.error,
-      copilotState.revalidate,
-      copilotState.lastFetchedAt,
       cursorState.isLoading,
       cursorState.usage,
       cursorState.error,
@@ -389,6 +373,33 @@ export default function MenuBarCommand() {
     }));
   }, [isCodexVisible, codexState]);
 
+  const copilotAgents = useMemo<MenuBarAgent[]>(() => {
+    if (!isCopilotVisible) return [];
+    if (copilotState.isLoading) {
+      return [
+        {
+          id: "copilot" as AgentId,
+          name: "Copilot",
+          icon: getThemeIcon("copilot-icon.svg"),
+          visible: true,
+          isLoading: true,
+          accessory: getCopilotAccessory(null, null, true),
+          revalidate: copilotState.revalidate,
+        },
+      ];
+    }
+    return copilotState.accounts.map((account) => ({
+      id: `copilot-${account.accountId}` as AgentId,
+      name: account.label === "Default" ? "Copilot" : `Copilot • ${account.label}`,
+      icon: getThemeIcon("copilot-icon.svg"),
+      visible: true,
+      isLoading: account.isLoading,
+      accessory: getCopilotAccessory(account.usage, account.error, account.isLoading),
+      revalidate: account.revalidate,
+      lastFetchedAt: account.lastFetchedAt,
+    }));
+  }, [isCopilotVisible, copilotState]);
+
   const kimiAgents = useMemo<MenuBarAgent[]>(() => {
     if (!isKimiVisible) return [];
     if (kimiState.isLoading) {
@@ -476,11 +487,17 @@ export default function MenuBarCommand() {
   const visibleAgents = useMemo(
     () =>
       sortByDefaultAgentOrder(
-        [...singleAgents, ...clinePassAgents, ...codexAgents, ...kimiAgents, ...syntheticAgents, ...zaiAgents].filter(
-          (a) => a.visible,
-        ),
+        [
+          ...singleAgents,
+          ...clinePassAgents,
+          ...codexAgents,
+          ...copilotAgents,
+          ...kimiAgents,
+          ...syntheticAgents,
+          ...zaiAgents,
+        ].filter((a) => a.visible),
       ),
-    [singleAgents, clinePassAgents, codexAgents, kimiAgents, syntheticAgents, zaiAgents],
+    [singleAgents, clinePassAgents, codexAgents, copilotAgents, kimiAgents, syntheticAgents, zaiAgents],
   );
   const isLoading = visibleAgents.some((agent) => agent.isLoading);
 

--- a/extensions/agent-usage/src/agent-usage.tsx
+++ b/extensions/agent-usage/src/agent-usage.tsx
@@ -18,7 +18,7 @@ import { ManageAccountsForm } from "./accounts/ManageAccountsForm.tsx";
 import type { AccountUsageState } from "./accounts/types.ts";
 import { formatErrorMarkdown } from "./agents/detail-format.ts";
 import { formatClock, latestTimestamp } from "./agents/format.ts";
-import { DEFAULT_AGENT_ORDER, getInitialSelectedRowId } from "./agents/order.ts";
+import { DEFAULT_AGENT_ORDER, getInitialSelectedRowId, getRequestedSelectedRowId } from "./agents/order.ts";
 import {
   useAihubmixUsage,
   useAmpUsage,
@@ -685,9 +685,7 @@ export default function Command(props: LaunchProps<{ launchContext: CommandLaunc
 
   const requestedSelectedAgentId = props.launchContext?.selectedAgentId;
   const [selectedItemId, setSelectedItemId] = useState<string | undefined>(() =>
-    typeof requestedSelectedAgentId === "string" && isAgentId(requestedSelectedAgentId)
-      ? requestedSelectedAgentId
-      : undefined,
+    getRequestedSelectedRowId(requestedSelectedAgentId),
   );
 
   useEffect(() => {

--- a/extensions/agent-usage/src/agent-usage.tsx
+++ b/extensions/agent-usage/src/agent-usage.tsx
@@ -26,7 +26,7 @@ import {
   useClaudeUsage,
   useClinePassAccounts,
   useCodexAccounts,
-  useCopilotUsage,
+  useCopilotAccounts,
   useCursorUsage,
   useDeepSeekUsage,
   useDroidUsage,
@@ -96,7 +96,7 @@ interface AgentRegistryEntry<TUsage, TError extends ErrorLike> extends AgentDefi
 }
 
 /** Providers rendered from account rows — they have no single-usage hook. */
-type MultiAccountAgentId = "clinepass" | "codex" | "kimi" | "synthetic" | "zai";
+type MultiAccountAgentId = "clinepass" | "codex" | "copilot" | "kimi" | "synthetic" | "zai";
 
 interface AgentUsageById {
   aihubmix: AihubmixUsage;
@@ -178,7 +178,7 @@ interface AccountedAgentView {
   /** The account id, for use in the manage-accounts form */
   accountId: string;
   /** The provider key, for use in the manage-accounts form */
-  provider: "clinepass" | "kimi" | "zai" | "codex" | "synthetic";
+  provider: "clinepass" | "kimi" | "zai" | "codex" | "copilot" | "synthetic";
   /** Whether this provider is supported (always true for accounted views) */
   isSupported: boolean;
   /** The API token for this account (for copying) */
@@ -254,7 +254,6 @@ const AGENT_REGISTRY: AgentRegistry = {
     description: "GitHub Copilot",
     isSupported: true,
     settingsUrl: "https://github.com/settings/copilot",
-    useUsage: useCopilotUsage,
     renderDetail: renderCopilotDetail,
     getAccessory: getCopilotAccessory,
     formatUsageText: formatCopilotUsageText,
@@ -434,7 +433,7 @@ function createAccountedViews<TUsage, TError extends { type: string; message: st
   providerName: string,
   icon: string,
   settingsUrl: string | undefined,
-  provider: "clinepass" | "kimi" | "zai" | "codex" | "synthetic",
+  provider: "clinepass" | "kimi" | "zai" | "codex" | "copilot" | "synthetic",
   isVisible: boolean,
   accountStates: AccountUsageState<TUsage, TError>[],
   renderDetail: (usage: TUsage | null, error: TError | null) => React.ReactNode,
@@ -472,6 +471,7 @@ function getAccountedTitle(providerName: string, label: string): string {
 function getProviderName(agentId: MultiAccountAgentId): string {
   if (agentId === "clinepass") return "ClinePass";
   if (agentId === "codex") return "Codex";
+  if (agentId === "copilot") return "Copilot";
   if (agentId === "kimi") return "Kimi";
   if (agentId === "zai") return "z.ai";
   return "Synthetic";
@@ -485,7 +485,6 @@ export default function Command(props: LaunchProps<{ launchContext: CommandLaunc
   const aihubmixState = AGENT_REGISTRY.aihubmix.useUsage(Boolean(prefs.showAihubmix));
   const ampState = AGENT_REGISTRY.amp.useUsage(Boolean(prefs.showAmp));
   const claudeState = AGENT_REGISTRY.claude.useUsage(Boolean(prefs.showClaude));
-  const copilotState = AGENT_REGISTRY.copilot.useUsage(Boolean(prefs.showCopilot));
   const cursorState = AGENT_REGISTRY.cursor.useUsage(Boolean(prefs.showCursor));
   const deepseekState = AGENT_REGISTRY.deepseek.useUsage(Boolean(prefs.showDeepSeek));
   const droidState = AGENT_REGISTRY.droid.useUsage(Boolean(prefs.showDroid));
@@ -499,6 +498,7 @@ export default function Command(props: LaunchProps<{ launchContext: CommandLaunc
   // Multi-account providers
   const clinePassState = useClinePassAccounts(Boolean(prefs.showClinePass));
   const codexState = useCodexAccounts(Boolean(prefs.showCodex));
+  const copilotState = useCopilotAccounts(Boolean(prefs.showCopilot));
   const kimiState = useKimiAccounts(Boolean(prefs.showKimi));
   const syntheticState = useSyntheticAccounts(Boolean(prefs.showSynthetic));
   const zaiState = useZaiAccounts(Boolean(prefs.showZai));
@@ -507,7 +507,6 @@ export default function Command(props: LaunchProps<{ launchContext: CommandLaunc
     aihubmix: createAgentView(AGENT_REGISTRY.aihubmix, aihubmixState, Boolean(prefs.showAihubmix)),
     amp: createAgentView(AGENT_REGISTRY.amp, ampState, Boolean(prefs.showAmp)),
     claude: createAgentView(AGENT_REGISTRY.claude, claudeState, Boolean(prefs.showClaude)),
-    copilot: createAgentView(AGENT_REGISTRY.copilot, copilotState, Boolean(prefs.showCopilot)),
     cursor: createAgentView(AGENT_REGISTRY.cursor, cursorState, Boolean(prefs.showCursor)),
     deepseek: createAgentView(AGENT_REGISTRY.deepseek, deepseekState, Boolean(prefs.showDeepSeek)),
     droid: createAgentView(AGENT_REGISTRY.droid, droidState, Boolean(prefs.showDroid)),
@@ -543,6 +542,19 @@ export default function Command(props: LaunchProps<{ launchContext: CommandLaunc
     renderKimiDetail,
     getKimiAccessory,
     formatKimiUsageText,
+  );
+
+  const copilotAccountedViews = createAccountedViews(
+    "copilot",
+    "Copilot",
+    AGENT_REGISTRY.copilot.icon,
+    AGENT_REGISTRY.copilot.settingsUrl,
+    "copilot",
+    Boolean(prefs.showCopilot),
+    copilotState.accounts,
+    renderCopilotDetail,
+    getCopilotAccessory,
+    formatCopilotUsageText,
   );
 
   const zaiAccountedViews = createAccountedViews(
@@ -640,6 +652,9 @@ export default function Command(props: LaunchProps<{ launchContext: CommandLaunc
         if (agentId === "codex") {
           return codexAccountedViews.filter((v) => v.isVisible).map((view) => ({ kind: "accounted", view }));
         }
+        if (agentId === "copilot") {
+          return copilotAccountedViews.filter((v) => v.isVisible).map((view) => ({ kind: "accounted", view }));
+        }
         if (agentId === "kimi") {
           return kimiAccountedViews.filter((v) => v.isVisible).map((view) => ({ kind: "accounted", view }));
         }
@@ -660,6 +675,7 @@ export default function Command(props: LaunchProps<{ launchContext: CommandLaunc
       agentOrder,
       clinePassAccountedViews,
       codexAccountedViews,
+      copilotAccountedViews,
       kimiAccountedViews,
       syntheticAccountedViews,
       zaiAccountedViews,
@@ -696,7 +712,7 @@ export default function Command(props: LaunchProps<{ launchContext: CommandLaunc
 
   const isLoading =
     allRows.some((row) => row.view.isLoading) ||
-    [clinePassState, codexState, kimiState, syntheticState, zaiState].some((state) => state.isLoading);
+    [clinePassState, codexState, copilotState, kimiState, syntheticState, zaiState].some((state) => state.isLoading);
 
   const hasPromptedGeminiReauth = useRef(false);
 

--- a/extensions/agent-usage/src/agents/order.test.ts
+++ b/extensions/agent-usage/src/agents/order.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { getInitialSelectedRowId, sortByDefaultAgentOrder } from "./order.ts";
+import { getInitialSelectedRowId, getRequestedSelectedRowId, sortByDefaultAgentOrder } from "./order.ts";
 import type { AgentId } from "./types.ts";
 
 test("sortByDefaultAgentOrder uses the canonical provider order and keeps provider accounts together", () => {
@@ -71,4 +71,9 @@ test("getInitialSelectedRowId falls back to the first rendered row without a sav
 
   assert.equal(getInitialSelectedRowId(rows), "amp");
   assert.equal(getInitialSelectedRowId([]), undefined);
+});
+
+test("getRequestedSelectedRowId accepts dynamic account row IDs", () => {
+  assert.equal(getRequestedSelectedRowId("copilot-account-1"), "copilot-account-1");
+  assert.equal(getRequestedSelectedRowId(undefined), undefined);
 });

--- a/extensions/agent-usage/src/agents/order.ts
+++ b/extensions/agent-usage/src/agents/order.ts
@@ -48,3 +48,7 @@ export function getInitialSelectedRowId(
 
   return rows[0]?.rowId;
 }
+
+export function getRequestedSelectedRowId(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}

--- a/extensions/agent-usage/src/agents/provider-hooks.ts
+++ b/extensions/agent-usage/src/agents/provider-hooks.ts
@@ -19,7 +19,8 @@ import { buildCodexAccountCandidates } from "../codex/accounts.ts";
 import { listCodexOAuthAccounts, parseAdditionalCodexHomes } from "../codex/auth.ts";
 import { fetchCodexUsage } from "../codex/fetcher.ts";
 import type { CodexError, CodexUsage } from "../codex/types.ts";
-import { resolveCopilotAuthTokens, shouldFallbackToPreferenceToken } from "../copilot/auth.ts";
+import { buildCopilotAccountCandidates } from "../copilot/accounts.ts";
+import { resolveCopilotAuthTokens } from "../copilot/auth.ts";
 import { fetchCopilotUsage } from "../copilot/fetcher.ts";
 import type { CopilotError, CopilotUsage } from "../copilot/types.ts";
 import { fetchCursorUsage, resolveCursorCredential } from "../cursor/fetcher.ts";
@@ -119,35 +120,25 @@ export const useClaudeUsage = createUsageHook<ClaudeUsage, ClaudeError>({
   },
 });
 
-async function resolveCopilotTokens() {
-  return resolveCopilotAuthTokens({ preferenceToken: prefValue("copilotAuthToken") });
-}
-
-export const useCopilotUsage = createUsageHook<CopilotUsage, CopilotError>({
+export const useCopilotAccounts = createAccountsHook<
+  CopilotUsage,
+  CopilotError,
+  ReturnType<typeof buildCopilotAccountCandidates>[number]
+>({
   agentId: "copilot",
-  resolveAuthKey: async () => {
-    const { primaryToken, preferenceToken } = await resolveCopilotTokens();
-    return `${primaryToken ?? ""}\n${preferenceToken ?? ""}`;
+  getAccounts: async () => {
+    const { githubToken, ghToken } = await resolveCopilotAuthTokens();
+    return buildCopilotAccountCandidates({
+      manualAccounts: await loadAccounts("copilot"),
+      preferenceToken: prefValue("copilotAuthToken"),
+      githubToken,
+      ghToken,
+    });
   },
-  fetcher: async () => {
-    const { primaryToken, localToken, preferenceToken } = await resolveCopilotTokens();
-    if (!primaryToken) {
-      return {
-        usage: null,
-        error: {
-          type: "not_configured",
-          message: "Copilot is not configured. Set GH_TOKEN/GITHUB_TOKEN or add a token in extension settings (Cmd+,).",
-        },
-      };
-    }
-    let result = await fetchCopilotUsage(primaryToken);
-    if (
-      preferenceToken &&
-      shouldFallbackToPreferenceToken({ localToken, preferenceToken, errorType: result.error?.type })
-    ) {
-      result = await fetchCopilotUsage(preferenceToken);
-    }
-    return result;
+  fetcher: (account) => fetchCopilotUsage(account.token),
+  noAccountsError: {
+    type: "not_configured",
+    message: "Copilot is not configured. Set GH_TOKEN/GITHUB_TOKEN or add an account via Manage Accounts.",
   },
 });
 

--- a/extensions/agent-usage/src/agents/provider-hooks.ts
+++ b/extensions/agent-usage/src/agents/provider-hooks.ts
@@ -127,10 +127,11 @@ export const useCopilotAccounts = createAccountsHook<
 >({
   agentId: "copilot",
   getAccounts: async () => {
-    const { githubToken, ghToken } = await resolveCopilotAuthTokens();
+    const { cliToken, githubToken, ghToken } = await resolveCopilotAuthTokens();
     return buildCopilotAccountCandidates({
       manualAccounts: await loadAccounts("copilot"),
       preferenceToken: prefValue("copilotAuthToken"),
+      cliToken,
       githubToken,
       ghToken,
     });

--- a/extensions/agent-usage/src/copilot/accounts.test.ts
+++ b/extensions/agent-usage/src/copilot/accounts.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildCopilotAccountCandidates } from "./accounts.ts";
+
+test("buildCopilotAccountCandidates keeps named manual accounts first", () => {
+  const accounts = buildCopilotAccountCandidates({
+    manualAccounts: [
+      { id: "work", label: "Work", token: "work-token" },
+      { id: "personal", label: "Personal", token: "personal-token" },
+    ],
+    preferenceToken: "preference-token",
+    githubToken: "github-token",
+    ghToken: "gh-token",
+  });
+
+  assert.deepEqual(
+    accounts.map(({ id, label, token }) => ({ id, label, token })),
+    [
+      { id: "work", label: "Work", token: "work-token" },
+      { id: "personal", label: "Personal", token: "personal-token" },
+      { id: "copilot-pref", label: "Preference", token: "preference-token" },
+      { id: "copilot-github-env", label: "GITHUB_TOKEN", token: "github-token" },
+      { id: "copilot-gh-env", label: "GH_TOKEN", token: "gh-token" },
+    ],
+  );
+});
+
+test("buildCopilotAccountCandidates deduplicates tokens and preserves the first label", () => {
+  const accounts = buildCopilotAccountCandidates({
+    manualAccounts: [{ id: "work", label: "Work", token: " shared-token " }],
+    preferenceToken: "shared-token",
+    githubToken: "shared-token",
+    ghToken: "other-token",
+  });
+
+  assert.deepEqual(accounts, [
+    { id: "work", label: "Work", token: "shared-token" },
+    { id: "copilot-gh-env", label: "GH_TOKEN", token: "other-token" },
+  ]);
+});
+
+test("buildCopilotAccountCandidates drops empty tokens", () => {
+  const accounts = buildCopilotAccountCandidates({
+    manualAccounts: [],
+    preferenceToken: "  ",
+    githubToken: null,
+    ghToken: null,
+  });
+
+  assert.deepEqual(accounts, []);
+});

--- a/extensions/agent-usage/src/copilot/accounts.test.ts
+++ b/extensions/agent-usage/src/copilot/accounts.test.ts
@@ -10,6 +10,7 @@ test("buildCopilotAccountCandidates keeps named manual accounts first", () => {
       { id: "personal", label: "Personal", token: "personal-token" },
     ],
     preferenceToken: "preference-token",
+    cliToken: "cli-token",
     githubToken: "github-token",
     ghToken: "gh-token",
   });
@@ -20,6 +21,7 @@ test("buildCopilotAccountCandidates keeps named manual accounts first", () => {
       { id: "work", label: "Work", token: "work-token" },
       { id: "personal", label: "Personal", token: "personal-token" },
       { id: "copilot-pref", label: "Preference", token: "preference-token" },
+      { id: "copilot-gh-cli", label: "GitHub CLI", token: "cli-token" },
       { id: "copilot-github-env", label: "GITHUB_TOKEN", token: "github-token" },
       { id: "copilot-gh-env", label: "GH_TOKEN", token: "gh-token" },
     ],
@@ -30,6 +32,7 @@ test("buildCopilotAccountCandidates deduplicates tokens and preserves the first 
   const accounts = buildCopilotAccountCandidates({
     manualAccounts: [{ id: "work", label: "Work", token: " shared-token " }],
     preferenceToken: "shared-token",
+    cliToken: "shared-token",
     githubToken: "shared-token",
     ghToken: "other-token",
   });
@@ -44,6 +47,7 @@ test("buildCopilotAccountCandidates drops empty tokens", () => {
   const accounts = buildCopilotAccountCandidates({
     manualAccounts: [],
     preferenceToken: "  ",
+    cliToken: null,
     githubToken: null,
     ghToken: null,
   });

--- a/extensions/agent-usage/src/copilot/accounts.ts
+++ b/extensions/agent-usage/src/copilot/accounts.ts
@@ -1,0 +1,41 @@
+import type { AccountEntry } from "../accounts/types.ts";
+
+export interface CopilotAccountCandidate {
+  id: string;
+  label: string;
+  token: string;
+}
+
+interface BuildCopilotAccountCandidatesOptions {
+  manualAccounts: AccountEntry[];
+  preferenceToken?: string;
+  githubToken?: string | null;
+  ghToken?: string | null;
+}
+
+export function buildCopilotAccountCandidates({
+  manualAccounts,
+  preferenceToken,
+  githubToken,
+  ghToken,
+}: BuildCopilotAccountCandidatesOptions): CopilotAccountCandidate[] {
+  const accounts: CopilotAccountCandidate[] = [];
+  const seenTokens = new Set<string>();
+
+  const addAccount = (account: CopilotAccountCandidate): void => {
+    const token = account.token.trim();
+    if (!token || seenTokens.has(token)) return;
+    seenTokens.add(token);
+    accounts.push({ ...account, token });
+  };
+
+  for (const account of manualAccounts) {
+    addAccount(account);
+  }
+
+  addAccount({ id: "copilot-pref", label: "Preference", token: preferenceToken ?? "" });
+  addAccount({ id: "copilot-github-env", label: "GITHUB_TOKEN", token: githubToken ?? "" });
+  addAccount({ id: "copilot-gh-env", label: "GH_TOKEN", token: ghToken ?? "" });
+
+  return accounts;
+}

--- a/extensions/agent-usage/src/copilot/accounts.ts
+++ b/extensions/agent-usage/src/copilot/accounts.ts
@@ -9,6 +9,7 @@ export interface CopilotAccountCandidate {
 interface BuildCopilotAccountCandidatesOptions {
   manualAccounts: AccountEntry[];
   preferenceToken?: string;
+  cliToken?: string | null;
   githubToken?: string | null;
   ghToken?: string | null;
 }
@@ -16,6 +17,7 @@ interface BuildCopilotAccountCandidatesOptions {
 export function buildCopilotAccountCandidates({
   manualAccounts,
   preferenceToken,
+  cliToken,
   githubToken,
   ghToken,
 }: BuildCopilotAccountCandidatesOptions): CopilotAccountCandidate[] {
@@ -34,6 +36,7 @@ export function buildCopilotAccountCandidates({
   }
 
   addAccount({ id: "copilot-pref", label: "Preference", token: preferenceToken ?? "" });
+  addAccount({ id: "copilot-gh-cli", label: "GitHub CLI", token: cliToken ?? "" });
   addAccount({ id: "copilot-github-env", label: "GITHUB_TOKEN", token: githubToken ?? "" });
   addAccount({ id: "copilot-gh-env", label: "GH_TOKEN", token: ghToken ?? "" });
 

--- a/extensions/agent-usage/src/copilot/auth.test.ts
+++ b/extensions/agent-usage/src/copilot/auth.test.ts
@@ -8,8 +8,23 @@ function makeFakeShell(outputLines: string[]): { dir: string; shellPath: string 
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "copilot-auth-test-"));
   const isWindows = process.platform === "win32";
   const shellPath = path.join(dir, isWindows ? "fake-shell.cmd" : "fake-shell.sh");
+  const githubToken = outputLines
+    .find((line) => line.includes("__GITHUB_TOKEN_START__"))
+    ?.replace(/^.*__GITHUB_TOKEN_START__/, "")
+    .replace(/__GITHUB_TOKEN_END__.*$/, "");
+  const ghToken = outputLines
+    .find((line) => line.includes("__GH_TOKEN_START__"))
+    ?.replace(/^.*__GH_TOKEN_START__/, "")
+    .replace(/__GH_TOKEN_END__.*$/, "");
   const scriptBody = isWindows
-    ? `@echo off\r\n${outputLines.map((line) => `echo ${line}`).join("\r\n")}\r\n`
+    ? [
+        "@echo off",
+        ...outputLines.filter((line) => !line.includes("_TOKEN_START__")).map((line) => `echo ${line}`),
+        githubToken ? `set GITHUB_TOKEN=${githubToken}` : "",
+        ghToken ? `set GH_TOKEN=${ghToken}` : "",
+      ]
+        .filter(Boolean)
+        .join("\r\n")
     : `#!/bin/sh\n${outputLines.map((line) => `printf '%s\\n' '${line}'`).join("\n")}\n`;
   fs.writeFileSync(shellPath, scriptBody, "utf-8");
   if (!isWindows) fs.chmodSync(shellPath, 0o755);
@@ -37,9 +52,22 @@ test("resolveCopilotAuthTokens returns both process environment tokens", async (
   const { resolveCopilotAuthTokens } = await import("./auth.ts");
 
   await withEnv({ GITHUB_TOKEN: " github-token ", GH_TOKEN: "gh-token" }, async () => {
-    assert.deepEqual(await resolveCopilotAuthTokens(), {
+    assert.deepEqual(await resolveCopilotAuthTokens({ readGhToken: async () => null }), {
+      cliToken: null,
       githubToken: "github-token",
       ghToken: "gh-token",
+    });
+  });
+});
+
+test("resolveCopilotAuthTokens prefers the GitHub CLI token over environment tokens", async () => {
+  const { resolveCopilotAuthTokens } = await import("./auth.ts");
+
+  await withEnv({ GITHUB_TOKEN: "github-token", GH_TOKEN: "gh-token" }, async () => {
+    assert.deepEqual(await resolveCopilotAuthTokens({ readGhToken: async () => " cli-token " }), {
+      cliToken: "cli-token",
+      githubToken: null,
+      ghToken: null,
     });
   });
 });
@@ -54,7 +82,8 @@ test("resolveCopilotAuthTokens reads both tokens from noisy shell output", async
 
   try {
     await withEnv({ GITHUB_TOKEN: undefined, GH_TOKEN: undefined, SHELL: shellPath }, async () => {
-      assert.deepEqual(await resolveCopilotAuthTokens(), {
+      assert.deepEqual(await resolveCopilotAuthTokens({ readGhToken: async () => null }), {
+        cliToken: null,
         githubToken: "shell-github",
         ghToken: "shell-gh",
       });
@@ -73,7 +102,8 @@ test("resolveCopilotAuthTokens prefers each process token over its shell value",
 
   try {
     await withEnv({ GITHUB_TOKEN: "direct-github", GH_TOKEN: undefined, SHELL: shellPath }, async () => {
-      assert.deepEqual(await resolveCopilotAuthTokens(), {
+      assert.deepEqual(await resolveCopilotAuthTokens({ readGhToken: async () => null }), {
+        cliToken: null,
         githubToken: "direct-github",
         ghToken: "shell-gh",
       });
@@ -82,3 +112,30 @@ test("resolveCopilotAuthTokens prefers each process token over its shell value",
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test(
+  "resolveCopilotAuthTokens runs lookup after a Windows batch wrapper initializes tokens",
+  { skip: process.platform !== "win32" },
+  async () => {
+    const { resolveCopilotAuthTokens } = await import("./auth.ts");
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "copilot-batch-auth-test-"));
+    const shellPath = path.join(dir, "fake-shell.cmd");
+    fs.writeFileSync(
+      shellPath,
+      ["@echo off", "set GITHUB_TOKEN=batch-github", "set GH_TOKEN=batch-gh"].join("\r\n"),
+      "utf-8",
+    );
+
+    try {
+      await withEnv({ GITHUB_TOKEN: undefined, GH_TOKEN: undefined, SHELL: shellPath }, async () => {
+        assert.deepEqual(await resolveCopilotAuthTokens({ readGhToken: async () => null }), {
+          cliToken: null,
+          githubToken: "batch-github",
+          ghToken: "batch-gh",
+        });
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);

--- a/extensions/agent-usage/src/copilot/auth.test.ts
+++ b/extensions/agent-usage/src/copilot/auth.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+function makeFakeShell(outputLines: string[]): { dir: string; shellPath: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "copilot-auth-test-"));
+  const isWindows = process.platform === "win32";
+  const shellPath = path.join(dir, isWindows ? "fake-shell.cmd" : "fake-shell.sh");
+  const scriptBody = isWindows
+    ? `@echo off\r\n${outputLines.map((line) => `echo ${line}`).join("\r\n")}\r\n`
+    : `#!/bin/sh\n${outputLines.map((line) => `printf '%s\\n' '${line}'`).join("\n")}\n`;
+  fs.writeFileSync(shellPath, scriptBody, "utf-8");
+  if (!isWindows) fs.chmodSync(shellPath, 0o755);
+  return { dir, shellPath };
+}
+
+async function withEnv<T>(updates: Record<string, string | undefined>, run: () => Promise<T>): Promise<T> {
+  const previous = Object.fromEntries(Object.keys(updates).map((key) => [key, process.env[key]]));
+  for (const [key, value] of Object.entries(updates)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+
+  try {
+    return await run();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+test("resolveCopilotAuthTokens returns both process environment tokens", async () => {
+  const { resolveCopilotAuthTokens } = await import("./auth.ts");
+
+  await withEnv({ GITHUB_TOKEN: " github-token ", GH_TOKEN: "gh-token" }, async () => {
+    assert.deepEqual(await resolveCopilotAuthTokens(), {
+      githubToken: "github-token",
+      ghToken: "gh-token",
+    });
+  });
+});
+
+test("resolveCopilotAuthTokens reads both tokens from noisy shell output", async () => {
+  const { resolveCopilotAuthTokens } = await import("./auth.ts");
+  const { dir, shellPath } = makeFakeShell([
+    "loading shell plugins...",
+    "__GITHUB_TOKEN_START__shell-github__GITHUB_TOKEN_END__",
+    "__GH_TOKEN_START__shell-gh__GH_TOKEN_END__",
+  ]);
+
+  try {
+    await withEnv({ GITHUB_TOKEN: undefined, GH_TOKEN: undefined, SHELL: shellPath }, async () => {
+      assert.deepEqual(await resolveCopilotAuthTokens(), {
+        githubToken: "shell-github",
+        ghToken: "shell-gh",
+      });
+    });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveCopilotAuthTokens prefers each process token over its shell value", async () => {
+  const { resolveCopilotAuthTokens } = await import("./auth.ts");
+  const { dir, shellPath } = makeFakeShell([
+    "__GITHUB_TOKEN_START__shell-github__GITHUB_TOKEN_END__",
+    "__GH_TOKEN_START__shell-gh__GH_TOKEN_END__",
+  ]);
+
+  try {
+    await withEnv({ GITHUB_TOKEN: "direct-github", GH_TOKEN: undefined, SHELL: shellPath }, async () => {
+      assert.deepEqual(await resolveCopilotAuthTokens(), {
+        githubToken: "direct-github",
+        ghToken: "shell-gh",
+      });
+    });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/extensions/agent-usage/src/copilot/auth.ts
+++ b/extensions/agent-usage/src/copilot/auth.ts
@@ -29,21 +29,32 @@ function extractMarkedValue(output: string, startMarker: string, endMarker: stri
 }
 
 function parseShellLookupOutput(output: string): { githubToken: string | null; ghToken: string | null } {
+  const githubToken = extractMarkedValue(output, GITHUB_TOKEN_START_MARKER, GITHUB_TOKEN_END_MARKER);
+  const ghToken = extractMarkedValue(output, GH_TOKEN_START_MARKER, GH_TOKEN_END_MARKER);
+
   return {
-    githubToken: extractMarkedValue(output, GITHUB_TOKEN_START_MARKER, GITHUB_TOKEN_END_MARKER),
-    ghToken: extractMarkedValue(output, GH_TOKEN_START_MARKER, GH_TOKEN_END_MARKER),
+    githubToken: githubToken === "%GITHUB_TOKEN%" ? null : githubToken,
+    ghToken: ghToken === "%GH_TOKEN%" ? null : ghToken,
   };
 }
 
 async function readShellEnvTokens(): Promise<{ githubToken: string | null; ghToken: string | null }> {
   try {
-    const shell = process.env.SHELL || "/bin/zsh";
-    const lookupScript = [
-      `printf '${GITHUB_TOKEN_START_MARKER}%s${GITHUB_TOKEN_END_MARKER}\\n' "$GITHUB_TOKEN"`,
-      `printf '${GH_TOKEN_START_MARKER}%s${GH_TOKEN_END_MARKER}\\n' "$GH_TOKEN"`,
-    ].join("; ");
+    const shell = process.env.SHELL || (process.platform === "win32" ? process.env.ComSpec || "cmd.exe" : "/bin/zsh");
+    const shellName = shell.replaceAll("\\", "/").split("/").pop()?.toLowerCase() ?? "";
+    const isCommandShell = shellName === "cmd.exe" || shellName.endsWith(".cmd") || shellName.endsWith(".bat");
+    const lookupScript = isCommandShell
+      ? `echo ${GITHUB_TOKEN_START_MARKER}%GITHUB_TOKEN%${GITHUB_TOKEN_END_MARKER} & echo ${GH_TOKEN_START_MARKER}%GH_TOKEN%${GH_TOKEN_END_MARKER}`
+      : [
+          `printf '${GITHUB_TOKEN_START_MARKER}%s${GITHUB_TOKEN_END_MARKER}\\n' "$GITHUB_TOKEN"`,
+          `printf '${GH_TOKEN_START_MARKER}%s${GH_TOKEN_END_MARKER}\\n' "$GH_TOKEN"`,
+        ].join("; ");
+    const shellArgs = isCommandShell ? ["/d", "/s", "/c", lookupScript] : ["-ilc", lookupScript];
+    const isBatchShell = shellName.endsWith(".cmd") || shellName.endsWith(".bat");
+    const executable = isBatchShell ? process.env.ComSpec || "cmd.exe" : shell;
+    const executableArgs = isBatchShell ? ["/d", "/c", shell] : shellArgs;
 
-    const { stdout } = await execFileAsync(shell, ["-ilc", lookupScript], {
+    const { stdout } = await execFileAsync(executable, executableArgs, {
       encoding: "utf-8",
       timeout: SHELL_LOOKUP_TIMEOUT_MS,
       maxBuffer: 64 * 1024,
@@ -55,44 +66,22 @@ async function readShellEnvTokens(): Promise<{ githubToken: string | null; ghTok
   }
 }
 
-async function readLocalToken(): Promise<string | null> {
-  const direct = cleanToken(process.env.GITHUB_TOKEN) ?? cleanToken(process.env.GH_TOKEN);
-  if (direct) {
-    return direct;
+export interface CopilotAuthTokens {
+  githubToken: string | null;
+  ghToken: string | null;
+}
+
+export async function resolveCopilotAuthTokens(): Promise<CopilotAuthTokens> {
+  const directGithubToken = cleanToken(process.env.GITHUB_TOKEN);
+  const directGhToken = cleanToken(process.env.GH_TOKEN);
+  if (directGithubToken && directGhToken) {
+    return { githubToken: directGithubToken, ghToken: directGhToken };
   }
 
   const { githubToken, ghToken } = await readShellEnvTokens();
-  return githubToken ?? ghToken;
-}
-
-interface ResolveCopilotAuthTokensResult {
-  primaryToken: string | null;
-  localToken: string | null;
-  preferenceToken: string | null;
-}
-
-export async function resolveCopilotAuthTokens(
-  options: { preferenceToken?: string } = {},
-): Promise<ResolveCopilotAuthTokensResult> {
-  const localToken = await readLocalToken();
-  const preferenceToken = cleanToken(options.preferenceToken);
 
   return {
-    primaryToken: localToken ?? preferenceToken,
-    localToken,
-    preferenceToken,
+    githubToken: directGithubToken ?? githubToken,
+    ghToken: directGhToken ?? ghToken,
   };
-}
-
-export function shouldFallbackToPreferenceToken(options: {
-  localToken: string | null;
-  preferenceToken: string | null;
-  errorType?: string;
-}): boolean {
-  return (
-    options.errorType === "unauthorized" &&
-    options.localToken !== null &&
-    options.preferenceToken !== null &&
-    options.localToken !== options.preferenceToken
-  );
 }

--- a/extensions/agent-usage/src/copilot/auth.ts
+++ b/extensions/agent-usage/src/copilot/auth.ts
@@ -8,7 +8,7 @@ const GITHUB_TOKEN_END_MARKER = "__GITHUB_TOKEN_END__";
 const GH_TOKEN_START_MARKER = "__GH_TOKEN_START__";
 const GH_TOKEN_END_MARKER = "__GH_TOKEN_END__";
 
-function cleanToken(token: string | undefined): string | null {
+function cleanToken(token: string | null | undefined): string | null {
   const trimmed = token?.trim();
   return trimmed ? trimmed : null;
 }
@@ -44,20 +44,21 @@ async function readShellEnvTokens(): Promise<{ githubToken: string | null; ghTok
     const shellName = shell.replaceAll("\\", "/").split("/").pop()?.toLowerCase() ?? "";
     const isCommandShell = shellName === "cmd.exe" || shellName.endsWith(".cmd") || shellName.endsWith(".bat");
     const lookupScript = isCommandShell
-      ? `echo ${GITHUB_TOKEN_START_MARKER}%GITHUB_TOKEN%${GITHUB_TOKEN_END_MARKER} & echo ${GH_TOKEN_START_MARKER}%GH_TOKEN%${GH_TOKEN_END_MARKER}`
+      ? `echo ${GITHUB_TOKEN_START_MARKER}!GITHUB_TOKEN!${GITHUB_TOKEN_END_MARKER} & echo ${GH_TOKEN_START_MARKER}!GH_TOKEN!${GH_TOKEN_END_MARKER}`
       : [
           `printf '${GITHUB_TOKEN_START_MARKER}%s${GITHUB_TOKEN_END_MARKER}\\n' "$GITHUB_TOKEN"`,
           `printf '${GH_TOKEN_START_MARKER}%s${GH_TOKEN_END_MARKER}\\n' "$GH_TOKEN"`,
         ].join("; ");
-    const shellArgs = isCommandShell ? ["/d", "/s", "/c", lookupScript] : ["-ilc", lookupScript];
+    const shellArgs = isCommandShell ? ["/d", "/v:on", "/s", "/c", lookupScript] : ["-ilc", lookupScript];
     const isBatchShell = shellName.endsWith(".cmd") || shellName.endsWith(".bat");
     const executable = isBatchShell ? process.env.ComSpec || "cmd.exe" : shell;
-    const executableArgs = isBatchShell ? ["/d", "/c", shell] : shellArgs;
+    const executableArgs = isBatchShell ? ["/d", "/v:on", "/c", `call "${shell}" & ${lookupScript}`] : shellArgs;
 
     const { stdout } = await execFileAsync(executable, executableArgs, {
       encoding: "utf-8",
       timeout: SHELL_LOOKUP_TIMEOUT_MS,
       maxBuffer: 64 * 1024,
+      windowsVerbatimArguments: isCommandShell,
     });
 
     return parseShellLookupOutput(stdout);
@@ -66,21 +67,47 @@ async function readShellEnvTokens(): Promise<{ githubToken: string | null; ghTok
   }
 }
 
+async function readGhCliToken(): Promise<string | null> {
+  try {
+    const env = { ...process.env };
+    delete env.GITHUB_TOKEN;
+    delete env.GH_TOKEN;
+    const { stdout } = await execFileAsync("gh", ["auth", "token"], {
+      encoding: "utf-8",
+      timeout: SHELL_LOOKUP_TIMEOUT_MS,
+      maxBuffer: 64 * 1024,
+      env,
+    });
+    return cleanToken(stdout);
+  } catch {
+    return null;
+  }
+}
+
 export interface CopilotAuthTokens {
+  cliToken: string | null;
   githubToken: string | null;
   ghToken: string | null;
 }
 
-export async function resolveCopilotAuthTokens(): Promise<CopilotAuthTokens> {
+export async function resolveCopilotAuthTokens(
+  options: { readGhToken?: () => Promise<string | null> } = {},
+): Promise<CopilotAuthTokens> {
+  const cliToken = cleanToken(await (options.readGhToken ?? readGhCliToken)());
+  if (cliToken) {
+    return { cliToken, githubToken: null, ghToken: null };
+  }
+
   const directGithubToken = cleanToken(process.env.GITHUB_TOKEN);
   const directGhToken = cleanToken(process.env.GH_TOKEN);
   if (directGithubToken && directGhToken) {
-    return { githubToken: directGithubToken, ghToken: directGhToken };
+    return { cliToken: null, githubToken: directGithubToken, ghToken: directGhToken };
   }
 
   const { githubToken, ghToken } = await readShellEnvTokens();
 
   return {
+    cliToken: null,
     githubToken: directGithubToken ?? githubToken,
     ghToken: directGhToken ?? ghToken,
   };

--- a/extensions/agent-usage/src/copilot/fetcher.test.ts
+++ b/extensions/agent-usage/src/copilot/fetcher.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseCopilotResponse } from "./fetcher.ts";
+
+test("parseCopilotResponse maps premium interactions to AI credit percentage and units", () => {
+  const { usage, error } = parseCopilotResponse({
+    copilot_plan: "business",
+    quota_reset_date: "2026-09-01T00:00:00Z",
+    quota_snapshots: {
+      premium_interactions: {
+        percent_remaining: 8,
+        remaining: 24,
+        entitlement: 300,
+      },
+      chat: { percent_remaining: 100 },
+    },
+  });
+
+  assert.equal(error, null);
+  assert.deepEqual(usage, {
+    plan: "Business",
+    aiCreditsRemainingPercent: 8,
+    aiCreditsRemaining: 24,
+    aiCreditsEntitlement: 300,
+    chatRemaining: 100,
+    quotaResetDate: "2026-09-01T00:00:00Z",
+  });
+});
+
+test("parseCopilotResponse derives AI credit units from legacy quota fields", () => {
+  const { usage, error } = parseCopilotResponse({
+    monthly_quotas: { completions: "300", chat: 100 },
+    limited_user_quotas: { completions: "75", chat: 50 },
+  });
+
+  assert.equal(error, null);
+  assert.equal(usage?.aiCreditsRemainingPercent, 25);
+  assert.equal(usage?.aiCreditsRemaining, 75);
+  assert.equal(usage?.aiCreditsEntitlement, 300);
+});

--- a/extensions/agent-usage/src/copilot/fetcher.ts
+++ b/extensions/agent-usage/src/copilot/fetcher.ts
@@ -75,22 +75,27 @@ function deriveFromMonthlyAndLimited(monthly?: number | string, limited?: number
   return clampPercent((limitedNum / monthlyNum) * 100);
 }
 
-function parseCopilotResponse(data: unknown): { usage: CopilotUsage | null; error: CopilotError | null } {
+export function parseCopilotResponse(data: unknown): { usage: CopilotUsage | null; error: CopilotError | null } {
   if (!data || typeof data !== "object") {
     return { usage: null, error: { type: "parse_error", message: "Invalid Copilot API response format" } };
   }
 
   const response = data as CopilotResponse;
 
-  const premiumRemaining =
-    getPercentRemaining(response.quota_snapshots?.premium_interactions) ??
+  const aiCreditsSnapshot = response.quota_snapshots?.premium_interactions;
+  const aiCreditsRemainingPercent =
+    getPercentRemaining(aiCreditsSnapshot) ??
     deriveFromMonthlyAndLimited(response.monthly_quotas?.completions, response.limited_user_quotas?.completions);
+  const aiCreditsEntitlement =
+    toNumber(aiCreditsSnapshot?.entitlement) ?? toNumber(response.monthly_quotas?.completions);
+  const aiCreditsRemaining =
+    toNumber(aiCreditsSnapshot?.remaining) ?? toNumber(response.limited_user_quotas?.completions);
 
   const chatRemaining =
     getPercentRemaining(response.quota_snapshots?.chat) ??
     deriveFromMonthlyAndLimited(response.monthly_quotas?.chat, response.limited_user_quotas?.chat);
 
-  if (premiumRemaining === null && chatRemaining === null) {
+  if (aiCreditsRemainingPercent === null && chatRemaining === null) {
     return {
       usage: null,
       error: {
@@ -103,7 +108,9 @@ function parseCopilotResponse(data: unknown): { usage: CopilotUsage | null; erro
   return {
     usage: {
       plan: formatPlan(response.copilot_plan),
-      premiumRemaining,
+      aiCreditsRemainingPercent,
+      aiCreditsRemaining,
+      aiCreditsEntitlement,
       chatRemaining,
       quotaResetDate: response.quota_reset_date || null,
     },

--- a/extensions/agent-usage/src/copilot/renderer.tsx
+++ b/extensions/agent-usage/src/copilot/renderer.tsx
@@ -16,16 +16,37 @@ function formatPercent(value: number | null): string {
   return value === null ? "N/A" : `${value}%`;
 }
 
+function getAiCreditsRemainingPercent(usage: CopilotUsage): number | null {
+  return usage.aiCreditsRemainingPercent ?? usage.premiumRemaining ?? null;
+}
+
+function formatCreditAmount(value: number): string {
+  return new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 }).format(value);
+}
+
+function formatAiCreditsBalance(usage: CopilotUsage): string | null {
+  const remaining = usage.aiCreditsRemaining ?? null;
+  const entitlement = usage.aiCreditsEntitlement ?? null;
+  if (remaining === null) return null;
+  if (entitlement === null) return `${formatCreditAmount(remaining)} credits`;
+  return `${formatCreditAmount(remaining)} / ${formatCreditAmount(entitlement)} credits`;
+}
+
 export function formatCopilotUsageText(usage: CopilotUsage | null, error: CopilotError | null): string {
   const fallback = formatErrorOrNoData("Copilot", usage, error);
   if (fallback !== null) return fallback;
   const u = usage as CopilotUsage;
+  const aiCreditsRemainingPercent = getAiCreditsRemainingPercent(u);
+  const aiCreditsBalance = formatAiCreditsBalance(u);
 
   let text = `Copilot Usage\nPlan: ${u.plan}`;
-  if (u.premiumRemaining !== null) {
-    text += `\n\nPremium Interactions: ${generateAsciiBar(u.premiumRemaining)} ${formatPercent(u.premiumRemaining)} remaining`;
+  if (aiCreditsRemainingPercent !== null) {
+    text += `\n\nAI Credits: ${generateAsciiBar(aiCreditsRemainingPercent)} ${formatPercent(aiCreditsRemainingPercent)} remaining`;
   } else {
-    text += `\n\nPremium Interactions: ${formatPercent(u.premiumRemaining)} remaining`;
+    text += `\n\nAI Credits: ${formatPercent(aiCreditsRemainingPercent)} remaining`;
+  }
+  if (aiCreditsBalance) {
+    text += `\nAI Credits Balance: ${aiCreditsBalance}`;
   }
   if (u.chatRemaining !== null) {
     text += `\nChat Quota: ${generateAsciiBar(u.chatRemaining)} ${formatPercent(u.chatRemaining)} remaining`;
@@ -43,19 +64,22 @@ export function renderCopilotDetail(usage: CopilotUsage | null, error: CopilotEr
   const fallback = renderErrorOrNoData(usage, error);
   if (fallback !== null) return fallback;
   const u = usage as CopilotUsage;
+  const aiCreditsRemainingPercent = getAiCreditsRemainingPercent(u);
+  const aiCreditsBalance = formatAiCreditsBalance(u);
 
   return (
     <List.Item.Detail.Metadata>
       <List.Item.Detail.Metadata.Label title="Plan" text={u.plan} />
       <List.Item.Detail.Metadata.Separator />
       <List.Item.Detail.Metadata.Label
-        title="Premium Interactions"
+        title="AI Credits"
         text={
-          u.premiumRemaining !== null
-            ? `${generateAsciiBar(u.premiumRemaining)} ${formatPercent(u.premiumRemaining)} remaining`
-            : `${formatPercent(u.premiumRemaining)} remaining`
+          aiCreditsRemainingPercent !== null
+            ? `${generateAsciiBar(aiCreditsRemainingPercent)} ${formatPercent(aiCreditsRemainingPercent)} remaining`
+            : `${formatPercent(aiCreditsRemainingPercent)} remaining`
         }
       />
+      {aiCreditsBalance && <List.Item.Detail.Metadata.Label title="AI Credits Balance" text={aiCreditsBalance} />}
       <List.Item.Detail.Metadata.Label
         title="Chat Quota"
         text={
@@ -97,9 +121,17 @@ export function getCopilotAccessory(
     return getNoDataAccessory();
   }
 
-  const primaryPercent = usage.premiumRemaining ?? usage.chatRemaining;
+  const aiCreditsRemainingPercent = getAiCreditsRemainingPercent(usage);
+  const aiCreditsBalance = formatAiCreditsBalance(usage);
+  const primaryPercent = aiCreditsRemainingPercent ?? usage.chatRemaining;
   const text = primaryPercent !== null ? `${primaryPercent}%` : "—";
-  const tooltip = `Premium: ${formatPercent(usage.premiumRemaining)} | Chat: ${formatPercent(usage.chatRemaining)}`;
+  const tooltip = [
+    `AI Credits: ${formatPercent(aiCreditsRemainingPercent)}`,
+    aiCreditsBalance ? `Balance: ${aiCreditsBalance}` : null,
+    `Chat: ${formatPercent(usage.chatRemaining)}`,
+  ]
+    .filter(Boolean)
+    .join(" | ");
 
   return {
     icon: primaryPercent !== null ? generatePieIcon(primaryPercent) : undefined,

--- a/extensions/agent-usage/src/copilot/types.ts
+++ b/extensions/agent-usage/src/copilot/types.ts
@@ -1,6 +1,10 @@
 export interface CopilotUsage {
   plan: string;
-  premiumRemaining: number | null;
+  aiCreditsRemainingPercent: number | null;
+  aiCreditsRemaining: number | null;
+  aiCreditsEntitlement: number | null;
+  /** Kept optional so usage cached by older extension versions still renders correctly. */
+  premiumRemaining?: number | null;
   chatRemaining: number | null;
   quotaResetDate: string | null;
 }


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

- Add named multi-account support for GitHub Copilot
- Show each Copilot account separately in the main list and menu bar
- Add account management through the existing Manage Accounts action
- Detect GITHUB_TOKEN and GH_TOKEN as separate accounts
- Preserve the legacy Copilot preference token
- Rename Premium Interactions to AI Credits
- Display AI Credits as both a remaining percentage and credit balance, such as 24 / 300 credits
- Support token discovery from Windows command shells and Unix login shells

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

<img width="750" height="475" alt="image" src="https://github.com/user-attachments/assets/f3e6ceab-c90f-4e7f-9728-9ebfe0affbc2" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
