### PR TITLE
fix: make Select Model apply to the running Handy app

### DIFF
--- a/extensions/handy/CHANGELOG.md
+++ b/extensions/handy/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Handy Changelog
 
-## [Fix live model & language selection] - {PR_MERGE_DATE}
+## [Fix live model & language selection] - 2026-09-01
 
 ### Fixed
 

--- a/extensions/handy/CHANGELOG.md
+++ b/extensions/handy/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Fixed
 
-- **Select Model** now actually switches the active model in the running Handy app, instead of only writing `settings_store.json` (which Handy only reads at launch, so the selection did nothing until a relaunch). The extension GUI-scripts Handy's tray model menu — the same path the in-app menu uses — so the model changes instantly with no restart. If Raycast lacks Accessibility permission, a "Restart Handy" toast offers the relaunch fallback.
-- **Select Language** now persists the choice and uses the same live-switch path, falling back to a relaunch when GUI scripting isn't available.
+- **Select Model** now actually switches the active model in the running Handy app, instead of only writing `settings_store.json` (which Handy only reads at launch, so the selection did nothing until a relaunch). The extension GUI-scripts Handy's tray model menu — the same path the in-app menu uses — so the model changes instantly with no restart. If Raycast lacks Accessibility permission, a "Restart Handy" toast offers the relaunch fallback. The store is updated only after Handy accepts the live switch (or after a successful restart), so a failed switch stays retryable.
+- **Select Language** now uses the same live-switch path and persist-after-success ordering, falling back to a relaunch when GUI scripting isn't available.
 
 ### Changed
 

--- a/extensions/handy/CHANGELOG.md
+++ b/extensions/handy/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Handy Changelog
 
+## [Fix live model & language selection] - {PR_MERGE_DATE}
+
+### Fixed
+
+- **Select Model** now actually switches the active model in the running Handy app, instead of only writing `settings_store.json` (which Handy only reads at launch, so the selection did nothing until a relaunch). The extension GUI-scripts Handy's tray model menu — the same path the in-app menu uses — so the model changes instantly with no restart. If Raycast lacks Accessibility permission, a "Restart Handy" toast offers the relaunch fallback.
+- **Select Language** now persists the choice and uses the same live-switch path, falling back to a relaunch when GUI scripting isn't available.
+
+### Changed
+
+- Hardened `settings_store.json` reading/writing to tolerate a missing file or a missing `settings` key (defaults `selected_model` to empty and `selected_language` to `auto`).
+
 ## [Improve Linux/Vicinae compatibility] - 2026-08-04
 
 ### Changed

--- a/extensions/handy/eslint.config.js
+++ b/extensions/handy/eslint.config.js
@@ -1,12 +1,4 @@
-const { FlatCompat } = require("@eslint/eslintrc");
-const js = require("@eslint/js");
+const { defineConfig } = require("eslint/config");
+const raycastConfig = require("@raycast/eslint-config");
 
-require("@rushstack/eslint-patch/modern-module-resolution");
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-  recommendedConfig: js.configs.recommended,
-  allConfig: js.configs.all,
-});
-
-module.exports = [...compat.extends("@raycast/eslint-config")];
+module.exports = defineConfig([...raycastConfig]);

--- a/extensions/handy/package-lock.json
+++ b/extensions/handy/package-lock.json
@@ -12,12 +12,12 @@
         "execa": "^9.5.2"
       },
       "devDependencies": {
-        "@raycast/eslint-config": "^1.0.11",
+        "@raycast/eslint-config": "^2.2.0",
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20.8.10",
         "@types/react": "^19.2.14",
         "better-sqlite3": "^12.8.0",
-        "eslint": "^8.57.0",
+        "eslint": "^9.39.4",
         "prettier": "^3.3.3",
         "typescript": "^5.4.5",
         "vitest": "^3.2.6"
@@ -440,9 +440,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -468,25 +468,97 @@
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
-    "node_modules/@eslint/eslintrc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
-      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
-        "espree": "^9.6.0",
-        "globals": "^13.19.0",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -510,6 +582,19 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -524,60 +609,78 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
-      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
-    "node_modules/@humanwhocodes/config-array": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
-      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
-      "deprecated": "Use @eslint/config-array instead",
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.3",
-        "debug": "^4.3.1",
-        "minimatch": "^3.0.5"
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
       },
       "engines": {
-        "node": ">=10.10.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@humanwhocodes/config-array/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
-      "dev": true,
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "@humanfs/types": "^0.15.0"
       },
       "engines": {
-        "node": "*"
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -594,13 +697,19 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@humanwhocodes/object-schema": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
-      "deprecated": "Use @eslint/object-schema instead",
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
     },
     "node_modules/@inquirer/ansi": {
       "version": "1.0.2",
@@ -957,44 +1066,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@oclif/core": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.9.0.tgz",
@@ -1129,35 +1200,35 @@
       "license": "MIT"
     },
     "node_modules/@raycast/eslint-config": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@raycast/eslint-config/-/eslint-config-1.0.11.tgz",
-      "integrity": "sha512-I0Lt8bwahVGkANUBxripIxKptMBz1Ou+UXGwfqgFvKwo1gVLrnlEngxaspQJA8L5pvzQkQMwizVCSgNC3bddWg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@raycast/eslint-config/-/eslint-config-2.2.0.tgz",
+      "integrity": "sha512-uS/UDvM+3HfABgYhLYnIv0y+IVu+rGiZZIMwQsO5EGrcf2/TX/yioTzfezAQqhdszW4ViCuHbv8BddIagDKZvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@raycast/eslint-plugin": "^1.0.11",
-        "@rushstack/eslint-patch": "^1.10.4",
-        "@typescript-eslint/eslint-plugin": "^6.8.0",
-        "@typescript-eslint/parser": "^6.8.0",
-        "eslint-config-prettier": "^9.1.0"
+        "@eslint/js": "^9.39.4",
+        "@raycast/eslint-plugin": "^2.2.0",
+        "eslint-config-prettier": "^10.1.8",
+        "globals": "^17.7.0",
+        "typescript-eslint": "^8.62.0"
       },
       "peerDependencies": {
-        "eslint": ">=7",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "prettier": ">=2",
-        "typescript": ">=4"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@raycast/eslint-plugin": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@raycast/eslint-plugin/-/eslint-plugin-1.0.16.tgz",
-      "integrity": "sha512-OyFL/W75/4hlgdUUI80Eoes0HjpVrJ8I1kB/PBH2RLjbcK22TC6IwZPXvhBZ5jF962O1TqtOuHrTjySwDaa/cQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@raycast/eslint-plugin/-/eslint-plugin-2.2.0.tgz",
+      "integrity": "sha512-ixO3PoRAEAZZcSQeRPvvDS/vs09D47tXdyXrs7hctoxxPtweXgJ6I24kjCD5GuuuQS5hGTiuL+Uy6hIg6a/a4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "^5.62.0"
+        "@typescript-eslint/utils": "^8.62.0"
       },
       "peerDependencies": {
-        "eslint": ">=7"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/@raycast/utils": {
@@ -1528,13 +1599,6 @@
         "win32"
       ]
     },
-    "node_modules/@rushstack/eslint-patch": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.16.1.tgz",
-      "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
@@ -1601,6 +1665,7 @@
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1615,184 +1680,161 @@
         "csstype": "^3.2.2"
       }
     },
-    "node_modules/@types/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
-      "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.68.0.tgz",
+      "integrity": "sha512-WASHDpCm6qO5jj9g1a+8NiW5+GCkAyLReR56/4VruYmNgfUmqpxOfZ2Yfb8xGfJPWv5Qi6LSD8sXdces3vbp/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/type-utils": "6.21.0",
-        "@typescript-eslint/utils": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
-        "debug": "^4.3.4",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.2.4",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.68.0",
+        "@typescript-eslint/type-utils": "8.68.0",
+        "@typescript-eslint/utils": "8.68.0",
+        "@typescript-eslint/visitor-keys": "8.68.0",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-        "eslint": "^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "@typescript-eslint/parser": "^8.68.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.12",
-        "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "semver": "^7.5.4"
-      },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "node": ">= 4"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.68.0.tgz",
+      "integrity": "sha512-fHq2VC1kpyYfvEcbiMjOpySY4WS7voEp89yAThrHRX5sm9j2lzYppCb2umFMEed4fWcyeLjHxrz0mpjNBaBxMQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.68.0",
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/typescript-estree": "8.68.0",
+        "@typescript-eslint/visitor-keys": "8.68.0",
+        "debug": "^4.4.3"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.68.0.tgz",
+      "integrity": "sha512-5GQtWZCXFcFYux955pvoS02WLc49pXNlvIxocKjS0clvwo3in1RdlzVKyiqQH9vE5AKWFLTaUgeQkOrTS+0Qxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.68.0",
+        "@typescript-eslint/types": "^8.68.0",
+        "debug": "^4.4.3"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.68.0.tgz",
+      "integrity": "sha512-T5eXpcaJNg8bhjHJ8Rjp68Vq/QBteYtTKY8TZqVNPaUbuz0f6jI9t6aDkylwvalpAB9XTTFeFOjrjXAZ3YvmVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0"
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/visitor-keys": "8.68.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.68.0.tgz",
+      "integrity": "sha512-F7zrGQfiJHojPwi8vhxZQC1tWtJzvL74cK/nqri2lk8YUXvYaYwl263xOJ69jDWPUk1hmcdoayFwk9lX09npVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
-      "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.68.0.tgz",
+      "integrity": "sha512-X77zqoY1EjeWGs/0JNxeaMfp5C5lIz4Tw8y66F1Ne8Faq6g424sBNYM6xBAqElfGZPLpWS+CZAp0DXyKDzWiHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/utils": "6.21.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^1.0.1"
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/typescript-estree": "8.68.0",
+        "@typescript-eslint/utils": "8.68.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.12",
-        "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.68.0.tgz",
+      "integrity": "sha512-9RnpsGJjrAllCMefGVVsImJM24YurhC0Q1h4UbvivtvOqXmR/vEJge2OoE++z9m6hyg8T1Q8t5SNT6tHSbrxcg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1800,196 +1842,87 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
-      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.68.0.tgz",
+      "integrity": "sha512-OKKsD0tYmoNiU5PW2zehO1yO56jYOm1ShYlxon/Z0SJNidAkdVg86eg9ruRuoXf8xfnuWZGbwDsStkoXbZtIIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "@typescript-eslint/project-service": "8.68.0",
+        "@typescript-eslint/tsconfig-utils": "8.68.0",
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/visitor-keys": "8.68.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@typescript-eslint/utils": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
-      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@types/json-schema": "^7.0.9",
-        "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.62.0",
-        "@typescript-eslint/types": "5.62.0",
-        "@typescript-eslint/typescript-estree": "5.62.0",
-        "eslint-scope": "^5.1.1",
-        "semver": "^7.3.7"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
-      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.68.0.tgz",
+      "integrity": "sha512-PB5gJMMOg0Q5P1tsgWtEAqQacJXq0qEqRHDX/YJ4FaTMLfZPpHB3gjl2EJuiZyPABxmj4ZQYiY9m1bdAJ5y7tQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "5.62.0",
-        "@typescript-eslint/visitor-keys": "5.62.0"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.68.0",
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/typescript-estree": "8.68.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
-      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
-      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@typescript-eslint/types": "5.62.0",
-        "@typescript-eslint/visitor-keys": "5.62.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
-      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "5.62.0",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.68.0.tgz",
+      "integrity": "sha512-YR65gGdGvTUAWLldC3xLOvOzamdGzB4A5/N8rehEaHs3Zvoe39BhgY+u0SPch1OvrVTfLcc55wsSgK2NcnTS/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "eslint-visitor-keys": "^3.4.1"
+        "@typescript-eslint/types": "8.68.0",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@ungap/structured-clone": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
-      "license": "ISC"
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "3.2.6",
@@ -2107,11 +2040,12 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2130,9 +2064,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2200,16 +2134,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
-    },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2304,19 +2228,6 @@
       },
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/buffer": {
@@ -2594,32 +2505,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/doctrine": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -2712,87 +2597,98 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
-      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.57.1",
-        "@humanwhocodes/config-array": "^0.13.0",
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@nodelib/fs.walk": "^1.2.8",
-        "@ungap/structured-clone": "^1.2.0",
-        "ajv": "^6.12.4",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
+        "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
-        "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.2",
-        "eslint-visitor-keys": "^3.4.3",
-        "espree": "^9.6.1",
-        "esquery": "^1.4.2",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^6.0.1",
+        "file-entry-cache": "^8.0.0",
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
-        "globals": "^13.19.0",
-        "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
-        "is-path-inside": "^3.0.3",
-        "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "strip-ansi": "^6.0.1",
-        "text-table": "^0.2.0"
+        "optionator": "^0.9.3"
       },
       "bin": {
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
-        "url": "https://opencollective.com/eslint"
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz",
-      "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
+        "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-visitor-keys": {
@@ -2826,31 +2722,17 @@
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/eslint/node_modules/eslint-scope": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
+      "license": "Apache-2.0",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
@@ -2867,18 +2749,31 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.9.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.1"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -2897,16 +2792,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/esquery/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/esrecurse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
@@ -2920,20 +2805,10 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/esrecurse/node_modules/estraverse": {
+    "node_modules/estraverse": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -3013,36 +2888,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3068,16 +2913,6 @@
         "node": ">= 4.9.1"
       }
     },
