### PR TITLE
[Herdr] Fix a menu bar toast that never dismissed

### DIFF
--- a/extensions/herdr/CHANGELOG.md
+++ b/extensions/herdr/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Fix Stuck Menu Bar Toast] - {PR_MERGE_DATE}
+
+- Report menu bar failures with a HUD instead of a toast held open across the action. Clicking an item unloads the menu bar command, which left the toast on screen with nothing to resolve it.
+
 ## [Bug Fixes] - 2026-08-18
 
 - Show a readable name for unnamed agents instead of the status-line glyph.

--- a/extensions/herdr/CHANGELOG.md
+++ b/extensions/herdr/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Fix Stuck Menu Bar Toast] - {PR_MERGE_DATE}
+## [Fix Stuck Menu Bar Toast] - 2026-08-29
 
 - Report menu bar failures with a HUD instead of a toast held open across the action. Clicking an item unloads the menu bar command, which left the toast on screen with nothing to resolve it.
 

--- a/extensions/herdr/src/menu-bar.tsx
+++ b/extensions/herdr/src/menu-bar.tsx
@@ -1,11 +1,19 @@
-import { Icon, Keyboard, LaunchType, MenuBarExtra, launchCommand, openExtensionPreferences } from "@raycast/api";
+import {
+  Icon,
+  Keyboard,
+  LaunchType,
+  MenuBarExtra,
+  launchCommand,
+  openExtensionPreferences,
+  showHUD,
+} from "@raycast/api";
 import { useHerdrSnapshot } from "./hooks/use-herdr-snapshot";
 import { agentIcon, agentName } from "./lib/agent-appearance";
-import { focusResource, getAgentTarget } from "./lib/herdr";
+import { focusResource, formatHerdrError, getAgentTarget } from "./lib/herdr";
 import { getHerdrPreferences } from "./lib/preferences";
 import { launchHerdrInTerminal, revealFocusedHerdr } from "./lib/terminal";
 import type { AgentInfo, AgentStatus, HerdrSnapshot } from "./lib/types";
-import { runAction, statusIcon, statusTitle } from "./lib/ui";
+import { statusIcon, statusTitle } from "./lib/ui";
 
 const DISPLAYED_STATUSES: AgentStatus[] = ["blocked", "done", "working", "unknown"];
 
@@ -17,19 +25,30 @@ function agentLocation(agent: AgentInfo, snapshot: HerdrSnapshot): string {
   );
 }
 
-async function focusAgent(agent: AgentInfo): Promise<void> {
-  await runAction(
-    `Focusing ${agentName(agent)}`,
-    async () => {
-      await focusResource("agent", getAgentTarget(agent));
-      await revealFocusedHerdr();
-    },
-    { success: `Focused ${agentName(agent)}` },
-  );
+// Clicking an item unloads the menu bar command, so a toast held open across the
+// work would never be resolved. A HUD expires on its own. Reporting is
+// best-effort for the same reason: an unloaded command cannot show one either.
+async function reportFailure(error: unknown): Promise<void> {
+  const formatted = formatHerdrError(error);
+  const title = formatted.message ? `${formatted.title}: ${formatted.message}` : formatted.title;
+  await showHUD(title).catch(() => undefined);
 }
 
-function openHerdr(): Promise<boolean> {
-  return runAction("Opening Herdr", () => launchHerdrInTerminal(), { success: "Herdr Opened" });
+async function focusAgent(agent: AgentInfo): Promise<void> {
+  try {
+    await focusResource("agent", getAgentTarget(agent));
+    await revealFocusedHerdr();
+  } catch (error) {
+    await reportFailure(error);
+  }
+}
+
+async function openHerdr(): Promise<void> {
+  try {
+    await launchHerdrInTerminal();
+  } catch (error) {
+    await reportFailure(error);
+  }
 }
 
 function AgentItem({ agent, snapshot }: { agent: AgentInfo; snapshot: HerdrSnapshot }) {


### PR DESCRIPTION
## Description

Focusing an agent from the Herdr menu bar left a toast pinned to the screen that never dismissed.

`focusAgent` opened an animated toast and mutated it to Success once the focus landed. Clicking a `MenuBarExtra.Item` unloads the command, so that mutation had no process left to run in, and an animated toast carries no timeout of its own. The pill stayed until another toast replaced it or Raycast restarted.

Menu bar actions now run without a leading toast and report failures through `showHUD`, which Raycast expires on its own. If the command is unloaded before an error lands, the message is simply dropped. Success reports nothing, since focusing already brings the terminal to the front.

The view and no-view commands keep `runAction`. Raycast awaits their exported default, so their toasts always resolve.

## Screencast

Screenshot before:

![Toast reading "Focusing ec2pricing" stuck on screen after focusing an agent from the menu bar](https://github.com/user-attachments/assets/fb0d6eca-4fd9-42cb-8d6e-57a69f518b53)

Confirmed after that success shows nothing on screen.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
