### PR TITLE
fix(virustotal): accept scheme-less URL input

### DIFF
--- a/extensions/virustotal/CHANGELOG.md
+++ b/extensions/virustotal/CHANGELOG.md
@@ -1,5 +1,9 @@
 # VirusTotal Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Fixed URL input without a scheme (e.g. `google.com`, `google.com/path`) being rejected as invalid; it's now accepted and submitted to VirusTotal unmodified
+
 ## [Add IP Address Support] - 2026-01-12
 
 - Added support for IP address analysis (IPv4 and IPv6)

--- a/extensions/virustotal/CHANGELOG.md
+++ b/extensions/virustotal/CHANGELOG.md
@@ -1,6 +1,6 @@
 # VirusTotal Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-08-30
 
 - Fixed URL input without a scheme (e.g. `google.com`, `google.com/path`) being rejected as invalid; it's now accepted and submitted to VirusTotal unmodified
 

--- a/extensions/virustotal/src/check.ts
+++ b/extensions/virustotal/src/check.ts
@@ -228,13 +228,21 @@ export default async function Command(props: LaunchProps<{ arguments: Arguments 
     // Check if input looks like a hash or URL
     const isHash = /^[a-fA-F0-9]{32,64}$/.test(input);
 
-    // Basic URL validation to avoid malformed URLs
+    // Basic URL validation to avoid malformed URLs. Bare domains (e.g. "google.com") have no
+    // scheme and fail the URL constructor, so we also accept them by checking with an
+    // "https://" prefix - but we submit the original, unmodified input to VirusTotal, since
+    // VirusTotal scores a bare domain and its "https://" URL as distinct resources.
     const isValidUrl = (urlString: string): boolean => {
       try {
         new URL(urlString);
         return true;
       } catch {
-        return false;
+        try {
+          new URL(`https://${urlString}`);
+          return true;
+        } catch {
+          return false;
+        }
       }
     };
 


### PR DESCRIPTION
## Description

URL input without a scheme (e.g. `evil.com`, `evil.com/path`) was rejected with "Invalid input format" because `new URL()` requires a scheme, and only a scheme-qualified string (`https://evil.com`) would parse successfully.

The fix accepts scheme-less input by also checking it with an `https://` prefix, but **submits the original, unmodified input** to VirusTotal's `/urls` endpoint. It intentionally does not rewrite the input to add a scheme.

**Why:** VirusTotal's canonicalization only normalizes "minor aspects, like some escaped characters" — it does not insert a missing scheme. Since the URL identifier (`url_id`) is derived from the submitted string, `google.com` and `https://google.com` resolve to different IDs and are tracked as separate resources with independent detection stats and submission history. Silently rewriting user input to add `https://` would have shown a report for a different resource than what the user actually typed.

**Sources:**
- https://docs.virustotal.com/reference/url
- https://docs.virustotal.com/reference/domains-object


## Screencast
N/A - bug fix to existing validation logic in an existing command, no new extension/command added.

## Checklist
- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the README are located outside the metadata folder