### PR TITLE
Update messages extension

### DIFF
--- a/extensions/messages/CHANGELOG.md
+++ b/extensions/messages/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Messages Changelog
 
+## [AI Message History and Activity] - {PR_MERGE_DATE}
+
+- Add stable cursor pagination, date and unread filters, attachment metadata, and plain-text fallback to AI message search
+- Add an AI tool for overall and per-chat sent/received activity
+- Use stable chat IDs for existing-conversation sends and report AppleScript send failures accurately
+- Add unread and date filters to AI chat search
+- Search the full Contacts catalog when an AI request names someone without a recent conversation
+
 ## [Faster chat and recipient search] - 2026-07-10
 
 - Show cached Send Message recipients immediately, grouped under `Recents` and `Contacts`

--- a/extensions/messages/CHANGELOG.md
+++ b/extensions/messages/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Messages Changelog
 
-## [AI Message History and Activity] - {PR_MERGE_DATE}
+## [AI Message History and Activity] - 2026-08-31
 
 - Add stable cursor pagination, date and unread filters, attachment metadata, and plain-text fallback to AI message search
 - Add an AI tool for overall and per-chat sent/received activity

--- a/extensions/messages/CHANGELOG.md
+++ b/extensions/messages/CHANGELOG.md
@@ -5,8 +5,8 @@
 - Add stable cursor pagination, date and unread filters, attachment metadata, and plain-text fallback to AI message search
 - Add an AI tool for overall and per-chat sent/received activity
 - Use stable chat IDs for existing-conversation sends and report AppleScript send failures accurately
-- Add unread and date filters to AI chat search
-- Search the full Contacts catalog when an AI request names someone without a recent conversation
+- Add unread filters and message-activity date ranges to AI chat search
+- Search a cached full Contacts catalog when an AI request names someone without a recent conversation
 
 ## [Faster chat and recipient search] - 2026-07-10
 

--- a/extensions/messages/README.md
+++ b/extensions/messages/README.md
@@ -1,6 +1,6 @@
 # Messages
 
-A great companion for Raycast users using the Messages app. 
+A great companion for Raycast users using the Messages app.
 
 This extension allows you to:
 
@@ -53,7 +53,7 @@ This is a weird one. If your group chat has a name, you can send messages from R
 
 ### Some of my group chats are not showing up
 
-Another weird one. Group chats with a name can't be opened from Raycast. Why? Because the `sms://` URL scheme doesn't support opening them by name or ID. While it's technically possible to open them with all the participants' phone numbers, this would create a new group chat besides the existing one that actually has a name. 
+Another weird one. Group chats with a name can't be opened from Raycast. Why? Because the `sms://` URL scheme doesn't support opening them by name or ID. While it's technically possible to open them with all the participants' phone numbers, this would create a new group chat besides the existing one that actually has a name.
 
 Let's take an example, you have a group chat named "Best Friends" with two of your friends:
 

--- a/extensions/messages/package.json
+++ b/extensions/messages/package.json
@@ -13,7 +13,8 @@
     "hayden_barnes",
     "micha_van_eijk",
     "islamtayeb",
-    "janosorcsik"
+    "janosorcsik",
+    "0xdhrv"
   ],
   "keywords": [
     "2fa",
@@ -99,7 +100,7 @@
     {
       "name": "search-chats",
       "title": "Search Chats",
-      "description": "Search for a chat in your chats list"
+      "description": "Search existing chats and messageable contacts"
     },
     {
       "name": "send-message",
@@ -110,10 +111,15 @@
       "name": "search-latest-messages",
       "title": "Search Latest Messages",
       "description": "Search your latest messages from the Apple Messages app"
+    },
+    {
+      "name": "count-message-activity",
+      "title": "Count Message Activity",
+      "description": "Count sent and received Messages activity over time"
     }
   ],
   "ai": {
-    "instructions": "You are a Messages assistant. Help the user read, summarize, search, analyze, and send iMessage and SMS messages.\\n\\nTOOL USAGE:\\n- search-chats: find a chat by contact name or phone number. Always call this first when the user mentions a specific person or group, to get the correct chatIdentifier.\\n- search-latest-messages: fetch messages. Pass chatIdentifier to scope to one conversation. Do NOT pass searchText unless the user explicitly wants to filter by keywords — omitting it returns the most recent messages. Only fetch messages when you need conversation context (e.g. writing a reply, summarizing, answering questions). For simple sends with a clear message (e.g. 'Ask John to call me'), skip it and send directly.\\n- send-message: send a message to a chat. Always use search-chats first to get the chatIdentifier.\\n- The user can search for a chat by group name — do not search for the literal word \\\"group\\\".\\n- PAGINATION: Each call returns up to 50 messages in chronological order (oldest first, newest last). To go further back in time, call search-latest-messages again with `before` set to the `date` of the first (oldest, index 0) message from the previous response. Repeat until you have enough context.\\n\\nDATA FORMAT:\\n- sender: who sent the message. \\\"You\\\" means the user themselves.\\n- date: ISO 8601 timestamp.\\n- text: the message body.\\n- group: present only for group chats.\\n- replyingTo: only present when a message explicitly replies to an earlier (non-adjacent) message. The value is the text of that earlier message. Sequential replies to the immediately preceding message are omitted to reduce noise.\\n\\nBEHAVIOR:\\n- Always present messages in chronological order (oldest first).\\n- When summarizing a conversation, focus on topics, tone, and key events — not metadata.\\n- When the user asks about an ongoing thread, fetch as many pages as needed before answering.\\n- If you get a database error, tell the user to grant Raycast Full Disk Access in System Settings → Privacy & Security → Full Disk Access (step by step). If no contacts were found, simply say you haven't found the contact.\\n- Be concise. Do not repeat raw message data back to the user unless explicitly asked.",
+    "instructions": "You are a Messages assistant. Help the user read, summarize, search, analyze, and send iMessage, SMS, and RCS messages.\n\nTOOL USAGE:\n- search-chats: find existing conversations and messageable Contacts by name, address, recency, date, or unread state. When a person or group is named, call this first. Prefer chatGuid for an existing chat. A contact result has no chatGuid; use its chatIdentifier and service \"auto\" when sending a new direct conversation. The user can search by group name; do not search for the literal word \"group\".\n- search-latest-messages: read or search message history. Pass chatGuid to scope one conversation. Only pass searchText when the user explicitly requests keywords. Use from/to for date questions and unreadOnly for unread requests. Results are chronological. If nextCursor is present and more context is needed, call the tool again with the same filters and that cursor.\n- count-message-activity: answer questions about message volume, sent/received counts, trends, or most active chats. Use overall for combined totals and chat for ranked conversations. Resolve named chats with search-chats first, then pass chatGuids. Follow nextCursor for additional ranked chat pages.\n- send-message: send a clear message. Resolve existing chats with search-chats first and pass chat_guid. For a contact without an existing chat, pass chat_identifier and service_name \"auto\". The user approves the recipient and text through Raycast before sending. For simple sends with clear wording, do not read message history first.\n\nDATA FORMAT:\n- sender \"You\" means the current user.\n- attachments contains metadata only, never attachment contents.\n- replyingTo is included only when reply context is available.\n\nBEHAVIOR:\n- Present messages in chronological order.\n- Summaries should focus on topics, tone, decisions, and next actions rather than metadata.\n- Fetch additional pages only when the question needs more context.\n- If database access fails, explain how to grant Raycast Full Disk Access in System Settings → Privacy & Security → Full Disk Access.\n- Be concise and do not repeat raw private message data unless explicitly asked.",
     "evals": [
       {
         "input": "@messages Ask John to call me",
@@ -332,6 +338,41 @@
           },
           {
             "meetsCriteria": "The answer declines the invitation politely"
+          }
+        ]
+      },
+      {
+        "input": "@messages How many messages did I send and receive this month?",
+        "mocks": {
+          "count-message-activity": {
+            "breakdown": "overall",
+            "range": {
+              "from": "2026-08-01T00:00:00.000Z",
+              "to": "2026-09-01T00:00:00.000Z"
+            },
+            "interval": "month",
+            "timeZone": "Asia/Kolkata",
+            "buckets": [
+              {
+                "bucket": "2026-08",
+                "total": 42,
+                "sent": 17,
+                "received": 25
+              }
+            ],
+            "totals": {
+              "total": 42,
+              "sent": 17,
+              "received": 25
+            }
+          }
+        },
+        "expected": [
+          {
+            "callsTool": "count-message-activity"
+          },
+          {
+            "meetsCriteria": "The answer says 17 messages were sent and 25 were received"
           }
         ]
       }

--- a/extensions/messages/src/api/get-chats.ts
+++ b/extensions/messages/src/api/get-chats.ts
@@ -9,11 +9,31 @@ import { buildChatQuery, type SQLChat } from "../chat-query";
 import { createContactMap } from "../contact-map-persist";
 import { buildChatSearchableText, getContactLookupIdentifiers, getContactOrGroupInfo, fuzzySearch } from "../helpers";
 import type { Chat } from "../open-chat-list";
-import type { ChatOrMessageInfo } from "../types";
+import type { ChatOrMessageInfo, Contact } from "../types";
 
 const DB_PATH = resolve(homedir(), "Library/Messages/chat.db");
 
