### PR TITLE
Update folder search extension

### DIFF
--- a/extensions/folder-search/CHANGELOG.md
+++ b/extensions/folder-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Folder Search Changelog
 
-## [Finder Open Behavior] - {PR_MERGE_DATE}
+## [Finder Open Behavior] - 2026-08-29
 
 - **enhanced** Added "Open Behavior" preference to open folders in a new Finder window, a new tab, or the current tab
 

--- a/extensions/folder-search/CHANGELOG.md
+++ b/extensions/folder-search/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Folder Search Changelog
 
+## [Finder Open Behavior] - {PR_MERGE_DATE}
+
+- **enhanced** Added "Open Behavior" preference to open folders in a new Finder window, a new tab, or the current tab
+
 ## [Enhancements] - 2025-06-18
 
 - **enhanced** Added "Open Folder After Move" preference to control whether destination folders open automatically after moving files. When disabled, files will be moved without opening the folder, keeping your workflow uninterrupted. Default is enabled

--- a/extensions/folder-search/package.json
+++ b/extensions/folder-search/package.json
@@ -63,6 +63,28 @@
       "type": "checkbox"
     },
     {
+      "default": "newWindow",
+      "description": "Choose how folders open in Finder: a new window, a new tab of the frontmost window, or the current tab of the frontmost window",
+      "name": "openBehaviour",
+      "required": false,
+      "title": "Open Behavior",
+      "type": "dropdown",
+      "data": [
+        {
+          "title": "Open in New Finder Window",
+          "value": "newWindow"
+        },
+        {
+          "title": "Open in New Finder Tab",
+          "value": "newTab"
+        },
+        {
+          "title": "Open in Current Finder Tab",
+          "value": "currentTab"
+        }
+      ]
+    },
+    {
       "default": false,
       "description": "Enables support for custom 'AppleScript' plugins in Folder Search. See README",
       "label": "Enabled",

--- a/extensions/folder-search/src/components/Directory.tsx
+++ b/extensions/folder-search/src/components/Directory.tsx
@@ -1,10 +1,10 @@
-import { Action, ActionPanel, Icon, List, popToRoot, Color } from "@raycast/api";
+import { Action, ActionPanel, Icon, List, popToRoot, Color, closeMainWindow, getPreferenceValues } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
 import path from "path";
 import { useEffect, useState } from "react";
 import fs from "fs";
-import { folderName, log } from "../utils";
-import { SpotlightSearchResult } from "../types";
+import { folderName, log, openNewFinderTab, openInCurrentFinderTab } from "../utils";
+import { SpotlightSearchResult, SpotlightSearchPreferences } from "../types";
 import { useFolderSearch } from "../hooks/useFolderSearch";
 
 interface DirectoryProps {
@@ -151,6 +151,63 @@ export function Directory({ path: directoryPath, onReturn }: DirectoryProps) {
         {files.map((file) => {
           const filePath = path.join(directoryPath, file);
           const result = createSpotlightResult(filePath);
+          const { openBehaviour } = getPreferenceValues<SpotlightSearchPreferences>();
+
+          const openInNewWindowAction = (
+            <Action.Open
+              title="Open in New Finder Window"
+              icon={Icon.Folder}
+              target={filePath}
+              onOpen={() => {
+                handleReturn();
+                popToRoot({ clearSearchBar: true });
+              }}
+            />
+          );
+
+          const openInNewTabAction = (
+            <Action
+              title="Open in New Finder Tab"
+              icon={Icon.Finder}
+              onAction={async () => {
+                try {
+                  await closeMainWindow();
+                  await openNewFinderTab(filePath);
+                  handleReturn();
+                  popToRoot({ clearSearchBar: true });
+                } catch (error) {
+                  showFailureToast(error, { title: "Could not open folder in Finder" });
+                }
+              }}
+            />
+          );
+
+          const openInCurrentTabAction = (
+            <Action
+              title="Open in Current Finder Tab"
+              icon={Icon.AppWindow}
+              onAction={async () => {
+                try {
+                  await closeMainWindow();
+                  await openInCurrentFinderTab(filePath);
+                  handleReturn();
+                  popToRoot({ clearSearchBar: true });
+                } catch (error) {
+                  showFailureToast(error, { title: "Could not open folder in Finder" });
+                }
+              }}
+            />
+          );
+
+          const openActions = {
+            newWindow: openInNewWindowAction,
+            newTab: openInNewTabAction,
+            currentTab: openInCurrentTabAction,
+          };
+          const orderedOpenActions = [
+            openBehaviour,
+            ...(Object.keys(openActions) as (keyof typeof openActions)[]).filter((key) => key !== openBehaviour),
+          ];
 
           return (
             <List.Item
@@ -160,15 +217,9 @@ export function Directory({ path: directoryPath, onReturn }: DirectoryProps) {
               accessories={resultIsPinned(result) ? [{ icon: { source: Icon.Star, tintColor: Color.Yellow } }] : []}
               actions={
                 <ActionPanel title={folderName(result)}>
-                  <Action.Open
-                    title="Open in Finder"
-                    icon={Icon.Folder}
-                    target={filePath}
-                    onOpen={() => {
-                      handleReturn();
-                      popToRoot({ clearSearchBar: true });
-                    }}
-                  />
+                  {openActions[orderedOpenActions[0]]}
+                  {openActions[orderedOpenActions[1]]}
+                  {openActions[orderedOpenActions[2]]}
                   <Action.OpenWith
                     title="Open with…"
                     shortcut={{ modifiers: ["cmd"], key: "o" }}

--- a/extensions/folder-search/src/search.tsx
+++ b/extensions/folder-search/src/search.tsx
@@ -12,7 +12,15 @@ import {
   getPreferenceValues,
 } from "@raycast/api";
 import React, { useRef } from "react";
-import { folderName, copyFolderToClipboard, maybeMoveResultToTrash, log, logDiagnostics } from "./utils";
+import {
+  folderName,
+  copyFolderToClipboard,
+  maybeMoveResultToTrash,
+  log,
+  logDiagnostics,
+  openNewFinderTab,
+  openInCurrentFinderTab,
+} from "./utils";
 import { runAppleScript } from "run-applescript";
 import { SpotlightSearchResult, SpotlightSearchPreferences } from "./types";
 import { useFolderSearch } from "./hooks/useFolderSearch";
@@ -92,14 +100,64 @@ function Command(props: LaunchProps) {
   // Render actions for the folder list items
   const renderFolderActions = (result: SpotlightSearchResult, resultIndex: number, isPinnedSection = false) => {
     const enclosingFolder = path.dirname(result.path);
+    const { openBehaviour } = getPreferenceValues<SpotlightSearchPreferences>();
+
+    const openInNewWindowAction = (
+      <Action.Open
+        title="Open in New Finder Window"
+        icon={Icon.Folder}
+        target={result.path}
+        onOpen={() => popToRoot({ clearSearchBar: true })}
+      />
+    );
+
+    const openInNewTabAction = (
+      <Action
+        title="Open in New Finder Tab"
+        icon={Icon.Finder}
+        onAction={async () => {
+          try {
+            await closeMainWindow();
+            await openNewFinderTab(result.path);
+            popToRoot({ clearSearchBar: true });
+          } catch (error) {
+            showFailureToast(error, { title: "Could not open folder in Finder" });
+          }
+        }}
+      />
+    );
+
+    const openInCurrentTabAction = (
+      <Action
+        title="Open in Current Finder Tab"
+        icon={Icon.AppWindow}
+        onAction={async () => {
+          try {
+            await closeMainWindow();
+            await openInCurrentFinderTab(result.path);
+            popToRoot({ clearSearchBar: true });
+          } catch (error) {
+            showFailureToast(error, { title: "Could not open folder in Finder" });
+          }
+        }}
+      />
+    );
+
+    const openActions = {
+      newWindow: openInNewWindowAction,
+      newTab: openInNewTabAction,
+      currentTab: openInCurrentTabAction,
+    };
+    const orderedOpenActions = [
+      openBehaviour,
+      ...(Object.keys(openActions) as (keyof typeof openActions)[]).filter((key) => key !== openBehaviour),
+    ];
+
     return (
       <ActionPanel title={folderName(result)}>
-        <Action.Open
-          title="Open in Finder"
-          icon={Icon.Folder}
-          target={result.path}
-          onOpen={() => popToRoot({ clearSearchBar: true })}
-        />
+        {openActions[orderedOpenActions[0]]}
+        {openActions[orderedOpenActions[1]]}
+        {openActions[orderedOpenActions[2]]}
         <Action
           title="Move Finder Selection"
           icon={Icon.NewFolder}

--- a/extensions/folder-search/src/types.tsx
+++ b/extensions/folder-search/src/types.tsx
@@ -10,6 +10,7 @@ type SpotlightSearchPreferences = {
   searchScope: string;
   isShowingDetail: boolean;
   openFolderAfterMove: boolean;
+  openBehaviour: "newWindow" | "newTab" | "currentTab";
 };
 
 type FolderSearchPlugin = {

--- a/extensions/folder-search/src/utils.tsx
+++ b/extensions/folder-search/src/utils.tsx
@@ -319,6 +319,42 @@ export const showFolderInfoInFinder = (result: SpotlightSearchResult) => {
   `);
 };
 
+export const openNewFinderTab = async (targetPath: string) => {
+  const escapedPath = targetPath.replace(/"/g, '\\"');
+
+  await runAppleScript(`
+    set targetFolder to (POSIX file "${escapedPath}" as alias)
+    tell application "Finder"
+      if (count of Finder windows) > 0 then
+        activate
+        delay 0.2
+        tell application "System Events" to keystroke "t" using {command down}
+        delay 0.2
+        set target of front Finder window to targetFolder
+      else
+        open targetFolder
+        activate
+      end if
+    end tell
+  `);
+};
+
+export const openInCurrentFinderTab = async (targetPath: string) => {
+  const escapedPath = targetPath.replace(/"/g, '\\"');
+
+  await runAppleScript(`
+    set targetFolder to (POSIX file "${escapedPath}" as alias)
+    tell application "Finder"
+      if (count of Finder windows) > 0 then
+        set target of front Finder window to targetFolder
+      else
+        open targetFolder
+      end if
+      activate
+    end tell
+  `);
+};
+
 export const copyFolderToClipboard = (result: SpotlightSearchResult) => {
   runAppleScript(`set the clipboard to POSIX file "${result.path}"`);
 };

--- a/extensions/folder-search/src/utils.tsx
+++ b/extensions/folder-search/src/utils.tsx
@@ -306,12 +306,14 @@ export const enclosingFolderName = (result: SpotlightSearchResult) => {
     .join("/");
 };
 
+const escapeForAppleScript = (value: string) => value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+
 export const showFolderInfoInFinder = (result: SpotlightSearchResult) => {
   popToRoot({ clearSearchBar: true });
   closeMainWindow({ clearRootSearch: true });
 
   runAppleScript(`
-    set result to (POSIX file "${result.path}") as alias
+    set result to (POSIX file "${escapeForAppleScript(result.path)}") as alias
     tell application "Finder"
       open information window of result
       activate
@@ -320,7 +322,7 @@ export const showFolderInfoInFinder = (result: SpotlightSearchResult) => {
 };
 
 export const openNewFinderTab = async (targetPath: string) => {
-  const escapedPath = targetPath.replace(/"/g, '\\"');
+  const escapedPath = escapeForAppleScript(targetPath);
 
   await runAppleScript(`
     set targetFolder to (POSIX file "${escapedPath}" as alias)
@@ -340,7 +342,7 @@ export const openNewFinderTab = async (targetPath: string) => {
 };
 
 export const openInCurrentFinderTab = async (targetPath: string) => {
-  const escapedPath = targetPath.replace(/"/g, '\\"');
+  const escapedPath = escapeForAppleScript(targetPath);
 
   await runAppleScript(`
     set targetFolder to (POSIX file "${escapedPath}" as alias)
@@ -356,7 +358,7 @@ export const openInCurrentFinderTab = async (targetPath: string) => {
 };
 
 export const copyFolderToClipboard = (result: SpotlightSearchResult) => {
-  runAppleScript(`set the clipboard to POSIX file "${result.path}"`);
+  runAppleScript(`set the clipboard to POSIX file "${escapeForAppleScript(result.path)}"`);
 };
 
 export const maybeMoveResultToTrash = async (result: SpotlightSearchResult, resultWasTrashed: () => void) => {

--- a/extensions/folder-search/src/utils.tsx
+++ b/extensions/folder-search/src/utils.tsx
@@ -306,7 +306,8 @@ export const enclosingFolderName = (result: SpotlightSearchResult) => {
     .join("/");
 };
 
-const escapeForAppleScript = (value: string) => value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+const escapeForAppleScript = (value: string) =>
+  value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r");
 
 export const showFolderInfoInFinder = (result: SpotlightSearchResult) => {
   popToRoot({ clearSearchBar: true });


### PR DESCRIPTION
## Description
- **enhanced** Added "Open Behavior" preference to open folders in a new Finder window, a new tab, or the current tab. Close #30603 
<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast
<img width="1690" height="1506" alt="CleanShot 2026-08-29 at 17 09 44@2x" src="https://github.com/user-attachments/assets/d575b537-69b1-4659-a34f-87e1c1e960a1" />

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
