### PR TITLE
[Things] Fix list membership under Things 3.23

### DIFF
--- a/extensions/things/CHANGELOG.md
+++ b/extensions/things/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Things Changelog
 
-## [Things 3.23 Compatibility] - {PR_MERGE_DATE}
+## [Things 3.23 Compatibility] - 2026-08-29
 
 - Fixed Today and Anytime missing to-dos whose scheduled date had arrived when the Unofficial API preference is enabled. Things 3.23 leaves such a to-do marked as scheduled, so the extension has to decide list membership by date.
 - Fixed Upcoming dropping repeating to-dos while an occurrence was pending. They now appear as dateless entries after the dated ones, matching Things, which computes the next date internally and does not expose it.

--- a/extensions/things/CHANGELOG.md
+++ b/extensions/things/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Things Changelog
 
+## [Things 3.23 Compatibility] - {PR_MERGE_DATE}
+
+- Fixed Today and Anytime missing to-dos whose scheduled date had arrived when the Unofficial API preference is enabled. Things 3.23 leaves such a to-do marked as scheduled, so the extension has to decide list membership by date.
+- Fixed Upcoming dropping repeating to-dos while an occurrence was pending. They now appear as dateless entries after the dated ones, matching Things, which computes the next date internally and does not expose it.
+- Fixed to-dos inside trashed projects leaking into every Unofficial API list, into Quick Find, and into search results. Trashing a project leaves its to-dos untouched in the database, so each query has to check the parent.
+- Marking a repeating to-do's template as completed or canceled now shows an error instead of a false success toast. Things silently ignores the write, so complete or cancel the scheduled occurrence instead.
+
 ## [Fix Marking To-Dos Completed] - 2026-07-22
 
 - Restore marking to-dos completed or canceled from list rows and the Today menu bar. The previous release's writable-key allowlist in the property setter rejected `status`, so those actions threw an error.

--- a/extensions/things/src/api-sql.ts
+++ b/extensions/things/src/api-sql.ts
@@ -147,8 +147,14 @@ const TODO_SELECT_DETAIL = `${TODO_SELECT_SUMMARY},
   COALESCE(t.notes, '') as notes,
   ${taskTagsSql('t')} as tagList`;
 
-// Used by AI tool queries (queryTodos, searchTodos) — todos only, no projects
-const TODO_BASE_WHERE = `t.type = 0 AND t.trashed = 0 AND t.status = 0`;
+// Trashing a project does not set trashed on its child todos, so the parent's
+// flag has to be checked explicitly. Requires a `p` join onto t.project, present
+// in both TODO_JOINS and LIST_SELECT. COALESCE covers the rows where p is absent:
+// a todo outside any project, or one whose project uuid no longer resolves.
+const PARENT_PROJECT_NOT_TRASHED = `COALESCE(p.trashed, 0) = 0`;
+
+// Used by AI tool queries (queryTodos, searchTodos) — todos only, no projects.
+const TODO_BASE_WHERE = `t.type = 0 AND t.trashed = 0 AND t.status = 0 AND ${PARENT_PROJECT_NOT_TRASHED}`;
 
 /** Build WHERE clause for queryTodos() project/area filters, mutually exclusive. */
 function buildTodosWhereClause(projectId?: string | null, areaId?: string | null): string {
@@ -481,18 +487,23 @@ const LIST_SELECT = `
     LEFT JOIN TMArea pa ON p.area = pa.uuid
     LEFT JOIN TMArea a ON t.area = a.uuid`;
 
-// Excludes recurring master templates that have at least one active instance scheduled.
-// Active instances have rt1_repeatingTemplate pointing back to the master.
-const EXCLUDE_MASTER_WHERE = `
-  AND NOT (
-    t.rt1_repeatingTemplate IS NULL
-    AND t.rt1_recurrenceRule IS NOT NULL
-    AND EXISTS (
+// A repeating master's open instance, which points back at it via
+// rt1_repeatingTemplate and may be materialized well ahead of its scheduled date.
+const HAS_OPEN_INSTANCE = `
+    EXISTS (
       SELECT 1 FROM TMTask i
       WHERE i.rt1_repeatingTemplate = t.uuid
         AND i.trashed = 0
         AND i.status = 0
-    )
+    )`;
+
+// Excludes recurring master templates that have at least one open instance. The
+// instance row is shown in place of the master.
+const EXCLUDE_MASTER_WHERE = `
+  AND NOT (
+    t.rt1_repeatingTemplate IS NULL
+    AND t.rt1_recurrenceRule IS NOT NULL
+    AND ${HAS_OPEN_INSTANCE}
   )`;
 
 type ListTodoRow = {
@@ -600,12 +611,15 @@ async function getInboxTodosFromDB(dbPath: string): Promise<Todo[]> {
       AND t.trashed = 0
       AND t.status = 0
       AND t.start = 0
+      AND ${PARENT_PROJECT_NOT_TRASHED}
     ORDER BY t."index" ASC
   `,
   );
 }
 
