### PR TITLE
Update bookstack extension

### DIFF
--- a/extensions/bookstack/CHANGELOG.md
+++ b/extensions/bookstack/CHANGELOG.md
@@ -1,6 +1,6 @@
 # BookStack Changelog
 
-## [Add Copy Link action] - {PR_MERGE_DATE}
+## [Add Copy Link action] - 2026-08-29
 
 - Added a "Copy Link" action to the search, books, and shelves lists
 

--- a/extensions/bookstack/CHANGELOG.md
+++ b/extensions/bookstack/CHANGELOG.md
@@ -1,3 +1,7 @@
 # BookStack Changelog
 
+## [Add Copy Link action] - {PR_MERGE_DATE}
+
+- Added a "Copy Link" action to the search, books, and shelves lists
+
 ## [Initial Version] - 2024-04-26

--- a/extensions/bookstack/package.json
+++ b/extensions/bookstack/package.json
@@ -1,85 +1,88 @@
 {
-    "$schema": "https://www.raycast.com/schemas/extension.json",
-    "name": "bookstack",
-    "title": "BookStack",
-    "description": "Seamlessly integrates Raycast with BookStack to search and manage your documentation directly from your macOS desktop.",
-    "icon": "bookstack.png",
-    "author": "huskii",
-    "license": "MIT",
-    "commands": [
-      {
-        "name": "search-command",
-        "title": "Search Documentation",
-        "subtitle": "BookStack",
-        "description": "Quickly search through your BookStack contents and open the results directly from Raycast.",
-        "mode": "view"
-      },
-      {
-        "name": "show-all-books",
-        "title": "Show All Books",
-        "subtitle": "BookStack",
-        "description": "Quickly list all your BookStack books and open the results directly from Raycast.",
-        "mode": "view"
-      },
-      {
-        "name": "show-all-shelves",
-        "title": "Show All Shelves",
-        "subtitle": "BookStack",
-        "description": "Quickly list all your BookStack shelves and open the results directly from Raycast.",
-        "mode": "view"
-      }
-    ],
-    "preferences": [
-      {
-        "name": "baseUrl",
-        "type": "textfield",
-        "required": true,
-        "title": "BookStack Base URL",
-        "description": "Enter your BookStack base URL here",
-        "placeholder": "https://example.bookstack.com"
-      },
-      {
-        "name": "tokenId",
-        "type": "textfield",
-        "required": true,
-        "title": "BookStack API Token ID",
-        "description": "Enter your BookStack API token ID here",
-        "placeholder": "Enter your token ID here"
-      },
-      {
-        "name": "tokenSecret",
-        "type": "password",
-        "required": true,
-        "title": "BookStack API Token Secret",
-        "description": "Enter your BookStack API token secret here",
-        "placeholder": "Enter your token secret here"
-      }
-    ],
-    "keywords": [
-      "Huskii",
-      "BookStack",
-      "Documentation",
-      "Productivity",
-      "Search",
-      "API"
-    ],
-    "dependencies": {
-      "@raycast/api": "^1.72.1",
-      "axios": "^1.8.4"
+  "$schema": "https://www.raycast.com/schemas/extension.json",
+  "name": "bookstack",
+  "title": "BookStack",
+  "description": "Seamlessly integrates Raycast with BookStack to search and manage your documentation directly from your macOS desktop.",
+  "icon": "bookstack.png",
+  "author": "huskii",
+  "license": "MIT",
+  "commands": [
+    {
+      "name": "search-command",
+      "title": "Search Documentation",
+      "subtitle": "BookStack",
+      "description": "Quickly search through your BookStack contents and open the results directly from Raycast.",
+      "mode": "view"
     },
-    "devDependencies": {
-      "@raycast/eslint-config": "^1.0.6",
-      "@types/node": "20.8.10",
-      "@types/react": "18.2.27",
-      "eslint": "^8.51.0",
-      "prettier": "^3.2.5",
-      "typescript": "^5.2.2"
+    {
+      "name": "show-all-books",
+      "title": "Show All Books",
+      "subtitle": "BookStack",
+      "description": "Quickly list all your BookStack books and open the results directly from Raycast.",
+      "mode": "view"
     },
-    "scripts": {
-      "build": "ray build -e dist",
-      "dev": "ray develop",
-      "fix-lint": "ray lint --fix",
-      "lint": "ray lint",
-      "publish": "npx @raycast/api@latest publish"
+    {
+      "name": "show-all-shelves",
+      "title": "Show All Shelves",
+      "subtitle": "BookStack",
+      "description": "Quickly list all your BookStack shelves and open the results directly from Raycast.",
+      "mode": "view"
     }
-  }
+  ],
+  "preferences": [
+    {
+      "name": "baseUrl",
+      "type": "textfield",
+      "required": true,
+      "title": "BookStack Base URL",
+      "description": "Enter your BookStack base URL here",
+      "placeholder": "https://example.bookstack.com"
+    },
+    {
+      "name": "tokenId",
+      "type": "textfield",
+      "required": true,
+      "title": "BookStack API Token ID",
+      "description": "Enter your BookStack API token ID here",
+      "placeholder": "Enter your token ID here"
+    },
+    {
+      "name": "tokenSecret",
+      "type": "password",
+      "required": true,
+      "title": "BookStack API Token Secret",
+      "description": "Enter your BookStack API token secret here",
+      "placeholder": "Enter your token secret here"
+    }
+  ],
+  "keywords": [
+    "Huskii",
+    "BookStack",
+    "Documentation",
+    "Productivity",
+    "Search",
+    "API"
+  ],
+  "dependencies": {
+    "@raycast/api": "^1.72.1",
+    "axios": "^1.8.4"
+  },
+  "devDependencies": {
+    "@raycast/eslint-config": "^1.0.6",
+    "@types/node": "20.8.10",
+    "@types/react": "18.2.27",
+    "eslint": "^8.51.0",
+    "prettier": "^3.2.5",
+    "typescript": "^5.2.2"
+  },
+  "scripts": {
+    "build": "ray build -e dist",
+    "dev": "ray develop",
+    "fix-lint": "ray lint --fix",
+    "lint": "ray lint",
+    "publish": "npx @raycast/api@latest publish"
+  },
+  "platforms": [
+    "macOS"
+  ]
+}

--- a/extensions/bookstack/src/search-command.tsx
+++ b/extensions/bookstack/src/search-command.tsx
@@ -1,6 +1,6 @@
 // src/search-command.tsx
 import React, { useState, useEffect } from "react";
-import { List, ActionPanel, Action, showToast, Toast } from "@raycast/api";
+import { List, ActionPanel, Action, showToast, Toast, Keyboard } from "@raycast/api";
 import { searchBookStack, SearchResultItem } from "./bookstack-api";
 import { stripHtmlTags } from "./utils";
 
@@ -43,6 +43,7 @@ export default function SearchDocumentation() {
           actions={
             <ActionPanel>
               <Action.OpenInBrowser url={item.url} title="Open URL" />
+              <Action.CopyToClipboard title="Copy Link" content={item.url} shortcut={Keyboard.Shortcut.Common.Copy} />
             </ActionPanel>
           }
         />

--- a/extensions/bookstack/src/show-all-books.tsx
+++ b/extensions/bookstack/src/show-all-books.tsx
@@ -1,6 +1,6 @@
 // src/show-all-books.tsx
 import React, { useState, useEffect } from "react";
-import { List, ActionPanel, Action, showToast, Toast } from "@raycast/api";
+import { List, ActionPanel, Action, showToast, Toast, Keyboard } from "@raycast/api";
 import { getAllBooks, SearchResultItem, baseUrl } from "./bookstack-api";
 import { stripHtmlTags } from "./utils";
 
@@ -35,6 +35,11 @@ export default function ShowAllBooks() {
           actions={
             <ActionPanel>
               <Action.OpenInBrowser url={`${baseUrl}${book.url}`} />
+              <Action.CopyToClipboard
+                title="Copy Link"
+                content={`${baseUrl}${book.url}`}
+                shortcut={Keyboard.Shortcut.Common.Copy}
+              />
             </ActionPanel>
           }
         />

--- a/extensions/bookstack/src/show-all-shelves.tsx
+++ b/extensions/bookstack/src/show-all-shelves.tsx
@@ -1,6 +1,6 @@
 // src/show-all-shelves.tsx
 import React, { useState, useEffect } from "react";
-import { List, ActionPanel, Action, showToast, Toast } from "@raycast/api";
+import { List, ActionPanel, Action, showToast, Toast, Keyboard } from "@raycast/api";
 import { getAllShelves, SearchResultItem, baseUrl } from "./bookstack-api";
 import { stripHtmlTags } from "./utils";
 
@@ -36,6 +36,11 @@ export default function ShowAllShelves() {
           actions={
             <ActionPanel>
               <Action.OpenInBrowser url={`${baseUrl}${shelf.url}`} title="View Shelf" />
+              <Action.CopyToClipboard
+                title="Copy Link"
+                content={`${baseUrl}${shelf.url}`}
+                shortcut={Keyboard.Shortcut.Common.Copy}
+              />
             </ActionPanel>
           }
         />


### PR DESCRIPTION
## Description

Adds a **Copy Link** action next to the existing Open in Browser action in all three BookStack commands: Search Documentation, Show All Books, and Show All Shelves.

Each action copies the same URL its neighbouring Open action already uses — `item.url` for search results, and the `baseUrl`-prefixed path for books and shelves — and is bound to the standard `Keyboard.Shortcut.Common.Copy` (⌘⇧C).

Copying a page link is a common follow-up to finding it, and previously the only way to get one out of Raycast was to open it in the browser first and copy from the address bar.

## Screencast

Straightforward change with no new UI surface — the action appears in the existing action panel (⌘K) of each list. `ray build` and `ray lint` both pass, and all three commands were tested against a live BookStack instance.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