-export async function getChats(searchText: string = ""): Promise<Chat[]> {
+type GetChatsOptions = {
+  unreadOnly?: boolean;
+  from?: string;
+  to?: string;
+  limit?: number;
+  contacts?: Contact[];
+};
+
+export async function getChats(searchText: string = "", options: GetChatsOptions = {}): Promise<Chat[]> {
+  const limit = options.limit ?? 50;
+  if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
+    throw new Error("limit must be an integer between 1 and 100.");
+  }
+  const fromTime = options.from ? Date.parse(options.from) : undefined;
+  const toTime = options.to ? Date.parse(options.to) : undefined;
+  if (fromTime !== undefined && !Number.isFinite(fromTime)) throw new Error("from must be an ISO 8601 date-time.");
+  if (toTime !== undefined && !Number.isFinite(toTime)) throw new Error("to must be an ISO 8601 date-time.");
+  if (fromTime !== undefined && toTime !== undefined && fromTime > toTime) {
+    throw new Error("from must not be later than to.");
+  }
+
   const rawData = await executeSQL<SQLChat>(DB_PATH, buildChatQuery());
 
   if (!rawData) return [];
@@ -31,7 +51,7 @@ export async function getChats(searchText: string = ""): Promise<Chat[]> {
   }));
 
   const lookupIdentifiers = [...new Set(chatInfos.flatMap(({ info }) => getContactLookupIdentifiers(info)))];
-  const contacts = await fetchContactsForChatIdentifiers(lookupIdentifiers);
+  const contacts = options.contacts ?? (await fetchContactsForChatIdentifiers(lookupIdentifiers));
   const contactMap = createContactMap(contacts);
 
   const hydratedChats = chatInfos.map(({ chat, info }) => {
@@ -46,9 +66,15 @@ export async function getChats(searchText: string = ""): Promise<Chat[]> {
       searchableText: buildChatSearchableText(chat, displayName),
     };
   });
-  const chats = collapseChatRows(hydratedChats);
+  const chats = collapseChatRows(hydratedChats).filter((chat) => {
+    if (options.unreadOnly && !(Number(chat.unread_count) > 0)) return false;
+    const lastMessageTime = Date.parse(chat.last_message_date);
+    if (fromTime !== undefined && lastMessageTime < fromTime) return false;
+    if (toTime !== undefined && lastMessageTime >= toTime) return false;
+    return true;
+  });
 
-  if (!searchText) return chats.slice(0, 50);
+  if (!searchText) return chats.slice(0, limit);
 
   const searchTerms = searchText
     .toLowerCase()
@@ -60,5 +86,5 @@ export async function getChats(searchText: string = ""): Promise<Chat[]> {
       const searchString = c.searchableText ?? buildChatSearchableText(c, c.displayName);
       return fuzzySearch(searchString, searchTerms);
     })
-    .slice(0, 50);
+    .slice(0, limit);
 }

--- a/extensions/messages/src/api/get-chats.ts
+++ b/extensions/messages/src/api/get-chats.ts
@@ -8,6 +8,7 @@ import { collapseChatRows } from "../chat-collapse";
 import { buildChatQuery, type SQLChat } from "../chat-query";
 import { createContactMap } from "../contact-map-persist";
 import { buildChatSearchableText, getContactLookupIdentifiers, getContactOrGroupInfo, fuzzySearch } from "../helpers";
+import { dateToAppleNanoseconds } from "../message-pagination";
 import type { Chat } from "../open-chat-list";
 import type { ChatOrMessageInfo, Contact } from "../types";
 
@@ -26,15 +27,19 @@ export async function getChats(searchText: string = "", options: GetChatsOptions
   if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
     throw new Error("limit must be an integer between 1 and 100.");
   }
-  const fromTime = options.from ? Date.parse(options.from) : undefined;
-  const toTime = options.to ? Date.parse(options.to) : undefined;
-  if (fromTime !== undefined && !Number.isFinite(fromTime)) throw new Error("from must be an ISO 8601 date-time.");
-  if (toTime !== undefined && !Number.isFinite(toTime)) throw new Error("to must be an ISO 8601 date-time.");
-  if (fromTime !== undefined && toTime !== undefined && fromTime > toTime) {
+  const fromNanoseconds = options.from ? dateToAppleNanoseconds(options.from, "from") : undefined;
+  const toNanoseconds = options.to ? dateToAppleNanoseconds(options.to, "to") : undefined;
+  if (fromNanoseconds && toNanoseconds && BigInt(fromNanoseconds) > BigInt(toNanoseconds)) {
     throw new Error("from must not be later than to.");
   }
 
-  const rawData = await executeSQL<SQLChat>(DB_PATH, buildChatQuery());
+  const rawData = await executeSQL<SQLChat>(
+    DB_PATH,
+    buildChatQuery({
+      activityFromNanoseconds: fromNanoseconds,
+      activityToNanoseconds: toNanoseconds,
+    }),
+  );
 
   if (!rawData) return [];
 
@@ -68,9 +73,6 @@ export async function getChats(searchText: string = "", options: GetChatsOptions
   });
   const chats = collapseChatRows(hydratedChats).filter((chat) => {
     if (options.unreadOnly && !(Number(chat.unread_count) > 0)) return false;
-    const lastMessageTime = Date.parse(chat.last_message_date);
-    if (fromTime !== undefined && lastMessageTime < fromTime) return false;
-    if (toTime !== undefined && lastMessageTime >= toTime) return false;
     return true;
   });
 

