### PR TITLE
zed-recent-projects: fix PATH missing entries from ~/.zshrc

### DIFF
--- a/extensions/zed-recent-projects/CHANGELOG.md
+++ b/extensions/zed-recent-projects/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Zed Recent Projects Changelog
 
-## [Fix Missing PATH Entries from ~/.zshrc] - 2026-08-28
+## [Fix Missing PATH Entries from ~/.zshrc] - {PR_MERGE_DATE}
 
 - Fix `PATH` (and other rc-file-only env vars) not being visible to processes spawned by Zed (e.g. external formatters) when launched via this extension. The clean-env shell invocation now runs login *and* interactive (`-ilc`) instead of just login (`-lc`), so `~/.zshrc`/`~/.bashrc`, not just profile files, get sourced.
 

--- a/extensions/zed-recent-projects/CHANGELOG.md
+++ b/extensions/zed-recent-projects/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zed Recent Projects Changelog
 
+## [Fix Missing PATH Entries from ~/.zshrc] - 2026-08-28
+
+- Fix `PATH` (and other rc-file-only env vars) not being visible to processes spawned by Zed (e.g. external formatters) when launched via this extension. The clean-env shell invocation now runs login *and* interactive (`-ilc`) instead of just login (`-lc`), so `~/.zshrc`/`~/.bashrc`, not just profile files, get sourced.
+
 ## [Fix Project Launch in Raycast 2] - 2026-08-15
 
 - Open projects before closing Raycast so CLI launches complete reliably.

--- a/extensions/zed-recent-projects/CHANGELOG.md
+++ b/extensions/zed-recent-projects/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Zed Recent Projects Changelog
 
-## [Fix Missing PATH Entries from ~/.zshrc] - {PR_MERGE_DATE}
+## [Fix Missing PATH Entries from ~/.zshrc] - 2026-09-10
 
 - Fix `PATH` (and other rc-file-only env vars) not being visible to processes spawned by Zed (e.g. external formatters) when launched via this extension. The clean-env shell invocation now runs login *and* interactive (`-ilc`) instead of just login (`-lc`), so `~/.zshrc`/`~/.bashrc`, not just profile files, get sourced.
 

