### PR TITLE
Update downloads-manager extension

### DIFF
--- a/extensions/downloads-manager/CHANGELOG.md
+++ b/extensions/downloads-manager/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Downloads Manager Changelog
 
-## [Add toggle to show filename being deleted permanently] - {PR_MERGE_DATE}
+## [Add toggle to show filename being deleted permanently] - 2026-08-30
 
 - Added a toggle to the preference to show/hide the latest downloaded file being permanently deleted.
 

--- a/extensions/downloads-manager/CHANGELOG.md
+++ b/extensions/downloads-manager/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Downloads Manager Changelog
 
+## [Add toggle to show filename being deleted permanently] - {PR_MERGE_DATE}
+
+- Added a toggle to the preference to show/hide the latest downloaded file being permanently deleted.
+
 ## [Fix download management reliability] - 2026-08-25
 
 - Fixed moving downloads to Trash on macOS when the Downloads folder is backed by iCloud Drive, including keeping the list accurate when only some selected items move successfully ([#29951](https://github.com/raycast/extensions/issues/29951), [#30503](https://github.com/raycast/extensions/issues/30503)).

--- a/extensions/downloads-manager/package.json
+++ b/extensions/downloads-manager/package.json
@@ -181,6 +181,15 @@
           "value": "permaDel"
         }
       ]
+    },
+    {
+      "type": "checkbox",
+      "name": "showDeletingFilename",
+      "label": "Show Deleting Filename",
+      "title": "Show Deleting Filename",
+      "description": "Whether to show the filename being permanently deleted in the confirmation message",
+      "required": false,
+      "default": true
     }
   ],
   "tools": [

--- a/extensions/downloads-manager/src/delete-latest-download.tsx
+++ b/extensions/downloads-manager/src/delete-latest-download.tsx
@@ -4,6 +4,7 @@ import {
   deleteFileOrFolder,
   getDeletionBehavior,
   getPermanentDeleteConfirmationChoice,
+  getShowDeletingFilenameBehavior,
 } from "./utils";
 import { closeMainWindow, environment, LaunchType, PopToRootType, showHUD } from "@raycast/api";
 import { showFailureToast } from "@raycast/utils";
@@ -30,6 +31,8 @@ export default async function main() {
 
   const deletionBehavior = await getDeletionBehavior();
   const permanentDeleteChoice = isBackgroundLaunch ? await getPermanentDeleteConfirmationChoice() : undefined;
+  const showDeletingFilenameBehavior = await getShowDeletingFilenameBehavior();
+  const deletionFilenameText = showDeletingFilenameBehavior ? `:\n${latestDownload.path}?\n` : " the latest download? ";
 
   if (isBackgroundLaunch && deletionBehavior !== "trash" && permanentDeleteChoice !== "delete") {
     return;
@@ -37,8 +40,7 @@ export default async function main() {
 
   try {
     await deleteFileOrFolder(latestDownload.path, {
-      confirmationMessage:
-        "Are you sure you want to permanently delete the latest download? This action cannot be undone.",
+      confirmationMessage: `Are you sure you want to permanently delete${deletionFilenameText}This action cannot be undone.`,
       deletionBehavior,
       feedback: isBackgroundLaunch ? "none" : "hud",
       skipConfirmation: isBackgroundLaunch && permanentDeleteChoice === "delete",

--- a/extensions/downloads-manager/src/utils.tsx
+++ b/extensions/downloads-manager/src/utils.tsx
@@ -406,6 +406,10 @@ export async function getDeletionBehavior(): Promise<DeletionBehavior> {
   return preferences.deletionBehavior as DeletionBehavior;
 }
 
+export async function getShowDeletingFilenameBehavior(): Promise<boolean> {
+  return preferences.showDeletingFilename;
+}
+
 export async function toggleDeletionBehavior() {
   const currentDeletionBehavior = await getDeletionBehavior();
   const nextDeletionBehavior = currentDeletionBehavior === "trash" ? "permaDel" : "trash";


### PR DESCRIPTION
## Description

Added a toggle to show the filename of the latest downloaded file in the confirmation dialog box for permanent deletion.

## Screencast

<img width="262" height="263" alt="image" src="https://github.com/user-attachments/assets/f3a12b57-57ab-4cd4-9aa5-f0019ba3498e" />
<img width="536" height="240" alt="image" src="https://github.com/user-attachments/assets/a7314a0c-8b3c-48ff-b956-fd46ec7f3395" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