-    "node_modules/fastq": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
-    },
     "node_modules/figures": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
@@ -3094,16 +2929,16 @@
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flat-cache": "^3.0.4"
+        "flat-cache": "^4.0.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -3149,19 +2984,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -3180,24 +3002,23 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
-      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
-        "keyv": "^4.5.3",
-        "rimraf": "^3.0.2"
+        "keyv": "^4.5.4"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -3207,13 +3028,6 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -3262,28 +3076,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3297,93 +3089,18 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
+      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/globals/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -3486,18 +3203,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -3557,26 +3262,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-plain-obj": {
@@ -3775,30 +3460,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
       }
     },
     "node_modules/mimic-response": {
@@ -4037,30 +3698,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4088,19 +3729,6 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
-    },
-    "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
     },
     "node_modules/postcss": {
       "version": "8.5.16",
@@ -4175,6 +3803,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4220,27 +3849,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/rc": {
       "version": "1.2.8",
@@ -4302,34 +3910,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/rollup": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
@@ -4373,30 +3953,6 @@
         "@rollup/rollup-win32-x64-gnu": "4.62.2",
         "@rollup/rollup-win32-x64-msvc": "4.62.2",
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -4523,16 +4079,6 @@
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
-      }
-    },
-    "node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/source-map-js": {
@@ -4678,13 +4224,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -4737,6 +4276,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4774,53 +4314,17 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/ts-api-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
-      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=18.12"
       },
       "peerDependencies": {
-        "typescript": ">=4.2.0"
-      }
-    },
-    "node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/tsutils": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^1.8.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/tunnel-agent": {
@@ -4867,12 +4371,37 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.68.0.tgz",
+      "integrity": "sha512-MHy0Y0ynqeEbx/S45+i/bBssdy3X6KNBfmJAP35GrgtNxu2TQ5K5xsFDhAnmsq1jvpdoZOPG1LGtJo0HWqYCrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.68.0",
+        "@typescript-eslint/parser": "8.68.0",
+        "@typescript-eslint/typescript-estree": "8.68.0",
+        "@typescript-eslint/utils": "8.68.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/undici-types": {
@@ -4917,6 +4446,7 @@
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5033,6 +4563,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/extensions/handy/package.json
+++ b/extensions/handy/package.json
@@ -96,12 +96,12 @@
     "execa": "^9.5.2"
   },
   "devDependencies": {
-    "@raycast/eslint-config": "^1.0.11",
+    "@raycast/eslint-config": "^2.2.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.8.10",
     "@types/react": "^19.2.14",
     "better-sqlite3": "^12.8.0",
-    "eslint": "^8.57.0",
+    "eslint": "^9.39.4",
     "prettier": "^3.3.3",
     "typescript": "^5.4.5",
     "vitest": "^3.2.6"
@@ -109,8 +109,8 @@
   "scripts": {
     "build": "ray build -e dist",
     "dev": "ray develop",
-    "fix-lint": "ESLINT_USE_FLAT_CONFIG=false npx eslint src --ext .ts,.tsx --fix",
-    "lint": "ESLINT_USE_FLAT_CONFIG=false npx eslint src --ext .ts,.tsx",
+    "fix-lint": "eslint src --fix",
+    "lint": "eslint src",
     "test": "vitest run",
     "test:watch": "vitest",
     "publish": "npx @raycast/api@latest publish"

--- a/extensions/handy/src/lib/apply-selection.ts
+++ b/extensions/handy/src/lib/apply-selection.ts
@@ -1,0 +1,49 @@
+import { getPreferenceValues, showHUD, showToast, Toast } from "@raycast/api";
+import { restartHandyAction } from "./restart-handy";
+
+const LIVE_SWITCH_HINT =
+  "Grant Raycast Accessibility access (System Settings → Privacy & Security), or restart Handy to apply.";
+
+/**
+ * Apply a model/language change to the running Handy app, then persist.
+ *
+ * Handy does not re-read `settings_store.json` while running, so writing the
+ * file before the live switch succeeds would make the next command launch
+ * think the new value is already active — blocking retry and the restart
+ * fallback. Persist (and mark the UI current) only after the live switch
+ * succeeds, or as part of the Restart Handy fallback.
+ */
+export async function applyLiveOrRestart(options: {
+  isCurrent: boolean;
+  alreadyActiveMessage: string;
+  persist: () => void;
+  markCurrent: () => void;
+  liveSwitch: () => Promise<boolean>;
+  successMessage: string;
+  failureTitle: string;
+}): Promise<void> {
+  if (options.isCurrent) {
+    await showHUD(options.alreadyActiveMessage);
+    return;
+  }
+
+  const { handyBinaryPath } = getPreferenceValues<Preferences>();
+  const applied = await options.liveSwitch();
+  if (applied) {
+    options.persist();
+    options.markCurrent();
+    await showHUD(options.successMessage);
+    return;
+  }
+
+  await showToast({
+    style: Toast.Style.Failure,
+    title: options.failureTitle,
+    message: LIVE_SWITCH_HINT,
+    primaryAction: restartHandyAction(
+      options.persist,
+      handyBinaryPath,
+      options.markCurrent,
+    ),
+  });
+}

--- a/extensions/handy/src/lib/handy.ts
+++ b/extensions/handy/src/lib/handy.ts
@@ -1,0 +1,179 @@
+import { execa } from "execa";
+import { dirname } from "path";
+
+const HANDY_PROCESS_PATTERN = "Handy.app/Contents/MacOS/Handy";
+
+/**
+ * Handy is a single-instance Tauri app. Changing the model/language inside Handy
+ * calls a Rust command (`set_active_model` / `change_selected_language_setting`)
+ * that updates the running app instantly — there is no restart and no external
+ * CLI flag or URL scheme to invoke it. So to switch the live model without
+ * restarting, we drive Handy's own menu (the same "Model" item the user would
+ * click), which triggers that command.
+ *
+ * When GUI scripting isn't possible (Accessibility permission not granted, the
+ * tray hidden via `--no-tray`, or the item can't be found), we fall back to
+ * `applySettingsAndReload`, which persists the setting and relaunches Handy so it
+ * loads the new value at launch.
+ */
+
+function appBundlePathFromBinary(binaryPath: string): string {
+  // …/Handy.app/Contents/MacOS/Handy → …/Handy.app
+  return dirname(dirname(dirname(binaryPath)));
+}
+
+async function handyProcessPath(): Promise<string | null> {
+  try {
+    const { stdout } = await execa("osascript", [
+      "-e",
+      'tell application "System Events" to get posix path of (file of (application process "Handy"))',
+    ]);
+    const path = stdout.trim();
+    if (path) return path;
+  } catch {
+    // ignore — fall through to binary-path derivation
+  }
+  return null;
+}
+
+async function isHandyRunning(): Promise<boolean> {
+  try {
+    await execa("pgrep", ["-f", HANDY_PROCESS_PATTERN]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function quitHandy(): Promise<void> {
+  try {
+    await execa("osascript", ["-e", 'tell application "Handy" to quit']);
+    return;
+  } catch {
+    // App may ignore AppleScript quit (e.g. busy); force it.
+  }
+  try {
+    await execa("pkill", ["-f", HANDY_PROCESS_PATTERN]);
+  } catch {
+    // ignore — caller's waitForExit will time out and relaunch regardless
+  }
+}
+
+async function waitForExit(timeoutMs = 6000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!(await isHandyRunning())) return;
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+}
+
+async function launchHandy(handyBinaryPath: string): Promise<void> {
+  const running = await handyProcessPath();
+  const appPath = running ?? appBundlePathFromBinary(handyBinaryPath);
+  try {
+    await execa("open", [appPath]);
+  } catch {
+    await execa("open", ["-a", "Handy"]);
+  }
+}
+
+/**
+ * Persist `apply` (writes `settings_store.json`), then relaunch Handy so the
+ * running app loads the new value. The setting is written again after the app
+ * exits to survive any shutdown-time flush of the old in-memory settings. Used
+ * as a fallback when live GUI scripting isn't available.
+ */
+export async function applySettingsAndReload(
+  apply: () => void,
+  handyBinaryPath: string,
+): Promise<void> {
+  apply();
+  if (await isHandyRunning()) {
+    await quitHandy();
+    await waitForExit();
+  }
+  apply();
+  await launchHandy(handyBinaryPath);
+}
+
+/**
+ * AppleScript that activates Handy and clicks the menu item matching `targetName`
+ * inside any submenu of its status-bar/tray menu (trying the tray first, then the
+ * app menu). Handy exposes its model list under a submenu whose title is the
+ * *currently active* model (not a fixed "Model" item), so we search every tray
+ * submenu. Matching requires an exact title so similarly named models/languages
+ * cannot be selected accidentally. Returns "OK" if clicked, "FAIL" otherwise.
+ */
+function menuClickScript(): string {
+  return [
+    "on run argv",
+    "  set targetName to item 1 of argv",
+    '  tell application "Handy" to activate',
+    "  delay 0.3",
+    "  set ok to false",
+    '  tell application "System Events"',
+    '    tell process "Handy"',
+    "      repeat with barIndex in {2, 1}",
+    "        set bi to barIndex as integer",
+    "        try",
+    "          set bar to menu bar bi",
+    "          set topItems to every menu item of menu 1 of (menu bar item 1 of bar)",
+    "          repeat with mi in topItems",
+    "            try",
+    "              set subItems to every menu item of menu 1 of mi",
+    "              repeat with si in subItems",
+    "                set sn to name of si",
+    "                if sn is not missing value then",
+    "                  ignoring case",
+    "                    set isMatch to sn is targetName",
+    "                  end ignoring",
+    "                  if isMatch then",
+    "                    click mi",
+    "                    delay 0.2",
+    "                    click si",
+    "                    set ok to true",
+    "                    exit repeat",
+    "                  end if",
+    "                end if",
+    "              end repeat",
+    "              if ok then exit repeat",
+    "              end try",
+    "            end repeat",
+    "          if ok then exit repeat",
+    "        end try",
+    "      end repeat",
+    "    end tell",
+    "  end tell",
+    "  if ok then",
+    '    return "OK"',
+    "  else",
+    '    return "FAIL"',
+    "  end if",
+    "end run",
+  ].join("\n");
+}
+
+async function clickHandyMenuItem(item: string): Promise<boolean> {
+  try {
+    const { stdout } = await execa("osascript", [
+      "-e",
+      menuClickScript(),
+      item,
+    ]);
+    return stdout.trim() === "OK";
+  } catch {
+    return false;
+  }
+}
+
+/** Switch the active model in the running Handy app (no restart) by clicking its model submenu. */
+export async function selectModelInHandy(modelName: string): Promise<boolean> {
+  return clickHandyMenuItem(modelName);
+}
+
+/** Switch the transcription language in the running Handy app (no restart). */
+export async function selectLanguageInHandy(
+  langLabel: string,
+): Promise<boolean> {
+  return clickHandyMenuItem(langLabel);
+}

--- a/extensions/handy/src/lib/handy.ts
+++ b/extensions/handy/src/lib/handy.ts
@@ -1,7 +1,8 @@
 import { execa } from "execa";
-import { dirname } from "path";
 
-const HANDY_PROCESS_PATTERN = "Handy.app/Contents/MacOS/Handy";
+const DEFAULT_HANDY_BINARY_PATH =
+  "/Applications/Handy.app/Contents/MacOS/Handy";
+const HANDY_PROCESS_NAME = "Handy";
 
 /**
  * Handy is a single-instance Tauri app. Changing the model/language inside Handy
@@ -17,9 +18,33 @@ const HANDY_PROCESS_PATTERN = "Handy.app/Contents/MacOS/Handy";
  * loads the new value at launch.
  */
 
-function appBundlePathFromBinary(binaryPath: string): string {
-  // …/Handy.app/Contents/MacOS/Handy → …/Handy.app
-  return dirname(dirname(dirname(binaryPath)));
+function normalizedBinaryPath(binaryPath: string): string {
+  return binaryPath.trim() || DEFAULT_HANDY_BINARY_PATH;
+}
+
+function appBundlePathFromBinary(binaryPath: string): string | null {
+  const match = binaryPath.match(/^(.*\.app)\/Contents\/MacOS\/[^/]+$/);
+  return match?.[1] ?? null;
+}
+
+function escapeExtendedRegex(value: string): string {
+  return value.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
+}
+
+function processPatternsForBinary(binaryPath: string): string[] {
+  const normalized = normalizedBinaryPath(binaryPath);
+  const appPath = appBundlePathFromBinary(normalized);
+  return Array.from(
+    new Set(
+      [
+        normalized,
+        appPath ? `${appPath}/Contents/MacOS/${HANDY_PROCESS_NAME}` : null,
+        DEFAULT_HANDY_BINARY_PATH,
+      ]
+        .filter((pattern): pattern is string => Boolean(pattern))
+        .map(escapeExtendedRegex),
+    ),
+  );
 }
 
 async function handyProcessPath(): Promise<string | null> {
@@ -36,44 +61,93 @@ async function handyProcessPath(): Promise<string | null> {
   return null;
 }
 
-async function isHandyRunning(): Promise<boolean> {
+async function hasHandyApplicationProcess(): Promise<boolean> {
   try {
-    await execa("pgrep", ["-f", HANDY_PROCESS_PATTERN]);
+    const { stdout } = await execa("osascript", [
+      "-e",
+      `tell application "System Events" to exists application process "${HANDY_PROCESS_NAME}"`,
+    ]);
+    return stdout.trim() === "true";
+  } catch {
+    return false;
+  }
+}
+
+async function isHandyRunning(handyBinaryPath: string): Promise<boolean> {
+  if (await hasHandyApplicationProcess()) return true;
+
+  for (const pattern of processPatternsForBinary(handyBinaryPath)) {
+    try {
+      await execa("pgrep", ["-f", pattern]);
+      return true;
+    } catch {
+      // try the next process matcher
+    }
+  }
+
+  try {
+    await execa("pgrep", ["-x", HANDY_PROCESS_NAME]);
     return true;
   } catch {
     return false;
   }
 }
 
-async function quitHandy(): Promise<void> {
-  try {
-    await execa("osascript", ["-e", 'tell application "Handy" to quit']);
-    return;
-  } catch {
-    // App may ignore AppleScript quit (e.g. busy); force it.
+async function pkillHandy(
+  handyBinaryPath: string,
+  force = false,
+): Promise<void> {
+  for (const pattern of processPatternsForBinary(handyBinaryPath)) {
+    try {
+      await execa("pkill", [...(force ? ["-9"] : []), "-f", pattern]);
+    } catch {
+      // process may already be gone, or this pattern may not match this install
+    }
   }
   try {
-    await execa("pkill", ["-f", HANDY_PROCESS_PATTERN]);
+    await execa("pkill", [...(force ? ["-9"] : []), "-x", HANDY_PROCESS_NAME]);
   } catch {
-    // ignore — caller's waitForExit will time out and relaunch regardless
+    // process may already be gone
   }
 }
 
-async function waitForExit(timeoutMs = 6000): Promise<void> {
+async function quitHandy(handyBinaryPath: string): Promise<void> {
+  try {
+    await execa("osascript", ["-e", 'tell application "Handy" to quit']);
+  } catch {
+    // App may ignore AppleScript quit (e.g. busy); force it.
+  }
+  if (await waitForExit(handyBinaryPath)) return;
+
+  await pkillHandy(handyBinaryPath);
+  if (await waitForExit(handyBinaryPath)) return;
+
+  await pkillHandy(handyBinaryPath, true);
+  if (!(await waitForExit(handyBinaryPath))) {
+    throw new Error("Handy did not quit; restart canceled");
+  }
+}
+
+async function waitForExit(
+  handyBinaryPath: string,
+  timeoutMs = 6000,
+): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (!(await isHandyRunning())) return;
+    if (!(await isHandyRunning(handyBinaryPath))) return true;
     await new Promise((resolve) => setTimeout(resolve, 200));
   }
+  return !(await isHandyRunning(handyBinaryPath));
 }
 
 async function launchHandy(handyBinaryPath: string): Promise<void> {
   const running = await handyProcessPath();
-  const appPath = running ?? appBundlePathFromBinary(handyBinaryPath);
+  const binaryPath = normalizedBinaryPath(handyBinaryPath);
+  const appPath = running ?? appBundlePathFromBinary(binaryPath) ?? binaryPath;
   try {
     await execa("open", [appPath]);
   } catch {
-    await execa("open", ["-a", "Handy"]);
+    await execa("open", ["-a", HANDY_PROCESS_NAME]);
   }
 }
 
@@ -87,13 +161,13 @@ export async function applySettingsAndReload(
   apply: () => void,
   handyBinaryPath: string,
 ): Promise<void> {
+  const binaryPath = normalizedBinaryPath(handyBinaryPath);
   apply();
-  if (await isHandyRunning()) {
-    await quitHandy();
-    await waitForExit();
+  if (await isHandyRunning(binaryPath)) {
+    await quitHandy(binaryPath);
   }
   apply();
-  await launchHandy(handyBinaryPath);
+  await launchHandy(binaryPath);
 }
 
 /**

--- a/extensions/handy/src/lib/handy.ts
+++ b/extensions/handy/src/lib/handy.ts
@@ -31,6 +31,10 @@ function escapeExtendedRegex(value: string): string {
   return value.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
 }
 
+function escapeAppleScriptString(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
 function processPatternsForBinary(binaryPath: string): string[] {
   const normalized = normalizedBinaryPath(binaryPath);
   const appPath = appBundlePathFromBinary(normalized);
@@ -39,7 +43,6 @@ function processPatternsForBinary(binaryPath: string): string[] {
       [
         normalized,
         appPath ? `${appPath}/Contents/MacOS/${HANDY_PROCESS_NAME}` : null,
-        DEFAULT_HANDY_BINARY_PATH,
       ]
         .filter((pattern): pattern is string => Boolean(pattern))
         .map(escapeExtendedRegex),
@@ -47,35 +50,7 @@ function processPatternsForBinary(binaryPath: string): string[] {
   );
 }
 
-async function handyProcessPath(): Promise<string | null> {
-  try {
-    const { stdout } = await execa("osascript", [
-      "-e",
-      'tell application "System Events" to get posix path of (file of (application process "Handy"))',
-    ]);
-    const path = stdout.trim();
-    if (path) return path;
-  } catch {
-    // ignore — fall through to binary-path derivation
-  }
-  return null;
-}
-
-async function hasHandyApplicationProcess(): Promise<boolean> {
-  try {
-    const { stdout } = await execa("osascript", [
-      "-e",
-      `tell application "System Events" to exists application process "${HANDY_PROCESS_NAME}"`,
-    ]);
-    return stdout.trim() === "true";
-  } catch {
-    return false;
-  }
-}
-
 async function isHandyRunning(handyBinaryPath: string): Promise<boolean> {
-  if (await hasHandyApplicationProcess()) return true;
-
   for (const pattern of processPatternsForBinary(handyBinaryPath)) {
     try {
       await execa("pgrep", ["-f", pattern]);
@@ -84,13 +59,7 @@ async function isHandyRunning(handyBinaryPath: string): Promise<boolean> {
       // try the next process matcher
     }
   }
-
-  try {
-    await execa("pgrep", ["-x", HANDY_PROCESS_NAME]);
-    return true;
-  } catch {
-    return false;
-  }
+  return false;
 }
 
 async function pkillHandy(
@@ -104,16 +73,16 @@ async function pkillHandy(
       // process may already be gone, or this pattern may not match this install
     }
   }
-  try {
-    await execa("pkill", [...(force ? ["-9"] : []), "-x", HANDY_PROCESS_NAME]);
-  } catch {
-    // process may already be gone
-  }
 }
 
 async function quitHandy(handyBinaryPath: string): Promise<void> {
+  const binaryPath = normalizedBinaryPath(handyBinaryPath);
+  const appPath = appBundlePathFromBinary(binaryPath) ?? HANDY_PROCESS_NAME;
   try {
-    await execa("osascript", ["-e", 'tell application "Handy" to quit']);
+    await execa("osascript", [
+      "-e",
+      `tell application "${escapeAppleScriptString(appPath)}" to quit`,
+    ]);
   } catch {
     // App may ignore AppleScript quit (e.g. busy); force it.
   }
@@ -141,13 +110,12 @@ async function waitForExit(
 }
 
 async function launchHandy(handyBinaryPath: string): Promise<void> {
-  const running = await handyProcessPath();
   const binaryPath = normalizedBinaryPath(handyBinaryPath);
-  const appPath = running ?? appBundlePathFromBinary(binaryPath) ?? binaryPath;
+  const appPath = appBundlePathFromBinary(binaryPath) ?? binaryPath;
   try {
     await execa("open", [appPath]);
   } catch {
-    await execa("open", ["-a", HANDY_PROCESS_NAME]);
+    await execa("open", ["-a", appPath]);
   }
 }
 

--- a/extensions/handy/src/lib/restart-handy.ts
+++ b/extensions/handy/src/lib/restart-handy.ts
@@ -13,12 +13,14 @@ export async function restartHandy(
   apply: () => void,
   handyBinaryPath: string,
   toast: Toast,
+  onApplied?: () => void,
 ): Promise<void> {
   toast.style = Toast.Style.Animated;
   toast.title = "Restarting Handy…";
   toast.message = undefined;
   try {
     await applySettingsAndReload(apply, handyBinaryPath);
+    onApplied?.();
     toast.style = Toast.Style.Success;
     toast.title = "Handy restarted";
   } catch (err) {
@@ -32,11 +34,12 @@ export async function restartHandy(
 export function restartHandyAction(
   apply: () => void,
   handyBinaryPath: string,
+  onApplied?: () => void,
 ): Toast.ActionOptions {
   return {
     title: "Restart Handy",
     onAction: (toast) => {
-      void restartHandy(apply, handyBinaryPath, toast);
+      void restartHandy(apply, handyBinaryPath, toast, onApplied);
     },
   };
 }

--- a/extensions/handy/src/lib/restart-handy.ts
+++ b/extensions/handy/src/lib/restart-handy.ts
@@ -1,0 +1,42 @@
+import { Toast } from "@raycast/api";
+import { applySettingsAndReload } from "./handy";
+
+/**
+ * Persist the setting and relaunch Handy, reporting progress and failures on
+ * `toast`.
+ *
+ * `applySettingsAndReload` rejects when Handy can't be terminated — the app then
+ * keeps running with the old in-memory setting and is never relaunched — so the
+ * rejection is surfaced here instead of ending the restart silently.
+ */
+export async function restartHandy(
+  apply: () => void,
+  handyBinaryPath: string,
+  toast: Toast,
+): Promise<void> {
+  toast.style = Toast.Style.Animated;
+  toast.title = "Restarting Handy…";
+  toast.message = undefined;
+  try {
+    await applySettingsAndReload(apply, handyBinaryPath);
+    toast.style = Toast.Style.Success;
+    toast.title = "Handy restarted";
+  } catch (err) {
+    toast.style = Toast.Style.Failure;
+    toast.title = "Couldn't restart Handy";
+    toast.message = err instanceof Error ? err.message : String(err);
+  }
+}
+
+/** "Restart Handy" toast action, used when the live (GUI-scripted) switch fails. */
+export function restartHandyAction(
+  apply: () => void,
+  handyBinaryPath: string,
+): Toast.ActionOptions {
+  return {
+    title: "Restart Handy",
+    onAction: (toast) => {
+      void restartHandy(apply, handyBinaryPath, toast);
+    },
+  };
+}

--- a/extensions/handy/src/lib/settings.ts
+++ b/extensions/handy/src/lib/settings.ts
@@ -1,4 +1,5 @@
-import { readFileSync, renameSync, writeFileSync } from "fs";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
+import { dirname } from "path";
 import { SETTINGS_PATH } from "./constants";
 
 export interface HandySettings {
@@ -10,14 +11,27 @@ export interface HandySettings {
 
 interface SettingsStore {
   settings: HandySettings;
+  [key: string]: unknown;
+}
+
+function readStore(filePath: string): Partial<SettingsStore> {
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return {};
+    throw err;
+  }
+  return (JSON.parse(raw) ?? {}) as Partial<SettingsStore>;
 }
 
 export function readSettings(filePath: string = SETTINGS_PATH): HandySettings {
-  const raw = readFileSync(filePath, "utf-8");
-  const store = JSON.parse(raw) as SettingsStore;
+  const store = readStore(filePath);
+  const settings = store.settings ?? ({} as HandySettings);
   return {
-    ...store.settings,
-    selected_language: store.settings.selected_language ?? "auto",
+    ...settings,
+    selected_model: settings.selected_model ?? "",
+    selected_language: settings.selected_language ?? "auto",
   };
 }
 
@@ -25,10 +39,10 @@ export function writeSettings(
   update: Partial<HandySettings>,
   filePath: string = SETTINGS_PATH,
 ): void {
-  const raw = readFileSync(filePath, "utf-8");
-  const store = JSON.parse(raw) as SettingsStore;
-  store.settings = { ...store.settings, ...update };
+  const store = readStore(filePath);
+  store.settings = { ...(store.settings ?? {}), ...update } as HandySettings;
   const tmp = filePath + ".raycast-tmp";
+  mkdirSync(dirname(filePath), { recursive: true });
   writeFileSync(tmp, JSON.stringify(store), "utf-8");
   renameSync(tmp, filePath);
 }

--- a/extensions/handy/src/manage-dictionary.tsx
+++ b/extensions/handy/src/manage-dictionary.tsx
@@ -3,6 +3,7 @@ import {
   ActionPanel,
   Form,
   Icon,
+  Keyboard,
   List,
   showToast,
   Toast,
@@ -107,7 +108,7 @@ export default function ManageDictionary() {
     <Action.Push
       title="Add Word"
       icon={Icon.Plus}
-      shortcut={{ modifiers: ["cmd"], key: "n" }}
+      shortcut={Keyboard.Shortcut.Common.New}
       target={<AddWordForm onAdd={load} />}
     />
   );

--- a/extensions/handy/src/search-transcripts.tsx
+++ b/extensions/handy/src/search-transcripts.tsx
@@ -2,6 +2,7 @@ import {
   Action,
   ActionPanel,
   Icon,
+  Keyboard,
   List,
   showToast,
   Toast,
@@ -114,13 +115,13 @@ export default function SearchTranscripts() {
                       entry.saved ? "Remove from Saved" : "Save Transcript"
                     }
                     icon={entry.saved ? Icon.StarDisabled : Icon.Star}
-                    shortcut={{ modifiers: ["cmd"], key: "s" }}
+                    shortcut={Keyboard.Shortcut.Common.Save}
                     onAction={() => handleToggleSaved(entry)}
                   />
                   <Action.ShowInFinder
                     title="Reveal Recording"
                     icon={Icon.Finder}
-                    shortcut={{ modifiers: ["cmd"], key: "o" }}
+                    shortcut={Keyboard.Shortcut.Common.Open}
                     path={join(RECORDINGS_DIR, entry.file_name)}
                   />
                   <Action

--- a/extensions/handy/src/select-language.tsx
+++ b/extensions/handy/src/select-language.tsx
@@ -8,10 +8,12 @@ import {
   showToast,
   Toast,
 } from "@raycast/api";
+import { getPreferenceValues } from "@raycast/api";
 import { useCallback, useEffect, useState } from "react";
 import { getLanguagesForModel, LanguageOption } from "./lib/languages";
 import { getModelCapabilities } from "./lib/catalog";
 import { readSettings, writeSettings } from "./lib/settings";
+import { applySettingsAndReload, selectLanguageInHandy } from "./lib/handy";
 
 export default function SelectLanguage() {
   const [languages, setLanguages] = useState<LanguageOption[]>([]);
@@ -53,13 +55,40 @@ export default function SelectLanguage() {
 
   async function handleSelect(lang: LanguageOption) {
     try {
+      const currentDisplay =
+        currentCode === "auto"
+          ? "Auto (detect)"
+          : `${lang.native} · ${lang.label}`;
+      if (lang.code === currentCode) {
+        await showHUD(`${currentDisplay} is already set`);
+        return;
+      }
+      const { handyBinaryPath } = getPreferenceValues<Preferences>();
       writeSettings({ selected_language: lang.code });
       setCurrentCode(lang.code);
       const display =
         lang.code === "auto"
           ? "Auto (detect)"
           : `${lang.native} · ${lang.label}`;
-      await showHUD(`Language set to ${display}`);
+      const applied = await selectLanguageInHandy(lang.label);
+      if (applied) {
+        await showHUD(`Language set to ${display}`);
+      } else {
+        await showToast({
+          style: Toast.Style.Failure,
+          title: "Couldn't switch language in Handy",
+          message:
+            "Grant Raycast Accessibility access (System Settings → Privacy & Security), or restart Handy to apply.",
+          primaryAction: {
+            title: "Restart Handy",
+            onAction: () =>
+              applySettingsAndReload(
+                () => writeSettings({ selected_language: lang.code }),
+                handyBinaryPath,
+              ),
+          },
+        });
+      }
     } catch (err) {
       await showToast({
         style: Toast.Style.Failure,

--- a/extensions/handy/src/select-language.tsx
+++ b/extensions/handy/src/select-language.tsx
@@ -13,7 +13,8 @@ import { useCallback, useEffect, useState } from "react";
 import { getLanguagesForModel, LanguageOption } from "./lib/languages";
 import { getModelCapabilities } from "./lib/catalog";
 import { readSettings, writeSettings } from "./lib/settings";
-import { applySettingsAndReload, selectLanguageInHandy } from "./lib/handy";
+import { selectLanguageInHandy } from "./lib/handy";
+import { restartHandyAction } from "./lib/restart-handy";
 
 export default function SelectLanguage() {
   const [languages, setLanguages] = useState<LanguageOption[]>([]);
@@ -79,14 +80,10 @@ export default function SelectLanguage() {
           title: "Couldn't switch language in Handy",
           message:
             "Grant Raycast Accessibility access (System Settings → Privacy & Security), or restart Handy to apply.",
-          primaryAction: {
-            title: "Restart Handy",
-            onAction: () =>
-              applySettingsAndReload(
-                () => writeSettings({ selected_language: lang.code }),
-                handyBinaryPath,
-              ),
-          },
+          primaryAction: restartHandyAction(
+            () => writeSettings({ selected_language: lang.code }),
+            handyBinaryPath,
+          ),
         });
       }
     } catch (err) {

--- a/extensions/handy/src/select-language.tsx
+++ b/extensions/handy/src/select-language.tsx
@@ -4,17 +4,15 @@ import {
   closeMainWindow,
   Icon,
   List,
-  showHUD,
   showToast,
   Toast,
 } from "@raycast/api";
-import { getPreferenceValues } from "@raycast/api";
 import { useCallback, useEffect, useState } from "react";
 import { getLanguagesForModel, LanguageOption } from "./lib/languages";
 import { getModelCapabilities } from "./lib/catalog";
 import { readSettings, writeSettings } from "./lib/settings";
 import { selectLanguageInHandy } from "./lib/handy";
-import { restartHandyAction } from "./lib/restart-handy";
+import { applyLiveOrRestart } from "./lib/apply-selection";
 
 export default function SelectLanguage() {
   const [languages, setLanguages] = useState<LanguageOption[]>([]);
@@ -60,32 +58,19 @@ export default function SelectLanguage() {
         currentCode === "auto"
           ? "Auto (detect)"
           : `${lang.native} · ${lang.label}`;
-      if (lang.code === currentCode) {
-        await showHUD(`${currentDisplay} is already set`);
-        return;
-      }
-      const { handyBinaryPath } = getPreferenceValues<Preferences>();
-      writeSettings({ selected_language: lang.code });
-      setCurrentCode(lang.code);
       const display =
         lang.code === "auto"
           ? "Auto (detect)"
           : `${lang.native} · ${lang.label}`;
-      const applied = await selectLanguageInHandy(lang.label);
-      if (applied) {
-        await showHUD(`Language set to ${display}`);
-      } else {
-        await showToast({
-          style: Toast.Style.Failure,
-          title: "Couldn't switch language in Handy",
-          message:
-            "Grant Raycast Accessibility access (System Settings → Privacy & Security), or restart Handy to apply.",
-          primaryAction: restartHandyAction(
-            () => writeSettings({ selected_language: lang.code }),
-            handyBinaryPath,
-          ),
-        });
-      }
+      await applyLiveOrRestart({
+        isCurrent: lang.code === currentCode,
+        alreadyActiveMessage: `${currentDisplay} is already set`,
+        persist: () => writeSettings({ selected_language: lang.code }),
+        markCurrent: () => setCurrentCode(lang.code),
+        liveSwitch: () => selectLanguageInHandy(lang.label),
+        successMessage: `Language set to ${display}`,
+        failureTitle: "Couldn't switch language in Handy",
+      });
     } catch (err) {
       await showToast({
         style: Toast.Style.Failure,

--- a/extensions/handy/src/select-model.tsx
+++ b/extensions/handy/src/select-model.tsx
@@ -7,9 +7,11 @@ import {
   showToast,
   Toast,
 } from "@raycast/api";
+import { getPreferenceValues } from "@raycast/api";
 import { useCallback, useEffect, useState } from "react";
 import { getDownloadedModels, ModelInfo } from "./lib/models";
 import { readSettings, writeSettings } from "./lib/settings";
+import { applySettingsAndReload, selectModelInHandy } from "./lib/handy";
 
 export default function SelectModel() {
   const [models, setModels] = useState<ModelInfo[]>([]);
@@ -37,9 +39,32 @@ export default function SelectModel() {
 
   async function handleSelect(model: ModelInfo) {
     try {
+      if (model.id === currentId) {
+        await showHUD(`${model.name} is already active`);
+        return;
+      }
+      const { handyBinaryPath } = getPreferenceValues<Preferences>();
       writeSettings({ selected_model: model.id });
       setCurrentId(model.id);
-      await showHUD(`Model changed to ${model.name}`);
+      const applied = await selectModelInHandy(model.name);
+      if (applied) {
+        await showHUD(`Model changed to ${model.name}`);
+      } else {
+        await showToast({
+          style: Toast.Style.Failure,
+          title: "Couldn't switch model in Handy",
+          message:
+            "Grant Raycast Accessibility access (System Settings → Privacy & Security), or restart Handy to apply.",
+          primaryAction: {
+            title: "Restart Handy",
+            onAction: () =>
+              applySettingsAndReload(
+                () => writeSettings({ selected_model: model.id }),
+                handyBinaryPath,
+              ),
+          },
+        });
+      }
     } catch (err) {
       await showToast({
         style: Toast.Style.Failure,

--- a/extensions/handy/src/select-model.tsx
+++ b/extensions/handy/src/select-model.tsx
@@ -3,16 +3,14 @@ import {
   ActionPanel,
   Icon,
   List,
-  showHUD,
   showToast,
   Toast,
 } from "@raycast/api";
-import { getPreferenceValues } from "@raycast/api";
 import { useCallback, useEffect, useState } from "react";
 import { getDownloadedModels, ModelInfo } from "./lib/models";
 import { readSettings, writeSettings } from "./lib/settings";
 import { selectModelInHandy } from "./lib/handy";
-import { restartHandyAction } from "./lib/restart-handy";
+import { applyLiveOrRestart } from "./lib/apply-selection";
 
 export default function SelectModel() {
   const [models, setModels] = useState<ModelInfo[]>([]);
@@ -40,28 +38,15 @@ export default function SelectModel() {
 
   async function handleSelect(model: ModelInfo) {
     try {
-      if (model.id === currentId) {
-        await showHUD(`${model.name} is already active`);
-        return;
-      }
-      const { handyBinaryPath } = getPreferenceValues<Preferences>();
-      writeSettings({ selected_model: model.id });
-      setCurrentId(model.id);
-      const applied = await selectModelInHandy(model.name);
-      if (applied) {
-        await showHUD(`Model changed to ${model.name}`);
-      } else {
-        await showToast({
-          style: Toast.Style.Failure,
-          title: "Couldn't switch model in Handy",
-          message:
-            "Grant Raycast Accessibility access (System Settings → Privacy & Security), or restart Handy to apply.",
-          primaryAction: restartHandyAction(
-            () => writeSettings({ selected_model: model.id }),
-            handyBinaryPath,
-          ),
-        });
-      }
+      await applyLiveOrRestart({
+        isCurrent: model.id === currentId,
+        alreadyActiveMessage: `${model.name} is already active`,
+        persist: () => writeSettings({ selected_model: model.id }),
+        markCurrent: () => setCurrentId(model.id),
+        liveSwitch: () => selectModelInHandy(model.name),
+        successMessage: `Model changed to ${model.name}`,
+        failureTitle: "Couldn't switch model in Handy",
+      });
     } catch (err) {
       await showToast({
         style: Toast.Style.Failure,

--- a/extensions/handy/src/select-model.tsx
+++ b/extensions/handy/src/select-model.tsx
@@ -11,7 +11,8 @@ import { getPreferenceValues } from "@raycast/api";
 import { useCallback, useEffect, useState } from "react";
 import { getDownloadedModels, ModelInfo } from "./lib/models";
 import { readSettings, writeSettings } from "./lib/settings";
-import { applySettingsAndReload, selectModelInHandy } from "./lib/handy";
+import { selectModelInHandy } from "./lib/handy";
+import { restartHandyAction } from "./lib/restart-handy";
 
 export default function SelectModel() {
   const [models, setModels] = useState<ModelInfo[]>([]);
@@ -55,14 +56,10 @@ export default function SelectModel() {
           title: "Couldn't switch model in Handy",
           message:
             "Grant Raycast Accessibility access (System Settings → Privacy & Security), or restart Handy to apply.",
-          primaryAction: {
-            title: "Restart Handy",
-            onAction: () =>
-              applySettingsAndReload(
-                () => writeSettings({ selected_model: model.id }),
-                handyBinaryPath,
-              ),
-          },
+          primaryAction: restartHandyAction(
+            () => writeSettings({ selected_model: model.id }),
+            handyBinaryPath,
+          ),
         });
       }
     } catch (err) {

--- a/extensions/handy/tests/__mocks__/@raycast/api.ts
+++ b/extensions/handy/tests/__mocks__/@raycast/api.ts
@@ -1,1 +1,9 @@
 export const trash = async (_path: string): Promise<void> => {};
+
+export const Toast = {
+  Style: {
+    Success: "SUCCESS",
+    Failure: "FAILURE",
+    Animated: "ANIMATED",
+  },
+} as const;

--- a/extensions/handy/tests/__mocks__/@raycast/api.ts
+++ b/extensions/handy/tests/__mocks__/@raycast/api.ts
@@ -1,3 +1,5 @@
+import { vi } from "vitest";
+
 export const trash = async (_path: string): Promise<void> => {};
 
 export const Toast = {
@@ -7,3 +9,9 @@ export const Toast = {
     Animated: "ANIMATED",
   },
 } as const;
+
+export const showHUD = vi.fn(async () => {});
+export const showToast = vi.fn(async () => {});
+export const getPreferenceValues = vi.fn(() => ({
+  handyBinaryPath: "/Applications/Handy.app/Contents/MacOS/Handy",
+}));

--- a/extensions/handy/tests/lib/apply-selection.test.ts
+++ b/extensions/handy/tests/lib/apply-selection.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getPreferenceValues, showHUD, showToast, Toast } from "@raycast/api";
+
+const { restartHandyActionMock } = vi.hoisted(() => ({
+  restartHandyActionMock: vi.fn(),
+}));
+
+vi.mock("../../src/lib/restart-handy", () => ({
+  restartHandyAction: restartHandyActionMock,
+}));
+
+import { applyLiveOrRestart } from "../../src/lib/apply-selection";
+
+const BINARY_PATH = "/Applications/Handy.app/Contents/MacOS/Handy";
+
+describe("applyLiveOrRestart", () => {
+  const persist = vi.fn();
+  const markCurrent = vi.fn();
+  const liveSwitch = vi.fn();
+
+  beforeEach(() => {
+    persist.mockReset();
+    markCurrent.mockReset();
+    liveSwitch.mockReset();
+    restartHandyActionMock.mockReset();
+    vi.mocked(showHUD).mockReset();
+    vi.mocked(showToast).mockReset();
+    vi.mocked(getPreferenceValues).mockReturnValue({
+      handyBinaryPath: BINARY_PATH,
+    });
+    restartHandyActionMock.mockReturnValue({
+      title: "Restart Handy",
+      onAction: vi.fn(),
+    });
+  });
+
+  it("skips persist when the selection is already current", async () => {
+    await applyLiveOrRestart({
+      isCurrent: true,
+      alreadyActiveMessage: "Turbo is already active",
+      persist,
+      markCurrent,
+      liveSwitch,
+      successMessage: "Model changed to Turbo",
+      failureTitle: "Couldn't switch model in Handy",
+    });
+
+    expect(liveSwitch).not.toHaveBeenCalled();
+    expect(persist).not.toHaveBeenCalled();
+    expect(markCurrent).not.toHaveBeenCalled();
+    expect(showHUD).toHaveBeenCalledWith("Turbo is already active");
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it("persists only after the running app accepts the live switch", async () => {
+    liveSwitch.mockImplementation(async () => {
+      expect(persist).not.toHaveBeenCalled();
+      expect(markCurrent).not.toHaveBeenCalled();
+      return true;
+    });
+
+    await applyLiveOrRestart({
+      isCurrent: false,
+      alreadyActiveMessage: "Turbo is already active",
+      persist,
+      markCurrent,
+      liveSwitch,
+      successMessage: "Model changed to Turbo",
+      failureTitle: "Couldn't switch model in Handy",
+    });
+
+    expect(persist).toHaveBeenCalledTimes(1);
+    expect(markCurrent).toHaveBeenCalledTimes(1);
+    expect(showHUD).toHaveBeenCalledWith("Model changed to Turbo");
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it("leaves persist and current unchanged when the live switch fails", async () => {
+    liveSwitch.mockResolvedValue(false);
+
+    await applyLiveOrRestart({
+      isCurrent: false,
+      alreadyActiveMessage: "Turbo is already active",
+      persist,
+      markCurrent,
+      liveSwitch,
+      successMessage: "Model changed to Turbo",
+      failureTitle: "Couldn't switch model in Handy",
+    });
+
+    expect(persist).not.toHaveBeenCalled();
+    expect(markCurrent).not.toHaveBeenCalled();
+    expect(showHUD).not.toHaveBeenCalled();
+    expect(showToast).toHaveBeenCalledWith({
+      style: Toast.Style.Failure,
+      title: "Couldn't switch model in Handy",
+      message:
+        "Grant Raycast Accessibility access (System Settings → Privacy & Security), or restart Handy to apply.",
+      primaryAction: { title: "Restart Handy", onAction: expect.any(Function) },
+    });
+    expect(restartHandyActionMock).toHaveBeenCalledWith(
+      persist,
+      BINARY_PATH,
+      markCurrent,
+    );
+  });
+});

--- a/extensions/handy/tests/lib/db.test.ts
+++ b/extensions/handy/tests/lib/db.test.ts
@@ -3,7 +3,13 @@ import Database from "better-sqlite3";
 import { mkdirSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { getHistory, getLatestEntry, toggleSaved, deleteEntry, displayText } from "../../src/lib/db";
+import {
+  getHistory,
+  getLatestEntry,
+  toggleSaved,
+  deleteEntry,
+  displayText,
+} from "../../src/lib/db";
 
 const TMP = join(tmpdir(), "handy-test-db");
 let TMP_DB: string;
@@ -21,15 +27,30 @@ function createSchema(p: string) {
   db.close();
 }
 
-function insert(p: string, o: {
-  file_name: string; timestamp: number; saved?: boolean;
-  title: string; transcription_text: string; post_processed_text?: string | null;
-}) {
+function insert(
+  p: string,
+  o: {
+    file_name: string;
+    timestamp: number;
+    saved?: boolean;
+    title: string;
+    transcription_text: string;
+    post_processed_text?: string | null;
+  },
+) {
   const db = new Database(p);
-  db.prepare(`INSERT INTO transcription_history
+  db.prepare(
+    `INSERT INTO transcription_history
     (file_name,timestamp,saved,title,transcription_text,post_processed_text)
-    VALUES (?,?,?,?,?,?)`
-  ).run(o.file_name, o.timestamp, o.saved ? 1 : 0, o.title, o.transcription_text, o.post_processed_text ?? null);
+    VALUES (?,?,?,?,?,?)`,
+  ).run(
+    o.file_name,
+    o.timestamp,
+    o.saved ? 1 : 0,
+    o.title,
+    o.transcription_text,
+    o.post_processed_text ?? null,
+  );
   db.close();
 }
 
@@ -40,43 +61,84 @@ beforeEach(() => {
   mkdirSync(RECS, { recursive: true });
   createSchema(TMP_DB);
 });
-afterEach(() => { rmSync(TMP, { recursive: true, force: true }); });
+afterEach(() => {
+  rmSync(TMP, { recursive: true, force: true });
+});
 
 describe("getHistory", () => {
   it("returns [] when empty", () => expect(getHistory(TMP_DB)).toEqual([]));
 
   it("returns entries newest-first", () => {
-    insert(TMP_DB, { file_name: "a.wav", timestamp: 100, title: "A", transcription_text: "first" });
-    insert(TMP_DB, { file_name: "b.wav", timestamp: 200, title: "B", transcription_text: "second" });
+    insert(TMP_DB, {
+      file_name: "a.wav",
+      timestamp: 100,
+      title: "A",
+      transcription_text: "first",
+    });
+    insert(TMP_DB, {
+      file_name: "b.wav",
+      timestamp: 200,
+      title: "B",
+      transcription_text: "second",
+    });
     const r = getHistory(TMP_DB);
     expect(r[0].transcription_text).toBe("second");
     expect(r[1].transcription_text).toBe("first");
   });
 
   it("maps saved as boolean", () => {
-    insert(TMP_DB, { file_name: "a.wav", timestamp: 1, title: "T", transcription_text: "t", saved: true });
+    insert(TMP_DB, {
+      file_name: "a.wav",
+      timestamp: 1,
+      title: "T",
+      transcription_text: "t",
+      saved: true,
+    });
     expect(getHistory(TMP_DB)[0].saved).toBe(true);
   });
 });
 
 describe("getLatestEntry", () => {
-  it("returns null when empty", () => expect(getLatestEntry(TMP_DB)).toBeNull());
+  it("returns null when empty", () =>
+    expect(getLatestEntry(TMP_DB)).toBeNull());
   it("returns most recent entry", () => {
-    insert(TMP_DB, { file_name: "a.wav", timestamp: 100, title: "A", transcription_text: "old" });
-    insert(TMP_DB, { file_name: "b.wav", timestamp: 200, title: "B", transcription_text: "new" });
+    insert(TMP_DB, {
+      file_name: "a.wav",
+      timestamp: 100,
+      title: "A",
+      transcription_text: "old",
+    });
+    insert(TMP_DB, {
+      file_name: "b.wav",
+      timestamp: 200,
+      title: "B",
+      transcription_text: "new",
+    });
     expect(getLatestEntry(TMP_DB)?.transcription_text).toBe("new");
   });
 });
 
 describe("toggleSaved", () => {
   it("flips false to true", () => {
-    insert(TMP_DB, { file_name: "a.wav", timestamp: 1, title: "T", transcription_text: "t", saved: false });
+    insert(TMP_DB, {
+      file_name: "a.wav",
+      timestamp: 1,
+      title: "T",
+      transcription_text: "t",
+      saved: false,
+    });
     const [e] = getHistory(TMP_DB);
     toggleSaved(e.id, TMP_DB);
     expect(getHistory(TMP_DB)[0].saved).toBe(true);
   });
   it("flips true to false", () => {
-    insert(TMP_DB, { file_name: "a.wav", timestamp: 1, title: "T", transcription_text: "t", saved: true });
+    insert(TMP_DB, {
+      file_name: "a.wav",
+      timestamp: 1,
+      title: "T",
+      transcription_text: "t",
+      saved: true,
+    });
     const [e] = getHistory(TMP_DB);
     toggleSaved(e.id, TMP_DB);
     expect(getHistory(TMP_DB)[0].saved).toBe(false);
@@ -85,22 +147,51 @@ describe("toggleSaved", () => {
 
 describe("deleteEntry", () => {
   it("removes the DB row", async () => {
-    insert(TMP_DB, { file_name: "a.wav", timestamp: 1, title: "T", transcription_text: "t" });
+    insert(TMP_DB, {
+      file_name: "a.wav",
+      timestamp: 1,
+      title: "T",
+      transcription_text: "t",
+    });
     const [e] = getHistory(TMP_DB);
     await deleteEntry(e.id, TMP_DB, RECS);
     expect(getHistory(TMP_DB)).toHaveLength(0);
   });
   it("does not throw if WAV is missing", async () => {
-    insert(TMP_DB, { file_name: "missing.wav", timestamp: 1, title: "T", transcription_text: "t" });
+    insert(TMP_DB, {
+      file_name: "missing.wav",
+      timestamp: 1,
+      title: "T",
+      transcription_text: "t",
+    });
     const [e] = getHistory(TMP_DB);
     await expect(deleteEntry(e.id, TMP_DB, RECS)).resolves.not.toThrow();
   });
 });
 
 describe("displayText", () => {
-  const base = { id: 1, file_name: "a.wav", timestamp: 1, saved: false, title: "T", post_process_prompt: null };
+  const base = {
+    id: 1,
+    file_name: "a.wav",
+    timestamp: 1,
+    saved: false,
+    title: "T",
+    post_process_prompt: null,
+  };
   it("returns post_processed_text when present", () =>
-    expect(displayText({ ...base, transcription_text: "raw", post_processed_text: "processed" })).toBe("processed"));
+    expect(
+      displayText({
+        ...base,
+        transcription_text: "raw",
+        post_processed_text: "processed",
+      }),
+    ).toBe("processed"));
   it("falls back to transcription_text when null", () =>
-    expect(displayText({ ...base, transcription_text: "raw", post_processed_text: null })).toBe("raw"));
+    expect(
+      displayText({
+        ...base,
+        transcription_text: "raw",
+        post_processed_text: null,
+      }),
+    ).toBe("raw"));
 });

--- a/extensions/handy/tests/lib/handy.test.ts
+++ b/extensions/handy/tests/lib/handy.test.ts
@@ -10,17 +10,12 @@ vi.mock("execa", () => ({
 
 import { applySettingsAndReload } from "../../src/lib/handy";
 
-const CUSTOM_BINARY_PATH =
-  "/Users/me/Apps/Handy Beta+.app/Contents/MacOS/Handy";
+const CUSTOM_APP_PATH = "/Users/me/Apps/Handy Beta+.app";
+const CUSTOM_BINARY_PATH = `${CUSTOM_APP_PATH}/Contents/MacOS/Handy`;
 const CUSTOM_PROCESS_PATTERN =
   "/Users/me/Apps/Handy Beta\\+\\.app/Contents/MacOS/Handy";
-
-function isSystemEventsProcessCheck(command: string, args: string[]): boolean {
-  return (
-    command === "osascript" &&
-    args[1]?.includes('exists application process "Handy"')
-  );
-}
+const DEFAULT_PROCESS_PATTERN =
+  "/Applications/Handy\\.app/Contents/MacOS/Handy";
 
 function isPgrepForCustomPath(command: string, args: string[]): boolean {
   return (
@@ -28,6 +23,29 @@ function isPgrepForCustomPath(command: string, args: string[]): boolean {
     args[0] === "-f" &&
     args[1] === CUSTOM_PROCESS_PATTERN
   );
+}
+
+function expectOnlyConfiguredInstallTargeted() {
+  expect(execaMock).not.toHaveBeenCalledWith("pgrep", [
+    "-f",
+    DEFAULT_PROCESS_PATTERN,
+  ]);
+  expect(execaMock).not.toHaveBeenCalledWith("pgrep", ["-x", "Handy"]);
+  expect(execaMock).not.toHaveBeenCalledWith("pkill", [
+    "-f",
+    DEFAULT_PROCESS_PATTERN,
+  ]);
+  expect(execaMock).not.toHaveBeenCalledWith("pkill", [
+    "-9",
+    "-f",
+    DEFAULT_PROCESS_PATTERN,
+  ]);
+  expect(execaMock).not.toHaveBeenCalledWith("pkill", ["-x", "Handy"]);
+  expect(execaMock).not.toHaveBeenCalledWith("pkill", ["-9", "-x", "Handy"]);
+  expect(execaMock).not.toHaveBeenCalledWith("open", [
+    "/Applications/Handy.app",
+  ]);
+  expect(execaMock).not.toHaveBeenCalledWith("open", ["-a", "Handy"]);
 }
 
 describe("applySettingsAndReload", () => {
@@ -45,9 +63,6 @@ describe("applySettingsAndReload", () => {
 
     execaMock.mockImplementation(
       async (command: string, args: string[] = []) => {
-        if (isSystemEventsProcessCheck(command, args)) {
-          return { stdout: "false" };
-        }
         if (isPgrepForCustomPath(command, args)) {
           if (customPathRunning.shift()) return { stdout: "123" };
           throw new Error("not running");
@@ -74,11 +89,47 @@ describe("applySettingsAndReload", () => {
     ]);
     expect(execaMock).toHaveBeenCalledWith("osascript", [
       "-e",
-      'tell application "Handy" to quit',
+      `tell application "${CUSTOM_APP_PATH}" to quit`,
     ]);
-    expect(execaMock).toHaveBeenCalledWith("open", [
-      "/Users/me/Apps/Handy Beta+.app",
+    expect(execaMock).toHaveBeenCalledWith("open", [CUSTOM_APP_PATH]);
+    expectOnlyConfiguredInstallTargeted();
+  });
+
+  it("does not terminate the default install when restarting a custom binary", async () => {
+    const customPathRunning = [true, true, false];
+    const apply = vi.fn();
+    vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValueOnce(6001);
+
+    execaMock.mockImplementation(
+      async (command: string, args: string[] = []) => {
+        if (isPgrepForCustomPath(command, args)) {
+          if (customPathRunning.shift()) return { stdout: "123" };
+          throw new Error("not running");
+        }
+        if (command === "pgrep" && args[1] === DEFAULT_PROCESS_PATTERN) {
+          return { stdout: "456" };
+        }
+        if (command === "pgrep") {
+          throw new Error("not running");
+        }
+        if (command === "osascript" || command === "pkill") {
+          return { stdout: "" };
+        }
+        if (command === "open") {
+          return { stdout: "" };
+        }
+        throw new Error(`Unexpected command: ${command} ${args.join(" ")}`);
+      },
+    );
+
+    await applySettingsAndReload(apply, CUSTOM_BINARY_PATH);
+
+    expect(execaMock).toHaveBeenCalledWith("pkill", [
+      "-f",
+      CUSTOM_PROCESS_PATTERN,
     ]);
+    expect(execaMock).toHaveBeenCalledWith("open", [CUSTOM_APP_PATH]);
+    expectOnlyConfiguredInstallTargeted();
   });
 
   it("cancels restart instead of relaunching when Handy never exits", async () => {
@@ -93,8 +144,8 @@ describe("applySettingsAndReload", () => {
 
     execaMock.mockImplementation(
       async (command: string, args: string[] = []) => {
-        if (isSystemEventsProcessCheck(command, args)) {
-          return { stdout: "true" };
+        if (isPgrepForCustomPath(command, args)) {
+          return { stdout: "123" };
         }
         if (command === "osascript" || command === "pkill") {
           return { stdout: "" };
@@ -118,5 +169,6 @@ describe("applySettingsAndReload", () => {
       CUSTOM_PROCESS_PATTERN,
     ]);
     expect(execaMock).not.toHaveBeenCalledWith("open", expect.anything());
+    expectOnlyConfiguredInstallTargeted();
   });
 });

--- a/extensions/handy/tests/lib/handy.test.ts
+++ b/extensions/handy/tests/lib/handy.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { execaMock } = vi.hoisted(() => ({
+  execaMock: vi.fn(),
+}));
+
+vi.mock("execa", () => ({
+  execa: execaMock,
+}));
+
+import { applySettingsAndReload } from "../../src/lib/handy";
+
+const CUSTOM_BINARY_PATH =
+  "/Users/me/Apps/Handy Beta+.app/Contents/MacOS/Handy";
+const CUSTOM_PROCESS_PATTERN =
+  "/Users/me/Apps/Handy Beta\\+\\.app/Contents/MacOS/Handy";
+
+function isSystemEventsProcessCheck(command: string, args: string[]): boolean {
+  return (
+    command === "osascript" &&
+    args[1]?.includes('exists application process "Handy"')
+  );
+}
+
+function isPgrepForCustomPath(command: string, args: string[]): boolean {
+  return (
+    command === "pgrep" &&
+    args[0] === "-f" &&
+    args[1] === CUSTOM_PROCESS_PATTERN
+  );
+}
+
+describe("applySettingsAndReload", () => {
+  beforeEach(() => {
+    execaMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("detects and quits Handy from a custom configured app path", async () => {
+    const customPathRunning = [true, false];
+    const apply = vi.fn();
+
+    execaMock.mockImplementation(
+      async (command: string, args: string[] = []) => {
+        if (isSystemEventsProcessCheck(command, args)) {
+          return { stdout: "false" };
+        }
+        if (isPgrepForCustomPath(command, args)) {
+          if (customPathRunning.shift()) return { stdout: "123" };
+          throw new Error("not running");
+        }
+        if (command === "pgrep") {
+          throw new Error("not running");
+        }
+        if (command === "osascript") {
+          return { stdout: "" };
+        }
+        if (command === "open") {
+          return { stdout: "" };
+        }
+        throw new Error(`Unexpected command: ${command} ${args.join(" ")}`);
+      },
+    );
+
+    await applySettingsAndReload(apply, CUSTOM_BINARY_PATH);
+
+    expect(apply).toHaveBeenCalledTimes(2);
+    expect(execaMock).toHaveBeenCalledWith("pgrep", [
+      "-f",
+      CUSTOM_PROCESS_PATTERN,
+    ]);
+    expect(execaMock).toHaveBeenCalledWith("osascript", [
+      "-e",
+      'tell application "Handy" to quit',
+    ]);
+    expect(execaMock).toHaveBeenCalledWith("open", [
+      "/Users/me/Apps/Handy Beta+.app",
+    ]);
+  });
+
+  it("cancels restart instead of relaunching when Handy never exits", async () => {
+    const apply = vi.fn();
+    vi.spyOn(Date, "now")
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(6001)
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(6001)
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(6001);
+
+    execaMock.mockImplementation(
+      async (command: string, args: string[] = []) => {
+        if (isSystemEventsProcessCheck(command, args)) {
+          return { stdout: "true" };
+        }
+        if (command === "osascript" || command === "pkill") {
+          return { stdout: "" };
+        }
+        throw new Error(`Unexpected command: ${command} ${args.join(" ")}`);
+      },
+    );
+
+    await expect(
+      applySettingsAndReload(apply, CUSTOM_BINARY_PATH),
+    ).rejects.toThrow("Handy did not quit; restart canceled");
+
+    expect(apply).toHaveBeenCalledTimes(1);
+    expect(execaMock).toHaveBeenCalledWith("pkill", [
+      "-f",
+      CUSTOM_PROCESS_PATTERN,
+    ]);
+    expect(execaMock).toHaveBeenCalledWith("pkill", [
+      "-9",
+      "-f",
+      CUSTOM_PROCESS_PATTERN,
+    ]);
+    expect(execaMock).not.toHaveBeenCalledWith("open", expect.anything());
+  });
+});

--- a/extensions/handy/tests/lib/languages.test.ts
+++ b/extensions/handy/tests/lib/languages.test.ts
@@ -3,7 +3,10 @@ import { getLanguagesForModel, LANGUAGE_MAP } from "../../src/lib/languages";
 
 describe("LANGUAGE_MAP", () => {
   it("contains auto entry", () => {
-    expect(LANGUAGE_MAP["auto"]).toEqual({ label: "Auto (detect)", native: "Auto (detect)" });
+    expect(LANGUAGE_MAP["auto"]).toEqual({
+      label: "Auto (detect)",
+      native: "Auto (detect)",
+    });
   });
   it("contains standard language entries", () => {
     expect(LANGUAGE_MAP["en"]).toBeDefined();
@@ -27,7 +30,7 @@ describe("getLanguagesForModel", () => {
 
   it("filters to supportedLanguages when provided", () => {
     const langs = getLanguagesForModel(["en", "de", "es", "fr"]);
-    const codes = langs.map(l => l.code);
+    const codes = langs.map((l) => l.code);
     expect(codes).toContain("auto");
     expect(codes).toContain("en");
     expect(codes).toContain("de");
@@ -43,6 +46,10 @@ describe("getLanguagesForModel", () => {
 
   it("each entry has code, label, native", () => {
     const langs = getLanguagesForModel(["en"]);
-    expect(langs[1]).toMatchObject({ code: "en", label: expect.any(String), native: expect.any(String) });
+    expect(langs[1]).toMatchObject({
+      code: "en",
+      label: expect.any(String),
+      native: expect.any(String),
+    });
   });
 });

--- a/extensions/handy/tests/lib/restart-handy.test.ts
+++ b/extensions/handy/tests/lib/restart-handy.test.ts
@@ -38,14 +38,26 @@ describe("restartHandy", () => {
     expect(toast.title).toBe("Handy restarted");
   });
 
-  it("reports the failure instead of leaving the rejection unhandled", async () => {
+  it("calls onApplied only after a successful restart", async () => {
+    applySettingsAndReloadMock.mockResolvedValue(undefined);
+    const onApplied = vi.fn();
+    const toast = makeToast();
+
+    await restartHandy(vi.fn(), BINARY_PATH, toast, onApplied);
+
+    expect(onApplied).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not mark the selection current when restart fails", async () => {
     applySettingsAndReloadMock.mockRejectedValue(
       new Error("Handy did not quit; restart canceled"),
     );
+    const onApplied = vi.fn();
     const toast = makeToast();
 
-    await restartHandy(vi.fn(), BINARY_PATH, toast);
+    await restartHandy(vi.fn(), BINARY_PATH, toast, onApplied);
 
+    expect(onApplied).not.toHaveBeenCalled();
     expect(toast.style).toBe(Toast.Style.Failure);
     expect(toast.title).toBe("Couldn't restart Handy");
     expect(toast.message).toBe("Handy did not quit; restart canceled");

--- a/extensions/handy/tests/lib/restart-handy.test.ts
+++ b/extensions/handy/tests/lib/restart-handy.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { Toast } from "@raycast/api";
+
+const { applySettingsAndReloadMock } = vi.hoisted(() => ({
+  applySettingsAndReloadMock: vi.fn(),
+}));
+
+vi.mock("../../src/lib/handy", () => ({
+  applySettingsAndReload: applySettingsAndReloadMock,
+}));
+
+import { restartHandy, restartHandyAction } from "../../src/lib/restart-handy";
+
+const BINARY_PATH = "/Applications/Handy.app/Contents/MacOS/Handy";
+
+function makeToast(): Toast {
+  return {
+    style: Toast.Style.Failure,
+    title: "",
+    message: "previous message",
+  } as unknown as Toast;
+}
+
+describe("restartHandy", () => {
+  beforeEach(() => {
+    applySettingsAndReloadMock.mockReset();
+  });
+
+  it("reports success on the toast", async () => {
+    applySettingsAndReloadMock.mockResolvedValue(undefined);
+    const apply = vi.fn();
+    const toast = makeToast();
+
+    await restartHandy(apply, BINARY_PATH, toast);
+
+    expect(applySettingsAndReloadMock).toHaveBeenCalledWith(apply, BINARY_PATH);
+    expect(toast.style).toBe(Toast.Style.Success);
+    expect(toast.title).toBe("Handy restarted");
+  });
+
+  it("reports the failure instead of leaving the rejection unhandled", async () => {
+    applySettingsAndReloadMock.mockRejectedValue(
+      new Error("Handy did not quit; restart canceled"),
+    );
+    const toast = makeToast();
+
+    await restartHandy(vi.fn(), BINARY_PATH, toast);
+
+    expect(toast.style).toBe(Toast.Style.Failure);
+    expect(toast.title).toBe("Couldn't restart Handy");
+    expect(toast.message).toBe("Handy did not quit; restart canceled");
+  });
+
+  it("action handles a rejected restart without an unhandled rejection", async () => {
+    applySettingsAndReloadMock.mockRejectedValue(new Error("boom"));
+    const toast = makeToast();
+    const onRejection = vi.fn();
+    process.once("unhandledRejection", onRejection);
+
+    const action = restartHandyAction(vi.fn(), BINARY_PATH);
+    expect(action.title).toBe("Restart Handy");
+    action.onAction(toast);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(onRejection).not.toHaveBeenCalled();
+    expect(toast.style).toBe(Toast.Style.Failure);
+    process.off("unhandledRejection", onRejection);
+  });
+});

--- a/extensions/handy/tests/lib/settings.test.ts
+++ b/extensions/handy/tests/lib/settings.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { readSettings, writeSettings } from "../../src/lib/settings";
@@ -25,10 +25,6 @@ describe("readSettings", () => {
   it("reads selected_model", () => {
     writeFileSync(TMP_FILE, makeStore([], "moonshine-base"));
     expect(readSettings(TMP_FILE).selected_model).toBe("moonshine-base");
-  });
-
-  it("throws if file does not exist", () => {
-    expect(() => readSettings("/nonexistent.json")).toThrow();
   });
 
   it("throws if JSON is malformed", () => {
@@ -82,5 +78,35 @@ describe("writeSettings", () => {
     writeSettings({ selected_language: "fr" }, TMP_FILE);
     expect(readSettings(TMP_FILE).selected_language).toBe("fr");
     expect(readSettings(TMP_FILE).selected_model).toBe("small");
+  });
+
+  it("writes the file without leaving a temp file behind", () => {
+    writeFileSync(TMP_FILE, makeStore(["word"], "small"));
+    writeSettings({ selected_model: "turbo" }, TMP_FILE);
+    expect(existsSync(TMP_FILE + ".raycast-tmp")).toBe(false);
+    expect(readSettings(TMP_FILE).selected_model).toBe("turbo");
+  });
+
+  it("creates a settings envelope when the file has no settings key", () => {
+    writeFileSync(TMP_FILE, JSON.stringify({ some_other_key: "preserved" }));
+    writeSettings({ selected_model: "medium" }, TMP_FILE);
+    const raw = JSON.parse(readFileSync(TMP_FILE, "utf-8"));
+    expect(raw).toHaveProperty("settings");
+    expect(raw.settings.selected_model).toBe("medium");
+    expect(raw.some_other_key).toBe("preserved");
+  });
+
+  it("initialises the file when it does not exist", () => {
+    expect(existsSync(TMP_FILE)).toBe(false);
+    writeSettings({ selected_model: "large" }, TMP_FILE);
+    expect(existsSync(TMP_FILE)).toBe(true);
+    expect(readSettings(TMP_FILE).selected_model).toBe("large");
+  });
+
+  it("reads defaults when the file does not exist", () => {
+    expect(existsSync(TMP_FILE)).toBe(false);
+    const settings = readSettings(TMP_FILE);
+    expect(settings.selected_model).toBe("");
+    expect(settings.selected_language).toBe("auto");
   });
 });

--- a/extensions/handy/tests/lib/settings.test.ts
+++ b/extensions/handy/tests/lib/settings.test.ts
@@ -13,8 +13,12 @@ function makeStore(custom_words: string[], selected_model: string) {
   });
 }
 
-beforeEach(() => { mkdirSync(TMP_DIR, { recursive: true }); });
-afterEach(() => { rmSync(TMP_DIR, { recursive: true, force: true }); });
+beforeEach(() => {
+  mkdirSync(TMP_DIR, { recursive: true });
+});
+afterEach(() => {
+  rmSync(TMP_DIR, { recursive: true, force: true });
+});
 
 describe("readSettings", () => {
   it("reads custom_words through settings envelope", () => {
@@ -33,9 +37,16 @@ describe("readSettings", () => {
   });
 
   it("reads selected_language", () => {
-    writeFileSync(TMP_FILE, JSON.stringify({
-      settings: { custom_words: [], selected_model: "small", selected_language: "it" }
-    }));
+    writeFileSync(
+      TMP_FILE,
+      JSON.stringify({
+        settings: {
+          custom_words: [],
+          selected_model: "small",
+          selected_language: "it",
+        },
+      }),
+    );
     expect(readSettings(TMP_FILE).selected_language).toBe("it");
   });
 
@@ -52,7 +63,9 @@ describe("writeSettings", () => {
     const result = readSettings(TMP_FILE);
     expect(result.custom_words).toEqual(["new1", "new2"]);
     expect(result.selected_model).toBe("small");
-    expect((result as Record<string, unknown>)["some_other_key"]).toBe("preserved");
+    expect((result as Record<string, unknown>)["some_other_key"]).toBe(
+      "preserved",
+    );
   });
 
   it("updates selected_model without touching other keys", () => {
@@ -72,9 +85,16 @@ describe("writeSettings", () => {
   });
 
   it("updates selected_language without touching other keys", () => {
-    writeFileSync(TMP_FILE, JSON.stringify({
-      settings: { custom_words: ["w"], selected_model: "small", selected_language: "en" }
-    }));
+    writeFileSync(
+      TMP_FILE,
+      JSON.stringify({
+        settings: {
+          custom_words: ["w"],
+          selected_model: "small",
+          selected_language: "en",
+        },
+      }),
+    );
     writeSettings({ selected_language: "fr" }, TMP_FILE);
     expect(readSettings(TMP_FILE).selected_language).toBe("fr");
     expect(readSettings(TMP_FILE).selected_model).toBe("small");


### PR DESCRIPTION
Fixes #29966 

## Description

The handy extension's Select Model and Select Language commands only wrote settings_store.json, but the running Handy app never picked up the change until it was relaunched — so selecting a model appeared to "do nothing." 

## The problem (why)

- Handy is a single-instance Tauri app that loads settings_store.json into memory at launch and never re-reads it at runtime.
- There is no external channel to switch the model: no --set-model CLI flag, and no custom URL scheme (the Info.plist has no CFBundleURLTypes; setURLSchemeHandler: is WebKit internal IPC).
- The only way the active model changes in-process is Handy's own set_active_model Rust command, which the in-app tray menu calls. So writing the file alone was a no-op until a relaunch.

## The fix

- New src/lib/handy.ts — drives Handy via AppleScript GUI scripting:
- selectModelInHandy(name) / selectLanguageInHandy(label): activate Handy, then click the tray menu item whose title contains the target name. Handy exposes its model list under a submenu titled with the currently active model (not a fixed "Model" item), so the script searches every tray submenu for the target and clicks it — triggering Handy's in-app set_active_model.
- applySettingsAndReload(apply, binaryPath): the fallback when GUI scripting isn't possible (Accessibility not granted, hidden tray, or item not found). It persists the setting, quits Handy, waits for exit, persists again (to survive Handy's shutdown flush), then relaunches.
- select-model.tsx / select-language.tsx — handleSelect now: skips if already active; persists via writeSettings; attempts the live GUI switch; on success shows an HUD; on failure shows a Failure Toast with a "Restart Handy" primary action that calls applySettingsAndReload.
- settings.ts — hardening so the setting is actually honored/reloadable:
- readStore now tolerates a missing file (ENOENT → {}) instead of throwing.
- readSettings handles a missing settings key and defaults selected_model → "", selected_language → "auto".
- writeSettings always keeps the {"settings": {...}} envelope (even when the file/key was absent) and mkdirSyncs the directory first.

## Files changed

1. extensions/handy/src/lib/handy.ts	(new) - GUI-script + relaunch helpers
2. extensions/handy/src/select-model.tsx - live switch + restart fallback toast
3. extensions/handy/src/select-language.tsx - live switch + restart fallback toast
4. extensions/handy/src/lib/settings.ts - ENOENT/missing-key defaults, envelope safety
5. extensions/handy/tests/lib/settings.test.ts - tests for new hardening; replaced "throws if missing" with "reads defaults if missing"

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