--- a/extensions/zed-recent-projects/src/lib/utils.test.ts
+++ b/extensions/zed-recent-projects/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { shellEscape, isPosixShell } from "./utils";
+import { shellEscape, isPosixShell, buildCleanEnvArgs } from "./utils";
 
 describe("shellEscape", () => {
   it("should wrap simple strings in single quotes", () => {
@@ -73,5 +73,26 @@ describe("isPosixShell", () => {
   it("treats unknown or empty shells as non-POSIX", () => {
     expect(isPosixShell("")).toBe(false);
     expect(isPosixShell("/some/unknown/shell")).toBe(false);
+  });
+});
+
+describe("buildCleanEnvArgs", () => {
+  it("runs the shell as interactive+login (-ilc), not just login (-lc)", () => {
+    // Regression test: `-lc` alone doesn't source ~/.zshrc (only ~/.zprofile),
+    // which is where most users actually set PATH.
+    const args = buildCleanEnvArgs("/usr/local/bin/zed", ["/some/project"], "/bin/zsh", "/Users/test");
+    expect(args).toContain("-ilc");
+    expect(args).not.toContain("-lc");
+  });
+
+  it("passes HOME and the given shell through", () => {
+    const args = buildCleanEnvArgs("cmd", [], "/bin/bash", "/Users/test");
+    expect(args).toEqual(["-i", "HOME=/Users/test", expect.stringMatching(/^USER=/), "/bin/bash", "-ilc", "'cmd' "]);
+  });
+
+  it("shell-escapes the command and its arguments", () => {
+    const args = buildCleanEnvArgs("/path/with space/zed", ["it's a path"], "/bin/zsh", "/Users/test");
+    const shellCommand = args[args.length - 1];
+    expect(shellCommand).toBe("'/path/with space/zed' 'it'\\''s a path'");
   });
 });

--- a/extensions/zed-recent-projects/src/lib/utils.ts
+++ b/extensions/zed-recent-projects/src/lib/utils.ts
@@ -51,40 +51,47 @@ function getUserShell(): string {
 }
 
 /**
- * Executes a command with a clean environment using `env -i` and a login shell.
- * This ensures child processes don't inherit Raycast's environment variables.
+ * Builds the `env -i ...` argv for running `command args` inside an
+ * interactive login shell. Pulled out of `execWithCleanEnv` so the flags
+ * (`-ilc`, not just `-lc`) are unit-testable without spawning a real shell.
  *
- * The approach:
- * 1. `env -i` starts with an empty environment
- * 2. Only HOME is passed (required for login shell to find profile files)
- * 3. A POSIX-compatible login shell (zsh or bash) sources the user's profile,
- *    then execs the target command directly — avoiding shell-escaping issues
- *    with non-POSIX shells like fish, nushell, etc.
+ * Login-only (`-l`) is not enough: zsh only sources `~/.zshrc` for
+ * *interactive* shells, and that's where most users actually set PATH (nvm,
+ * pyenv, oh-my-zsh, manual edits) rather than in `~/.zprofile`. So we run
+ * login *and* interactive (`-i`), matching what a normal terminal - and Zed
+ * itself when launched from Finder - resolves.
  *
- * This gives the command the same environment as a fresh terminal window.
+ * Non-POSIX shells (fish, nushell, elvish, xonsh, pwsh, ...) don't accept
+ * the POSIX-style quoted command built here, so the caller should pass
+ * `/bin/zsh` instead of the user's actual shell in that case. The user's
+ * profile still gets sourced, just by a POSIX shell instead of their own.
  */
-export async function execWithCleanEnv(command: string, args: string[]): Promise<void> {
-  const userShell = getUserShell();
-
-  // Non-POSIX shells (fish, nushell, elvish, xonsh, pwsh, ...) don't accept
-  // the POSIX-style quoted command we build below, so fall back to /bin/zsh
-  // for the -lc invocation. The user's profile still gets sourced, just by a
-  // POSIX shell instead of their interactive shell.
-  const posixShell = isPosixShell(userShell) ? userShell : "/bin/zsh";
-
+export function buildCleanEnvArgs(command: string, args: string[], posixShell: string, home: string): string[] {
   const escapedArgs = args.map(shellEscape).join(" ");
   const shellCommand = `${shellEscape(command)} ${escapedArgs}`;
 
-  // Use env -i to start with empty environment, then login shell for user's profile
-  // -l = login shell (sources profile), -c = execute command
-  await execFilePromise("env", [
+  return [
     "-i",
-    `HOME=${process.env.HOME || homedir()}`,
+    `HOME=${home}`,
     `USER=${userInfo().username}`,
     posixShell,
-    "-lc",
+    // -i = interactive shell (sources rc), -l = login shell (sources profile), -c = execute command
+    "-ilc",
     shellCommand,
-  ]);
+  ];
+}
+
+/**
+ * Executes a command with a clean environment using `env -i` and an
+ * interactive login shell (see `buildCleanEnvArgs`).
+ * This ensures child processes don't inherit Raycast's environment variables,
+ * while still resolving the user's PATH the same way a fresh terminal does.
+ */
+export async function execWithCleanEnv(command: string, args: string[]): Promise<void> {
+  const userShell = getUserShell();
+  const posixShell = isPosixShell(userShell) ? userShell : "/bin/zsh";
+
+  await execFilePromise("env", buildCleanEnvArgs(command, args, posixShell, process.env.HOME || homedir()));
 }
 
 export function exists(p: string) {


### PR DESCRIPTION
Fix for #25787

execWithCleanEnv spawned the user's shell as `-lc` (login, non-interactive). zsh only sources ~/.zshrc for interactive shells, so PATH additions from nvm/pyenv/oh-my-zsh/manual edits (the common case) were dropped, and Zed's formatters etc. only saw the bare system PATH when launched via this extension.

Switch to `-ilc` (interactive + login) so rc files get sourced too, matching what a normal terminal - and Zed itself when launched from Finder - already resolves.

Also extract the `env` argv building into buildCleanEnvArgs() so the flag choice is unit-testable without spawning a real shell, and add a regression test asserting -ilc is used.

## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
