### PR TITLE
Add suggested sites, OnlineOrNot, and FireHydrant support

### DIFF
--- a/extensions/is-it-alive/CHANGELOG.md
+++ b/extensions/is-it-alive/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Is It Alive? Changelog
 
+## [Suggested Sites, OnlineOrNot, and FireHydrant] - {PR_MERGE_DATE}
+
+- Add OnlineOrNot status pages through the public summary API. Look up hosted pages by subdomain and custom domains such as status.openrouter.ai by hostname
+- Add FireHydrant status pages (e.g. status.redis.io) via `/data/payload.json`
+- Follow incident.io status-page redirects so URLs like status.linear.app resolve to the canonical proxy JSON API
+- Add Developer Tools, Data, and Auth & Payments sections to the suggested sites list, along with more infrastructure and AI status pages
+- Fetch two status pages at a time and store compact list snapshots to stay under Raycast's memory limit. Fetch full history only in the detail view
+
 ## [OutageDeck Support] - 2026-08-21
 
 - Add OutageDeck provider URLs for normalized vendor-published status, service details, and active incidents across cloud and SaaS providers

--- a/extensions/is-it-alive/CHANGELOG.md
+++ b/extensions/is-it-alive/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Is It Alive? Changelog
 
-## [Suggested Sites, OnlineOrNot, and FireHydrant] - {PR_MERGE_DATE}
+## [Suggested Sites, OnlineOrNot, and FireHydrant] - 2026-08-29
 
 - Add OnlineOrNot status pages through the public summary API. Look up hosted pages by subdomain and custom domains such as status.openrouter.ai by hostname
 - Add FireHydrant status pages (e.g. status.redis.io) via `/data/payload.json`

--- a/extensions/is-it-alive/README.md
+++ b/extensions/is-it-alive/README.md
@@ -32,7 +32,7 @@
 
 ## Supported status pages
 
-The extension auto-detects the provider when you add a URL. Detection order: **Railway → OutageDeck → AWS → Salesforce Trust → Google Cloud → AI Studio → incident.io → Better Stack → Instatus → Statuspage → Checkly → Uptime.com → RSS**.
+The extension auto-detects the provider when you add a URL. Detection order: **Railway → OutageDeck → AWS → Salesforce Trust → Google Cloud → AI Studio → incident.io → Better Stack → Instatus → Statuspage → OnlineOrNot → FireHydrant → Checkly → Uptime.com → RSS**.
 
 | Provider          | Examples                                                       | Detection                             |
 | ----------------- | -------------------------------------------------------------- | ------------------------------------- |