-// Open, scheduled for today or earlier (start=1, startDate <= end-of-today).
+// Open, scheduled for today or earlier (startDate <= end-of-today). Membership
+// is date-driven: a scheduled item can still carry start=2 after its date has
+// arrived, so both start values qualify and only the date decides.
 // Includes todos (type=0) and projects (type=1) — Things shows both in Today.
 // Excludes recurring master templates that have an active instance already scheduled.
 async function getTodayTodosFromDB(dbPath: string): Promise<Todo[]> {
@@ -618,9 +632,10 @@ async function getTodayTodosFromDB(dbPath: string): Promise<Todo[]> {
       t.type IN (0, 1)
       AND t.trashed = 0
       AND t.status = 0
-      AND t.start = 1
+      AND t.start IN (1, 2)
       AND t.startDate IS NOT NULL
       AND t.startDate <= ${todayEnd}
+      AND ${PARENT_PROJECT_NOT_TRASHED}
       ${EXCLUDE_MASTER_WHERE}
     ORDER BY t.todayIndex ASC, t."index" ASC
   `,
@@ -628,7 +643,9 @@ async function getTodayTodosFromDB(dbPath: string): Promise<Todo[]> {
 }
 
 // Anytime is built in two groups:
-//   1. Today todos (type=0, start=1, startDate <= today) — sorted by index
+//   1. Today todos (type=0, start IN (1, 2), startDate <= today) — sorted by index.
+//      Both start values qualify because a scheduled todo can still carry
+//      start=2 after its date has arrived.
 //   2. Rest todos  (type=0, start=1, startDate IS NULL or > today) — sorted by index
 // Projects are not included. Todos inside Someday/Upcoming projects (project.start = 2) are excluded.
 // Recurring master templates that have an active instance are excluded (the instance is shown instead).
@@ -643,9 +660,10 @@ async function getAnytimeTodosFromDB(dbPath: string): Promise<Todo[]> {
         t.type = 0
         AND t.trashed = 0
         AND t.status = 0
-        AND t.start = 1
+        AND t.start IN (1, 2)
         AND t.startDate IS NOT NULL
         AND t.startDate <= ${todayEnd}
+        AND ${PARENT_PROJECT_NOT_TRASHED}
         AND (t.project IS NULL OR (SELECT p.start FROM TMTask p WHERE p.uuid = t.project) = 1)
         ${EXCLUDE_MASTER_WHERE}
       ORDER BY
@@ -664,6 +682,7 @@ async function getAnytimeTodosFromDB(dbPath: string): Promise<Todo[]> {
         AND t.status = 0
         AND t.start = 1
         AND (t.startDate IS NULL OR t.startDate > ${todayEnd})
+        AND ${PARENT_PROJECT_NOT_TRASHED}
         AND (t.project IS NULL OR (SELECT p.start FROM TMTask p WHERE p.uuid = t.project) = 1)
         ${EXCLUDE_MASTER_WHERE}
       ORDER BY
@@ -677,10 +696,14 @@ async function getAnytimeTodosFromDB(dbPath: string): Promise<Todo[]> {
   return [...todayTodos, ...restTodos.filter((t) => !seenIds.has(t.id))];
 }
 
-// Open, start=2, has a concrete startDate OR is a recurring master with a known next instance date
-// (rt1_nextInstanceStartDate != NEXT_INSTANCE_PLACEHOLDER). Things shows these in Upcoming via the next instance date.
-// Includes todos (type=0) and projects (type=1). Sorted: todos first, then projects, each by index.
+// Open, start=2, scheduled strictly after today, OR a recurring master awaiting its
+// next instance. Rows whose date has arrived belong to Today. A master
+// qualifies via a known next instance date, or datelessly while an open instance
+// exists (Things clears rt1_nextInstanceStartDate until that instance completes and
+// computes the "future repeat" date internally, so no date is available to show).
+// Includes todos (type=0) and projects (type=1). Dateless masters sort last.
 async function getUpcomingTodosFromDB(dbPath: string): Promise<Todo[]> {
+  const todayEnd = getEndOfToday();
   return runListQuery(
     dbPath,
     `
@@ -690,16 +713,23 @@ async function getUpcomingTodosFromDB(dbPath: string): Promise<Todo[]> {
       AND t.trashed = 0
       AND t.status = 0
       AND t.start = 2
+      AND ${PARENT_PROJECT_NOT_TRASHED}
       AND (
-        t.startDate IS NOT NULL
+        (t.startDate IS NOT NULL AND t.startDate > ${todayEnd})
         OR (
           t.rt1_recurrenceRule IS NOT NULL
           AND t.rt1_repeatingTemplate IS NULL
-          AND t.rt1_nextInstanceStartDate IS NOT NULL
-          AND t.rt1_nextInstanceStartDate != ${NEXT_INSTANCE_PLACEHOLDER}
+          AND (
+            (
+              t.rt1_nextInstanceStartDate IS NOT NULL
+              AND t.rt1_nextInstanceStartDate != ${NEXT_INSTANCE_PLACEHOLDER}
+            )
+            OR ${HAS_OPEN_INSTANCE}
+          )
         )
       )
     ORDER BY
+      COALESCE(t.startDate, NULLIF(t.rt1_nextInstanceStartDate, ${NEXT_INSTANCE_PLACEHOLDER})) IS NULL ASC,
       COALESCE(t.startDate, NULLIF(t.rt1_nextInstanceStartDate, ${NEXT_INSTANCE_PLACEHOLDER})) ASC,
       CASE WHEN t.project IS NULL THEN 0 ELSE 1 END ASC,
       p."index" ASC,
@@ -727,6 +757,7 @@ async function getSomedayTodosFromDB(dbPath: string): Promise<Todo[]> {
       AND t.startDate IS NULL
       AND t.rt1_recurrenceRule IS NULL
       AND t.rt1_repeatingTemplate IS NULL
+      AND ${PARENT_PROJECT_NOT_TRASHED}
     ORDER BY t.type ASC, t."index" ASC
   `,
   );
@@ -744,6 +775,7 @@ async function getLogbookTodosFromDB(dbPath: string): Promise<Todo[]> {
       AND t.trashed = 0
       AND t.status IN (2, 3)
       AND t.stopDate IS NOT NULL
+      AND ${PARENT_PROJECT_NOT_TRASHED}
     ORDER BY t.stopDate DESC
   `,
   );
@@ -945,7 +977,7 @@ export const getQuickFindDataFromDB = async (): Promise<QuickFindData> => {
       LEFT JOIN TMTask p ON p.uuid = t.project
       LEFT JOIN TMArea da ON da.uuid = t.area
       LEFT JOIN TMArea pa ON pa.uuid = p.area
-      WHERE t.type = 0 AND t.trashed = 0 AND t.status = 0`,
+      WHERE t.type = 0 AND t.trashed = 0 AND t.status = 0 AND ${PARENT_PROJECT_NOT_TRASHED}`,
     ),
   ]);
 

--- a/extensions/things/src/api.ts
+++ b/extensions/things/src/api.ts
@@ -165,10 +165,20 @@ export const setTodoProperty = (todoId: string, key: WritableTodoProperty, value
   } else {
     valueExpr = `'${escapeJxa(value)}'`;
   }
+  // Things silently ignores status writes on a repeating to-do's template, so a
+  // status write reads the value back and throws when it did not take.
+  const verifyStatus =
+    key === 'status'
+      ? `
+  if (todo.status() !== ${valueExpr}) {
+    throw new Error("Things ignored the status change. If this is a repeating to-do, complete or cancel its scheduled occurrence instead.");
+  }`
+      : '';
   return executeJxa(
     `
   const things = Application('${preferences.thingsAppIdentifier}');
-  things.toDos.byId('${escapeJxa(todoId)}').${key} = ${valueExpr};
+  const todo = things.toDos.byId('${escapeJxa(todoId)}');
+  todo.${key} = ${valueExpr};${verifyStatus}
 `,
     'Set todo property',
   );

--- a/extensions/things/src/show-today-in-menu-bar.tsx
+++ b/extensions/things/src/show-today-in-menu-bar.tsx
@@ -33,14 +33,18 @@ export default function ShowTodayInMenuBar() {
   }
 
   async function completeTodo(todo: Todo) {
-    await mutate(setTodoProperty(todo.id, 'status', 'completed'), {
-      optimisticUpdate(data) {
-        if (!data) return;
-        return data.filter((t) => t.id !== todo.id);
-      },
-      shouldRevalidateAfter: false,
-    });
-    await showToast({ style: Toast.Style.Success, title: 'Marked as Completed' });
+    try {
+      await mutate(setTodoProperty(todo.id, 'status', 'completed'), {
+        optimisticUpdate(data) {
+          if (!data) return;
+          return data.filter((t) => t.id !== todo.id);
+        },
+        shouldRevalidateAfter: false,
+      });
+      await showToast({ style: Toast.Style.Success, title: 'Marked as Completed' });
+    } catch (error) {
+      await handleError(error);
+    }
   }
 
   async function schedule(todo: Todo, when: string) {

--- a/extensions/things/src/things-internals.ts
+++ b/extensions/things/src/things-internals.ts
@@ -14,6 +14,19 @@
  *   - Sentinel values: special packed-date constants used as placeholders
  *   - Recurring deadline resolution: recurring tasks store a relative offset in a
  *     plist XML blob (rt1_recurrenceRule) instead of an absolute deadline
+ *   - Scheduled items: an item scheduled for a future date has start=2, and keeps
+ *     it once that date arrives and Things rolls it into Today. List membership
+ *     therefore follows startDate, not start.
+ *   - Repeating instances: Things materializes instance rows ahead of their date
+ *     (start=2 with a future startDate). While an open instance exists, the
+ *     master's rt1_nextInstanceStartDate is NULL and the date of the following
+ *     occurrence is computed internally, unavailable even via AppleScript/JXA.
+ *
+ * Watch item: TMTask carries `repeater`, `repeaterMigrationDate`, and
+ * `experimental` columns that Things leaves unpopulated. The schema assertion
+ * below checks that columns exist, so it cannot catch recurrence moving onto
+ * them while the rt1_* columns stay in place. If repeating data goes missing
+ * while assertions still pass, check whether `repeater` is populated.
  */
 
 import type { ResolvedDates } from './types';


### PR DESCRIPTION
## Description

Things 3.23 changed two things the extension's optional database path relied on. A to-do keeps its "scheduled" marker after its date arrives and Things rolls it into Today, so list membership now has to follow the date rather than that marker. And while a repeating to-do has an open occurrence, Things clears the template's next-occurrence date and computes it internally, so Upcoming has to show those templates without a date, the way Things itself does.

I checked this by diffing the database path's list membership against what Things reports over AppleScript, on a real database. Against 3.23 the old queries left Today short by 6 items and Upcoming short by 31; with these changes all five lists match Things exactly.

Two fixes came out of that comparison rather than from 3.23 itself. To-dos inside a trashed project were leaking into the lists, Quick Find, and search, because trashing a project leaves its to-dos untouched in the database. That applies to the Logbook too: Things omits those to-dos from its own Logbook, so the query filters them the same way. Separately, Things silently ignores an attempt to complete a repeating to-do's template, which the extension reported as success, so the write now reads the value back and surfaces a real error.

This all sits behind the Unofficial API preference, which is off by default. The only change on the default AppleScript path is that status read-back, which also gets error handling in the menu bar command where it was missing.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