--- a/extensions/messages/src/api/get-message-activity.ts
+++ b/extensions/messages/src/api/get-message-activity.ts
@@ -1,0 +1,279 @@
+import { createHash } from "crypto";
+import { homedir } from "os";
+import { resolve } from "path";
+
+import { executeSQL } from "@raycast/utils";
+
+import { dateToAppleNanoseconds } from "../message-pagination";
+
+const DB_PATH = resolve(homedir(), "Library/Messages/chat.db");
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+const CURSOR_VERSION = 1;
+const SORT_DATE = "COALESCE(NULLIF(chat_message_join.message_date, 0), message.date)";
+
+type Interval = "total" | "day" | "week" | "month" | "year";
+type Breakdown = "overall" | "chat";
+type RankBy = "total" | "sent" | "received";
+
+export type MessageActivityInput = {
+  from?: string;
+  to?: string;
+  interval?: Interval;
+  chatGuids?: string[];
+  chatType?: "direct" | "group";
+  breakdown?: Breakdown;
+  rankBy?: RankBy;
+  limit?: number;
+  cursor?: string;
+};
+
+type ActivityRow = {
+  bucket: string;
+  total: number;
+  sent: number;
+  received: number;
+};
+
+type ChatActivityRow = {
+  chat_guid: string;
+  chat_identifier: string;
+  display_name: string | null;
+  service_name: string;
+  chat_type: "direct" | "group";
+  participants: string | null;
+  total: number;
+  sent: number;
+  received: number;
+};
+
+type ChatBucketRow = ActivityRow & {
+  chat_guid: string;
+};
+
+type ActivityCursor = {
+  version: number;
+  offset: number;
+  to: string;
+  fingerprint: string;
+};
+
+function quoteSQL(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function normalizeLimit(value?: number): number {
+  if (value === undefined) return DEFAULT_LIMIT;
+  if (!Number.isInteger(value) || value < 1 || value > MAX_LIMIT) {
+    throw new Error(`limit must be an integer between 1 and ${MAX_LIMIT}.`);
+  }
+  return value;
+}
+
+function bucketExpression(interval: Interval): string {
+  const localDate = `datetime(${SORT_DATE} / 1000000000 + strftime('%s', '2001-01-01'), 'unixepoch', 'localtime')`;
+  switch (interval) {
+    case "day":
+      return `strftime('%Y-%m-%d', ${localDate})`;
+    case "week":
+      return `strftime('%Y-W%W', ${localDate})`;
+    case "month":
+      return `strftime('%Y-%m', ${localDate})`;
+    case "year":
+      return `strftime('%Y', ${localDate})`;
+    case "total":
+      return "'total'";
+  }
+}
+
+function fingerprint(input: Omit<MessageActivityInput, "cursor" | "limit" | "to">, resolvedTo: string): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        from: input.from || null,
+        to: resolvedTo,
+        interval: input.interval ?? "total",
+        chatGuids: [...(input.chatGuids ?? [])].sort(),
+        chatType: input.chatType || null,
+        breakdown: input.breakdown ?? "overall",
+        rankBy: input.rankBy ?? "total",
+      }),
+    )
+    .digest("base64url");
+}
+
+function decodeCursor(value: string): ActivityCursor {
+  try {
+    const parsed: unknown = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+    if (!parsed || typeof parsed !== "object") throw new Error();
+    const cursor = parsed as Partial<ActivityCursor>;
+    if (
+      cursor.version !== CURSOR_VERSION ||
+      !Number.isInteger(cursor.offset) ||
+      Number(cursor.offset) < 0 ||
+      typeof cursor.to !== "string" ||
+      typeof cursor.fingerprint !== "string"
+    ) {
+      throw new Error();
+    }
+    return cursor as ActivityCursor;
+  } catch {
+    throw new Error("The activity cursor is invalid.");
+  }
+}
+
+function encodeCursor(cursor: Omit<ActivityCursor, "version">): string {
+  return Buffer.from(JSON.stringify({ ...cursor, version: CURSOR_VERSION })).toString("base64url");
+}
+
+export async function getMessageActivity(input: MessageActivityInput) {
+  const interval = input.interval ?? "total";
+  const breakdown = input.breakdown ?? "overall";
+  const rankBy = input.rankBy ?? "total";
+  const limit = normalizeLimit(input.limit);
+  const decodedCursor = input.cursor ? decodeCursor(input.cursor) : undefined;
+
+  if (input.cursor && breakdown !== "chat") throw new Error("cursor is only supported for chat breakdowns.");
+  if (input.chatGuids && (input.chatGuids.length < 1 || input.chatGuids.length > 20)) {
+    throw new Error("chatGuids must contain between 1 and 20 values.");
+  }
+  if (input.chatGuids?.some((value) => !value.trim())) throw new Error("chatGuids cannot contain empty values.");
+
+  const resolvedTo = decodedCursor?.to ?? input.to ?? new Date().toISOString();
+  const fromNanoseconds = input.from ? dateToAppleNanoseconds(input.from, "from") : undefined;
+  const toNanoseconds = dateToAppleNanoseconds(resolvedTo, "to");
+  if (fromNanoseconds && BigInt(fromNanoseconds) > BigInt(toNanoseconds)) {
+    throw new Error("from must not be later than to.");
+  }
+
+  const expectedFingerprint = fingerprint(input, resolvedTo);
+  if (decodedCursor && decodedCursor.fingerprint !== expectedFingerprint) {
+    throw new Error("The activity cursor belongs to a different query.");
+  }
+
+  const filters = [
+    `${SORT_DATE} < ${toNanoseconds}`,
+    fromNanoseconds ? `${SORT_DATE} >= ${fromNanoseconds}` : "",
+    input.chatGuids?.length ? `chat.guid IN (${input.chatGuids.map(quoteSQL).join(", ")})` : "",
+    input.chatType === "group" ? "chat.style = 43" : input.chatType === "direct" ? "chat.style != 43" : "",
+    `(message.associated_message_type IS NULL OR (
+      message.associated_message_type != 1000
+      AND message.associated_message_type NOT BETWEEN 2000 AND 2007
+      AND message.associated_message_type NOT BETWEEN 3000 AND 3007
+      AND message.associated_message_type != 4000
+    ))`,
+  ].filter(Boolean);
+  const bucket = bucketExpression(interval);
+  const base = `
+    FROM message
+    JOIN chat_message_join ON message.ROWID = chat_message_join.message_id
+    JOIN chat ON chat_message_join.chat_id = chat.ROWID
+    WHERE ${filters.join(" AND ")}
+  `;
+
+  if (breakdown === "overall") {
+    const rows =
+      (await executeSQL<ActivityRow>(
+        DB_PATH,
+        `SELECT
+          ${bucket} AS bucket,
+          COUNT(*) AS total,
+          COALESCE(SUM(CASE WHEN message.is_from_me = 1 THEN 1 ELSE 0 END), 0) AS sent,
+          COALESCE(SUM(CASE WHEN message.is_from_me = 0 THEN 1 ELSE 0 END), 0) AS received
+        ${base}
+        GROUP BY bucket
+        ORDER BY bucket`,
+      )) ?? [];
+
+    return {
+      breakdown,
+      range: { from: input.from ?? null, to: resolvedTo },
+      interval,
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      buckets: rows,
+      totals: rows.reduce(
+        (total, row) => ({
+          total: total.total + Number(row.total),
+          sent: total.sent + Number(row.sent),
+          received: total.received + Number(row.received),
+        }),
+        { total: 0, sent: 0, received: 0 },
+      ),
+    };
+  }
+
+  const offset = decodedCursor?.offset ?? 0;
+  const rankColumn = rankBy === "sent" ? "sent" : rankBy === "received" ? "received" : "total";
+  const rows =
+    (await executeSQL<ChatActivityRow>(
+      DB_PATH,
+      `SELECT
+        chat.guid AS chat_guid,
+        chat.chat_identifier,
+        NULLIF(TRIM(chat.display_name), '') AS display_name,
+        chat.service_name,
+        CASE WHEN chat.style = 43 THEN 'group' ELSE 'direct' END AS chat_type,
+        (
+          SELECT GROUP_CONCAT(handle.id)
+          FROM chat_handle_join
+          JOIN handle ON chat_handle_join.handle_id = handle.ROWID
+          WHERE chat_handle_join.chat_id = chat.ROWID
+        ) AS participants,
+        COUNT(*) AS total,
+        COALESCE(SUM(CASE WHEN message.is_from_me = 1 THEN 1 ELSE 0 END), 0) AS sent,
+        COALESCE(SUM(CASE WHEN message.is_from_me = 0 THEN 1 ELSE 0 END), 0) AS received
+      ${base}
+      GROUP BY chat.ROWID
+      ORDER BY ${rankColumn} DESC, chat.ROWID DESC
+      LIMIT ${limit + 1} OFFSET ${offset}`,
+    )) ?? [];
+  const hasMore = rows.length > limit;
+  const selectedRows = rows.slice(0, limit);
+  const selectedChatGuids = selectedRows.map((row) => row.chat_guid);
+  const bucketRows = selectedChatGuids.length
+    ? ((await executeSQL<ChatBucketRow>(
+        DB_PATH,
+        `SELECT
+          chat.guid AS chat_guid,
+          ${bucket} AS bucket,
+          COUNT(*) AS total,
+          COALESCE(SUM(CASE WHEN message.is_from_me = 1 THEN 1 ELSE 0 END), 0) AS sent,
+          COALESCE(SUM(CASE WHEN message.is_from_me = 0 THEN 1 ELSE 0 END), 0) AS received
+        ${base}
+          AND chat.guid IN (${selectedChatGuids.map(quoteSQL).join(", ")})
+        GROUP BY chat.ROWID, bucket
+        ORDER BY chat.ROWID, bucket`,
+      )) ?? [])
+    : [];
+
+  return {
+    breakdown,
+    range: { from: input.from ?? null, to: resolvedTo },
+    interval,
+    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    chats: selectedRows.map((row) => ({
+      chatGuid: row.chat_guid,
+      chatIdentifier: row.chat_identifier,
+      displayName: row.display_name || row.chat_identifier,
+      service: row.service_name,
+      type: row.chat_type,
+      participants: row.participants?.split(",") ?? [],
+      total: Number(row.total),
+      sent: Number(row.sent),
+      received: Number(row.received),
+      countsByBucket: bucketRows
+        .filter((bucketRow) => bucketRow.chat_guid === row.chat_guid)
+        .map((bucketRow) => ({
+          bucket: bucketRow.bucket,
+          total: Number(bucketRow.total),
+          sent: Number(bucketRow.sent),
+          received: Number(bucketRow.received),
+        })),
+    })),
+    ...(hasMore
+      ? {
+          nextCursor: encodeCursor({ offset: offset + limit, to: resolvedTo, fingerprint: expectedFingerprint }),
+        }
+      : {}),
+  };
+}

--- a/extensions/messages/src/api/get-message-page.ts
+++ b/extensions/messages/src/api/get-message-page.ts
@@ -158,9 +158,9 @@ export async function getMessagePage(input: MessagePageInput): Promise<MessagePa
     }
 
     if (matches.length === limit) break;
+    // A full batch advances the internal scan position, but it does not prove that another page exists.
+    // Only expose that position when the result limit or bounded scan cap requires a continuation cursor.
     if (rawRows.length < queryLimit) break;