@@ -42,17 +42,23 @@ The extension auto-detects the provider when you add a URL. Detection order: **R
 | **Salesforce Trust** | [status.salesforce.com/products/Heroku](https://status.salesforce.com/products/Heroku), [status.heroku.com](https://status.heroku.com) | Hostname match |
 | **Google Cloud**  | [status.cloud.google.com](https://status.cloud.google.com), `status.cloud.google.com/products/vertex-gemini-api` | Hostname match |
 | **AI Studio**     | [aistudio.google.com/status](https://aistudio.google.com/status) | Hostname match |
-| **incident.io**   | [status.openai.com](https://status.openai.com)                 | `/proxy/{host}/component_impacts` API |
+| **incident.io**   | [status.openai.com](https://status.openai.com), [linearstatus.com](https://linearstatus.com) | `/proxy/{host}/component_impacts` JSON API |
 | **Better Stack**  | [status.yachtway.com](https://status.yachtway.com)             | `/index.json` JSON:API                |
 | **Instatus**      | [instat.us](https://instat.us)                                 | `/summary.json`                       |
 | **Statuspage.io** | [status.claude.com](https://status.claude.com), GitHub, Vercel | `/api/v2/summary.json`                |
+| **OnlineOrNot**   | [status.openrouter.ai](https://status.openrouter.ai), `*.onlineornot.com` | Public `/v1/status_pages/{subdomain or hostname}/summary` API |
+| **FireHydrant**   | [status.redis.io](https://status.redis.io)                     | `/data/payload.json`                  |
 | **Checkly**       | [status.mistral.ai](https://status.mistral.ai)                 | `__NUXT_DATA__` payload in page HTML  |
 | **Uptime.com**    | [status.uptime.com](https://status.uptime.com), [uptime.com/statuspage/hackerrank](https://uptime.com/statuspage/hackerrank) | React props payload in page HTML |
 | **RSS fallback**  | [status.x.ai](https://status.x.ai)                             | `/feed.xml` (and common feed paths)   |
 
-incident.io is checked before Statuspage because some Statuspage hosts expose proxy-style URLs that look similar but lack incident.io-only endpoints like `component_impacts`.
+incident.io is checked before Statuspage because some Statuspage hosts expose similar proxy URLs without incident.io endpoints such as `component_impacts`. For redirected pages such as `status.linear.app`, the adapter follows the redirect to `linearstatus.com` and reads the proxy JSON API there.
 
 Instatus must also be checked before Statuspage: Instatus pages serve a Statuspage-compatible `/api/v2/summary.json` shim, so the Statuspage detector matches them even though the payload lacks Statuspage-only fields.
+
+OnlineOrNot is checked after Statuspage. Hosted pages use `{subdomain}.onlineornot.com`. For custom domains such as [status.openrouter.ai](https://status.openrouter.ai), the adapter passes the hostname to the public summary API at `/v1/status_pages/status.openrouter.ai/summary`.
+
+FireHydrant status pages expose current status at `/data/payload.json` on the page origin. The adapter runs before Checkly, which must download and parse the full HTML page.
 
 Checkly has no public JSON API for status pages, so its adapter parses the Nuxt (`__NUXT_DATA__`) payload embedded in the page HTML. It is checked late because its detection requires downloading the full page.
 
@@ -109,6 +115,8 @@ src/
     instatus.ts          # Instatus public /summary.json API
     railway.ts           # Railway status API
     outagedeck.ts        # OutageDeck normalized public API
+    onlineornot.ts       # OnlineOrNot public summary API (e.g. OpenRouter)
+    firehydrant.ts       # FireHydrant /data/payload.json (e.g. Redis)
     rss.ts               # generic RSS feed fallback (e.g. status.x.ai)
     aistudio.ts          # Google AI Studio / Gemini API incidents RPC
     googlecloud.ts       # Google Cloud Service Health incidents/products JSON

--- a/extensions/is-it-alive/src/adapters/firehydrant.ts
+++ b/extensions/is-it-alive/src/adapters/firehydrant.ts
@@ -1,0 +1,234 @@
+import type {
+  ComponentStatusValue,
+  FetchSnapshotInput,
+  StatusAdapter,
+  StatusIncident,
+  StatusIndicator,
+  StatusSnapshot,
+} from "@/types";
+import type {
+  FireHydrantIncident,
+  FireHydrantPayload,
+} from "@/types/firehydrant";
+import { fetchJson } from "@/lib/fetch-json";
+import { overallDescription } from "@/lib/snapshot-text";
+import { getOrigin, normalizeSiteUrl } from "@/lib/url";
+
+function payloadUrl(siteUrl: string): string {
+  return `${getOrigin(normalizeSiteUrl(siteUrl))}/data/payload.json`;
+}
+
+export function isFireHydrantPayload(
+  data: unknown,
+): data is FireHydrantPayload {
+  if (typeof data !== "object" || data === null) {
+    return false;
+  }
+
+  if (!("config" in data) || typeof data.config !== "object" || !data.config) {
+    return false;
+  }
+
+  if (!("components" in data) || !Array.isArray(data.components)) {
+    return false;
+  }
+
+  return "incidents" in data && Array.isArray(data.incidents);
+}
+
+function conditionCode(
+  condition: string | undefined,
+  conditions: Record<string, string> | undefined,
+): string {
+  if (!condition) {
+    return "operational";
+  }
+
+  return (conditions?.[condition] ?? condition).toLowerCase();
+}
+
+function conditionToComponentStatus(
+  condition: string | undefined,
+  conditions: Record<string, string> | undefined,
+): ComponentStatusValue {
+  switch (conditionCode(condition, conditions)) {
+    case "operational":
+      return "operational";
+    case "degraded":
+    case "degraded_performance":
+      return "degraded_performance";
+    case "maintenance":
+    case "under_maintenance":
+      return "under_maintenance";
+    case "partial_outage":
+      return "partial_outage";
+    case "unavailable":
+    case "offline":
+    case "major_outage":
+      return "major_outage";
+    default:
+      return "degraded_performance";
+  }
+}
+
+function statusToIndicator(
+  status: ComponentStatusValue | string,
+): StatusIndicator {
+  switch (status) {
+    case "operational":
+      return "none";
+    case "degraded_performance":
+    case "under_maintenance":
+      return "minor";
+    case "partial_outage":
+      return "major";
+    case "major_outage":
+      return "critical";
+    default:
+      return "minor";
+  }
+}
+
+function worseIndicator(
+  current: StatusIndicator,
+  next: StatusIndicator,
+): StatusIndicator {
+  const order: StatusIndicator[] = ["none", "minor", "major", "critical"];
+  return order.indexOf(next) > order.indexOf(current) ? next : current;
+}
+
+function isActiveIncident(incident: FireHydrantIncident): boolean {
+  return !incident.timestamps?.resolved;
+}
+
+function latestTimestamp(
+  timestamps: FireHydrantIncident["timestamps"],
+): string {
+  let latest = "";
+  for (const value of Object.values(timestamps ?? {})) {
+    if (value && value > latest) {
+      latest = value;
+    }
+  }
+  return latest;
+}
+
+function severityToImpact(slug: string | undefined): string {
+  switch (slug) {
+    case "SEV1":
+    case "SEV2":
+      return "critical";
+    case "SEV3":
+      return "major";
+    case "MAINTENANCE":
+      return "maintenance";
+    case "SEV4":
+    case "UNSET":
+      return "minor";
+    default:
+      return slug?.toLowerCase() ?? "minor";
+  }
+}
+
+function mapIncident(incident: FireHydrantIncident): StatusIncident {
+  const affectedComponentIds = (incident.components ?? [])
+    .map((component) => component.id)
+    .filter(Boolean);
+
+  return {
+    id: incident.id,
+    name: incident.title,
+    status: isActiveIncident(incident) ? "active" : "resolved",
+    impact: severityToImpact(incident.severitySlug),
+    updatedAt: latestTimestamp(incident.timestamps),
+    affectedComponentIds:
+      affectedComponentIds.length > 0 ? affectedComponentIds : undefined,
+  };
+}
+
+function activeIncidentComponentConditions(
+  incidents: FireHydrantIncident[],
+): Map<string, string> {
+  const byId = new Map<string, string>();
+
+  for (const incident of incidents) {
+    for (const component of incident.components ?? []) {
+      if (component.id && component.condition) {
+        byId.set(component.id, component.condition);
+      }
+    }
+  }
+
+  return byId;
+}
+
+export const firehydrantAdapter: StatusAdapter = {
+  async detect(siteUrl: string): Promise<boolean> {
+    try {
+      const data = await fetchJson<unknown>(payloadUrl(siteUrl));
+      return isFireHydrantPayload(data);
+    } catch {
+      return false;
+    }
+  },
+
+  async fetchSnapshot(input: FetchSnapshotInput): Promise<StatusSnapshot> {
+    const normalized = normalizeSiteUrl(input.url);
+    const fetchedAt = new Date().toISOString();
+
+    try {
+      const data = await fetchJson<unknown>(payloadUrl(normalized));
+      if (!isFireHydrantPayload(data)) {
+        throw new Error("Not a FireHydrant status page");
+      }
+
+      const activeIncidents = (data.incidents ?? []).filter(isActiveIncident);
+      const activeIncidentConditions =
+        activeIncidentComponentConditions(activeIncidents);
+      const components = (data.components ?? []).map((component) => ({
+        id: component.id,
+        name: component.name,
+        status: conditionToComponentStatus(
+          activeIncidentConditions.get(component.id),
+          data.conditions,
+        ),
+      }));
+
+      const indicator = components.reduce<StatusIndicator>(
+        (worst, component) =>
+          worseIndicator(worst, statusToIndicator(component.status)),
+        activeIncidents.length > 0 ? "minor" : "none",
+      );
+
+      const pageName =
+        data.config.title?.trim() ||
+        data.config.companyName?.trim() ||
+        new URL(normalized).hostname;
+
+      return {
+        pageName,
+        pageUrl: normalized,
+        overallDescription:
+          activeIncidents.length === 0
+            ? (data.config.operationalMessage?.trim() ??
+              overallDescription(indicator, 0))
+            : overallDescription(indicator, activeIncidents.length),
+        indicator,
+        components,
+        incidents: activeIncidents.map(mapIncident),
+        fetchedAt,
+      };
+    } catch (error) {
+      return {
+        pageName: new URL(normalized).hostname,
+        pageUrl: normalized,
+        overallDescription: "Failed to fetch",
+        indicator: "none",
+        components: [],
+        incidents: [],
+        fetchedAt,
+        error: error instanceof Error ? error.message : "Unknown error",
+      };
+    }
+  },
+};

--- a/extensions/is-it-alive/src/adapters/incident-io.ts
+++ b/extensions/is-it-alive/src/adapters/incident-io.ts
@@ -30,6 +30,69 @@ function proxyBase(siteUrl: string): string {
   return `${origin}/proxy/${hostname}`;
 }
 
+async function discardBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // Some test and runtime response bodies do not support cancellation.
+  }
+}
+
+async function redirectedOrigin(siteUrl: string): Promise<string | null> {
+  try {
+    const response = await fetch(siteUrl, {
+      method: "GET",
+      redirect: "manual",
+      headers: { Accept: "text/html" },
+    });
+    await discardBody(response);
+
+    if (response.status < 300 || response.status >= 400) {
+      return null;
+    }
+
+    const location = response.headers.get("location");
+    if (!location) {
+      return null;
+    }
+
+    return normalizeSiteUrl(new URL(location, siteUrl).origin);
+  } catch {
+    return null;
+  }
+}
+
+async function isIncidentIoSite(siteUrl: string): Promise<boolean> {
+  try {
+    const data = await fetchJson<ComponentImpactsResponse>(
+      componentImpactsUrl(proxyBase(siteUrl)),
+    );
+    return Array.isArray(data.component_impacts);
+  } catch {
+    return false;
+  }
+}
+
+async function resolveIncidentIoSiteUrl(
+  siteUrl: string,
+): Promise<string | null> {
+  const normalized = normalizeSiteUrl(siteUrl);
+  if (await isIncidentIoSite(normalized)) {
+    return normalized;
+  }
+
+  const redirected = await redirectedOrigin(normalized);
+  if (
+    redirected &&
+    redirected !== normalized &&
+    (await isIncidentIoSite(redirected))
+  ) {
+    return redirected;
+  }
+
+  return null;
+}
+
 function impactToDayLevel(status: IncidentIoImpactStatus): DayStatus["level"] {
   switch (status) {
     case "operational":
@@ -288,11 +351,7 @@ function computeOverallIndicator(
 export const incidentIoAdapter: StatusAdapter = {
   async detect(siteUrl: string): Promise<boolean> {
     try {
-      const proxy = proxyBase(siteUrl);
-      const data = await fetchJson<ComponentImpactsResponse>(
-        componentImpactsUrl(proxy),
-      );
-      return Array.isArray(data.component_impacts);
+      return (await resolveIncidentIoSiteUrl(siteUrl)) !== null;
     } catch {
       return false;
     }
@@ -300,15 +359,17 @@ export const incidentIoAdapter: StatusAdapter = {
 
   async fetchSnapshot(input: FetchSnapshotInput): Promise<StatusSnapshot> {
     const normalized = normalizeSiteUrl(input.url);
-    const proxy = proxyBase(normalized);
-    const hostname = new URL(normalized).hostname;
+    const canonical =
+      (await resolveIncidentIoSiteUrl(normalized)) ?? normalized;
+    const proxy = proxyBase(canonical);
+    const hostname = new URL(canonical).hostname;
     const fetchedAt = new Date().toISOString();
 
     try {
       const [incidentsData, impactsData, pageMetadata] = await Promise.all([
         fetchJson<{ incidents: IncidentIoIncident[] }>(`${proxy}/incidents`),
         fetchJson<ComponentImpactsResponse>(componentImpactsUrl(proxy)),
-        fetchPageMetadata(normalized, hostname),
+        fetchPageMetadata(canonical, hostname),
       ]);
 
       const { catalog, pageName } = pageMetadata;
@@ -348,7 +409,7 @@ export const incidentIoAdapter: StatusAdapter = {
 
       return {
         pageName,
-        pageUrl: normalized,
+        pageUrl: canonical,
         overallDescription: overallDescription(
           indicator,
           activeIncidents.length,

--- a/extensions/is-it-alive/src/adapters/index.ts
+++ b/extensions/is-it-alive/src/adapters/index.ts
@@ -4,15 +4,19 @@ import type {
   StatusAdapter,
   StatusSnapshot,
 } from "@/types";
+import { compactSnapshotForList } from "@/lib/snapshot-compact";
+import { mapPool } from "@/lib/async-pool";
 import { applyRegionFilter } from "@/lib/regions";
 import { isRailwayHost, normalizeSiteUrl } from "@/lib/url";
 import { aiStudioAdapter } from "@/adapters/aistudio";
 import { awsAdapter } from "@/adapters/aws";
 import { betterstackAdapter } from "@/adapters/betterstack";
 import { checklyAdapter } from "@/adapters/checkly";
+import { firehydrantAdapter } from "@/adapters/firehydrant";
 import { googleCloudAdapter } from "@/adapters/googlecloud";
 import { incidentIoAdapter } from "@/adapters/incident-io";
 import { instatusAdapter } from "@/adapters/instatus";
+import { onlineornotAdapter } from "@/adapters/onlineornot";
 import { outagedeckAdapter } from "@/adapters/outagedeck";
 import { railwayAdapter } from "@/adapters/railway";
 import { rssAdapter } from "@/adapters/rss";
@@ -36,6 +40,8 @@ const adapters: Record<SiteProvider, StatusAdapter> = {
   googlecloud: googleCloudAdapter,
   aistudio: aiStudioAdapter,
   outagedeck: outagedeckAdapter,
+  onlineornot: onlineornotAdapter,
+  firehydrant: firehydrantAdapter,
 };
 
 export function getAdapter(provider: SiteProvider): StatusAdapter {
@@ -94,6 +100,16 @@ export async function detectProvider(siteUrl: string): Promise<SiteProvider> {
     return "statuspage";
   }
 
+  const isOnlineOrNot = await onlineornotAdapter.detect?.(normalized);
+  if (isOnlineOrNot) {
+    return "onlineornot";
+  }
+
+  const isFireHydrant = await firehydrantAdapter.detect?.(normalized);
+  if (isFireHydrant) {
+    return "firehydrant";
+  }
+
   const isCheckly = await checklyAdapter.detect?.(normalized);
   if (isCheckly) {
     return "checkly";
@@ -110,7 +126,7 @@ export async function detectProvider(siteUrl: string): Promise<SiteProvider> {
   }
 
   throw new Error(
-    "Unsupported status page. Try OutageDeck, Statuspage, Better Stack, incident.io, Instatus, Checkly, an RSS status feed, or status.railway.app",
+    "This URL does not match a supported status page or RSS feed.",
   );
 }
 
@@ -124,12 +140,10 @@ export async function fetchSnapshot(
 export async function fetchAllSnapshots(
   sites: Array<FetchSnapshotInput & { id: string; provider: SiteProvider }>,
 ): Promise<Record<string, StatusSnapshot>> {
-  const entries = await Promise.all(
-    sites.map(async (site) => {
-      const snapshot = await fetchSnapshot(site);
-      return [site.id, snapshot] as const;
-    }),
-  );
+  const entries = await mapPool(sites, 2, async (site) => {
+    const snapshot = await fetchSnapshot(site);
+    return [site.id, compactSnapshotForList(snapshot)] as const;
+  });
 
   return Object.fromEntries(entries);
 }

--- a/extensions/is-it-alive/src/adapters/onlineornot.ts
+++ b/extensions/is-it-alive/src/adapters/onlineornot.ts
@@ -1,0 +1,256 @@
+import type {
+  ComponentStatusValue,
+  FetchSnapshotInput,
+  StatusAdapter,
+  StatusIncident,
+  StatusIndicator,
+  StatusSnapshot,
+} from "@/types";
+import type {
+  OnlineOrNotComponent,
+  OnlineOrNotComponentStatus,
+  OnlineOrNotIncident,
+  OnlineOrNotSummary,
+} from "@/types/onlineornot";
+import { fetchJson } from "@/lib/fetch-json";
+import { overallDescription } from "@/lib/snapshot-text";
+import { normalizeSiteUrl } from "@/lib/url";
+
+const API_ORIGIN = "https://api.onlineornot.com";
+const HOSTED_SUFFIX = ".onlineornot.com";
+const MARKETING_HOSTS = new Set([
+  "onlineornot.com",
+  "www.onlineornot.com",
+  "api.onlineornot.com",
+  "developers.onlineornot.com",
+  "dashboard.onlineornot.com",
+  "metadata.onlineornot.com",
+  "img.onlineornot.com",
+]);
+function hostedSubdomain(siteUrl: string): string | null {
+  const hostname = new URL(normalizeSiteUrl(siteUrl)).hostname.toLowerCase();
+  if (!hostname.endsWith(HOSTED_SUFFIX)) {
+    return null;
+  }
+
+  const subdomain = hostname.slice(0, -HOSTED_SUFFIX.length);
+  if (!subdomain || subdomain.includes(".") || MARKETING_HOSTS.has(hostname)) {
+    return null;
+  }
+
+  return subdomain;
+}
+
+function summaryUrl(lookupKey: string): string {
+  return `${API_ORIGIN}/v1/status_pages/${encodeURIComponent(lookupKey)}/summary`;
+}
+
+function isOnlineOrNotSummary(data: unknown): data is OnlineOrNotSummary {
+  if (typeof data !== "object" || data === null || !("result" in data)) {
+    return false;
+  }
+
+  const result = data.result;
+  if (typeof result !== "object" || result === null) {
+    return false;
+  }
+
+  if (!("status_page" in result) || typeof result.status_page !== "object") {
+    return false;
+  }
+
+  const statusPage = result.status_page;
+  return (
+    statusPage !== null &&
+    "name" in statusPage &&
+    typeof statusPage.name === "string" &&
+    "subdomain" in statusPage &&
+    typeof statusPage.subdomain === "string"
+  );
+}
+
+function summaryLookupKey(siteUrl: string): string | null {
+  const hosted = hostedSubdomain(siteUrl);
+  if (hosted) {
+    return hosted;
+  }
+
+  const hostname = new URL(normalizeSiteUrl(siteUrl)).hostname.toLowerCase();
+  if (MARKETING_HOSTS.has(hostname)) {
+    return null;
+  }
+
+  return hostname;
+}
+
+async function fetchSummary(
+  siteUrl: string,
+): Promise<OnlineOrNotSummary | null> {
+  const key = summaryLookupKey(siteUrl);
+  if (!key) {
+    return null;
+  }
+
+  try {
+    const data = await fetchJson<unknown>(summaryUrl(key));
+    return isOnlineOrNotSummary(data) ? data : null;
+  } catch {
+    return null;
+  }
+}
+
+function componentStatus(
+  status: OnlineOrNotComponentStatus | string,
+): ComponentStatusValue | string {
+  switch (status) {
+    case "OPERATIONAL":
+      return "operational";
+    case "DEGRADED_PERFORMANCE":
+      return "degraded_performance";
+    case "PARTIAL_OUTAGE":
+      return "partial_outage";
+    case "MAJOR_OUTAGE":
+      return "major_outage";
+    case "UNDER_MAINTENANCE":
+      return "under_maintenance";
+    default:
+      return status.toLowerCase();
+  }
+}
+
+function componentIndicator(
+  status: OnlineOrNotComponentStatus | string,
+): StatusIndicator {
+  switch (status) {
+    case "OPERATIONAL":
+      return "none";
+    case "DEGRADED_PERFORMANCE":
+    case "UNDER_MAINTENANCE":
+      return "minor";
+    case "PARTIAL_OUTAGE":
+      return "major";
+    case "MAJOR_OUTAGE":
+      return "critical";
+    default:
+      return "minor";
+  }
+}
+
+function impactToIncidentImpact(impact: string | null | undefined): string {
+  switch (impact) {
+    case "MAJOR_OUTAGE":
+      return "critical";
+    case "PARTIAL_OUTAGE":
+      return "major";
+    case "DEGRADED_PERFORMANCE":
+      return "minor";
+    case "UNDER_MAINTENANCE":
+      return "maintenance";
+    default:
+      return impact?.toLowerCase() ?? "minor";
+  }
+}
+
+function worseIndicator(
+  current: StatusIndicator,
+  next: StatusIndicator,
+): StatusIndicator {
+  const order: StatusIndicator[] = ["none", "minor", "major", "critical"];
+  return order.indexOf(next) > order.indexOf(current) ? next : current;
+}
+
+function indicatorFromComponents(
+  components: OnlineOrNotComponent[],
+): StatusIndicator {
+  return components.reduce<StatusIndicator>(
+    (worst, component) =>
+      worseIndicator(worst, componentIndicator(component.status)),
+    "none",
+  );
+}
+
+function mapIncident(incident: OnlineOrNotIncident): StatusIncident {
+  return {
+    id: incident.id,
+    name: incident.title,
+    status: incident.ended ? "resolved" : "active",
+    impact: impactToIncidentImpact(incident.impact),
+    updatedAt: incident.updated_at || incident.created_at || incident.started,
+  };
+}
+
+function pageUrlFromSummary(
+  statusPage: OnlineOrNotSummary["result"]["status_page"],
+  fallback: string,
+): string {
+  const custom = statusPage.custom_domain?.trim();
+  if (custom) {
+    return /^https?:\/\//i.test(custom)
+      ? custom.replace(/\/+$/, "")
+      : `https://${custom}`;
+  }
+
+  if (statusPage.subdomain) {
+    return `https://${statusPage.subdomain}.onlineornot.com`;
+  }
+
+  return fallback;
+}
+
+export const onlineornotAdapter: StatusAdapter = {
+  async detect(siteUrl: string): Promise<boolean> {
+    try {
+      if (hostedSubdomain(siteUrl)) {
+        return true;
+      }
+
+      return (await fetchSummary(siteUrl)) !== null;
+    } catch {
+      return false;
+    }
+  },
+
+  async fetchSnapshot(input: FetchSnapshotInput): Promise<StatusSnapshot> {
+    const normalized = normalizeSiteUrl(input.url);
+    const fetchedAt = new Date().toISOString();
+
+    try {
+      const data = await fetchSummary(normalized);
+      if (!data?.result.status_page.name) {
+        throw new Error("Invalid OnlineOrNot status page response");
+      }
+
+      const components = data.result.components ?? [];
+      const incidents = (data.result.active_incidents ?? []).map(mapIncident);
+      const indicator = indicatorFromComponents(components);
+      const description =
+        data.result.status?.description?.trim() ||
+        overallDescription(indicator, incidents.length);
+
+      return {
+        pageName: data.result.status_page.name,
+        pageUrl: pageUrlFromSummary(data.result.status_page, normalized),
+        overallDescription: description,
+        indicator,
+        components: components.map((component) => ({
+          id: component.id,
+          name: component.name,
+          status: componentStatus(component.status),
+        })),
+        incidents,
+        fetchedAt,
+      };
+    } catch (error) {
+      return {
+        pageName: new URL(normalized).hostname,
+        pageUrl: normalized,
+        overallDescription: "Failed to fetch",
+        indicator: "none",
+        components: [],
+        incidents: [],
+        fetchedAt,
+        error: error instanceof Error ? error.message : "Unknown error",
+      };
+    }
+  },
+};

--- a/extensions/is-it-alive/src/check-status-pages.tsx
+++ b/extensions/is-it-alive/src/check-status-pages.tsx
@@ -3,7 +3,6 @@ import {
   ActionPanel,
   Color,
   Icon,
-  Image,
   List,
   showToast,
   Toast,
@@ -17,7 +16,7 @@ import { SiteForm } from "@/components/site-form";
 import { useSites, type SiteInput } from "@/hooks/use-sites";
 import { indicatorListIcon } from "@/lib/status-colors";
 import {
-  suggestedFaviconSource,
+  suggestedSiteIcon,
   unusedSuggestedSitesBySection,
   type SuggestedSite,
 } from "@/lib/suggested-sites";
@@ -304,11 +303,7 @@ export default function Command() {
                     key={site.url}
                     title={site.name}
                     subtitle={site.url}
-                    icon={{
-                      source: suggestedFaviconSource(site),
-                      fallback: Icon.Globe,
-                      mask: Image.Mask.Circle,
-                    }}
+                    icon={suggestedSiteIcon(site)}
                     keywords={[site.url, new URL(site.url).hostname]}
                     accessories={[
                       {

--- a/extensions/is-it-alive/src/check-status-pages.tsx
+++ b/extensions/is-it-alive/src/check-status-pages.tsx
@@ -3,16 +3,25 @@ import {
   ActionPanel,
   Color,
   Icon,
+  Image,
   List,
   showToast,
   Toast,
 } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
-import { fetchAllSnapshots } from "@/adapters";
+import { useState } from "react";
+import { detectProvider, fetchAllSnapshots, fetchSnapshot } from "@/adapters";
+import { mapPool } from "@/lib/async-pool";
 import { SiteDetail } from "@/components/site-detail";
 import { SiteForm } from "@/components/site-form";
-import { useSites } from "@/hooks/use-sites";
+import { useSites, type SiteInput } from "@/hooks/use-sites";
 import { indicatorListIcon } from "@/lib/status-colors";
+import {
+  suggestedFaviconSource,
+  unusedSuggestedSitesBySection,
+  type SuggestedSite,
+} from "@/lib/suggested-sites";
+import { normalizeSiteUrl } from "@/lib/url";
 import type { MonitoredSite, StatusSnapshot } from "@/types";
 
 export default function Command() {
@@ -20,9 +29,12 @@ export default function Command() {
     sites,
     isLoading: isLoadingSites,
     addSite,
+    addSites,
     deleteSite,
     updateSite,
   } = useSites();
+  const [selectedUrls, setSelectedUrls] = useState<string[]>([]);
+  const [addingUrls, setAddingUrls] = useState<string[]>([]);
 
   const {
     data: snapshots,
@@ -40,130 +52,361 @@ export default function Command() {
     { keepPreviousData: true },
   );
 
-  const isLoading = isLoadingSites || isLoadingSnapshots;
+  const suggestedSections = unusedSuggestedSitesBySection(
+    sites.map((site) => site.url),
+  );
+  const suggestedSites = suggestedSections.flatMap((section) => section.sites);
+  const selectedSet = new Set(
+    selectedUrls.filter((url) =>
+      suggestedSites.some((site) => site.url === url),
+    ),
+  );
+  const selectedSites = suggestedSites.filter((site) =>
+    selectedSet.has(site.url),
+  );
+  const showSuggestions = !isLoadingSites && suggestedSites.length > 0;
+  const isAddingSuggested = addingUrls.length > 0;
+  const isLoading = isLoadingSites || isLoadingSnapshots || isAddingSuggested;
+
+  async function handleSaveNewSite(values: SiteInput) {
+    await addSite(values);
+  }
+
+  function toggleSelected(url: string) {
+    setSelectedUrls((current) =>
+      current.includes(url)
+        ? current.filter((item) => item !== url)
+        : [...current, url],
+    );
+  }
+
+  function selectAllSuggested() {
+    setSelectedUrls(suggestedSites.map((site) => site.url));
+  }
+
+  function selectAllInSection(sectionSites: SuggestedSite[]) {
+    setSelectedUrls((current) => {
+      const next = new Set(current);
+      for (const site of sectionSites) {
+        next.add(site.url);
+      }
+      return [...next];
+    });
+  }
+
+  function clearSelection() {
+    setSelectedUrls([]);
+  }
+
+  async function handleAddSuggested(sitesToAdd: SuggestedSite[]) {
+    if (addingUrls.length > 0 || sitesToAdd.length === 0) {
+      return;
+    }
+
+    setAddingUrls(sitesToAdd.map((site) => site.url));
+
+    try {
+      const results = await mapPool(sitesToAdd, 2, async (site) => {
+        try {
+          return { ok: true as const, value: await resolveSuggestedSite(site) };
+        } catch {
+          return { ok: false as const, name: site.name };
+        }
+      });
+      const succeeded: SiteInput[] = [];
+      const failed: string[] = [];
+
+      for (const result of results) {
+        if (result.ok) {
+          succeeded.push(result.value);
+        } else {
+          failed.push(result.name);
+        }
+      }
+
+      if (succeeded.length > 0) {
+        await addSites(succeeded);
+      }
+
+      setSelectedUrls([]);
+
+      if (failed.length > 0 && succeeded.length > 0) {
+        await showToast({
+          style: Toast.Style.Failure,
+          title: `Added ${succeeded.length}, failed ${failed.length}`,
+          message: failed.join(", "),
+        });
+      } else if (failed.length > 0) {
+        await showToast({
+          style: Toast.Style.Failure,
+          title:
+            failed.length === 1 ? "Failed to add site" : "Failed to add sites",
+          message: failed.join(", "),
+        });
+      } else {
+        await showToast({
+          style: Toast.Style.Success,
+          title:
+            succeeded.length === 1
+              ? "Site added"
+              : `${succeeded.length} sites added`,
+          message: succeeded.map((site) => site.name).join(", "),
+        });
+      }
+    } finally {
+      setAddingUrls([]);
+    }
+  }
 
   async function handleDelete(site: MonitoredSite) {
     await deleteSite(site.id);
     await showToast({ style: Toast.Style.Success, title: "Site removed" });
   }
 
-  return (
-    <List
-      isLoading={isLoading}
-      searchBarPlaceholder="Search monitored sites..."
-    >
-      <List.EmptyView
-        title="No sites yet"
-        description="Add a status page URL to monitor services like Claude, GitHub, or Railway."
+  const monitoredItems = sites.map((site) => {
+    const snapshot = snapshots?.[site.id];
+    const hasSnapshotError = Boolean(snapshot?.error);
+    const hasLoadError = Boolean(snapshotsError && !snapshot);
+    const hasError = hasSnapshotError || hasLoadError;
+    const icon = hasError
+      ? { source: Icon.QuestionMark, tintColor: Color.SecondaryText }
+      : indicatorListIcon(snapshot?.indicator ?? "unknown");
+
+    const subtitle = hasSnapshotError
+      ? "Fetch failed. Press Enter to retry."
+      : hasLoadError
+        ? "Load failed. Press Enter to retry."
+        : (snapshot?.overallDescription ?? "Loading...");
+
+    return (
+      <List.Item
+        key={site.id}
+        title={site.name}
+        subtitle={subtitle}
+        icon={icon}
+        accessories={[
+          ...(snapshot?.incidents?.length
+            ? [
+                {
+                  icon: Icon.Warning,
+                  tooltip: `${snapshot.incidents.length} active incident${snapshot.incidents.length === 1 ? "" : "s"}`,
+                },
+              ]
+            : []),
+          ...(snapshot?.fetchedAt
+            ? [
+                {
+                  date: new Date(snapshot.fetchedAt),
+                  tooltip: "Last fetched",
+                },
+              ]
+            : []),
+        ]}
         actions={
           <ActionPanel>
+            {snapshot && !hasError ? (
+              <Action.Push
+                title="View Status Details"
+                icon={Icon.Eye}
+                target={<SiteDetail site={site} />}
+              />
+            ) : (
+              <Action
+                title="Refresh"
+                icon={Icon.ArrowClockwise}
+                onAction={revalidate}
+              />
+            )}
+            <AddSiteAction onSave={handleSaveNewSite} />
             <Action.Push
-              title="Add Site"
-              icon={Icon.Plus}
+              title="Edit Site"
+              icon={Icon.Pencil}
               target={
                 <SiteForm
-                  onSave={async (values) => {
-                    await addSite(values);
-                  }}
+                  site={site}
+                  onSave={(values) => updateSite(site.id, values)}
                 />
               }
+            />
+            <Action
+              title="Delete Site"
+              shortcut={{ modifiers: ["ctrl"], key: "delete" }}
+              icon={Icon.Trash}
+              style={Action.Style.Destructive}
+              onAction={() => handleDelete(site)}
+            />
+            <Action
+              title="Refresh All"
+              icon={Icon.ArrowClockwise}
+              onAction={revalidate}
             />
           </ActionPanel>
         }
       />
+    );
+  });
 
-      {sites.map((site) => {
-        const snapshot = snapshots?.[site.id];
-        const hasSnapshotError = Boolean(snapshot?.error);
-        const hasLoadError = Boolean(snapshotsError && !snapshot);
-        const hasError = hasSnapshotError || hasLoadError;
-        const icon = hasError
-          ? { source: Icon.QuestionMark, tintColor: Color.SecondaryText }
-          : indicatorListIcon(snapshot?.indicator ?? "unknown");
+  return (
+    <List
+      isLoading={isLoading}
+      searchBarPlaceholder={
+        showSuggestions && sites.length === 0
+          ? "Search suggested sites..."
+          : "Search monitored sites..."
+      }
+    >
+      <List.EmptyView
+        title={
+          showSuggestions ? "No matching suggestions" : "No matching sites"
+        }
+        description={
+          showSuggestions
+            ? "Clear the search to browse suggested status pages, or add a custom URL."
+            : "Add a status page URL to monitor services like Claude, GitHub, or Railway."
+        }
+        actions={
+          <ActionPanel>
+            <AddSiteAction onSave={handleSaveNewSite} />
+          </ActionPanel>
+        }
+      />
 
-        const subtitle = hasSnapshotError
-          ? "Failed to fetch — retry"
-          : hasLoadError
-            ? "Failed to load — retry"
-            : (snapshot?.overallDescription ?? "Loading...");
+      {sites.length > 0 && showSuggestions ? (
+        <List.Section title="Monitored">{monitoredItems}</List.Section>
+      ) : (
+        monitoredItems
+      )}
 
-        return (
-          <List.Item
-            key={site.id}
-            title={site.name}
-            subtitle={subtitle}
-            icon={icon}
-            accessories={[
-              ...(snapshot?.incidents?.length
-                ? [
-                    {
-                      icon: Icon.Warning,
-                      tooltip: `${snapshot.incidents.length} active incident(s)`,
-                    },
-                  ]
-                : []),
-              ...(snapshot?.fetchedAt
-                ? [
-                    {
-                      date: new Date(snapshot.fetchedAt),
-                      tooltip: "Last fetched",
-                    },
-                  ]
-                : []),
-            ]}
-            actions={
-              <ActionPanel>
-                {snapshot && !hasError ? (
-                  <Action.Push
-                    title="View Status Details"
-                    icon={Icon.Eye}
-                    target={<SiteDetail snapshot={snapshot} />}
+      {showSuggestions &&
+        suggestedSections.map((section, index) => {
+          const selectedInSection = section.sites.filter((site) =>
+            selectedSet.has(site.url),
+          ).length;
+
+          return (
+            <List.Section
+              key={section.category}
+              title={section.title}
+              subtitle={
+                selectedInSection > 0
+                  ? `${selectedInSection} selected · ⌘↵ to add`
+                  : index === 0
+                    ? "Enter to select · ⌘↵ to add"
+                    : undefined
+              }
+            >
+              {section.sites.map((site) => {
+                const isSelected = selectedSet.has(site.url);
+                const isAddingSite = addingUrls.includes(site.url);
+
+                return (
+                  <List.Item
+                    key={site.url}
+                    title={site.name}
+                    subtitle={site.url}
+                    icon={{
+                      source: suggestedFaviconSource(site),
+                      fallback: Icon.Globe,
+                      mask: Image.Mask.Circle,
+                    }}
+                    keywords={[site.url, new URL(site.url).hostname]}
+                    accessories={[
+                      {
+                        icon: isSelected
+                          ? { source: Icon.CheckCircle, tintColor: Color.Green }
+                          : Icon.Circle,
+                        tooltip: isSelected ? "Selected" : "Not selected",
+                      },
+                      ...(isAddingSite ? [{ text: "Adding..." }] : []),
+                    ]}
+                    actions={
+                      <ActionPanel>
+                        <ActionPanel.Section>
+                          <Action
+                            title={isSelected ? "Deselect" : "Select"}
+                            icon={isSelected ? Icon.Circle : Icon.CheckCircle}
+                            onAction={() => toggleSelected(site.url)}
+                          />
+                          <Action
+                            title={
+                              selectedSites.length > 0
+                                ? `Add ${selectedSites.length} Site${selectedSites.length === 1 ? "" : "s"}`
+                                : "Add Site"
+                            }
+                            icon={Icon.Plus}
+                            shortcut={{ modifiers: ["cmd"], key: "return" }}
+                            onAction={() =>
+                              handleAddSuggested(
+                                selectedSites.length > 0
+                                  ? selectedSites
+                                  : [site],
+                              )
+                            }
+                          />
+                        </ActionPanel.Section>
+                        <ActionPanel.Section>
+                          <Action
+                            title={`Select All ${section.title}`}
+                            icon={Icon.CheckList}
+                            onAction={() => selectAllInSection(section.sites)}
+                          />
+                          <Action
+                            title="Select All"
+                            icon={Icon.CheckList}
+                            onAction={selectAllSuggested}
+                          />
+                          {selectedSites.length > 0 && (
+                            <Action
+                              title="Clear Selection"
+                              icon={Icon.XMarkCircle}
+                              onAction={clearSelection}
+                            />
+                          )}
+                          <AddSiteAction
+                            title="Add Custom URL"
+                            onSave={handleSaveNewSite}
+                          />
+                        </ActionPanel.Section>
+                      </ActionPanel>
+                    }
                   />
-                ) : (
-                  <Action
-                    title="Refresh"
-                    icon={Icon.ArrowClockwise}
-                    onAction={revalidate}
-                  />
-                )}
-                <Action.Push
-                  title="Add Site"
-                  icon={Icon.Plus}
-                  target={
-                    <SiteForm
-                      onSave={async (values) => {
-                        await addSite(values);
-                      }}
-                    />
-                  }
-                />
-                <Action.Push
-                  title="Edit Site"
-                  icon={Icon.Pencil}
-                  target={
-                    <SiteForm
-                      site={site}
-                      onSave={(values) => updateSite(site.id, values)}
-                    />
-                  }
-                />
-                <Action
-                  title="Delete Site"
-                  shortcut={{ modifiers: ["ctrl"], key: "delete" }}
-                  icon={Icon.Trash}
-                  style={Action.Style.Destructive}
-                  onAction={() => handleDelete(site)}
-                />
-                <Action
-                  title="Refresh All"
-                  icon={Icon.ArrowClockwise}
-                  onAction={revalidate}
-                />
-              </ActionPanel>
-            }
-          />
-        );
-      })}
+                );
+              })}
+            </List.Section>
+          );
+        })}
     </List>
+  );
+}
+
+async function resolveSuggestedSite(site: SuggestedSite): Promise<SiteInput> {
+  const url = normalizeSiteUrl(site.url);
+  const provider = await detectProvider(url);
+  const snapshot = await fetchSnapshot({ url, provider });
+
+  if (snapshot.error) {
+    throw new Error(snapshot.error);
+  }
+
+  return {
+    name: site.name,
+    url,
+    provider,
+  };
+}
+
+function AddSiteAction({
+  title = "Add Site",
+  onSave,
+}: {
+  title?: string;
+  onSave: (values: SiteInput) => Promise<void>;
+}) {
+  return (
+    <Action.Push
+      title={title}
+      icon={Icon.Plus}
+      target={<SiteForm onSave={onSave} />}
+    />
   );
 }

--- a/extensions/is-it-alive/src/components/site-detail.tsx
+++ b/extensions/is-it-alive/src/components/site-detail.tsx
@@ -1,5 +1,7 @@
 import { Action, ActionPanel, Color, Icon, List } from "@raycast/api";
-import type { StatusSnapshot } from "@/types";
+import { useCachedPromise } from "@raycast/utils";
+import { fetchSnapshot } from "@/adapters";
+import type { MonitoredSite, StatusSnapshot } from "@/types";
 import {
   componentStatusLabel,
   componentStatusListIcon,
@@ -13,7 +15,7 @@ import {
 import { formatUptimePercent } from "@/lib/snapshot-text";
 
 interface SiteDetailProps {
-  snapshot: StatusSnapshot;
+  site: MonitoredSite;
 }
 
 function buildIncidentMarkdown(
@@ -60,7 +62,34 @@ function buildOverviewMarkdown(snapshot: StatusSnapshot): string {
   return `${uptimeMarkdown}\n\n---\n\n${incidentsMarkdown}`;
 }
 
-export function SiteDetail({ snapshot }: SiteDetailProps) {
+export function SiteDetail({ site }: SiteDetailProps) {
+  const {
+    data: snapshot,
+    isLoading,
+    error,
+  } = useCachedPromise(
+    async (monitored: MonitoredSite) =>
+      fetchSnapshot({
+        url: monitored.url,
+        provider: monitored.provider,
+        monitoredRegions: monitored.monitoredRegions,
+      }),
+    [site],
+  );
+
+  if (!snapshot) {
+    return (
+      <List isLoading={isLoading} navigationTitle={site.name}>
+        <List.EmptyView
+          title={error ? "Failed to load status" : "Loading status..."}
+          description={
+            error instanceof Error ? error.message : "Fetching the status page."
+          }
+        />
+      </List>
+    );
+  }
+
   const overviewIcon = snapshot.error
     ? { source: Icon.QuestionMark, tintColor: Color.SecondaryText }
     : indicatorListIcon(snapshot.indicator);

--- a/extensions/is-it-alive/src/hooks/use-sites.ts
+++ b/extensions/is-it-alive/src/hooks/use-sites.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { useLocalStorage } from "@raycast/utils";
 import { randomUUID } from "node:crypto";
 import type { MonitoredSite, SiteProvider } from "@/types";
@@ -11,6 +11,8 @@ export interface SiteInput {
   provider: SiteProvider;
   monitoredRegions?: string[];
 }
+
+type SiteMutation = (sites: MonitoredSite[]) => MonitoredSite[];
 
 function createId(): string {
   return randomUUID();
@@ -33,6 +35,27 @@ export function useSites() {
     setValue: setSites,
     isLoading,
   } = useLocalStorage<MonitoredSite[]>(STORAGE_KEY, []);
+  const sitesRef = useRef(sites ?? []);
+  const mutationQueue = useRef<Promise<void>>(Promise.resolve());
+  sitesRef.current = sites ?? [];
+
+  const mutateSites = useCallback(
+    (mutation: SiteMutation): Promise<void> => {
+      const operation = mutationQueue.current.then(async () => {
+        const nextSites = mutation(sitesRef.current);
+        await setSites(nextSites);
+        sitesRef.current = nextSites;
+      });
+
+      // Keep later mutations running if one storage write fails.
+      mutationQueue.current = operation.then(
+        () => undefined,
+        () => undefined,
+      );
+      return operation;
+    },
+    [setSites],
+  );
 
   const addSites = useCallback(
     async (inputs: SiteInput[]) => {
@@ -40,11 +63,11 @@ export function useSites() {
         return [];
       }
 
-      const next = inputs.map(toMonitoredSite);
-      await setSites([...(sites ?? []), ...next]);
-      return next;
+      const addedSites = inputs.map(toMonitoredSite);
+      await mutateSites((currentSites) => [...currentSites, ...addedSites]);
+      return addedSites;
     },
-    [setSites, sites],
+    [mutateSites],
   );
 
   const addSite = useCallback(
@@ -57,8 +80,8 @@ export function useSites() {
 
   const updateSite = useCallback(
     async (id: string, input: SiteInput) => {
-      await setSites(
-        (sites ?? []).map((site) =>
+      await mutateSites((currentSites) =>
+        currentSites.map((site) =>
           site.id === id
             ? {
                 ...site,
@@ -71,14 +94,16 @@ export function useSites() {
         ),
       );
     },
-    [setSites, sites],
+    [mutateSites],
   );
 
   const deleteSite = useCallback(
     async (id: string) => {
-      await setSites((sites ?? []).filter((site) => site.id !== id));
+      await mutateSites((currentSites) =>
+        currentSites.filter((site) => site.id !== id),
+      );
     },
-    [setSites, sites],
+    [mutateSites],
   );
 
   return {

--- a/extensions/is-it-alive/src/hooks/use-sites.ts
+++ b/extensions/is-it-alive/src/hooks/use-sites.ts
@@ -16,6 +16,17 @@ function createId(): string {
   return randomUUID();
 }
 
+function toMonitoredSite(input: SiteInput): MonitoredSite {
+  return {
+    id: createId(),
+    name: input.name,
+    url: input.url,
+    provider: input.provider,
+    monitoredRegions: input.monitoredRegions,
+    createdAt: new Date().toISOString(),
+  };
+}
+
 export function useSites() {
   const {
     value: sites,
@@ -23,21 +34,25 @@ export function useSites() {
     isLoading,
   } = useLocalStorage<MonitoredSite[]>(STORAGE_KEY, []);
 
-  const addSite = useCallback(
-    async (input: SiteInput) => {
-      const next: MonitoredSite = {
-        id: createId(),
-        name: input.name,
-        url: input.url,
-        provider: input.provider,
-        monitoredRegions: input.monitoredRegions,
-        createdAt: new Date().toISOString(),
-      };
+  const addSites = useCallback(
+    async (inputs: SiteInput[]) => {
+      if (inputs.length === 0) {
+        return [];
+      }
 
-      await setSites([...(sites ?? []), next]);
+      const next = inputs.map(toMonitoredSite);
+      await setSites([...(sites ?? []), ...next]);
       return next;
     },
     [setSites, sites],
+  );
+
+  const addSite = useCallback(
+    async (input: SiteInput) => {
+      const [next] = await addSites([input]);
+      return next;
+    },
+    [addSites],
   );
 
   const updateSite = useCallback(
@@ -70,6 +85,7 @@ export function useSites() {
     sites: sites ?? [],
     isLoading,
     addSite,
+    addSites,
     updateSite,
     deleteSite,
   };

--- a/extensions/is-it-alive/src/lib/async-pool.ts
+++ b/extensions/is-it-alive/src/lib/async-pool.ts
@@ -1,0 +1,30 @@
+export async function mapPool<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) {
+    return [];
+  }
+
+  const limit = Math.max(1, concurrency);
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (true) {
+      const index = nextIndex;
+      nextIndex += 1;
+      if (index >= items.length) {
+        return;
+      }
+
+      results[index] = await mapper(items[index], index);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, () => worker()),
+  );
+  return results;
+}

--- a/extensions/is-it-alive/src/lib/snapshot-compact.ts
+++ b/extensions/is-it-alive/src/lib/snapshot-compact.ts
@@ -1,0 +1,22 @@
+import type { StatusSnapshot } from "@/types";
+
+export function compactSnapshotForList(
+  snapshot: StatusSnapshot,
+): StatusSnapshot {
+  return {
+    pageName: snapshot.pageName,
+    pageUrl: snapshot.pageUrl,
+    overallDescription: snapshot.overallDescription,
+    indicator: snapshot.indicator,
+    fetchedAt: snapshot.fetchedAt,
+    error: snapshot.error,
+    components: [],
+    incidents: snapshot.incidents.map((incident) => ({
+      id: incident.id,
+      name: incident.name,
+      status: incident.status,
+      impact: incident.impact,
+      updatedAt: incident.updatedAt,
+    })),
+  };
+}

--- a/extensions/is-it-alive/src/lib/suggested-sites.ts
+++ b/extensions/is-it-alive/src/lib/suggested-sites.ts
@@ -1,3 +1,5 @@
+import { Icon, Image } from "@raycast/api";
+import { getFavicon } from "@raycast/utils";
 import { normalizeSiteUrl } from "@/lib/url";
 
 export type SuggestedSiteCategory =
@@ -311,13 +313,20 @@ export function unusedSuggestedSitesBySection(
 
 const DIRECT_IMAGE_PATTERN = /\.(png|ico|svg|jpe?g|webp)(\?|$)/i;
 
-export function suggestedFaviconSource(site: SuggestedSite): string {
+export function suggestedSiteIcon(site: SuggestedSite): Image.ImageLike {
   const favicon = site.favicon ?? site.url;
   if (DIRECT_IMAGE_PATTERN.test(favicon)) {
-    return favicon;
+    return {
+      source: favicon,
+      fallback: Icon.Globe,
+      mask: Image.Mask.Circle,
+    };
   }
 
-  return `https://www.google.com/s2/favicons?sz=64&domain_url=${encodeURIComponent(favicon)}`;
+  return getFavicon(favicon, {
+    fallback: Icon.Globe,
+    mask: Image.Mask.Circle,
+  });
 }
 
 function siteUrlKey(url: string): string {

--- a/extensions/is-it-alive/src/lib/suggested-sites.ts
+++ b/extensions/is-it-alive/src/lib/suggested-sites.ts
@@ -1,0 +1,329 @@
+import { normalizeSiteUrl } from "@/lib/url";
+
+export type SuggestedSiteCategory =
+  | "infrastructure"
+  | "developer-tools"
+  | "data"
+  | "auth-payments"
+  | "ai";
+
+export interface SuggestedSite {
+  name: string;
+  url: string;
+  favicon?: string;
+  category: SuggestedSiteCategory;
+}
+
+const INFRASTRUCTURE_SITES: readonly Omit<SuggestedSite, "category">[] = [
+  {
+    name: "GitHub",
+    url: "https://www.githubstatus.com",
+    favicon: "https://github.com",
+  },
+  {
+    name: "AWS",
+    url: "https://health.aws.amazon.com/health/status",
+    favicon: "https://aws.amazon.com",
+  },
+  {
+    name: "Vercel",
+    url: "https://www.vercel-status.com",
+    favicon: "https://vercel.com",
+  },
+  {
+    name: "Railway",
+    url: "https://status.railway.com",
+    favicon: "https://railway.com",
+  },
+  {
+    name: "Google Cloud",
+    url: "https://status.cloud.google.com",
+    favicon: "https://cloud.google.com",
+  },
+  {
+    name: "Cloudflare",
+    url: "https://www.cloudflarestatus.com",
+    favicon: "https://www.cloudflare.com",
+  },
+  {
+    name: "DigitalOcean",
+    url: "https://status.digitalocean.com",
+    favicon: "https://www.digitalocean.com",
+  },
+  {
+    name: "Netlify",
+    url: "https://www.netlifystatus.com",
+    favicon: "https://www.netlify.com",
+  },
+  {
+    name: "Render",
+    url: "https://status.render.com",
+    favicon: "https://render.com",
+  },
+  {
+    name: "Fly.io",
+    url: "https://status.fly.io",
+    favicon: "https://fly.io",
+  },
+];
+
+const DEVELOPER_TOOL_SITES: readonly Omit<SuggestedSite, "category">[] = [
+  {
+    name: "npm",
+    url: "https://status.npmjs.org",
+    favicon: "https://www.npmjs.com",
+  },
+  {
+    name: "Docker",
+    url: "https://www.dockerstatus.com",
+    favicon: "https://www.docker.com",
+  },
+  {
+    name: "CircleCI",
+    url: "https://status.circleci.com",
+    favicon: "https://circleci.com",
+  },
+  {
+    name: "Cursor",
+    url: "https://status.cursor.com",
+    favicon: "https://cursor.com",
+  },
+  {
+    name: "Linear",
+    url: "https://linearstatus.com",
+    favicon: "https://linear.app",
+  },
+];
+
+const DATA_SITES: readonly Omit<SuggestedSite, "category">[] = [
+  {
+    name: "Supabase",
+    url: "https://status.supabase.com",
+    favicon: "https://supabase.com",
+  },
+  {
+    name: "MongoDB",
+    url: "https://status.mongodb.com",
+    favicon: "https://www.mongodb.com",
+  },
+  {
+    name: "PlanetScale",
+    url: "https://www.planetscalestatus.com",
+    favicon: "https://planetscale.com",
+  },
+  {
+    name: "Redis",
+    url: "https://status.redis.io",
+    favicon: "https://redis.io",
+  },
+];
+
+const AUTH_PAYMENT_SITES: readonly Omit<SuggestedSite, "category">[] = [
+  {
+    name: "Clerk",
+    url: "https://status.clerk.com",
+    favicon: "https://clerk.com",
+  },
+  {
+    name: "Shopify",
+    url: "https://www.shopifystatus.com",
+    favicon: "https://www.shopify.com",
+  },
+];
+
+const AI_SITES: readonly Omit<SuggestedSite, "category">[] = [
+  {
+    name: "OpenAI",
+    url: "https://status.openai.com",
+    favicon: "https://openai.com",
+  },
+  {
+    name: "Claude",
+    url: "https://status.claude.com",
+    favicon: "https://claude.ai",
+  },
+  {
+    name: "Google AI Studio",
+    url: "https://aistudio.google.com/status",
+    favicon: "https://aistudio.google.com",
+  },
+  {
+    name: "xAI",
+    url: "https://status.x.ai",
+    favicon: "https://x.ai",
+  },
+  {
+    name: "Perplexity",
+    url: "https://status.perplexity.com",
+    favicon: "https://www.perplexity.ai",
+  },
+  {
+    name: "DeepSeek",
+    url: "https://status.deepseek.com",
+    favicon: "https://www.deepseek.com",
+  },
+  {
+    name: "Moonshot AI",
+    url: "https://status.moonshot.cn",
+    favicon: "https://www.moonshot.cn",
+  },
+  {
+    name: "MiniMax",
+    url: "https://status.minimax.io",
+    favicon: "https://www.minimax.io",
+  },
+  {
+    name: "Mistral",
+    url: "https://status.mistral.ai",
+    favicon: "https://mistral.ai",
+  },
+  {
+    name: "Cohere",
+    url: "https://status.cohere.com",
+    favicon: "https://cohere.com",
+  },
+  {
+    name: "OpenRouter",
+    url: "https://status.openrouter.ai",
+    favicon: "https://openrouter.ai",
+  },
+  {
+    name: "Groq",
+    url: "https://groqstatus.com",
+    favicon: "https://groq.com",
+  },
+  {
+    name: "Together AI",
+    url: "https://status.together.ai",
+    favicon: "https://www.together.ai",
+  },
+  {
+    name: "Fireworks AI",
+    url: "https://status.fireworks.ai",
+    favicon: "https://fireworks.ai",
+  },
+  {
+    name: "Cerebras",
+    url: "https://status.cerebras.ai",
+    favicon: "https://www.cerebras.ai",
+  },
+  {
+    name: "Replicate",
+    url: "https://www.replicatestatus.com",
+    favicon: "https://replicate.com",
+  },
+  {
+    name: "Hugging Face",
+    url: "https://status.huggingface.co",
+    favicon: "https://huggingface.co",
+  },
+  {
+    name: "Baseten",
+    url: "https://status.baseten.co",
+    favicon: "https://www.baseten.co",
+  },
+  {
+    name: "ElevenLabs",
+    url: "https://status.elevenlabs.io",
+    favicon: "https://elevenlabs.io",
+  },
+  {
+    name: "Stability AI",
+    url: "https://status.stability.ai",
+    favicon: "https://stability.ai",
+  },
+];
+
+function withCategory(
+  category: SuggestedSiteCategory,
+  sites: readonly Omit<SuggestedSite, "category">[],
+): SuggestedSite[] {
+  return sites.map((site) => ({ ...site, category }));
+}
+
+export const SUGGESTED_SITES: readonly SuggestedSite[] = [
+  ...withCategory("infrastructure", INFRASTRUCTURE_SITES),
+  ...withCategory("developer-tools", DEVELOPER_TOOL_SITES),
+  ...withCategory("data", DATA_SITES),
+  ...withCategory("auth-payments", AUTH_PAYMENT_SITES),
+  ...withCategory("ai", AI_SITES),
+];
+
+const SECTION_TITLES: Record<SuggestedSiteCategory, string> = {
+  infrastructure: "Infrastructure",
+  ai: "AI",
+  "developer-tools": "Developer Tools",
+  data: "Data",
+  "auth-payments": "Auth & Payments",
+};
+
+export interface SuggestedSiteSection {
+  category: SuggestedSiteCategory;
+  title: string;
+  sites: SuggestedSite[];
+}
+
+export function unusedSuggestedSites(
+  monitoredUrls: readonly string[],
+): SuggestedSite[] {
+  const monitoredUrlKeys = new Set(monitoredUrls.map(siteUrlKey));
+  return SUGGESTED_SITES.filter(
+    (site) => !monitoredUrlKeys.has(siteUrlKey(site.url)),
+  );
+}
+
+export function unusedSuggestedSitesBySection(
+  monitoredUrls: readonly string[],
+): SuggestedSiteSection[] {
+  const unused = unusedSuggestedSites(monitoredUrls);
+  const grouped: Record<SuggestedSiteCategory, SuggestedSite[]> = {
+    infrastructure: [],
+    "developer-tools": [],
+    data: [],
+    "auth-payments": [],
+    ai: [],
+  };
+
+  for (const site of unused) {
+    switch (site.category) {
+      case "infrastructure":
+      case "developer-tools":
+      case "data":
+      case "auth-payments":
+      case "ai":
+        grouped[site.category].push(site);
+        break;
+      default: {
+        const _exhaustive: never = site.category;
+        throw new Error(`Unhandled suggested site category: ${_exhaustive}`);
+      }
+    }
+  }
+
+  return (Object.keys(SECTION_TITLES) as SuggestedSiteCategory[])
+    .map((category) => ({
+      category,
+      title: SECTION_TITLES[category],
+      sites: grouped[category],
+    }))
+    .filter((section) => section.sites.length > 0);
+}
+
+const DIRECT_IMAGE_PATTERN = /\.(png|ico|svg|jpe?g|webp)(\?|$)/i;
+
+export function suggestedFaviconSource(site: SuggestedSite): string {
+  const favicon = site.favicon ?? site.url;
+  if (DIRECT_IMAGE_PATTERN.test(favicon)) {
+    return favicon;
+  }
+
+  return `https://www.google.com/s2/favicons?sz=64&domain_url=${encodeURIComponent(favicon)}`;
+}
+
+function siteUrlKey(url: string): string {
+  try {
+    return normalizeSiteUrl(url);
+  } catch {
+    return url;
+  }
+}

--- a/extensions/is-it-alive/src/types/firehydrant.ts
+++ b/extensions/is-it-alive/src/types/firehydrant.ts
@@ -1,0 +1,29 @@
+export interface FireHydrantComponent {
+  id: string;
+  name: string;
+  condition?: string;
+}
+
+export interface FireHydrantIncident {
+  id: string;
+  title: string;
+  timestamps?: {
+    started?: string;
+    resolved?: string;
+    [key: string]: string | undefined;
+  };
+  components?: FireHydrantComponent[];
+  componentConditions?: Record<string, string>;
+  severitySlug?: string;
+}
+
+export interface FireHydrantPayload {
+  config: {
+    title?: string;
+    companyName?: string;
+    operationalMessage?: string;
+  };
+  components: Array<{ id: string; name: string }>;
+  conditions?: Record<string, string>;
+  incidents: FireHydrantIncident[];
+}

--- a/extensions/is-it-alive/src/types/index.ts
+++ b/extensions/is-it-alive/src/types/index.ts
@@ -12,7 +12,9 @@ export type SiteProvider =
   | "uptimecom"
   | "googlecloud"
   | "aistudio"
-  | "outagedeck";
+  | "outagedeck"
+  | "onlineornot"
+  | "firehydrant";
 
 export type StatusIndicator = "none" | "minor" | "major" | "critical";
 

--- a/extensions/is-it-alive/src/types/onlineornot.ts
+++ b/extensions/is-it-alive/src/types/onlineornot.ts
@@ -1,0 +1,42 @@
+export type OnlineOrNotComponentStatus =
+  | "OPERATIONAL"
+  | "DEGRADED_PERFORMANCE"
+  | "PARTIAL_OUTAGE"
+  | "MAJOR_OUTAGE"
+  | "UNDER_MAINTENANCE";
+
+export interface OnlineOrNotStatusPage {
+  id: string;
+  name: string;
+  subdomain: string;
+  custom_domain?: string | null;
+}
+
+export interface OnlineOrNotComponent {
+  id: string;
+  name: string;
+  status: OnlineOrNotComponentStatus | string;
+}
+
+export interface OnlineOrNotIncident {
+  id: string;
+  title: string;
+  impact?: string | null;
+  started: string;
+  ended?: string | null;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface OnlineOrNotSummary {
+  success: boolean;
+  result: {
+    status?: {
+      description?: string;
+    };
+    status_page: OnlineOrNotStatusPage;
+    components?: OnlineOrNotComponent[];
+    active_incidents?: OnlineOrNotIncident[];
+    scheduled_maintenance?: OnlineOrNotIncident[];
+  };
+}

--- a/extensions/is-it-alive/tests/firehydrant.test.ts
+++ b/extensions/is-it-alive/tests/firehydrant.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { firehydrantAdapter } from "@/adapters/firehydrant";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const REDIS_PAYLOAD = {
+  config: {
+    companyName: "Redis Service Health",
+    title: "Redis Service Health",
+    operationalMessage: "Currently, there are no active incidents.",
+  },
+  components: [
+    { id: "rest", name: "REST API" },
+    { id: "dns", name: "DNS Resolvers" },
+  ],
+  conditions: {
+    Degraded: "DEGRADED",
+    Operational: "OPERATIONAL",
+    Unavailable: "OFFLINE",
+    Maintenance: "DEGRADED",
+  },
+  incidents: [
+    {
+      id: "resolved-1",
+      title: "Past outage",
+      timestamps: {
+        started: "2026-07-01T00:00:00Z",
+        resolved: "2026-07-01T01:00:00Z",
+      },
+      severitySlug: "SEV3",
+    },
+    {
+      id: "active-1",
+      title: "API latency",
+      timestamps: { started: "2026-08-28T12:00:00Z" },
+      severitySlug: "SEV2",
+      components: [{ id: "rest", name: "REST API", condition: "Degraded" }],
+    },
+  ],
+};
+
+describe("firehydrantAdapter", () => {
+  it("detects pages that serve /data/payload.json", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "https://status.redis.io/data/payload.json") {
+        return new Response(JSON.stringify(REDIS_PAYLOAD), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      return new Response("no", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      firehydrantAdapter.detect?.("https://status.redis.io"),
+    ).resolves.toBe(true);
+    await expect(
+      firehydrantAdapter.detect?.("https://www.githubstatus.com"),
+    ).resolves.toBe(false);
+  });
+
+  it("maps active incidents and component conditions from payload.json", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(REDIS_PAYLOAD), {
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    const snapshot = await firehydrantAdapter.fetchSnapshot({
+      url: "https://status.redis.io",
+    });
+
+    expect(snapshot.error).toBeUndefined();
+    expect(snapshot.pageName).toBe("Redis Service Health");
+    expect(snapshot.indicator).toBe("minor");
+    expect(snapshot.overallDescription).toBe("1 active incident");
+    expect(snapshot.components).toEqual([
+      { id: "rest", name: "REST API", status: "degraded_performance" },
+      { id: "dns", name: "DNS Resolvers", status: "operational" },
+    ]);
+    expect(snapshot.incidents).toEqual([
+      {
+        id: "active-1",
+        name: "API latency",
+        status: "active",
+        impact: "critical",
+        updatedAt: "2026-08-28T12:00:00Z",
+        affectedComponentIds: ["rest"],
+      },
+    ]);
+  });
+});

--- a/extensions/is-it-alive/tests/firehydrant.test.ts
+++ b/extensions/is-it-alive/tests/firehydrant.test.ts
@@ -44,7 +44,7 @@ const REDIS_PAYLOAD = {
 
 describe("firehydrantAdapter", () => {
   it("detects pages that serve /data/payload.json", async () => {
-    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const fetchMock = vi.fn(async (input: Parameters<typeof fetch>[0]) => {
       const url = String(input);
       if (url === "https://status.redis.io/data/payload.json") {
         return new Response(JSON.stringify(REDIS_PAYLOAD), {

--- a/extensions/is-it-alive/tests/incident-io.test.ts
+++ b/extensions/is-it-alive/tests/incident-io.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { incidentIoAdapter } from "@/adapters/incident-io";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const IMPACTS = {
+  component_impacts: [],
+  component_uptimes: [
+    {
+      component_id: "comp-1",
+      data_available_since: "2021-04-22T08:02:00Z",
+      uptime: "100.00",
+    },
+  ],
+};
+
+const INCIDENTS = { incidents: [] };
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("incidentIoAdapter", () => {
+  it("follows a status page redirect before calling the proxy JSON API", async () => {
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (
+          init?.redirect === "manual" &&
+          url === "https://status.linear.app"
+        ) {
+          return new Response(null, {
+            status: 301,
+            headers: { Location: "https://linearstatus.com/" },
+          });
+        }
+
+        if (url.includes("status.linear.app/proxy/status.linear.app")) {
+          return new Response("<html>redirected</html>", {
+            headers: { "Content-Type": "text/html" },
+          });
+        }
+
+        if (
+          url.includes(
+            "linearstatus.com/proxy/linearstatus.com/component_impacts",
+          )
+        ) {
+          return jsonResponse(IMPACTS);
+        }
+
+        if (url.includes("linearstatus.com/proxy/linearstatus.com/incidents")) {
+          return jsonResponse(INCIDENTS);
+        }
+
+        if (url === "https://linearstatus.com") {
+          return new Response("<html><title>Linear Status</title></html>", {
+            headers: { "Content-Type": "text/html" },
+          });
+        }
+
+        return new Response("missing", { status: 404 });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      incidentIoAdapter.detect?.("https://status.linear.app"),
+    ).resolves.toBe(true);
+
+    const snapshot = await incidentIoAdapter.fetchSnapshot({
+      url: "https://status.linear.app",
+    });
+
+    expect(snapshot.error).toBeUndefined();
+    expect(snapshot.pageName).toBe("Linear");
+    expect(snapshot.pageUrl).toBe("https://linearstatus.com");
+    expect(snapshot.components).toEqual([
+      {
+        id: "comp-1",
+        name: "comp-1",
+        status: "operational",
+        uptimePercent: 100,
+        historyDays: expect.any(Array),
+      },
+    ]);
+  });
+});

--- a/extensions/is-it-alive/tests/incident-io.test.ts
+++ b/extensions/is-it-alive/tests/incident-io.test.ts
@@ -28,7 +28,7 @@ function jsonResponse(body: unknown): Response {
 describe("incidentIoAdapter", () => {
   it("follows a status page redirect before calling the proxy JSON API", async () => {
     const fetchMock = vi.fn(
-      async (input: RequestInfo | URL, init?: RequestInit) => {
+      async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
         const url = String(input);
         if (
           init?.redirect === "manual" &&

--- a/extensions/is-it-alive/tests/onlineornot.test.ts
+++ b/extensions/is-it-alive/tests/onlineornot.test.ts
@@ -67,7 +67,7 @@ describe("onlineornotAdapter", () => {
   });
 
   it("looks up custom domains by hostname with the public summary API", async () => {
-    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const fetchMock = vi.fn(async (input: Parameters<typeof fetch>[0]) => {
       const url = String(input);
       if (url.includes("/status_pages/status.openrouter.ai/summary")) {
         return jsonResponse(OPENROUTER_SUMMARY);
@@ -131,7 +131,7 @@ describe("onlineornotAdapter", () => {
   });
 
   it("fetches a custom domain through the summary API without reading HTML", async () => {
-    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const fetchMock = vi.fn(async (input: Parameters<typeof fetch>[0]) => {
       const url = String(input);
       if (url.includes("/status_pages/status.openrouter.ai/summary")) {
         return jsonResponse(OPENROUTER_SUMMARY);

--- a/extensions/is-it-alive/tests/onlineornot.test.ts
+++ b/extensions/is-it-alive/tests/onlineornot.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { onlineornotAdapter } from "@/adapters/onlineornot";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const OPENROUTER_SUMMARY = {
+  success: true,
+  result: {
+    status: { description: "Minor Service Outage" },
+    status_page: {
+      id: "bLYZeyaq",
+      name: "OpenRouter",
+      subdomain: "openrouter",
+      custom_domain: "status.openrouter.ai",
+    },
+    components: [
+      {
+        id: "chat",
+        name: "Chat (/api/v1/chat/completions)",
+        status: "PARTIAL_OUTAGE",
+      },
+      {
+        id: "home",
+        name: "Homepage",
+        status: "OPERATIONAL",
+      },
+    ],
+    active_incidents: [
+      {
+        id: "inc-1",
+        title: "Elevated 429s on Anthropic and OpenAI",
+        impact: "PARTIAL_OUTAGE",
+        started: "2026-08-28T01:20:00.000Z",
+        updated_at: "2026-08-28T01:24:00.000Z",
+      },
+    ],
+    scheduled_maintenance: [],
+  },
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("onlineornotAdapter", () => {
+  it("detects hosted OnlineOrNot subdomains and skips marketing URLs", async () => {
+    await expect(
+      onlineornotAdapter.detect?.("https://openrouter.onlineornot.com"),
+    ).resolves.toBe(true);
+    await expect(
+      onlineornotAdapter.detect?.("https://onlineornot.com/status-pages"),
+    ).resolves.toBe(false);
+    await expect(
+      onlineornotAdapter.detect?.("https://www.onlineornot.com"),
+    ).resolves.toBe(false);
+    await expect(
+      onlineornotAdapter.detect?.(
+        "https://api.onlineornot.com/v1/status_pages",
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("looks up custom domains by hostname with the public summary API", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/status_pages/status.openrouter.ai/summary")) {
+        return jsonResponse(OPENROUTER_SUMMARY);
+      }
+
+      return jsonResponse(
+        { success: false, result: null, errors: [{ code: 10001 }] },
+        404,
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      onlineornotAdapter.detect?.("https://status.openrouter.ai"),
+    ).resolves.toBe(true);
+    await expect(
+      onlineornotAdapter.detect?.("https://www.githubstatus.com"),
+    ).resolves.toBe(false);
+    expect(fetchMock.mock.calls.map((call) => String(call[0]))).toEqual([
+      "https://api.onlineornot.com/v1/status_pages/status.openrouter.ai/summary",
+      "https://api.onlineornot.com/v1/status_pages/www.githubstatus.com/summary",
+    ]);
+  });
+
+  it("maps summary status, components, and active incidents", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(OPENROUTER_SUMMARY));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const snapshot = await onlineornotAdapter.fetchSnapshot({
+      url: "https://openrouter.onlineornot.com",
+    });
+
+    expect(snapshot.error).toBeUndefined();
+    expect(snapshot.pageName).toBe("OpenRouter");
+    expect(snapshot.pageUrl).toBe("https://status.openrouter.ai");
+    expect(snapshot.overallDescription).toBe("Minor Service Outage");
+    expect(snapshot.indicator).toBe("major");
+    expect(snapshot.components).toEqual([
+      {
+        id: "chat",
+        name: "Chat (/api/v1/chat/completions)",
+        status: "partial_outage",
+      },
+      {
+        id: "home",
+        name: "Homepage",
+        status: "operational",
+      },
+    ]);
+    expect(snapshot.incidents).toEqual([
+      {
+        id: "inc-1",
+        name: "Elevated 429s on Anthropic and OpenAI",
+        status: "active",
+        impact: "major",
+        updatedAt: "2026-08-28T01:24:00.000Z",
+      },
+    ]);
+  });
+
+  it("fetches a custom domain through the summary API without reading HTML", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/status_pages/status.openrouter.ai/summary")) {
+        return jsonResponse(OPENROUTER_SUMMARY);
+      }
+
+      return jsonResponse({}, 404);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const snapshot = await onlineornotAdapter.fetchSnapshot({
+      url: "https://status.openrouter.ai",
+    });
+
+    expect(snapshot.error).toBeUndefined();
+    expect(snapshot.pageName).toBe("OpenRouter");
+    expect(snapshot.indicator).toBe("major");
+    expect(fetchMock.mock.calls.map((call) => String(call[0]))).toEqual([
+      "https://api.onlineornot.com/v1/status_pages/status.openrouter.ai/summary",
+    ]);
+  });
+});

--- a/extensions/is-it-alive/tests/snapshot-compact.test.ts
+++ b/extensions/is-it-alive/tests/snapshot-compact.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { mapPool } from "@/lib/async-pool";
+import { compactSnapshotForList } from "@/lib/snapshot-compact";
+import type { StatusSnapshot } from "@/types";
+
+describe("mapPool", () => {
+  it("preserves order with a concurrency cap", async () => {
+    const started: number[] = [];
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    const result = await mapPool([1, 2, 3, 4], 2, async (value) => {
+      started.push(value);
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await Promise.resolve();
+      inFlight -= 1;
+      return value * 10;
+    });
+
+    expect(result).toEqual([10, 20, 30, 40]);
+    expect(maxInFlight).toBeLessThanOrEqual(2);
+    expect(started).toEqual([1, 2, 3, 4]);
+  });
+});
+
+describe("compactSnapshotForList", () => {
+  it("drops history, component rows, and incident bodies", () => {
+    const snapshot: StatusSnapshot = {
+      pageName: "Example",
+      pageUrl: "https://status.example.com",
+      overallDescription: "All Systems Operational",
+      indicator: "none",
+      fetchedAt: "2026-08-28T00:00:00.000Z",
+      uptimePercent: 99.9,
+      historyDays: [{ date: "2026-08-01", level: "operational" }],
+      components: [
+        {
+          id: "api",
+          name: "API",
+          status: "operational",
+          historyDays: [{ date: "2026-08-01", level: "operational" }],
+        },
+      ],
+      incidents: [
+        {
+          id: "inc-1",
+          name: "Outage",
+          status: "investigating",
+          impact: "major",
+          updatedAt: "2026-08-28T00:00:00.000Z",
+          body: "A".repeat(5000),
+        },
+      ],
+    };
+
+    expect(compactSnapshotForList(snapshot)).toEqual({
+      pageName: "Example",
+      pageUrl: "https://status.example.com",
+      overallDescription: "All Systems Operational",
+      indicator: "none",
+      fetchedAt: "2026-08-28T00:00:00.000Z",
+      components: [],
+      incidents: [
+        {
+          id: "inc-1",
+          name: "Outage",
+          status: "investigating",
+          impact: "major",
+          updatedAt: "2026-08-28T00:00:00.000Z",
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Description

- Add a categorized catalog of suggested status pages with multi-select and bulk add actions
- Add support for OnlineOrNot and FireHydrant status pages, plus incident.io pages that redirect to a canonical host
- Limit concurrent status requests and keep compact snapshots in the list to stay within Raycast's memory limit; the detail view fetches full history when opened
- Add adapter and snapshot tests for the new behavior

## Screencast

<img width="2000" height="1250" alt="Raycast 2026-08-28 22 24 40" src="https://github.com/user-attachments/assets/38929422-0f0c-474d-b559-5d7f97055f49" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder