### PR TITLE
Update kobbe extension: hide stale live visitors count on refresh error

### DIFF
--- a/extensions/kobbe/CHANGELOG.md
+++ b/extensions/kobbe/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Kobbe Changelog
 
+## [Fix Stale Live Count] - {PR_MERGE_DATE}
+
+- Hide the menu bar visitor count while a refresh has failed, instead of presenting the previous total as current.
+
 ## [Live Visitors and New Commands] - 2026-08-29
 
 - Add Live Visitors menu bar command showing who is online right now across your sites.

--- a/extensions/kobbe/CHANGELOG.md
+++ b/extensions/kobbe/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Kobbe Changelog
 
-## [Fix Stale Live Count] - {PR_MERGE_DATE}
+## [Fix Stale Live Count] - 2026-08-29
 
 - Hide the menu bar visitor count while a refresh has failed, instead of presenting the previous total as current.
 

--- a/extensions/kobbe/src/live-visitors.tsx
+++ b/extensions/kobbe/src/live-visitors.tsx
@@ -12,7 +12,7 @@ export default function LiveVisitors() {
   return (
     <MenuBarExtra
       icon={Icon.Livestream}
-      title={total != null ? `${total}${hasPartialFailures ? "+" : ""}` : undefined}
+      title={!live.error && total != null ? `${total}${hasPartialFailures ? "+" : ""}` : undefined}
       tooltip="Kobbe live visitors"
       isLoading={live.isLoading}
     >


### PR DESCRIPTION
## Description

Follow-up to #30621, addressing the post-merge review comment on `live-visitors.tsx`: with `keepPreviousData`, a failed background refresh kept showing the previous total in the menu bar as if it were current, while the dropdown reported the error. The count is now hidden while the command is in an error state, so a number in the menu bar always reflects a successful fetch.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder

Made with [Cursor](https://cursor.com)