-    nextKey = position;
-    hasMore = true;
   }
 
   if (searchText && scannedMessageCount >= MAX_SEARCH_SCAN && position) {

--- a/extensions/messages/src/api/get-message-page.ts
+++ b/extensions/messages/src/api/get-message-page.ts
@@ -1,0 +1,181 @@
+import { homedir } from "os";
+import { resolve } from "path";
+
+import { executeSQL } from "@raycast/utils";
+
+import { buildMessagesQuery } from "../helpers";
+import {
+  dateToAppleNanoseconds,
+  decodeMessageCursor,
+  encodeMessageCursor,
+  fingerprintMessageQuery,
+  type MessageCursorKey,
+  type MessageQueryScope,
+} from "../message-pagination";
+import type { Message, SQLMessage } from "../types";
+
+import { deduplicateReplyContext, hydrateMessages, messageMatchesSearch } from "./get-messages";
+
+const DB_PATH = resolve(homedir(), "Library/Messages/chat.db");
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+const SEARCH_SCAN_SIZE = 250;
+const MAX_SEARCH_SCAN = 5_000;
+const SORT_DATE = "COALESCE(NULLIF(chat_message_join.message_date, 0), message.date)";
+
+type MaxRow = { max_row_id: number | string | null };
+
+export type MessagePageInput = {
+  searchText?: string;
+  chatGuid?: string;
+  chatIdentifier?: string;
+  cursor?: string;
+  from?: string;
+  to?: string;
+  unreadOnly?: boolean;
+  limit?: number;
+};
+
+export type MessagePage = {
+  messages: Message[];
+  nextCursor?: string;
+  scannedMessageCount: number;
+};
+
+function quoteSQL(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function normalizedOptional(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+function normalizeLimit(value?: number): number {
+  if (value === undefined) return DEFAULT_LIMIT;
+  if (!Number.isInteger(value) || value < 1 || value > MAX_LIMIT) {
+    throw new Error(`limit must be an integer between 1 and ${MAX_LIMIT}.`);
+  }
+  return value;
+}
+
+function cursorClause(key?: MessageCursorKey): string {
+  if (!key) return "";
+  return `AND (
+    ${SORT_DATE} < ${key.dateNanoseconds}
+    OR (
+      ${SORT_DATE} = ${key.dateNanoseconds}
+      AND (
+        message.ROWID < ${key.rowID}
+        OR (message.ROWID = ${key.rowID} AND chat.ROWID < ${key.chatRowID})
+      )
+    )
+  )`;
+}
+
+function keyFor(row: SQLMessage): MessageCursorKey {
+  return {
+    dateNanoseconds: row.date_nanoseconds,
+    rowID: Number(row.row_id),
+    chatRowID: Number(row.chat_row_id),
+  };
+}
+
+async function currentMaxRowID(): Promise<number> {
+  const rows = await executeSQL<MaxRow>(DB_PATH, "SELECT COALESCE(MAX(ROWID), 0) AS max_row_id FROM message");
+  const value = Number(rows?.[0]?.max_row_id ?? 0);
+  if (!Number.isSafeInteger(value) || value < 0) throw new Error("Could not establish a message snapshot.");
+  return value;
+}
+
+export async function getMessagePage(input: MessagePageInput): Promise<MessagePage> {
+  const limit = normalizeLimit(input.limit);
+  const chatGuid = normalizedOptional(input.chatGuid);
+  const chatIdentifier = normalizedOptional(input.chatIdentifier);
+  const searchText = normalizedOptional(input.searchText);
+  const from = normalizedOptional(input.from);
+  const to = normalizedOptional(input.to);
+  const unreadOnly = input.unreadOnly ?? false;
+
+  if (chatGuid && chatIdentifier) throw new Error("Provide chatGuid or chatIdentifier, not both.");
+
+  const fromNanoseconds = from ? dateToAppleNanoseconds(from, "from") : undefined;
+  const toNanoseconds = to ? dateToAppleNanoseconds(to, "to") : undefined;
+  if (fromNanoseconds && toNanoseconds && BigInt(fromNanoseconds) > BigInt(toNanoseconds)) {
+    throw new Error("from must not be later than to.");
+  }
+
+  const scope: MessageQueryScope = { chatGuid, chatIdentifier, from, to, unreadOnly, searchText };
+  const fingerprint = fingerprintMessageQuery(scope);
+  const decodedCursor = input.cursor ? decodeMessageCursor(input.cursor, fingerprint) : undefined;
+  const snapshotRowID = decodedCursor?.snapshotRowID ?? (await currentMaxRowID());
+  let position = decodedCursor?.key;
+  let scannedMessageCount = 0;
+  const matches: Message[] = [];
+  let nextKey: MessageCursorKey | undefined;
+  let hasMore = false;
+
+  while (scannedMessageCount < MAX_SEARCH_SCAN) {
+    const queryLimit = searchText ? Math.min(SEARCH_SCAN_SIZE, MAX_SEARCH_SCAN - scannedMessageCount) : limit + 1;
+    const rawRows =
+      (await executeSQL<SQLMessage>(
+        DB_PATH,
+        buildMessagesQuery({
+          chatGuidClause: chatGuid ? `AND chat.guid = ${quoteSQL(chatGuid)}` : "",
+          chatIdentifierClause: chatIdentifier ? `AND chat.chat_identifier = ${quoteSQL(chatIdentifier)}` : "",
+          filterClause: unreadOnly ? "AND message.is_read = 0 AND message.is_from_me = 0" : "",
+          fromClause: fromNanoseconds ? `AND ${SORT_DATE} >= ${fromNanoseconds}` : "",
+          toClause: toNanoseconds ? `AND ${SORT_DATE} < ${toNanoseconds}` : "",
+          cursorClause: cursorClause(position),
+          snapshotClause: `AND message.ROWID <= ${snapshotRowID}`,
+          limit: String(queryLimit),
+        }),
+      )) ?? [];
+
+    if (!searchText) {
+      const selectedRows = rawRows.slice(0, limit);
+      const selectedMessages = await hydrateMessages(selectedRows);
+      matches.push(...selectedMessages);
+      scannedMessageCount += selectedRows.length;
+      hasMore = rawRows.length > limit;
+      nextKey = hasMore && selectedRows.length ? keyFor(selectedRows[selectedRows.length - 1]) : undefined;
+      break;
+    }
+
+    if (!rawRows.length) break;
+    const hydrated = await hydrateMessages(rawRows);
+
+    for (let index = 0; index < hydrated.length; index++) {
+      scannedMessageCount += 1;
+      position = keyFor(rawRows[index]);
+      if (messageMatchesSearch(hydrated[index], searchText)) matches.push(hydrated[index]);
+
+      if (matches.length === limit) {
+        nextKey = position;
+        hasMore = index < hydrated.length - 1 || rawRows.length === queryLimit;
+        break;
+      }
+    }
+
+    if (matches.length === limit) break;
+    if (rawRows.length < queryLimit) break;
+    nextKey = position;
+    hasMore = true;
+  }
+
+  if (searchText && scannedMessageCount >= MAX_SEARCH_SCAN && position) {
+    nextKey = position;
+    hasMore = true;
+  }
+
+  const messages = deduplicateReplyContext([...matches].reverse());
+  return {
+    messages,
+    scannedMessageCount,
+    ...(hasMore && nextKey
+      ? {
+          nextCursor: encodeMessageCursor({ key: nextKey, snapshotRowID, fingerprint }),
+        }
+      : {}),
+  };
+}

--- a/extensions/messages/src/api/get-messages.ts
+++ b/extensions/messages/src/api/get-messages.ts
@@ -5,7 +5,13 @@ import { executeSQL } from "@raycast/utils";
 import { fetchContactsForChatIdentifiers } from "swift:../../swift/contacts";
 
 import { createContactMap } from "../contact-map-persist";
-import { buildMessagesQuery, decodeHexString, fuzzySearch, getContactOrGroupInfo } from "../helpers";
+import {
+  buildMessagesQuery,
+  decodeMessageBody,
+  fuzzySearch,
+  getContactOrGroupInfo,
+  parseMessageAttachments,
+} from "../helpers";
 import type { ChatOrMessageInfo, Message, SQLMessage } from "../types";
 
 const DB_PATH = resolve(homedir(), "Library/Messages/chat.db");
@@ -30,13 +36,22 @@ export async function getMessages(searchText?: string, chatIdentifier?: string, 
 
   if (!rawData) return [];
 
+  const mapped = await hydrateMessages(rawData);
+  const messages = deduplicateReplyContext([...mapped].reverse());
+
+  if (!searchText) return messages;
+
+  return messages.filter((message) => messageMatchesSearch(message, searchText));
+}
+
+export async function hydrateMessages(rawData: SQLMessage[]): Promise<Message[]> {
   const lookupIdentifiers = [...new Set(rawData.flatMap((message) => getLookupIdentifiers(message)))];
   const contacts = await fetchContactsForChatIdentifiers(lookupIdentifiers);
   const contactMap = createContactMap(contacts);
 
-  const mapped = rawData.map((message) => {
-    const decodedBody = decodeHexString(message.body);
-    const decodedReply = message.reply_body ? decodeHexString(message.reply_body) : null;
+  return rawData.map((message) => {
+    const decodedBody = decodeMessageBody(message.body, message.plain_text);
+    const decodedReply = decodeMessageBody(message.reply_body, message.reply_plain_text) || null;
     const messageInfo: ChatOrMessageInfo = {
       chat_identifier: message.chat_identifier,
       is_from_me: Boolean(message.is_from_me),
@@ -56,13 +71,13 @@ export async function getMessages(searchText?: string, chatIdentifier?: string, 
       is_audio_message: Boolean(message.is_audio_message),
       is_sent: Boolean(message.is_sent),
       is_read: message.is_sent ? true : Boolean(message.is_read),
+      attachments: parseMessageAttachments(message.attachments_json),
       replyingTo: decodedReply || null,
     };
   });
+}
 
-  // Reverse to oldest-first, apply reply dedup filter.
-  // Dedup: strip consecutive identical replyingTo to reduce noise.
-  const messages = [...mapped].reverse();
+export function deduplicateReplyContext(messages: Message[]): Message[] {
   let prevReply: string | null = null;
   for (const message of messages) {
     const originalReply = message.replyingTo ?? null;
@@ -71,29 +86,29 @@ export async function getMessages(searchText?: string, chatIdentifier?: string, 
     }
     prevReply = originalReply;
   }
+  return messages;
+}
 
-  if (!searchText) return messages;
-
+export function messageMatchesSearch(message: Message, searchText: string): boolean {
   const searchTerms = searchText
     .toLowerCase()
     .split(/\s+/)
     .filter((term) => term.length > 0);
 
-  return messages.filter((message) => {
-    const searchableText = [
-      message.body,
-      message.senderName,
-      message.sender,
-      message.is_from_me ? "me" : "",
-      message.is_read ? "read" : "unread",
-      message.is_audio_message ? "audio" : "",
-      ...[message.attachment_mime_type?.split("/")],
-    ]
-      .join(" ")
-      .toLowerCase();
+  const searchableText = [
+    message.body,
+    message.senderName,
+    message.sender,
+    message.is_from_me ? "me" : "",
+    message.is_read ? "read" : "unread",
+    message.is_audio_message ? "audio" : "",
+    message.attachment_mime_type?.split("/"),
+    ...message.attachments.flatMap((attachment) => [attachment.name, attachment.mimeType]),
+  ]
+    .join(" ")
+    .toLowerCase();
 
-    return fuzzySearch(searchableText, searchTerms);
-  });
+  return fuzzySearch(searchableText, searchTerms);
 }
 
 function getLookupIdentifiers(message: SQLMessage): string[] {

--- a/extensions/messages/src/api/get-messages.ts
+++ b/extensions/messages/src/api/get-messages.ts
@@ -79,14 +79,12 @@ export async function hydrateMessages(rawData: SQLMessage[]): Promise<Message[]>
 
 export function deduplicateReplyContext(messages: Message[]): Message[] {
   let prevReply: string | null = null;
-  for (const message of messages) {
+  return messages.map((message) => {
     const originalReply = message.replyingTo ?? null;
-    if (message.replyingTo && message.replyingTo === prevReply) {
-      message.replyingTo = null;
-    }
+    const replyingTo = originalReply && originalReply === prevReply ? null : message.replyingTo;
     prevReply = originalReply;
-  }
-  return messages;
+    return { ...message, replyingTo };
+  });
 }
 
 export function messageMatchesSearch(message: Message, searchText: string): boolean {

--- a/extensions/messages/src/api/search-message-recipients.ts
+++ b/extensions/messages/src/api/search-message-recipients.ts
@@ -1,0 +1,64 @@
+import { fetchAllContacts } from "swift:../../swift/contacts";
+
+import { fuzzySearch } from "../helpers";
+import { buildRecipientSections, type Recipient } from "../recipient-catalog";
+import type { Contact } from "../types";
+
+import { getChats } from "./get-chats";
+
+type SearchMessageRecipientsOptions = {
+  unreadOnly?: boolean;
+  from?: string;
+  to?: string;
+  limit?: number;
+};
+
+export type MessageRecipientSearchResult = {
+  kind: "chat" | "contact";
+  chatGuid: string | null;
+  chatIdentifier: string;
+  displayName: string;
+  service: "iMessage" | "SMS" | "auto";
+  isGroup: boolean;
+  participants: string[];
+  unreadCount: number | null;
+  lastMessageDate: string | null;
+};
+
+function searchTerms(value: string): string[] {
+  return value.toLowerCase().split(/\s+/).filter(Boolean);
+}
+
+function mapRecipient(recipient: Recipient): MessageRecipientSearchResult {
+  return {
+    kind: recipient.kind === "recent" ? "chat" : "contact",
+    chatGuid: recipient.chat_guid ?? null,
+    chatIdentifier: recipient.chat_identifier,
+    displayName: recipient.displayName,
+    service: recipient.service_name,
+    isGroup: recipient.is_group,
+    participants: recipient.group_participants?.split(",").map((participant) => participant.trim()) ?? [],
+    unreadCount: recipient.kind === "recent" ? Number(recipient.unread_count ?? 0) : null,
+    lastMessageDate: recipient.kind === "recent" ? (recipient.last_message_date ?? null) : null,
+  };
+}
+
+export async function searchMessageRecipients(
+  searchText: string = "",
+  options: SearchMessageRecipientsOptions = {},
+): Promise<MessageRecipientSearchResult[]> {
+  const limit = options.limit ?? 50;
+  const hasActivityFilters = Boolean(options.unreadOnly || options.from || options.to);
+  const terms = searchTerms(searchText);
+  const contacts = terms.length && !hasActivityFilters ? ((await fetchAllContacts()) as Contact[]) : undefined;
+  const chats = await getChats(searchText, { ...options, contacts });
+
+  if (!terms.length || hasActivityFilters) {
+    return buildRecipientSections(chats, [], false).recents.map(mapRecipient).slice(0, limit);
+  }
+
+  const sections = buildRecipientSections(chats, contacts ?? [], false);
+  const matchingContacts = sections.contacts.filter((contact) => fuzzySearch(contact.keywords.join(" "), terms));
+
+  return [...sections.recents, ...matchingContacts].map(mapRecipient).slice(0, limit);
+}

--- a/extensions/messages/src/api/search-message-recipients.ts
+++ b/extensions/messages/src/api/search-message-recipients.ts
@@ -1,6 +1,8 @@
 import { fetchAllContacts } from "swift:../../swift/contacts";
 
+import { persistedCatalogToContacts } from "../contact-catalog-persist";
 import { fuzzySearch } from "../helpers";
+import { createMessagesCache, loadPersistedContactCatalog, savePersistedContactCatalog } from "../messages-cache";
 import { buildRecipientSections, type Recipient } from "../recipient-catalog";
 import type { Contact } from "../types";
 
@@ -12,6 +14,9 @@ type SearchMessageRecipientsOptions = {
   to?: string;
   limit?: number;
 };
+
+const CONTACT_CATALOG_MAX_AGE_MS = 5 * 60 * 1000;
+let pendingContactCatalog: Promise<Contact[]> | undefined;
 
 export type MessageRecipientSearchResult = {
   kind: "chat" | "contact";
@@ -27,6 +32,23 @@ export type MessageRecipientSearchResult = {
 
 function searchTerms(value: string): string[] {
   return value.toLowerCase().split(/\s+/).filter(Boolean);
+}
+
+async function getContactCatalog(): Promise<Contact[]> {
+  const cache = createMessagesCache();
+  const persisted = loadPersistedContactCatalog(cache);
+  if (persisted.updatedAtEpochMs > Date.now() - CONTACT_CATALOG_MAX_AGE_MS) {
+    return persistedCatalogToContacts(persisted);
+  }
+
+  pendingContactCatalog ??= (async () => {
+    const contacts = (await fetchAllContacts()) as Contact[];
+    savePersistedContactCatalog(cache, contacts);
+    return contacts;
+  })().finally(() => {
+    pendingContactCatalog = undefined;
+  });
+  return pendingContactCatalog;
 }
 
 function mapRecipient(recipient: Recipient): MessageRecipientSearchResult {
@@ -50,7 +72,7 @@ export async function searchMessageRecipients(
   const limit = options.limit ?? 50;
   const hasActivityFilters = Boolean(options.unreadOnly || options.from || options.to);
   const terms = searchTerms(searchText);
-  const contacts = terms.length && !hasActivityFilters ? ((await fetchAllContacts()) as Contact[]) : undefined;
+  const contacts = terms.length && !hasActivityFilters ? await getContactCatalog() : undefined;
   const chats = await getChats(searchText, { ...options, contacts });
 
   if (!terms.length || hasActivityFilters) {

--- a/extensions/messages/src/chat-query.ts
+++ b/extensions/messages/src/chat-query.ts
@@ -19,12 +19,16 @@ export type SQLChat = Omit<ChatParticipant, "is_group" | "latest_message_guid" |
 type ChatQueryOptions = {
   filterSpam?: boolean;
   filterUnknownSenders?: boolean;
+  activityFromNanoseconds?: string;
+  activityToNanoseconds?: string;
   limit?: number;
 };
 
 export function buildChatQuery({
   filterSpam = false,
   filterUnknownSenders = false,
+  activityFromNanoseconds,
+  activityToNanoseconds,
   limit = 1000,
 }: ChatQueryOptions = {}) {
   let filters = "";
@@ -36,6 +40,28 @@ export function buildChatQuery({
 
   if (filterUnknownSenders) {
     filterConditions.push(`(chat.is_filtered IS NULL OR chat.is_filtered != ${MessageFilterStatus.UNKNOWN_SENDER})`);
+  }
+
+  if (activityFromNanoseconds || activityToNanoseconds) {
+    const activityConditions = [
+      `activity_chat_message_join.chat_id = chat."ROWID"`,
+      ...(activityFromNanoseconds
+        ? [
+            `COALESCE(NULLIF(activity_chat_message_join.message_date, 0), activity_message.date) >= ${activityFromNanoseconds}`,
+          ]
+        : []),
+      ...(activityToNanoseconds
+        ? [
+            `COALESCE(NULLIF(activity_chat_message_join.message_date, 0), activity_message.date) < ${activityToNanoseconds}`,
+          ]
+        : []),
+    ];
+    filterConditions.push(`EXISTS (
+      SELECT 1
+      FROM chat_message_join activity_chat_message_join
+      JOIN message activity_message ON activity_chat_message_join.message_id = activity_message."ROWID"
+      WHERE ${activityConditions.join("\n        AND ")}
+    )`);
   }
 
   if (filterConditions.length > 0) {

--- a/extensions/messages/src/chat-query.ts
+++ b/extensions/messages/src/chat-query.ts
@@ -13,6 +13,7 @@ export type SQLChat = Omit<ChatParticipant, "is_group" | "latest_message_guid" |
   group_photo_path: string | null;
   last_message_timestamp: number | string | null;
   last_message_date: string;
+  unread_count?: number;
 };
 
 type ChatQueryOptions = {
@@ -71,6 +72,14 @@ export function buildChatQuery({
         )
         ELSE NULL
       END AS group_photo_path,
+      (
+        SELECT COUNT(*)
+        FROM chat_message_join unread_chat_message_join
+        JOIN message unread_message ON unread_chat_message_join.message_id = unread_message.ROWID
+        WHERE unread_chat_message_join.chat_id = chat.ROWID
+          AND unread_message.is_from_me = 0
+          AND unread_message.is_read = 0
+      ) AS unread_count,
       CASE
         WHEN EXISTS(SELECT 1 FROM pragma_table_info('chat') WHERE name='is_filtered')
         THEN chat.is_filtered

--- a/extensions/messages/src/components/Reply.tsx
+++ b/extensions/messages/src/components/Reply.tsx
@@ -22,6 +22,7 @@ export default function Reply({ message, initialReply }: ReplyProps) {
           text: values.reply,
           service_name: message.service,
           group_name: message.group_name,
+          chat_guid: message.chat_guid,
         });
         pop();
       } catch (error) {

--- a/extensions/messages/src/helpers.ts
+++ b/extensions/messages/src/helpers.ts
@@ -3,7 +3,7 @@ import { homedir } from "os";
 import { Icon, Image, Color } from "@raycast/api";
 import { getAvatarIcon, runAppleScript } from "@raycast/utils";
 
-import type { ChatOrMessageInfo, Contact, Message, MessagesTarget } from "./types";
+import type { ChatOrMessageInfo, Contact, Message, MessageAttachment, MessagesTarget } from "./types";
 
 export function buildChatSearchableText(
   chat: { chat_identifier: string; group_participants?: string | null },
@@ -64,11 +64,13 @@ export async function sendMessage({
   text,
   service_name,
   group_name,
+  chat_guid,
 }: {
   address: string;
   text: string;
   service_name: Message["service"] | "auto";
   group_name?: string | null;
+  chat_guid?: string | null;
 }): Promise<string> {
   if (typeof address !== "string" || !address.trim()) {
     return "Error: Invalid recipient address.";
@@ -79,9 +81,23 @@ export async function sendMessage({
   const escapeForAppleScript = (value: string) => value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
   const safeText = escapeForAppleScript(text);
 
-  const scripts = group_name
+  const scripts = chat_guid
     ? [
         `
+    tell application "Messages"
+      try
+        set targetChat to first chat whose id is "${escapeForAppleScript(chat_guid)}"
+        send "${safeText}" to targetChat
+        return "Success"
+      on error errMsg
+        return "Error: " & errMsg
+      end try
+    end tell
+    `,
+      ]
+    : group_name
+      ? [
+          `
     tell application "Messages"
       try
         set targetChat to chat "${escapeForAppleScript(group_name)}"
@@ -92,9 +108,9 @@ export async function sendMessage({
       end try
     end tell
     `,
-      ]
-    : (service_name === "auto" ? (["iMessage", "SMS"] as const) : [service_name]).map(
-        (service) => `
+        ]
+      : (service_name === "auto" ? (["iMessage", "SMS"] as const) : [service_name]).map(
+          (service) => `
     tell application "Messages"
       try
         set targetService to (service 1 whose service type = ${service})
@@ -106,7 +122,7 @@ export async function sendMessage({
       end try
     end tell
     `,
-      );
+        );
 
   let result = "Error: Could not find a Messages service for this recipient.";
   for (const script of scripts) {
@@ -121,12 +137,12 @@ export async function sendMessage({
   return result;
 }
 
-export function decodeHexString(hexString: string): string {
+export function decodeHexString(hexString: string | null | undefined): string {
   const START_PATTERN: number[] = [0x01, 0x2b];
   const END_PATTERN: number[] = [0x86, 0x84];
 
   // Convert hex string to byte array
-  const bytes = hexString.match(/.{1,2}/g)?.map((byte) => parseInt(byte, 16)) || [];
+  const bytes = hexString?.match(/.{1,2}/g)?.map((byte) => parseInt(byte, 16)) || [];
 
   // Find the start index and remove the start pattern
   let startIndex = -1;
@@ -174,6 +190,35 @@ export function decodeHexString(hexString: string): string {
   return result;
 }
 
+export function decodeMessageBody(hexBody: string | null | undefined, plainText?: string | null): string {
+  return decodeHexString(hexBody) || plainText || "";
+}
+
+export function parseMessageAttachments(value: string): MessageAttachment[] {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed.flatMap((attachment): MessageAttachment[] => {
+      if (!attachment || typeof attachment !== "object") return [];
+      const item = attachment as Record<string, unknown>;
+      if (typeof item.id !== "number" && typeof item.id !== "string") return [];
+
+      return [
+        {
+          id: String(item.id),
+          filename: typeof item.filename === "string" ? item.filename : null,
+          name: typeof item.name === "string" ? item.name : null,
+          mimeType: typeof item.mimeType === "string" ? item.mimeType : null,
+          sizeBytes: typeof item.sizeBytes === "number" ? item.sizeBytes : null,
+        },
+      ];
+    });
+  } catch {
+    return [];
+  }
+}
+
 export function getMessagesUrl(chat: MessagesTarget, body?: string): string {
   if (chat.is_group && chat.latest_message_guid && !body) {
     return `sms://open?message-guid=${encodeURIComponent(chat.latest_message_guid)}`;
@@ -209,20 +254,36 @@ export function buildMessagesQuery({
   filterClause = "",
   spamFilters = "",
   chatIdentifierClause = "",
+  chatGuidClause = "",
   beforeClause = "",
+  cursorClause = "",
+  snapshotClause = "",
+  fromClause = "",
+  toClause = "",
   limit = "50",
 }: {
   filterClause?: string;
   spamFilters?: string;
   chatIdentifierClause?: string;
+  chatGuidClause?: string;
   beforeClause?: string;
+  cursorClause?: string;
+  snapshotClause?: string;
+  fromClause?: string;
+  toClause?: string;
   limit?: string;
 }): string {
+  const sortDate = "COALESCE(NULLIF(chat_message_join.message_date, 0), message.date)";
+
   return `
     SELECT
+      message.ROWID AS row_id,
+      chat.ROWID AS chat_row_id,
+      chat.guid AS chat_guid,
       message.guid,
+      CAST(${sortDate} AS TEXT) AS date_nanoseconds,
       strftime('%Y-%m-%dT%H:%M:%fZ', datetime(
-        message.date / 1000000000 + strftime('%s', '2001-01-01'),
+        ${sortDate} / 1000000000 + strftime('%s', '2001-01-01'),
         'unixepoch'
       )) AS date,
       strftime('%Y-%m-%dT%H:%M:%fZ', datetime(
@@ -242,6 +303,7 @@ export function buildMessagesQuery({
       END as group_name,
       message.service,
       hex(message.attributedBody) as body,
+      message.text as plain_text,
       CASE WHEN chat.style = 43 THEN 1 ELSE 0 END as is_group,
       CASE
         WHEN chat.style = 43 THEN GROUP_CONCAT(DISTINCT handle.id)
@@ -250,7 +312,22 @@ export function buildMessagesQuery({
       attachment.filename as attachment_filename,
       attachment.transfer_name as attachment_name,
       attachment.mime_type as attachment_mime_type,
-      hex(replied.attributedBody) as reply_body
+      COALESCE((
+        SELECT json_group_array(json_object(
+          'id', message_attachment.ROWID,
+          'filename', message_attachment.filename,
+          'name', message_attachment.transfer_name,
+          'mimeType', message_attachment.mime_type,
+          'sizeBytes', message_attachment.total_bytes
+        ))
+        FROM message_attachment_join all_message_attachments
+        JOIN attachment message_attachment ON all_message_attachments.attachment_id = message_attachment.ROWID
+        WHERE all_message_attachments.message_id = message.ROWID
+          AND message_attachment.filename IS NOT NULL
+          AND message_attachment.filename NOT LIKE '%.pluginPayloadAttachment'
+      ), '[]') AS attachments_json,
+      hex(replied.attributedBody) as reply_body,
+      replied.text as reply_plain_text
     FROM
       message
       JOIN chat_message_join ON message."ROWID" = chat_message_join.message_id
@@ -261,16 +338,32 @@ export function buildMessagesQuery({
       LEFT JOIN attachment ON message_attachment_join.attachment_id = attachment."ROWID"
       LEFT JOIN message replied ON message.reply_to_guid = replied.guid
     WHERE
-      message.attributedBody IS NOT NULL
-      AND message.associated_message_type = 0
+      (message.attributedBody IS NOT NULL OR message.text IS NOT NULL OR attachment.filename IS NOT NULL)
+      AND (
+        message.associated_message_type IS NULL
+        OR (
+          message.associated_message_type != 1000
+          AND message.associated_message_type NOT BETWEEN 2000 AND 2007
+          AND message.associated_message_type NOT BETWEEN 3000 AND 3007
+          AND message.associated_message_type != 4000
+        )
+      )
       ${filterClause}
       ${spamFilters}
       ${chatIdentifierClause}
+      ${chatGuidClause}
       ${beforeClause}
+      ${cursorClause}
+      ${snapshotClause}
+      ${fromClause}
+      ${toClause}
     GROUP BY
-      message.guid
+      message.ROWID,
+      chat.ROWID
     ORDER BY
-      date DESC
+      ${sortDate} DESC,
+      message.ROWID DESC,
+      chat.ROWID DESC
     LIMIT ${limit}
   `;
 }

--- a/extensions/messages/src/hooks/useMessages.ts
+++ b/extensions/messages/src/hooks/useMessages.ts
@@ -11,10 +11,11 @@ import { createContactMap, mergeContactMaps, mergeContactPhotos, persistedToCont
 import { createDebouncedContactMapPersist, createMessagesCache, loadPersistedContactMap } from "../messages-cache";
 import {
   buildMessagesQuery,
-  decodeHexString,
+  decodeMessageBody,
   fuzzySearch,
   getContactLookupIdentifiers,
   getContactOrGroupInfo,
+  parseMessageAttachments,
 } from "../helpers";
 import type { ChatOrMessageInfo, Contact, Filter, Message, SQLMessage } from "../types";
 
@@ -81,8 +82,8 @@ export function useMessages(searchText?: string, filter?: Filter) {
         return {
           message,
           info,
-          body: decodeHexString(message.body),
-          replyingTo: message.reply_body ? decodeHexString(message.reply_body) : null,
+          body: decodeMessageBody(message.body, message.plain_text),
+          replyingTo: decodeMessageBody(message.reply_body, message.reply_plain_text) || null,
         };
       }),
     [rawData],
@@ -134,6 +135,7 @@ export function useMessages(searchText?: string, filter?: Filter) {
         is_audio_message: Boolean(message.is_audio_message),
         is_sent: Boolean(message.is_sent),
         is_read: message.is_sent ? true : Boolean(message.is_read),
+        attachments: parseMessageAttachments(message.attachments_json),
       };
     })
     .filter((message) => {

--- a/extensions/messages/src/message-pagination.ts
+++ b/extensions/messages/src/message-pagination.ts
@@ -1,0 +1,83 @@
+import { createHash } from "crypto";
+
+const CURSOR_VERSION = 1;
+const CURSOR_TYPE = "message-page";
+
+export type MessageCursorKey = {
+  dateNanoseconds: string;
+  rowID: number;
+  chatRowID: number;
+};
+
+export type MessageCursor = {
+  version: number;
+  type: string;
+  key: MessageCursorKey;
+  snapshotRowID: number;
+  fingerprint: string;
+};
+
+export type MessageQueryScope = {
+  chatGuid?: string;
+  chatIdentifier?: string;
+  from?: string;
+  to?: string;
+  unreadOnly: boolean;
+  searchText?: string;
+};
+
+export function fingerprintMessageQuery(scope: MessageQueryScope): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        chatGuid: scope.chatGuid || null,
+        chatIdentifier: scope.chatIdentifier || null,
+        from: scope.from || null,
+        to: scope.to || null,
+        unreadOnly: scope.unreadOnly,
+        searchText: scope.searchText?.trim().toLowerCase() || null,
+      }),
+    )
+    .digest("base64url");
+}
+
+export function encodeMessageCursor(cursor: Omit<MessageCursor, "version" | "type">): string {
+  return Buffer.from(JSON.stringify({ ...cursor, version: CURSOR_VERSION, type: CURSOR_TYPE })).toString("base64url");
+}
+
+export function decodeMessageCursor(value: string, expectedFingerprint: string): MessageCursor {
+  try {
+    const parsed: unknown = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+    if (!parsed || typeof parsed !== "object") throw new Error();
+
+    const cursor = parsed as Partial<MessageCursor>;
+    const key = cursor.key;
+    if (
+      cursor.version !== CURSOR_VERSION ||
+      cursor.type !== CURSOR_TYPE ||
+      cursor.fingerprint !== expectedFingerprint ||
+      !Number.isInteger(cursor.snapshotRowID) ||
+      Number(cursor.snapshotRowID) < 0 ||
+      !key ||
+      !/^-?\d+$/.test(key.dateNanoseconds) ||
+      !Number.isInteger(key.rowID) ||
+      key.rowID < 0 ||
+      !Number.isInteger(key.chatRowID) ||
+      key.chatRowID < 0
+    ) {
+      throw new Error();
+    }
+    return cursor as MessageCursor;
+  } catch {
+    throw new Error("The pagination cursor is invalid or belongs to a different message search.");
+  }
+}
+
+export function dateToAppleNanoseconds(value: string, fieldName: string): string {
+  const milliseconds = Date.parse(value);
+  if (!Number.isFinite(milliseconds)) {
+    throw new Error(`${fieldName} must be an ISO 8601 date-time.`);
+  }
+
+  return ((BigInt(milliseconds) - 978_307_200_000n) * 1_000_000n).toString();
+}

--- a/extensions/messages/src/recipient-catalog.ts
+++ b/extensions/messages/src/recipient-catalog.ts
@@ -5,25 +5,27 @@ import type { Contact, MessagesTarget } from "./types";
 
 const CONTACT_RECIPIENT_PREFIX = "contact:";
 
-type RecipientBase = MessagesTarget & {
+export type RecipientBase = MessagesTarget & {
   id: string;
   service_name: "iMessage" | "SMS" | "auto";
   group_name: string | null;
   displayName: string;
   avatar?: Image.ImageLike;
   keywords: string[];
+  unread_count?: number;
+  last_message_date?: string | null;
 };
 
-type RecentRecipient = RecipientBase & {
+export type RecentRecipient = RecipientBase & {
   kind: "recent";
 };
 
-type ContactRecipient = RecipientBase & {
+export type ContactRecipient = RecipientBase & {
   kind: "contact";
   imageData: string | null;
 };
 
-type Recipient = RecentRecipient | ContactRecipient;
+export type Recipient = RecentRecipient | ContactRecipient;
 export type RecipientSections = { recents: RecentRecipient[]; contacts: ContactRecipient[] };
 
 function normalizeIdentifier(value: unknown): string | undefined {
@@ -69,6 +71,7 @@ function recentRecipient(chat: Chat): RecentRecipient {
   const recipient = {
     kind: "recent" as const,
     id: chat.guid,
+    chat_guid: chat.guid,
     chat_identifier: chat.chat_identifier,
     service_name: chat.service_name,
     group_name: chat.group_name,
@@ -77,6 +80,8 @@ function recentRecipient(chat: Chat): RecentRecipient {
     is_group: chat.is_group,
     displayName: chat.displayName,
     avatar: chat.avatar,
+    unread_count: chat.unread_count,
+    last_message_date: chat.last_message_date,
   };
   return { ...recipient, keywords: recipientKeywords(recipient, chat.phoneNumber ? [chat.phoneNumber] : []) };
 }
@@ -86,6 +91,7 @@ function contactRecipient(contact: Contact, destination: string, loadContactPhot
   const recipient = {
     kind: "contact" as const,
     id: `${CONTACT_RECIPIENT_PREFIX}${contact.id}`,
+    chat_guid: null,
     chat_identifier: destination,
     service_name: destination.includes("@") ? ("iMessage" as const) : ("auto" as const),
     group_name: null,

--- a/extensions/messages/src/send-message.tsx
+++ b/extensions/messages/src/send-message.tsx
@@ -56,6 +56,7 @@ export default function Command({
         text: values.text,
         service_name: recipient.service_name,
         group_name: recipient.group_name,
+        chat_guid: recipient.chat_guid,
       });
       if (result !== "Success") {
         await showToast({ style: Toast.Style.Failure, title: "Could not send message", message: result });

--- a/extensions/messages/src/tools/count-message-activity.ts
+++ b/extensions/messages/src/tools/count-message-activity.ts
@@ -1,0 +1,39 @@
+import { getMessageActivity } from "../api/get-message-activity";
+
+type Input = {
+  /** Include activity at or after this ISO 8601 date-time. */
+  from?: string;
+  /** Include activity before this ISO 8601 date-time. */
+  to?: string;
+  /** Calendar grouping for counts. Weeks use the local calendar and begin Monday. */
+  interval?: "total" | "day" | "week" | "month" | "year";
+  /** Optional comma-separated stable chat GUIDs returned by search-chats. */
+  chatGuids?: string;
+  /** Include only direct or group chats. */
+  chatType?: "direct" | "group";
+  /** Return combined activity or a ranked page of chats. */
+  breakdown?: "overall" | "chat";
+  /** Rank chat results by total, sent, or received count. */
+  rankBy?: "total" | "sent" | "received";
+  /** Maximum chat rows per page, from 1 to 100. */
+  limit?: number;
+  /** Opaque nextCursor returned by the previous chat-breakdown call. */
+  cursor?: string;
+};
+
+export default async function (input: Input) {
+  try {
+    return await getMessageActivity({
+      ...input,
+      chatGuids: input.chatGuids
+        ?.split(",")
+        .map((value) => value.trim())
+        .filter(Boolean),
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("database")) {
+      return "Cannot access the Messages database. Grant Raycast Full Disk Access in System Settings → Privacy & Security → Full Disk Access.";
+    }
+    throw error;
+  }
+}

--- a/extensions/messages/src/tools/search-chats.ts
+++ b/extensions/messages/src/tools/search-chats.ts
@@ -1,26 +1,42 @@
-import { getChats } from "../api/get-chats";
+import { searchMessageRecipients } from "../api/search-message-recipients";
 
 type Input = {
   /**
-   * The search term to search for in the contacts list. To optimize your chances of getting results, you can include more terms by separating them with spaces.
+   * Optional contact name, group name, phone number, or email address. Searches Contacts as well as existing chats.
+   * Omit it to return recent chats.
    */
-  searchTerm: string;
+  searchTerm?: string;
+  /** Only return chats with unread messages. */
+  unreadOnly?: boolean;
+  /** Only return chats active at or after this ISO 8601 date-time. */
+  from?: string;
+  /** Only return chats active before this ISO 8601 date-time. */
+  to?: string;
+  /** Maximum number of chats to return, from 1 to 100. */
+  limit?: number;
 };
 
 export default async function (input: Input) {
   try {
-    const contacts = await getChats(input.searchTerm);
+    const recipients = await searchMessageRecipients(input.searchTerm, {
+      unreadOnly: input.unreadOnly,
+      from: input.from,
+      to: input.to,
+      limit: input.limit,
+    });
 
-    if (contacts.length === 0) {
-      return "No contacts were found.";
+    if (recipients.length === 0) {
+      return "No matching chats or contacts were found.";
     }
 
-    return contacts;
+    return {
+      recipients,
+    };
   } catch (error) {
     if (error instanceof Error && error.message.includes("database")) {
       return "The user can't access the chat database";
     }
 
-    return "An error occurred while searching for chats";
+    return `Could not search chats: ${error instanceof Error ? error.message : "Unknown error"}`;
   }
 }

--- a/extensions/messages/src/tools/search-latest-messages.ts
+++ b/extensions/messages/src/tools/search-latest-messages.ts
@@ -1,8 +1,8 @@
-import { getMessages } from "../api/get-messages";
+import { getMessagePage } from "../api/get-message-page";
 
 type Input = {
   /**
-   * Optional text to filter messages by. Matches against message text, sender name, and group name.
+   * Optional text to filter messages by. Matches message text, sender, group, and attachment metadata.
    * Leave empty to fetch the most recent messages without filtering.
    */
   searchText?: string;
@@ -13,40 +13,58 @@ type Input = {
    */
   chatIdentifier?: string;
   /**
-   * ISO 8601 cursor for pagination. To load older messages, pass the `date` of
-   * the first (oldest) message in the previous response — that is, the message at index 0,
-   * since results are returned oldest-first.
-   * Example: "2025-01-23T09:00:00.000Z"
+   * Stable chat GUID from search-chats. Prefer this over chatIdentifier when available.
    */
-  before?: string;
+  chatGuid?: string;
+  /** Opaque nextCursor returned by the previous call with the same filters. */
+  cursor?: string;
+  /** Include messages at or after this ISO 8601 date-time. */
+  from?: string;
+  /** Include messages before this ISO 8601 date-time. */
+  to?: string;
+  /** Only return unread incoming messages. */
+  unreadOnly?: boolean;
+  /** Maximum messages to return, from 1 to 100. */
+  limit?: number;
 };
 
 /**
- * Fetches up to 50 messages from iMessage/SMS, returned in chronological order (oldest first, newest last).
- * Tapbacks and reactions are excluded. Reply context is included when available.
- * Use `before` for cursor-based pagination to load older messages.
+ * Fetches a stable page of iMessage/SMS messages in chronological order.
+ * Tapbacks and reactions are excluded. Reply context and attachment metadata are included.
  */
 export default async function (input: Input) {
   try {
-    const messages = await getMessages(input.searchText, input.chatIdentifier, input.before);
+    const page = await getMessagePage(input);
 
-    if (messages.length === 0) {
+    if (page.messages.length === 0) {
       return "No messages were found.";
     }
 
-    // Return a compact AI-oriented format, oldest-first (already reversed in get-messages)
-    return messages.map((m) => ({
-      sender: m.is_from_me ? "You" : m.senderName,
-      date: m.date,
-      text: m.body,
-      ...(m.group_name ? { group: m.group_name } : {}),
-      ...(m.replyingTo ? { replyingTo: m.replyingTo } : {}),
-    }));
+    return {
+      messages: page.messages.map((message) => ({
+        sender: message.is_from_me ? "You" : message.senderName,
+        date: message.date,
+        text: message.body,
+        ...(message.group_name ? { group: message.group_name } : {}),
+        ...(message.replyingTo ? { replyingTo: message.replyingTo } : {}),
+        ...(message.attachments.length
+          ? {
+              attachments: message.attachments.map((attachment) => ({
+                name: attachment.name,
+                mimeType: attachment.mimeType,
+                sizeBytes: attachment.sizeBytes,
+              })),
+            }
+          : {}),
+      })),
+      ...(page.nextCursor ? { nextCursor: page.nextCursor } : {}),
+      scannedMessageCount: page.scannedMessageCount,
+    };
   } catch (error) {
     if (error instanceof Error && error.message.includes("database")) {
       return "Cannot access iMessage database. Please grant Full Disk Access to Raycast in System Settings → Privacy & Security → Full Disk Access.";
     }
 
-    return "An error occurred while searching for messages";
+    return `Could not search messages: ${error instanceof Error ? error.message : "Unknown error"}`;
   }
 }

--- a/extensions/messages/src/tools/search-latest-messages.ts
+++ b/extensions/messages/src/tools/search-latest-messages.ts
@@ -37,6 +37,14 @@ export default async function (input: Input) {
     const page = await getMessagePage(input);
 
     if (page.messages.length === 0) {
+      if (page.nextCursor) {
+        return {
+          messages: [],
+          nextCursor: page.nextCursor,
+          scannedMessageCount: page.scannedMessageCount,
+        };
+      }
+
       return "No messages were found.";
     }
 

--- a/extensions/messages/src/tools/send-message.ts
+++ b/extensions/messages/src/tools/send-message.ts
@@ -4,9 +4,13 @@ import { sendMessage } from "../helpers";
 
 type Input = {
   /**
-   * The chat identifier of the contact or the group chat identifier
+   * Stable chat GUID returned by search-chats. Prefer this for existing chats, especially groups.
    */
-  chat_identifier: string;
+  chat_guid?: string;
+  /**
+   * Contact phone number/email or legacy chat identifier. Required when chat_guid is unavailable.
+   */
+  chat_identifier?: string;
   /**
    * The display name of the contact or the group chat name
    */
@@ -22,7 +26,7 @@ type Input = {
   /**
    * The service name of the message
    */
-  service_name: "iMessage" | "SMS";
+  service_name: "iMessage" | "SMS" | "auto";
   /**
    * The text of the message
    */
@@ -30,12 +34,18 @@ type Input = {
 };
 
 export default async function (input: Input) {
-  await sendMessage({
-    address: input.chat_identifier,
+  if (!input.chat_guid && !input.chat_identifier) {
+    throw new Error("A chat_guid or chat_identifier is required.");
+  }
+
+  const result = await sendMessage({
+    address: input.chat_identifier ?? input.chat_guid ?? "",
     text: input.text,
     service_name: input.service_name,
     group_name: input.group_name,
+    chat_guid: input.chat_guid,
   });
+  if (result !== "Success") throw new Error(result.replace(/^Error:\s*/, ""));
   return "Message sent";
 }
 
@@ -47,6 +57,12 @@ export const confirmation: Tool.Confirmation<Input> = async (input) => {
 
   if (input.phoneNumber) {
     info.push({ name: "Phone Number", value: input.phoneNumber });
+  }
+
+  if (input.chat_guid) {
+    info.push({ name: "Chat", value: input.chat_guid });
+  } else if (input.chat_identifier) {
+    info.push({ name: "Recipient", value: input.chat_identifier });
   }
 
   return { info };

--- a/extensions/messages/src/types.ts
+++ b/extensions/messages/src/types.ts
@@ -18,7 +18,9 @@ export type ChatParticipant = {
 export type MessagesTarget = Pick<
   ChatParticipant,
   "chat_identifier" | "group_participants" | "is_group" | "latest_message_guid"
->;
+> & {
+  chat_guid?: string | null;
+};
 
 export type ChatOrMessageInfo = {
   chat_identifier: string;
@@ -41,10 +43,15 @@ export type Contact = {
 };
 
 export type SQLMessage = ChatParticipant & {
+  row_id: number;
+  chat_row_id: number;
+  chat_guid: string;
   guid: string;
+  date_nanoseconds: string;
   date: string;
   date_read: string | null;
   body: string;
+  plain_text: string | null;
   service: "iMessage" | "SMS";
   is_audio_message: boolean;
   is_from_me: boolean;
@@ -53,12 +60,23 @@ export type SQLMessage = ChatParticipant & {
   attachment_filename: string | null;
   attachment_name: string | null;
   attachment_mime_type: string | null;
+  attachments_json: string;
   reply_body: string | null;
+  reply_plain_text: string | null;
+};
+
+export type MessageAttachment = {
+  id: string;
+  filename: string | null;
+  name: string | null;
+  mimeType: string | null;
+  sizeBytes: number | null;
 };
 
 export type Message = SQLMessage & {
   avatar?: Image.ImageLike;
   sender: string;
   senderName: string;
+  attachments: MessageAttachment[];
   replyingTo?: string | null;
 };


### PR DESCRIPTION
## Description

Enhances the Messages extension's AI tools so they can search and analyze message history reliably, resolve recipients beyond recent chats, and send to stable existing-chat identifiers.

### What changed

- Add stable cursor pagination for message history, including continuation through bounded pages with no text matches.
- Add date, unread, chat, and text filters; attachment metadata; plain-text fallbacks; and reply context to AI message search.
- Add `count-message-activity` for overall and per-chat sent/received totals.
- Filter chat date ranges by messages within the requested period, rather than by each chat's latest message date.
- Search the full Contacts catalog for named recipients without recent chats, with a five-minute persisted cache and on-demand identifier hydration.
- Use stable chat GUIDs when sending to existing conversations and surface AppleScript send failures.
- Deduplicate reply context without mutating hydrated message objects.

### Database and query behavior

- Date ranges are half-open (`from` inclusive, `to` exclusive) and compare Apple-epoch nanosecond message timestamps.
- Chat activity filtering uses `chat_message_join` and `message`, so a chat is included when any message falls in the range even if it has newer activity.
- Message pagination uses a stable composite cursor and a snapshot row ID to avoid timestamp-only pagination gaps or duplicates.
- Text searches remain bounded and return a continuation cursor when older history may still contain matches.

### Validation and test scenarios

- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- Verified with a synthetic Messages database that a chat with an in-range historical message and a newer latest message is included, while a chat with no in-range activity is excluded.
- Verified reply-context deduplication returns mapped copies and preserves its inputs.
- Covered empty intermediate text-search pages by preserving `nextCursor` and scan metadata.
- `npx ray evals` was attempted; the current suite still requires updated namespaced tool mocks before it can produce meaningful scores.

## Screencast

Not applicable — this PR changes AI tools and backend query behavior without adding or changing command UI.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
  - `npm run build` passes; a manual distribution test in Raycast remains.
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
