### PR TITLE
Add Windows support to Proton Pass

### DIFF
--- a/extensions/proton-pass/CHANGELOG.md
+++ b/extensions/proton-pass/CHANGELOG.md
@@ -1,5 +1,11 @@
 # proton-pass Changelog
 
+## [Windows Support] - {PR_MERGE_DATE}
+
+- Add macOS and Windows x86_64 support with Proton Pass CLI 2.3.3
+- Stream secure browser login URLs and use platform-native keyboard shortcuts
+- Update passphrase generation for Proton Pass CLI 2.x
+
 ## [Improvements] - 2026-05-01
 
 - Fix: Search Items command could show results from only one vault when "All Vaults" was selected (vault share_id now used as fallback during item normalization)

--- a/extensions/proton-pass/CHANGELOG.md
+++ b/extensions/proton-pass/CHANGELOG.md
@@ -1,6 +1,6 @@
 # proton-pass Changelog
 
-## [Windows Support] - {PR_MERGE_DATE}
+## [Windows Support] - 2026-08-30
 
 - Add macOS and Windows x86_64 support with Proton Pass CLI 2.3.3
 - Stream secure browser login URLs and use platform-native keyboard shortcuts

--- a/extensions/proton-pass/README.md
+++ b/extensions/proton-pass/README.md
@@ -15,7 +15,7 @@ This extension requires the Proton Pass CLI (`pass-cli`) to be authenticated.
 
 The extension automatically downloads and installs the Proton Pass CLI on first use. No manual installation required!
 
-If you prefer to install manually, you can use Homebrew:
+If you prefer to install manually on macOS, you can use Homebrew:
 
 ```bash
 brew install protonmail/proton/pass-cli
@@ -68,6 +68,14 @@ export PROTON_PASS_KEY_PROVIDER=fs
 pass-cli login
 ```
 
+On Windows, if session persistence through Windows Credential Manager reports a `keyring_error`, retry from PowerShell:
+
+```powershell
+pass-cli logout --force
+$env:PROTON_PASS_KEY_PROVIDER = "fs"
+pass-cli login
+```
+
 ### CLI Not Found
 
 If the CLI is installed but not detected, set the full path in extension preferences:
@@ -79,3 +87,21 @@ If the CLI is installed but not detected, set the full path in extension prefere
 ### Re-download CLI
 
 If the auto-installed CLI becomes corrupted or you want to force a re-download, use the "Clear CLI Cache" action available in the error screens.
+
+## Platform Verification
+
+Run on Windows x86_64 from this extension directory:
+
+```powershell
+npm ci; if ($LASTEXITCODE) { exit $LASTEXITCODE }; npm test; if ($LASTEXITCODE) { exit $LASTEXITCODE }; npx tsc --noEmit
+```
+
+Then verify a fresh automatic install keeps `pass-cli.exe` beside `libcrypto-3-x64.dll`, browser login persists through Windows Credential Manager (or shows the documented `keyring_error` guidance), search/copy/TOTP work, shortcuts display Ctrl-based keys, and Browser Extension plus Terminal fallback actions stay absent.
+
+Run on macOS:
+
+```bash
+npm ci && npm test && npm run lint && npm run build
+```
+
+Then verify a fresh install passes Gatekeeper after chmod/quarantine removal, browser re-login works with CLI 2.3.3, and all commands complete a smoke test. Sessions from CLI 1.4.1 may require login again.

--- a/extensions/proton-pass/package.json
+++ b/extensions/proton-pass/package.json
@@ -9,7 +9,8 @@
     "FeernandoOFF"
   ],
   "platforms": [
-    "macOS"
+    "macOS",
+    "Windows"
   ],
   "categories": [
     "Security",
@@ -133,7 +134,7 @@
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
-    "test": "rm -rf .test-build && tsc -p tsconfig.test.json && node --test .test-build/src/lib/pass-cli-normalize.test.js",
+    "test": "node -e \"require('node:fs').rmSync('.test-build',{recursive:true,force:true})\" && tsc -p tsconfig.test.json && node -e \"const{readdirSync}=require('node:fs'),{join}=require('node:path'),{spawnSync}=require('node:child_process');const tests=readdirSync('.test-build',{recursive:true}).filter(f=>f.endsWith('.test.js')).map(f=>join('.test-build',f));process.exit(spawnSync(process.execPath,['--test',...tests],{stdio:'inherit'}).status??1)\"",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
   }

--- a/extensions/proton-pass/src/generate-password.tsx
+++ b/extensions/proton-pass/src/generate-password.tsx
@@ -1,9 +1,20 @@
-import { List, ActionPanel, Action, Icon, showToast, Toast, Clipboard, getPreferenceValues } from "@raycast/api";
+import {
+  List,
+  ActionPanel,
+  Action,
+  Icon,
+  showToast,
+  Toast,
+  Clipboard,
+  getPreferenceValues,
+  Keyboard,
+} from "@raycast/api";
 import { useState, useEffect, useCallback, useRef } from "react";
 import { generatePassword, passwordScore } from "./lib/pass-cli";
 import { PasswordScore, PassCliError, PassCliErrorType, PasswordType } from "./lib/types";
 import { getPasswordStrengthLabel, getPasswordStrengthIcon, maskPassword } from "./lib/utils";
 import { renderErrorView } from "./lib/error-views";
+import { platformShortcut } from "./lib/shortcuts";
 
 const MIN_RANDOM_LENGTH = 8;
 const MAX_RANDOM_LENGTH = 128;
@@ -11,7 +22,15 @@ const MIN_PASSPHRASE_WORDS = 3;
 const MAX_PASSPHRASE_WORDS = 10;
 const DEFAULT_RANDOM_LENGTH = 20;
 const DEFAULT_PASSPHRASE_WORDS = 4;
-const PASSPHRASE_SEPARATORS = ["-", "_", ".", " "] as const;
+const PASSPHRASE_SEPARATORS = [
+  "hyphens",
+  "spaces",
+  "periods",
+  "commas",
+  "underscores",
+  "numbers",
+  "numbers-and-symbols",
+] as const;
 
 type PassphraseSeparator = (typeof PASSPHRASE_SEPARATORS)[number];
 
@@ -44,7 +63,7 @@ function getInitialSettings(preferences: Preferences.GeneratePassword): Generato
     includeNumbers: true,
     includeUppercase: true,
     includeSymbols: true,
-    separator: "-",
+    separator: "hyphens",
     capitalize: true,
   };
 }
@@ -63,7 +82,7 @@ function areSettingsEqual(a: GeneratorSettings, b: GeneratorSettings): boolean {
 }
 
 function getSeparatorLabel(separator: PassphraseSeparator): string {
-  return separator === " " ? "space" : separator;
+  return separator.replaceAll("-", " ");
 }
 
 function getSettingsSummary(settings: GeneratorSettings): string {
@@ -183,25 +202,25 @@ export default function Command() {
         title="Copy Password"
         icon={Icon.Clipboard}
         onAction={copyPassword}
-        shortcut={{ modifiers: ["cmd"], key: "c" }}
+        shortcut={Keyboard.Shortcut.Common.Copy}
       />
       <Action
         title="Copy and Generate Next"
         icon={Icon.ArrowClockwise}
         onAction={copyAndGenerate}
-        shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+        shortcut={platformShortcut(["cmd", "shift"], "c")}
       />
       <Action
         title="Generate New Password"
         icon={Icon.Shuffle}
         onAction={() => generate(settings)}
-        shortcut={{ modifiers: ["cmd"], key: "r" }}
+        shortcut={Keyboard.Shortcut.Common.Refresh}
       />
       <Action
         title={showPassword ? "Hide Password" : "Show Password"}
         icon={showPassword ? Icon.EyeDisabled : Icon.Eye}
         onAction={() => setShowPassword(!showPassword)}
-        shortcut={{ modifiers: ["cmd"], key: "y" }}
+        shortcut={platformShortcut(["cmd"], "y")}
       />
       <Action
         title={settings.type === "random" ? "Switch to Passphrase" : "Switch to Random Password"}
@@ -212,7 +231,7 @@ export default function Command() {
             type: previous.type === "random" ? "passphrase" : "random",
           }))
         }
-        shortcut={{ modifiers: ["cmd"], key: "t" }}
+        shortcut={platformShortcut(["cmd"], "t")}
       />
 
       {settings.type === "random" ? (

--- a/extensions/proton-pass/src/get-totp.tsx
+++ b/extensions/proton-pass/src/get-totp.tsx
@@ -1,4 +1,15 @@
-import { List, ActionPanel, Action, Icon, showToast, Toast, Clipboard, Color, getPreferenceValues } from "@raycast/api";
+import {
+  List,
+  ActionPanel,
+  Action,
+  Icon,
+  showToast,
+  Toast,
+  Clipboard,
+  Color,
+  getPreferenceValues,
+  Keyboard,
+} from "@raycast/api";
 import { useState, useEffect, useRef } from "react";
 import { listItems, getTotp, checkAuth } from "./lib/pass-cli";
 import { Item, PassCliError, PassCliErrorType } from "./lib/types";
@@ -182,7 +193,7 @@ export default function Command() {
                 <Action
                   title="Refresh Codes"
                   icon={Icon.ArrowClockwise}
-                  shortcut={{ modifiers: ["cmd"], key: "r" }}
+                  shortcut={Keyboard.Shortcut.Common.Refresh}
                   onAction={refreshTotpCodes}
                 />
               </ActionPanel>

--- a/extensions/proton-pass/src/lib/cli.ts
+++ b/extensions/proton-pass/src/lib/cli.ts
@@ -5,6 +5,8 @@ import path from "node:path";
 import { PASS_CLI_VERSION, resolveArtifact } from "./core/artifact";
 import { installArtifact } from "./core/installer";
 
+let installPromise: Promise<string> | undefined;
+
 export function passCliDirectory(): string {
   return path.join(environment.supportPath, "cli", PASS_CLI_VERSION);
 }
@@ -19,14 +21,7 @@ export function isCliInstalled(): boolean {
   return artifact.requiredFiles.every((file) => fs.existsSync(path.join(passCliDirectory(), file)));
 }
 
-export async function ensureCli(): Promise<string> {
-  const artifact = resolveArtifact(process.platform, process.arch);
-  const cli = path.join(passCliDirectory(), artifact.binaryName);
-  if (isCliInstalled()) {
-    console.log("pass-cli already installed at:", cli);
-    return cli;
-  }
-
+async function installCli(artifact: ReturnType<typeof resolveArtifact>): Promise<string> {
   const installToast = await showToast({
     style: Toast.Style.Animated,
     title: "Installing Proton Pass CLI",
@@ -57,6 +52,23 @@ export async function ensureCli(): Promise<string> {
     installToast.title = "Failed to Install Proton Pass CLI";
     installToast.message = error instanceof Error ? error.message : String(error);
     throw new Error(`Could not install pass-cli: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+export async function ensureCli(): Promise<string> {
+  const artifact = resolveArtifact(process.platform, process.arch);
+  const cli = path.join(passCliDirectory(), artifact.binaryName);
+  if (isCliInstalled()) {
+    console.log("pass-cli already installed at:", cli);
+    return cli;
+  }
+
+  const currentInstall = installPromise ?? installCli(artifact);
+  installPromise = currentInstall;
+  try {
+    return await currentInstall;
+  } finally {
+    if (installPromise === currentInstall) installPromise = undefined;
   }
 }
 

--- a/extensions/proton-pass/src/lib/cli.ts
+++ b/extensions/proton-pass/src/lib/cli.ts
@@ -1,54 +1,28 @@
 import { environment, showToast, Toast } from "@raycast/api";
-import path from "path";
-import fs from "fs";
-import afs from "fs/promises";
-import { createHash } from "crypto";
-import { createReadStream } from "fs";
-import { execFile } from "child_process";
-import { promisify } from "util";
-
-const execFileAsync = promisify(execFile);
-
-const CLI_VERSION = "1.4.1";
-
-interface CliPlatformInfo {
-  filename: string;
-  sha256: string;
-}
-
-const CLI_PLATFORMS: Record<string, CliPlatformInfo> = {
-  "darwin-arm64": {
-    filename: "pass-cli-macos-aarch64",
-    sha256: "7019050f490d8289c045eca39a6abf3fd480f6bcc3fa7807831241b4ec13d7f1",
-  },
-  "darwin-x64": {
-    filename: "pass-cli-macos-x86_64",
-    sha256: "ceffa547d14af8ea5acf0963f11ef0d60ee0bd37fd7ed34a4c70ef86d82ad035",
-  },
-};
-
-function getPlatformKey(): string {
-  const platform = process.platform;
-  const arch = process.arch;
-  return `${platform}-${arch}`;
-}
+import fs from "node:fs";
+import afs from "node:fs/promises";
+import path from "node:path";
+import { PASS_CLI_VERSION, resolveArtifact } from "./core/artifact";
+import { installArtifact } from "./core/installer";
 
 export function passCliDirectory(): string {
-  return path.join(environment.supportPath, "cli");
+  return path.join(environment.supportPath, "cli", PASS_CLI_VERSION);
 }
 
 export function passCliFilepath(): string {
-  return path.join(passCliDirectory(), "pass-cli");
+  const artifact = resolveArtifact(process.platform, process.arch);
+  return path.join(passCliDirectory(), artifact.binaryName);
 }
 
 export function isCliInstalled(): boolean {
-  return fs.existsSync(passCliFilepath());
+  const artifact = resolveArtifact(process.platform, process.arch);
+  return artifact.requiredFiles.every((file) => fs.existsSync(path.join(passCliDirectory(), file)));
 }
 
 export async function ensureCli(): Promise<string> {
-  const cli = passCliFilepath();
-
-  if (fs.existsSync(cli)) {
+  const artifact = resolveArtifact(process.platform, process.arch);
+  const cli = path.join(passCliDirectory(), artifact.binaryName);
+  if (isCliInstalled()) {
     console.log("pass-cli already installed at:", cli);
     return cli;
   }
@@ -59,104 +33,37 @@ export async function ensureCli(): Promise<string> {
     message: "Downloading binary...",
   });
 
-  const platformKey = getPlatformKey();
-  const platformInfo = CLI_PLATFORMS[platformKey];
-
-  if (!platformInfo) {
-    throw new Error(
-      `Unsupported platform: ${platformKey}. Supported platforms: ${Object.keys(CLI_PLATFORMS).join(", ")}`,
-    );
-  }
-
-  const binaryUrl = `https://proton.me/download/pass-cli/${CLI_VERSION}/${platformInfo.filename}`;
-  const dir = passCliDirectory();
-  const tempDir = path.join(environment.supportPath, ".tmp");
-
-  console.log(`Downloading pass-cli from: ${binaryUrl}`);
-
-  const downloadedFile = path.join(tempDir, "pass-cli");
-
   try {
-    await afs.mkdir(tempDir, { recursive: true });
-    const response = await fetch(binaryUrl);
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status} ${response.statusText}`);
-    }
-    const buffer = Buffer.from(await response.arrayBuffer());
-    await afs.writeFile(downloadedFile, buffer);
-    installToast.message = "Download complete. Verifying binary...";
-  } catch (error) {
-    installToast.style = Toast.Style.Failure;
-    installToast.title = "Failed to Install Proton Pass CLI";
-    installToast.message = error instanceof Error ? error.message : String(error);
-    throw new Error(`Could not download pass-cli: ${error instanceof Error ? error.message : String(error)}`);
-  }
-
-  try {
-    const fileHash = await new Promise<string>((resolve, reject) => {
-      const hash = createHash("sha256");
-      const stream = createReadStream(downloadedFile);
-      stream.on("data", (data) => hash.update(data));
-      stream.on("end", () => resolve(hash.digest("hex")));
-      stream.on("error", reject);
+    const installed = await installArtifact({
+      artifact,
+      download: async (url) => {
+        const response = await fetch(url);
+        if (!response.ok) throw new Error(`HTTP ${response.status} ${response.statusText}`);
+        installToast.message = "Download complete. Verifying and installing...";
+        return Buffer.from(await response.arrayBuffer());
+      },
+      destDir: passCliDirectory(),
+      tmpDir: path.join(environment.supportPath, ".tmp"),
+      platform: process.platform,
     });
-    console.log(`Downloaded file hash: ${fileHash}`);
-    console.log(`Expected hash: ${platformInfo.sha256}`);
 
-    if (fileHash !== platformInfo.sha256) {
-      throw new Error(`SHA256 hash mismatch. Expected: ${platformInfo.sha256}, Got: ${fileHash}`);
-    }
-
-    installToast.message = "Installing binary...";
-    await afs.mkdir(dir, { recursive: true });
-    await afs.copyFile(downloadedFile, cli);
+    console.log("pass-cli installed successfully at:", installed);
+    installToast.style = Toast.Style.Success;
+    installToast.title = "Proton Pass CLI Ready";
+    installToast.message = "Download and installation complete.";
+    return installed;
   } catch (error) {
     installToast.style = Toast.Style.Failure;
     installToast.title = "Failed to Install Proton Pass CLI";
     installToast.message = error instanceof Error ? error.message : String(error);
-    throw new Error(`Could not verify pass-cli: ${error instanceof Error ? error.message : String(error)}`);
-  } finally {
-    try {
-      await afs.rm(tempDir, { recursive: true });
-    } catch {
-      // Ignore cleanup errors
-    }
+    throw new Error(`Could not install pass-cli: ${error instanceof Error ? error.message : String(error)}`);
   }
-
-  try {
-    await afs.chmod(cli, "755");
-  } catch (error) {
-    try {
-      await afs.rm(cli);
-    } catch {
-      // Ignore cleanup errors
-    }
-    installToast.style = Toast.Style.Failure;
-    installToast.title = "Failed to Install Proton Pass CLI";
-    installToast.message = error instanceof Error ? error.message : String(error);
-    throw new Error(`Could not set permissions on pass-cli: ${error instanceof Error ? error.message : String(error)}`);
-  }
-
-  // Remove macOS quarantine attribute — downloaded binaries are quarantined by
-  // Gatekeeper and will fail to execute without this step.
-  try {
-    await execFileAsync("/usr/bin/xattr", ["-d", "com.apple.quarantine", cli]);
-  } catch {
-    // Attribute may not be present; ignore.
-  }
-
-  console.log("pass-cli installed successfully at:", cli);
-  installToast.style = Toast.Style.Success;
-  installToast.title = "Proton Pass CLI Ready";
-  installToast.message = "Download and installation complete.";
-  return cli;
 }
 
 export async function clearCliCache(): Promise<void> {
   try {
-    const dir = passCliDirectory();
-    await afs.rm(dir, { recursive: true });
+    await afs.rm(path.join(environment.supportPath, "cli"), { recursive: true });
   } catch {
-    // Ignore errors if directory doesn't exist
+    // Ignore errors if directory doesn't exist.
   }
 }

--- a/extensions/proton-pass/src/lib/core/adapter.test.ts
+++ b/extensions/proton-pass/src/lib/core/adapter.test.ts
@@ -1,0 +1,150 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
+import {
+  authCheckArgs,
+  createPassCliAdapter,
+  itemListArgs,
+  itemTotpArgs,
+  itemViewArgs,
+  vaultListArgs,
+} from "./adapter";
+import { CommandDescriptor } from "./exec";
+import { PassCliError } from "../types";
+
+const fakeCli = resolve("src/lib/testing/fake-pass-cli.mjs");
+
+function fakeCommand(mode: string): CommandDescriptor {
+  return { file: process.execPath, args: [fakeCli, mode] };
+}
+
+test("generates a CLI 2.x passphrase with spaces", async () => {
+  const adapter = createPassCliAdapter(fakeCommand("echo-args"));
+
+  const output = await adapter.generatePassword({
+    type: "passphrase",
+    words: 4,
+    separator: "spaces",
+    capitalize: true,
+  });
+
+  assert.deepEqual(JSON.parse(output), [
+    "password",
+    "generate",
+    "passphrase",
+    "--count",
+    "4",
+    "--separator",
+    "spaces",
+    "--capitalise",
+    "true",
+  ]);
+});
+
+test("uses the CLI 2.x numbers-and-symbols separator literal", async () => {
+  const adapter = createPassCliAdapter(fakeCommand("echo-args"));
+
+  const output = await adapter.generatePassword({
+    type: "passphrase",
+    words: 6,
+    separator: "numbers-and-symbols",
+    capitalize: false,
+    includeNumbers: true,
+  });
+
+  const args = JSON.parse(output);
+  assert.deepEqual(args, [
+    "password",
+    "generate",
+    "passphrase",
+    "--count",
+    "6",
+    "--separator",
+    "numbers-and-symbols",
+    "--capitalise",
+    "false",
+    "--numbers",
+    "true",
+  ]);
+  assert.equal(args.includes("memorable"), false);
+  assert.equal(args.includes("--words"), false);
+});
+
+test("generates a random password with CLI 2.x arguments", async () => {
+  const adapter = createPassCliAdapter(fakeCommand("echo-args"));
+
+  const output = await adapter.generatePassword({ type: "random", length: 20, includeSymbols: false });
+
+  assert.deepEqual(JSON.parse(output), ["password", "generate", "random", "--length", "20", "--symbols", "false"]);
+});
+
+test("checks authentication with info", async () => {
+  const adapter = createPassCliAdapter(fakeCommand("auth-ok"));
+
+  assert.equal(await adapter.checkAuth(), true);
+  assert.deepEqual(authCheckArgs(), ["info"]);
+});
+
+test("returns false for the real unauthenticated CLI failure", async () => {
+  const adapter = createPassCliAdapter(fakeCommand("auth-denied"));
+
+  assert.equal(await adapter.checkAuth(), false);
+});
+
+test("uses exact list, view, and TOTP CLI arguments", () => {
+  assert.deepEqual(vaultListArgs(), ["vault", "list", "--output", "json"]);
+  assert.deepEqual(itemListArgs("X"), ["item", "list", "--share-id", "X", "--output", "json", "--show-secrets"]);
+  assert.deepEqual(itemViewArgs("X", "Y"), ["item", "view", "--share-id", "X", "--item-id", "Y", "--output", "json"]);
+  assert.deepEqual(itemTotpArgs("X", "Y"), ["item", "totp", "--share-id", "X", "--item-id", "Y", "--output", "json"]);
+  assert.equal(itemViewArgs("X", "Y").includes("--show-secrets"), false);
+  assert.equal(itemTotpArgs("X", "Y").includes("--show-secrets"), false);
+});
+
+test("accepts bare-array and wrapped vault lists", async () => {
+  const bare = await createPassCliAdapter(fakeCommand("json:vaults-array")).listVaults();
+  const wrapped = await createPassCliAdapter(fakeCommand("json:vaults-wrapper")).listVaults();
+
+  assert.deepEqual(bare, [{ shareId: "vault-1", name: "Personal", itemCount: 3, role: "owner" }]);
+  assert.deepEqual(wrapped, [{ shareId: "vault-2", name: "Work", itemCount: undefined, role: undefined }]);
+});
+
+test("lists active items and strips full-list secrets", async () => {
+  const items = await createPassCliAdapter(fakeCommand("json:items-full")).listItems("vault-1", "Personal");
+
+  assert.equal(items.length, 1);
+  assert.deepEqual(items[0], {
+    shareId: "vault-1",
+    itemId: "item-login",
+    title: "Example Login",
+    type: "login",
+    vaultName: "Personal",
+    urls: ["https://example.com/login"],
+    username: "alice",
+    email: "alice@example.com",
+    hasTotp: true,
+  });
+});
+
+test("gets item details without adding list-only show-secrets flag", async () => {
+  const detail = await createPassCliAdapter(fakeCommand("json:item-view")).getItem("vault-1", "item-login");
+
+  assert.equal(detail.password, "detail-password");
+  assert.equal(detail.shareId, "vault-1");
+});
+
+test("accepts wrapped and flat TOTP maps", async () => {
+  const wrapped = await createPassCliAdapter(fakeCommand("json:totps-wrapper")).getTotpCodes("vault-1", "item-1");
+  const flat = await createPassCliAdapter(fakeCommand("json:totps-flat")).getTotpCodes("vault-1", "item-1");
+
+  assert.deepEqual(wrapped, { totp: "123456", recovery: "654321" });
+  assert.deepEqual(flat, { primary: "111222", secondary: "333444" });
+});
+
+test("rejects malformed JSON as invalid CLI output", async () => {
+  const adapter = createPassCliAdapter(fakeCommand("malformed-json"));
+
+  await assert.rejects(adapter.listVaults(), (error: unknown) => {
+    assert.equal(error instanceof PassCliError && error.type, "invalid_output");
+    return true;
+  });
+});

--- a/extensions/proton-pass/src/lib/core/adapter.ts
+++ b/extensions/proton-pass/src/lib/core/adapter.ts
@@ -1,0 +1,144 @@
+import { normalizeItem, normalizeItemDetail, normalizeVault } from "../pass-cli-normalize";
+import { Item, ItemDetail, PassCliError, PasswordOptions, Vault } from "../types";
+import { CommandDescriptor, ExecCliOptions, execCli, normalizeCliExecutionError } from "./exec";
+
+export function passwordArgs(options: PasswordOptions): string[] {
+  if (options.type === "random") {
+    const args = ["password", "generate", "random"];
+    if (options.length !== undefined) args.push("--length", String(options.length));
+    if (options.includeNumbers !== undefined) args.push("--numbers", String(options.includeNumbers));
+    if (options.includeUppercase !== undefined) args.push("--uppercase", String(options.includeUppercase));
+    if (options.includeSymbols !== undefined) args.push("--symbols", String(options.includeSymbols));
+    return args;
+  }
+
+  const args = ["password", "generate", "passphrase"];
+  if (options.words !== undefined) args.push("--count", String(options.words));
+  if (options.separator !== undefined) args.push("--separator", options.separator);
+  if (options.capitalize !== undefined) args.push("--capitalise", String(options.capitalize));
+  if (options.includeNumbers !== undefined) args.push("--numbers", String(options.includeNumbers));
+  return args;
+}
+
+export function authCheckArgs(): string[] {
+  return ["info"];
+}
+
+export function vaultListArgs(): string[] {
+  return ["vault", "list", "--output", "json"];
+}
+
+export function itemListArgs(shareId: string): string[] {
+  return ["item", "list", "--share-id", shareId, "--output", "json", "--show-secrets"];
+}
+
+export function itemViewArgs(shareId: string, itemId: string): string[] {
+  return ["item", "view", "--share-id", shareId, "--item-id", itemId, "--output", "json"];
+}
+
+export function itemTotpArgs(shareId: string, itemId: string): string[] {
+  return ["item", "totp", "--share-id", shareId, "--item-id", itemId, "--output", "json"];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseJson(text: string, context: string): unknown {
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new PassCliError(
+      `Unexpected ${context} output from pass-cli. Please update pass-cli and try again.`,
+      "invalid_output",
+    );
+  }
+}
+
+function unwrapItemResponse(data: unknown): unknown {
+  if (!isRecord(data)) return data;
+  const wrapperKeys = ["item", "data", "result", "response", "payload"];
+  for (const key of wrapperKeys) {
+    if (!isRecord(data[key])) continue;
+    const inner = data[key] as Record<string, unknown>;
+    for (const innerKey of wrapperKeys) {
+      if (isRecord(inner[innerKey])) return inner[innerKey];
+    }
+    return inner;
+  }
+  return data;
+}
+
+function trimOrUndefined(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export interface PassCliAdapter {
+  generatePassword(options: PasswordOptions): Promise<string>;
+  checkAuth(): Promise<boolean>;
+  listVaults(): Promise<Vault[]>;
+  listItems(shareId: string, vaultName: string): Promise<Item[]>;
+  getItem(shareId: string, itemId: string): Promise<ItemDetail>;
+  getTotpCodes(shareId: string, itemId: string): Promise<Record<string, string>>;
+}
+
+export function createPassCliAdapter(command: CommandDescriptor, execOptions: ExecCliOptions = {}): PassCliAdapter {
+  async function run(args: readonly string[]): Promise<string> {
+    try {
+      const { stdout } = await execCli(command, args, execOptions);
+      return stdout.trim();
+    } catch (error) {
+      throw normalizeCliExecutionError(error, command.file);
+    }
+  }
+
+  return {
+    generatePassword: async (options) => run(passwordArgs(options)),
+    checkAuth: async () => {
+      try {
+        await run(authCheckArgs());
+        return true;
+      } catch (error) {
+        if (error instanceof PassCliError && error.type === "not_authenticated") return false;
+        throw error;
+      }
+    },
+    listVaults: async () => {
+      const data = parseJson(await run(vaultListArgs()), "vault list");
+      const rawVaults = Array.isArray(data) ? data : isRecord(data) ? data.vaults : undefined;
+      if (!Array.isArray(rawVaults)) {
+        throw new PassCliError("Unexpected vault list output from pass-cli.", "invalid_output");
+      }
+      return rawVaults.map(normalizeVault);
+    },
+    listItems: async (shareId, vaultName) => {
+      const data = parseJson(await run(itemListArgs(shareId)), "item list");
+      const rawItems = Array.isArray(data) ? data : isRecord(data) ? data.items : undefined;
+      if (!Array.isArray(rawItems)) {
+        throw new PassCliError("Unexpected item list output from pass-cli.", "invalid_output");
+      }
+      return rawItems
+        .filter(
+          (item): item is Record<string, unknown> =>
+            isRecord(item) && trimOrUndefined(item.state)?.toLowerCase() !== "trashed",
+        )
+        .map((item) => normalizeItem(item, vaultName, shareId));
+    },
+    getItem: async (shareId, itemId) => {
+      const data = parseJson(await run(itemViewArgs(shareId, itemId)), "item view");
+      return normalizeItemDetail(unwrapItemResponse(data), undefined, shareId);
+    },
+    getTotpCodes: async (shareId, itemId) => {
+      const data = parseJson(await run(itemTotpArgs(shareId, itemId)), "item totp");
+      const raw = isRecord(data) && isRecord(data.totps) ? data.totps : data;
+      if (!isRecord(raw)) {
+        throw new PassCliError("Unexpected TOTP output from pass-cli.", "invalid_output");
+      }
+      return Object.fromEntries(
+        Object.entries(raw)
+          .map(([key, value]) => [key, trimOrUndefined(value)] as const)
+          .filter((entry): entry is readonly [string, string] => Boolean(entry[1])),
+      );
+    },
+  };
+}

--- a/extensions/proton-pass/src/lib/core/artifact.test.ts
+++ b/extensions/proton-pass/src/lib/core/artifact.test.ts
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolveArtifact } from "./artifact";
+import { PassCliError } from "../types";
+
+test("resolves pinned pass-cli 2.3.3 artifacts", () => {
+  assert.deepEqual(resolveArtifact("darwin", "arm64"), {
+    url: "https://proton.me/download/pass-cli/2.3.3/pass-cli-macos-aarch64",
+    sha256: "3281587ac9c50ae2f1604ba75e9d1d39b6debb221b65a6cc56f64d626ede3dbc",
+    kind: "raw",
+    binaryName: "pass-cli",
+    requiredFiles: ["pass-cli"],
+  });
+  assert.deepEqual(resolveArtifact("darwin", "x64"), {
+    url: "https://proton.me/download/pass-cli/2.3.3/pass-cli-macos-x86_64",
+    sha256: "275f6159f63d152ecdd9d4e2969ef515291619005e0d30ab762daee26081621c",
+    kind: "raw",
+    binaryName: "pass-cli",
+    requiredFiles: ["pass-cli"],
+  });
+  assert.deepEqual(resolveArtifact("win32", "x64"), {
+    url: "https://proton.me/download/pass-cli/2.3.3/pass-cli-windows-x86_64.zip",
+    sha256: "4169c7644e3475f294d265e2f1262476573e41d372b905187222c52f1c6dbca5",
+    kind: "zip",
+    binaryName: "pass-cli.exe",
+    requiredFiles: ["pass-cli.exe", "libcrypto-3-x64.dll"],
+  });
+});
+
+test("rejects unsupported platform and architecture pairs", () => {
+  assert.throws(
+    () => resolveArtifact("win32", "arm64"),
+    (error: unknown) => {
+      assert.ok(error instanceof PassCliError);
+      assert.equal(error.type, "unsupported_platform");
+      assert.match(error.message, /Unsupported platform: win32-arm64/);
+      return true;
+    },
+  );
+  assert.throws(() => resolveArtifact("linux", "x64"), /Unsupported platform: linux-x64/);
+});

--- a/extensions/proton-pass/src/lib/core/artifact.ts
+++ b/extensions/proton-pass/src/lib/core/artifact.ts
@@ -1,0 +1,48 @@
+import { PassCliError } from "../types";
+
+export interface Artifact {
+  url: string;
+  sha256: string;
+  kind: "raw" | "zip";
+  binaryName: "pass-cli" | "pass-cli.exe";
+  requiredFiles: readonly string[];
+}
+
+export const PASS_CLI_VERSION = "2.3.3";
+const BASE_URL = `https://proton.me/download/pass-cli/${PASS_CLI_VERSION}`;
+
+const ARTIFACTS: Record<string, Artifact> = {
+  "darwin-arm64": {
+    url: `${BASE_URL}/pass-cli-macos-aarch64`,
+    sha256: "3281587ac9c50ae2f1604ba75e9d1d39b6debb221b65a6cc56f64d626ede3dbc",
+    kind: "raw",
+    binaryName: "pass-cli",
+    requiredFiles: ["pass-cli"],
+  },
+  "darwin-x64": {
+    url: `${BASE_URL}/pass-cli-macos-x86_64`,
+    sha256: "275f6159f63d152ecdd9d4e2969ef515291619005e0d30ab762daee26081621c",
+    kind: "raw",
+    binaryName: "pass-cli",
+    requiredFiles: ["pass-cli"],
+  },
+  "win32-x64": {
+    url: `${BASE_URL}/pass-cli-windows-x86_64.zip`,
+    sha256: "4169c7644e3475f294d265e2f1262476573e41d372b905187222c52f1c6dbca5",
+    kind: "zip",
+    binaryName: "pass-cli.exe",
+    requiredFiles: ["pass-cli.exe", "libcrypto-3-x64.dll"],
+  },
+};
+
+export function resolveArtifact(platform: string, arch: string): Artifact {
+  const key = `${platform}-${arch}`;
+  const artifact = ARTIFACTS[key];
+  if (!artifact) {
+    throw new PassCliError(
+      `Unsupported platform: ${key}. Supported platforms: ${Object.keys(ARTIFACTS).join(", ")}`,
+      "unsupported_platform",
+    );
+  }
+  return artifact;
+}

--- a/extensions/proton-pass/src/lib/core/exec.test.ts
+++ b/extensions/proton-pass/src/lib/core/exec.test.ts
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
+import { classifyCliError, CommandDescriptor, execCli, normalizeCliExecutionError } from "./exec";
+
+const fakeCli = resolve("src/lib/testing/fake-pass-cli.mjs");
+
+function fakeCommand(mode: string): CommandDescriptor {
+  return { file: process.execPath, args: [fakeCli, mode] };
+}
+
+test("executes a command descriptor with appended arguments", async () => {
+  const result = await execCli(fakeCommand("echo-args"), ["info", "--output", "json"]);
+
+  assert.deepEqual(JSON.parse(result.stdout), ["info", "--output", "json"]);
+  assert.equal(result.stderr, "");
+});
+
+test("classifies authentication and keyring failures", () => {
+  assert.equal(classifyCliError("Error: This operation requires an authenticated client"), "not_authenticated");
+  assert.equal(classifyCliError("cannot get the encryption key"), "keyring_error");
+});
+
+test("normalizes a missing executable with its path", () => {
+  const error = Object.assign(new Error("spawn failed"), { code: "ENOENT" });
+
+  const normalized = normalizeCliExecutionError(error, "/missing/pass-cli");
+
+  assert.equal(normalized.type, "not_installed");
+  assert.match(normalized.message, /\/missing\/pass-cli/);
+});
+
+test("normalizes the real fake CLI authentication failure", async () => {
+  await assert.rejects(execCli(fakeCommand("auth-denied"), ["info"]), (error: unknown) => {
+    const normalized = normalizeCliExecutionError(error, process.execPath);
+    assert.equal(normalized.type, "not_authenticated");
+    assert.doesNotMatch(normalized.message, /authenticated client/);
+    return true;
+  });
+});

--- a/extensions/proton-pass/src/lib/core/exec.ts
+++ b/extensions/proton-pass/src/lib/core/exec.ts
@@ -1,0 +1,115 @@
+import { execFile } from "node:child_process";
+import { PassCliError, PassCliErrorType } from "../types";
+
+export interface CommandDescriptor {
+  file: string;
+  args: readonly string[];
+}
+
+export interface ExecCliOptions {
+  env?: NodeJS.ProcessEnv;
+  timeout?: number;
+  maxBuffer?: number;
+}
+
+export interface CliExecution {
+  stdout: string;
+  stderr: string;
+}
+
+export function classifyCliError(text: string): PassCliErrorType {
+  const normalized = text.toLowerCase();
+
+  if (normalized.includes("cannot get the encryption key") || normalized.includes("error creating client features")) {
+    return "keyring_error";
+  }
+  if (
+    normalized.includes("requires an authenticated client") ||
+    normalized.includes("not authenticated") ||
+    normalized.includes("login required") ||
+    normalized.includes("please login") ||
+    normalized.includes("not logged in")
+  ) {
+    return "not_authenticated";
+  }
+  if (
+    normalized.includes("network") ||
+    normalized.includes("timeout") ||
+    normalized.includes("timed out") ||
+    normalized.includes("connection") ||
+    normalized.includes("dns")
+  ) {
+    return "network_error";
+  }
+  return "unknown";
+}
+
+export function execCli(
+  command: CommandDescriptor,
+  args: readonly string[],
+  options: ExecCliOptions = {},
+): Promise<CliExecution> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      command.file,
+      [...command.args, ...args],
+      {
+        env: options.env,
+        timeout: options.timeout ?? 60_000,
+        maxBuffer: options.maxBuffer ?? 20 * 1024 * 1024,
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          Object.assign(error, { stdout, stderr });
+          reject(error);
+          return;
+        }
+        resolve({ stdout: stdout ?? "", stderr: stderr ?? "" });
+      },
+    );
+  });
+}
+
+export function normalizeCliExecutionError(
+  error: unknown,
+  cliPath: string,
+  timeoutMessage = "pass-cli timed out. Please try again.",
+): PassCliError {
+  const execError = error as NodeJS.ErrnoException & { killed?: boolean; signal?: string; stderr?: string };
+  if (execError?.killed && typeof execError.signal === "string") {
+    return new PassCliError(timeoutMessage, "timeout");
+  }
+  if (execError?.code === "ENOENT" || execError?.errno === -2) {
+    return new PassCliError(
+      `pass-cli not found at '${cliPath}'. Install it or set the correct path in extension preferences.`,
+      "not_installed",
+    );
+  }
+
+  const message = error instanceof Error ? error.message : "";
+  const stderr = typeof execError?.stderr === "string" ? execError.stderr : "";
+  const combined = [stderr, message]
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .join("\n");
+  const type = classifyCliError(combined);
+
+  if (type === "keyring_error") {
+    return new PassCliError(
+      "pass-cli could not access secure key storage. Try: pass-cli logout --force, then set PROTON_PASS_KEY_PROVIDER=fs and login again.",
+      type,
+    );
+  }
+  if (type === "not_authenticated") {
+    return new PassCliError("Not authenticated. Run pass-cli login to authenticate.", type);
+  }
+  if (type === "network_error") {
+    return new PassCliError("Network error. Check your connection and try again.", type);
+  }
+
+  const safeDetails = combined || "An unknown error occurred while running pass-cli.";
+  return new PassCliError(
+    safeDetails.length > 600 ? `${safeDetails.slice(0, 299)}…${safeDetails.slice(-300)}` : safeDetails,
+    "unknown",
+  );
+}

--- a/extensions/proton-pass/src/lib/core/installer.test.ts
+++ b/extensions/proton-pass/src/lib/core/installer.test.ts
@@ -91,6 +91,43 @@ test("cleans partial paths when download fails", async () => {
   });
 });
 
+test("a concurrent failed install does not erase a successful install", async () => {
+  await withPaths(async (destDir, tempDir) => {
+    let markDownloadStarted: () => void = () => undefined;
+    const downloadStarted = new Promise<void>((resolve) => {
+      markDownloadStarted = resolve;
+    });
+    let rejectDownload: (error: Error) => void = () => undefined;
+    const failedInstall = installArtifact({
+      artifact: rawArtifact,
+      download: async () => {
+        markDownloadStarted();
+        return new Promise<Buffer>((_resolve, reject) => {
+          rejectDownload = reject;
+        });
+      },
+      destDir,
+      tmpDir: tempDir,
+      platform: "darwin",
+    });
+    const failedResult = assert.rejects(failedInstall, /download unavailable/);
+
+    await downloadStarted;
+    const binary = Buffer.from("fake macOS binary!!!");
+    const installed = await installArtifact({
+      artifact: rawArtifact,
+      download: async () => binary,
+      destDir,
+      tmpDir: tempDir,
+      platform: "darwin",
+    });
+
+    rejectDownload(new Error("download unavailable"));
+    await failedResult;
+    assert.deepEqual(await readFile(installed), binary);
+  });
+});
+
 test("does not install files left by an interrupted previous attempt", async () => {
   await withPaths(async (destDir, tempDir) => {
     await mkdir(path.join(tempDir, "install"), { recursive: true });

--- a/extensions/proton-pass/src/lib/core/installer.test.ts
+++ b/extensions/proton-pass/src/lib/core/installer.test.ts
@@ -1,0 +1,192 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { access, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { installArtifact } from "./installer";
+import { Artifact } from "./artifact";
+import { makeZip } from "./zip-test-helper";
+
+async function withPaths(run: (destDir: string, tempDir: string) => Promise<void>): Promise<void> {
+  const root = await mkdtemp(path.join(tmpdir(), "proton-pass-install-"));
+  try {
+    await run(path.join(root, "cli"), path.join(root, "download"));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+const rawArtifact: Artifact = {
+  url: "https://example.test/pass-cli",
+  sha256: "069e5fd5c6387236bbfd4060ea0bc7363812208733785c02dd9c089b233fe34a",
+  kind: "raw",
+  binaryName: "pass-cli",
+  requiredFiles: ["pass-cli"],
+};
+
+function zipArtifact(archive: Buffer): Artifact {
+  return {
+    url: "https://example.test/pass-cli.zip",
+    sha256: createHash("sha256").update(archive).digest("hex"),
+    kind: "zip",
+    binaryName: "pass-cli.exe",
+    requiredFiles: ["pass-cli.exe", "libcrypto-3-x64.dll"],
+  };
+}
+
+test("installs a verified macOS binary and makes it executable", async () => {
+  await withPaths(async (destDir, tempDir) => {
+    const binary = Buffer.from("fake macOS binary!!!");
+    const installed = await installArtifact({
+      artifact: rawArtifact,
+      download: async () => binary,
+      destDir,
+      tmpDir: tempDir,
+      platform: "darwin",
+    });
+
+    assert.equal(installed, path.join(destDir, "pass-cli"));
+    assert.deepEqual(await readFile(installed), binary);
+    if (process.platform !== "win32") assert.notEqual((await stat(installed)).mode & 0o111, 0);
+    await assert.rejects(access(tempDir));
+  });
+});
+
+test("rejects raw and ZIP checksum mismatches without leaving partial files", async () => {
+  for (const artifact of [rawArtifact, { ...zipArtifact(Buffer.from("not a zip")), sha256: "0".repeat(64) }]) {
+    await withPaths(async (destDir, tempDir) => {
+      await assert.rejects(
+        installArtifact({
+          artifact: { ...artifact, sha256: `${artifact.sha256.slice(0, -1)}0` },
+          download: async () => Buffer.from("tampered download"),
+          destDir,
+          tmpDir: tempDir,
+          platform: artifact.kind === "raw" ? "darwin" : "win32",
+        }),
+        /SHA256/,
+      );
+      await assert.rejects(access(path.join(destDir, artifact.binaryName)));
+      await assert.rejects(access(tempDir));
+    });
+  }
+});
+
+test("cleans partial paths when download fails", async () => {
+  await withPaths(async (destDir, tempDir) => {
+    await assert.rejects(
+      installArtifact({
+        artifact: rawArtifact,
+        download: async () => {
+          throw new Error("download unavailable");
+        },
+        destDir,
+        tmpDir: tempDir,
+        platform: "darwin",
+      }),
+      /download unavailable/,
+    );
+    await assert.rejects(access(path.join(destDir, "pass-cli")));
+    await assert.rejects(access(tempDir));
+  });
+});
+
+test("does not install files left by an interrupted previous attempt", async () => {
+  await withPaths(async (destDir, tempDir) => {
+    await mkdir(path.join(tempDir, "install"), { recursive: true });
+    await writeFile(path.join(tempDir, "install", "stale.dll"), "stale");
+    await installArtifact({
+      artifact: rawArtifact,
+      download: async () => Buffer.from("fake macOS binary!!!"),
+      destDir,
+      tmpDir: tempDir,
+      platform: "darwin",
+    });
+
+    await assert.rejects(access(path.join(destDir, "stale.dll")));
+  });
+});
+
+test("installs Windows executable with its companion DLL", async () => {
+  await withPaths(async (destDir, tempDir) => {
+    const executable = Buffer.from("windows executable");
+    const dll = Buffer.from([0, 1, 2, 255]);
+    const archive = makeZip([
+      { name: "pass-cli.exe", data: executable },
+      { name: "libcrypto-3-x64.dll", data: dll },
+    ]);
+    const artifact: Artifact = {
+      ...zipArtifact(archive),
+      sha256: "cefb7a8749567974fbfcf21cfe8c515400b4730ad0efaad9b95723c33f6b0e15",
+    };
+
+    const installed = await installArtifact({
+      artifact,
+      download: async () => archive,
+      destDir,
+      tmpDir: tempDir,
+      platform: "win32",
+    });
+
+    assert.equal(installed, path.join(destDir, "pass-cli.exe"));
+    assert.deepEqual(await readFile(installed), executable);
+    assert.deepEqual(await readFile(path.join(destDir, "libcrypto-3-x64.dll")), dll);
+    await assert.rejects(access(tempDir));
+  });
+});
+
+test("rejects a Windows archive missing pass-cli.exe", async () => {
+  await withPaths(async (destDir, tempDir) => {
+    const archive = makeZip([{ name: "libcrypto-3-x64.dll", data: Buffer.from("dll") }]);
+    await assert.rejects(
+      installArtifact({
+        artifact: zipArtifact(archive),
+        download: async () => archive,
+        destDir,
+        tmpDir: tempDir,
+        platform: "win32",
+      }),
+      /ZIP does not contain pass-cli\.exe/,
+    );
+    await assert.rejects(access(path.join(destDir, "pass-cli.exe")));
+    await assert.rejects(access(tempDir));
+  });
+});
+
+test("rejects a Windows archive missing its companion DLL", async () => {
+  await withPaths(async (destDir, tempDir) => {
+    const archive = makeZip([{ name: "pass-cli.exe", data: Buffer.from("windows executable") }]);
+    await assert.rejects(
+      installArtifact({
+        artifact: zipArtifact(archive),
+        download: async () => archive,
+        destDir,
+        tmpDir: tempDir,
+        platform: "win32",
+      }),
+      /ZIP does not contain libcrypto-3-x64\.dll/,
+    );
+    await assert.rejects(access(path.join(destDir, "pass-cli.exe")));
+    await assert.rejects(access(tempDir));
+  });
+});
+
+test("rejects ZIP traversal without writing outside installation directory", async () => {
+  await withPaths(async (destDir, tempDir) => {
+    const archive = makeZip([{ name: "../evil", data: Buffer.from("evil") }]);
+    const escapedPath = path.join(tempDir, "evil");
+    await assert.rejects(
+      installArtifact({
+        artifact: zipArtifact(archive),
+        download: async () => archive,
+        destDir,
+        tmpDir: tempDir,
+        platform: "win32",
+      }),
+      /Unsafe ZIP path/,
+    );
+    await assert.rejects(access(escapedPath));
+    await assert.rejects(access(path.join(destDir, "pass-cli.exe")));
+    await assert.rejects(access(tempDir));
+  });
+});

--- a/extensions/proton-pass/src/lib/core/installer.ts
+++ b/extensions/proton-pass/src/lib/core/installer.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
-import { access, chmod, cp, mkdir, rm, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, mkdtemp, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import { Artifact } from "./artifact";
@@ -19,15 +19,16 @@ export interface InstallArtifactOptions {
 export async function installArtifact(options: InstallArtifactOptions): Promise<string> {
   const { artifact, download, destDir, tmpDir, platform } = options;
   const binaryPath = path.join(destDir, artifact.binaryName);
+  let attemptDir: string | undefined;
   try {
-    await rm(tmpDir, { recursive: true, force: true });
+    await mkdir(path.dirname(tmpDir), { recursive: true });
+    attemptDir = await mkdtemp(`${tmpDir}-`);
     const buffer = await download(artifact.url);
     const hash = createHash("sha256").update(buffer).digest("hex");
     if (hash !== artifact.sha256) {
       throw new Error(`SHA256 hash mismatch. Expected: ${artifact.sha256}, Got: ${hash}`);
     }
-    await mkdir(tmpDir, { recursive: true });
-    const stagedDir = path.join(tmpDir, "install");
+    const stagedDir = path.join(attemptDir, "install");
     await mkdir(stagedDir, { recursive: true });
     const stagedBinary = path.join(stagedDir, artifact.binaryName);
     if (artifact.kind === "raw") {
@@ -43,22 +44,27 @@ export async function installArtifact(options: InstallArtifactOptions): Promise<
       }
     }
 
-    await mkdir(destDir, { recursive: true });
-    await cp(stagedDir, destDir, { recursive: true });
-
     if (platform === "darwin") {
-      await chmod(binaryPath, 0o755);
+      await chmod(stagedBinary, 0o755);
       try {
-        await execFileAsync("/usr/bin/xattr", ["-d", "com.apple.quarantine", binaryPath]);
+        await execFileAsync("/usr/bin/xattr", ["-d", "com.apple.quarantine", stagedBinary]);
       } catch {
         // Quarantine attribute may not exist.
       }
     }
+
+    await mkdir(path.dirname(destDir), { recursive: true });
+    try {
+      await rename(stagedDir, destDir);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST" && code !== "ENOTEMPTY") throw error;
+      for (const requiredFile of artifact.requiredFiles) {
+        await access(path.join(destDir, requiredFile));
+      }
+    }
     return binaryPath;
-  } catch (error) {
-    await rm(destDir, { recursive: true, force: true });
-    throw error;
   } finally {
-    await rm(tmpDir, { recursive: true, force: true });
+    if (attemptDir) await rm(attemptDir, { recursive: true, force: true });
   }
 }

--- a/extensions/proton-pass/src/lib/core/installer.ts
+++ b/extensions/proton-pass/src/lib/core/installer.ts
@@ -1,0 +1,64 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { access, chmod, cp, mkdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { Artifact } from "./artifact";
+import { extractZip } from "./zip";
+
+const execFileAsync = promisify(execFile);
+
+export interface InstallArtifactOptions {
+  artifact: Artifact;
+  download: (url: string) => Promise<Buffer>;
+  destDir: string;
+  tmpDir: string;
+  platform: string;
+}
+
+export async function installArtifact(options: InstallArtifactOptions): Promise<string> {
+  const { artifact, download, destDir, tmpDir, platform } = options;
+  const binaryPath = path.join(destDir, artifact.binaryName);
+  try {
+    await rm(tmpDir, { recursive: true, force: true });
+    const buffer = await download(artifact.url);
+    const hash = createHash("sha256").update(buffer).digest("hex");
+    if (hash !== artifact.sha256) {
+      throw new Error(`SHA256 hash mismatch. Expected: ${artifact.sha256}, Got: ${hash}`);
+    }
+    await mkdir(tmpDir, { recursive: true });
+    const stagedDir = path.join(tmpDir, "install");
+    await mkdir(stagedDir, { recursive: true });
+    const stagedBinary = path.join(stagedDir, artifact.binaryName);
+    if (artifact.kind === "raw") {
+      await writeFile(stagedBinary, buffer);
+    } else {
+      await extractZip(buffer, stagedDir);
+      for (const requiredFile of artifact.requiredFiles) {
+        try {
+          await access(path.join(stagedDir, requiredFile));
+        } catch {
+          throw new Error(`ZIP does not contain ${requiredFile}`);
+        }
+      }
+    }
+
+    await mkdir(destDir, { recursive: true });
+    await cp(stagedDir, destDir, { recursive: true });
+
+    if (platform === "darwin") {
+      await chmod(binaryPath, 0o755);
+      try {
+        await execFileAsync("/usr/bin/xattr", ["-d", "com.apple.quarantine", binaryPath]);
+      } catch {
+        // Quarantine attribute may not exist.
+      }
+    }
+    return binaryPath;
+  } catch (error) {
+    await rm(destDir, { recursive: true, force: true });
+    throw error;
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}

--- a/extensions/proton-pass/src/lib/core/login.test.ts
+++ b/extensions/proton-pass/src/lib/core/login.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
+import test from "node:test";
+import { extractLoginUrl, runBrowserLogin } from "./login";
+import { PassCliError } from "../types";
+
+const LOGIN_URL = "https://account.proton.me/desktop/login?app=pass#payload=fake%2Fpayload%3Dwith-encoded-data";
+const FAKE_LOGIN_URL = "https://account.proton.me/desktop/login?app=pass#payload=FAKE_PAYLOAD_TOKEN";
+
+function fakeCommand(mode: string) {
+  return {
+    file: process.execPath,
+    args: [resolve(process.cwd(), "src/lib/testing/fake-pass-cli.mjs"), mode],
+  };
+}
+
+test("extractLoginUrl returns the HTTPS Proton account URL from CLI output", () => {
+  const output = [
+    "",
+    "Please open the following URL in your browser to complete authentication:",
+    "",
+    LOGIN_URL,
+    "",
+    "Waiting for authentication to complete...",
+  ].join("\n");
+
+  assert.equal(extractLoginUrl(output), LOGIN_URL);
+});
+
+test("extractLoginUrl returns null when output has no URL", () => {
+  assert.equal(extractLoginUrl("Waiting for authentication to complete..."), null);
+});
+
+test("extractLoginUrl rejects an HTTP Proton account URL", () => {
+  assert.equal(extractLoginUrl("http://account.proton.me/desktop/login#payload=token"), null);
+});
+
+test("extractLoginUrl rejects a different HTTPS host", () => {
+  assert.equal(extractLoginUrl("https://evil.com/desktop/login#payload=token"), null);
+});
+
+test("extractLoginUrl rejects a Proton hostname on a nonstandard port", () => {
+  assert.equal(extractLoginUrl("https://account.proton.me:444/desktop/login#payload=token"), null);
+});
+
+test("runBrowserLogin opens the Proton login URL once and resolves on success", async () => {
+  const opened: string[] = [];
+
+  await runBrowserLogin(fakeCommand("login-ok"), {
+    openUrl: async (url) => {
+      opened.push(url);
+    },
+    timeoutMs: 1_000,
+  });
+
+  assert.deepEqual(opened, [FAKE_LOGIN_URL]);
+});
+
+test("runBrowserLogin waits for a complete URL split across stdout chunks", async () => {
+  const opened: string[] = [];
+
+  await runBrowserLogin(fakeCommand("login-split-url"), {
+    openUrl: async (url) => {
+      opened.push(url);
+    },
+    timeoutMs: 1_000,
+  });
+
+  assert.deepEqual(opened, [FAKE_LOGIN_URL]);
+});
+
+for (const mode of ["login-bad-host", "login-garbage"]) {
+  test(`runBrowserLogin never opens a URL for ${mode} output`, async () => {
+    const opened: string[] = [];
+
+    await runBrowserLogin(fakeCommand(mode), {
+      openUrl: async (url) => {
+        opened.push(url);
+      },
+      timeoutMs: 1_000,
+    });
+
+    assert.deepEqual(opened, []);
+  });
+}
+
+test("runBrowserLogin times out and kills a hanging child", async () => {
+  await assert.rejects(
+    runBrowserLogin(fakeCommand("login-hang"), {
+      openUrl: async () => undefined,
+      timeoutMs: 300,
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof PassCliError);
+      assert.equal(error.type, "timeout");
+      assert.doesNotMatch(error.message, /payload=|FAKE_PAYLOAD_TOKEN/);
+      return true;
+    },
+  );
+});
+
+test("runBrowserLogin classifies CLI failure without exposing payload data", async () => {
+  await assert.rejects(
+    runBrowserLogin(fakeCommand("login-fail"), {
+      openUrl: async () => undefined,
+      timeoutMs: 1_000,
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof PassCliError);
+      assert.equal(error.type, "not_authenticated");
+      assert.doesNotMatch(error.message, /payload=|FAIL_PAYLOAD_TOKEN/);
+      return true;
+    },
+  );
+});
+
+test("runBrowserLogin redacts payload data from an unknown CLI failure", async () => {
+  await assert.rejects(
+    runBrowserLogin(fakeCommand("login-fail-unknown"), {
+      openUrl: async () => undefined,
+      timeoutMs: 1_000,
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof PassCliError);
+      assert.equal(error.type, "unknown");
+      assert.doesNotMatch(error.message, /payload=|UNKNOWN_PAYLOAD_TOKEN/);
+      return true;
+    },
+  );
+});

--- a/extensions/proton-pass/src/lib/core/login.ts
+++ b/extensions/proton-pass/src/lib/core/login.ts
@@ -1,0 +1,88 @@
+import { spawn } from "node:child_process";
+import { CommandDescriptor, normalizeCliExecutionError } from "./exec";
+import { PassCliError } from "../types";
+
+const LOGIN_HOST = "account.proton.me";
+
+export interface BrowserLoginOptions {
+  openUrl: (url: string) => void | Promise<void>;
+  timeoutMs: number;
+}
+
+export function extractLoginUrl(text: string): string | null {
+  for (const candidate of text.match(/https?:\/\/\S+/g) ?? []) {
+    try {
+      const url = new URL(candidate);
+      if (url.protocol === "https:" && url.host === LOGIN_HOST) return candidate;
+    } catch {
+      // Keep scanning output. Browser opening is best-effort.
+    }
+  }
+
+  return null;
+}
+
+function normalizeLoginError(error: unknown, cliPath: string): PassCliError {
+  const normalized = normalizeCliExecutionError(error, cliPath);
+  return normalized.type === "unknown" ? new PassCliError("pass-cli login failed.", "unknown") : normalized;
+}
+
+export function runBrowserLogin(command: CommandDescriptor, options: BrowserLoginOptions): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command.file, [...command.args, "login"], { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    let opened = false;
+    let settled = false;
+    let openPromise: Promise<void> | undefined;
+
+    const finish = (error?: PassCliError) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (error) reject(error);
+      else resolve();
+    };
+
+    const scanCompleteLines = (flush = false) => {
+      const boundary = flush ? stdout.length : stdout.lastIndexOf("\n") + 1;
+      if (boundary === 0) return;
+      const complete = stdout.slice(0, boundary);
+      stdout = stdout.slice(boundary);
+      const url = opened ? null : extractLoginUrl(complete);
+      if (!url) return;
+      opened = true;
+      openPromise = Promise.resolve(options.openUrl(url)).then(
+        () => undefined,
+        () => {
+          child.kill();
+          finish(new PassCliError("Could not open Proton login URL.", "unknown"));
+        },
+      );
+    };
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+      scanCompleteLines();
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", (error) => finish(normalizeLoginError(error, command.file)));
+    child.on("close", (code) => {
+      scanCompleteLines(true);
+      if (settled) return;
+      if (code !== 0) {
+        const error = Object.assign(new Error(`pass-cli exited with code ${code ?? "unknown"}`), { stderr });
+        finish(normalizeLoginError(error, command.file));
+        return;
+      }
+      void (openPromise ?? Promise.resolve()).then(() => finish());
+    });
+
+    const timer = setTimeout(() => {
+      child.kill();
+      finish(new PassCliError("Login timed out. Complete browser authentication and try again.", "timeout"));
+    }, options.timeoutMs);
+  });
+}

--- a/extensions/proton-pass/src/lib/core/zip-test-helper.ts
+++ b/extensions/proton-pass/src/lib/core/zip-test-helper.ts
@@ -1,0 +1,52 @@
+import { crc32, deflateRawSync } from "node:zlib";
+
+export interface ZipEntry {
+  name: string;
+  data: Buffer;
+  method?: 0 | 8;
+}
+
+export function makeZip(entries: ZipEntry[]): Buffer {
+  const localParts: Buffer[] = [];
+  const centralParts: Buffer[] = [];
+  let offset = 0;
+
+  for (const entry of entries) {
+    const name = Buffer.from(entry.name);
+    const method = entry.method ?? 8;
+    const compressed = method === 8 ? deflateRawSync(entry.data) : entry.data;
+    const checksum = crc32(entry.data);
+
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(20, 4);
+    local.writeUInt16LE(method, 8);
+    local.writeUInt32LE(checksum, 14);
+    local.writeUInt32LE(compressed.length, 18);
+    local.writeUInt32LE(entry.data.length, 22);
+    local.writeUInt16LE(name.length, 26);
+    localParts.push(local, name, compressed);
+
+    const central = Buffer.alloc(46);
+    central.writeUInt32LE(0x02014b50, 0);
+    central.writeUInt16LE(20, 4);
+    central.writeUInt16LE(20, 6);
+    central.writeUInt16LE(method, 10);
+    central.writeUInt32LE(checksum, 16);
+    central.writeUInt32LE(compressed.length, 20);
+    central.writeUInt32LE(entry.data.length, 24);
+    central.writeUInt16LE(name.length, 28);
+    central.writeUInt32LE(offset, 42);
+    centralParts.push(central, name);
+    offset += local.length + name.length + compressed.length;
+  }
+
+  const centralDirectory = Buffer.concat(centralParts);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(entries.length, 8);
+  end.writeUInt16LE(entries.length, 10);
+  end.writeUInt32LE(centralDirectory.length, 12);
+  end.writeUInt32LE(offset, 16);
+  return Buffer.concat([...localParts, centralDirectory, end]);
+}

--- a/extensions/proton-pass/src/lib/core/zip.test.ts
+++ b/extensions/proton-pass/src/lib/core/zip.test.ts
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { extractZip } from "./zip";
+import { makeZip } from "./zip-test-helper";
+
+async function withTempDir(run: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(path.join(tmpdir(), "proton-pass-zip-"));
+  try {
+    await run(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("extracts stored and deflated files with identical bytes", async () => {
+  await withTempDir(async (dir) => {
+    await extractZip(
+      makeZip([
+        { name: "pass-cli.exe", data: Buffer.from("fake executable"), method: 0 },
+        { name: "libcrypto-3-x64.dll", data: Buffer.from([0, 1, 2, 255]), method: 8 },
+      ]),
+      dir,
+    );
+
+    assert.deepEqual(await readFile(path.join(dir, "pass-cli.exe")), Buffer.from("fake executable"));
+    assert.deepEqual(await readFile(path.join(dir, "libcrypto-3-x64.dll")), Buffer.from([0, 1, 2, 255]));
+  });
+});
+
+test("rejects traversal and absolute paths", async () => {
+  for (const name of ["../evil", "folder/../../evil", "/absolute", "C:\\absolute", "..\\evil"]) {
+    await withTempDir(async (dir) => {
+      await assert.rejects(extractZip(makeZip([{ name, data: Buffer.from("evil") }]), dir), /Unsafe ZIP path/);
+    });
+  }
+});
+
+test("rejects unsupported compression methods", async () => {
+  await withTempDir(async (dir) => {
+    const zip = makeZip([{ name: "pass-cli.exe", data: Buffer.from("exe"), method: 0 }]);
+    zip.writeUInt16LE(12, zip.indexOf(Buffer.from([0x50, 0x4b, 0x01, 0x02])) + 10);
+    await assert.rejects(extractZip(zip, dir), /Unsupported ZIP compression method: 12/);
+  });
+});

--- a/extensions/proton-pass/src/lib/core/zip.ts
+++ b/extensions/proton-pass/src/lib/core/zip.ts
@@ -1,0 +1,96 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { crc32, inflateRawSync } from "node:zlib";
+
+interface ExtractedEntry {
+  name: string;
+  data?: Buffer;
+}
+
+function endOfCentralDirectory(zip: Buffer): number {
+  const minimum = Math.max(0, zip.length - 65_557);
+  for (let offset = zip.length - 22; offset >= minimum; offset--) {
+    if (zip.readUInt32LE(offset) === 0x06054b50) return offset;
+  }
+  throw new Error("Invalid ZIP: end of central directory not found");
+}
+
+function safeName(rawName: string): string {
+  const name = rawName.replaceAll("\\", "/");
+  if (
+    !name ||
+    name.includes("\0") ||
+    name.startsWith("/") ||
+    /^[A-Za-z]:/.test(name) ||
+    name.split("/").some((part) => part === "..")
+  ) {
+    throw new Error(`Unsafe ZIP path: ${rawName}`);
+  }
+  return name;
+}
+
+function parseEntries(zip: Buffer): ExtractedEntry[] {
+  const end = endOfCentralDirectory(zip);
+  const entryCount = zip.readUInt16LE(end + 10);
+  const centralSize = zip.readUInt32LE(end + 12);
+  let offset = zip.readUInt32LE(end + 16);
+  const centralEnd = offset + centralSize;
+  if (centralEnd > end) throw new Error("Invalid ZIP: central directory is out of bounds");
+
+  const entries: ExtractedEntry[] = [];
+  for (let index = 0; index < entryCount; index++) {
+    if (offset + 46 > centralEnd || zip.readUInt32LE(offset) !== 0x02014b50) {
+      throw new Error("Invalid ZIP: malformed central directory");
+    }
+    const flags = zip.readUInt16LE(offset + 8);
+    const method = zip.readUInt16LE(offset + 10);
+    const expectedCrc = zip.readUInt32LE(offset + 16);
+    const compressedSize = zip.readUInt32LE(offset + 20);
+    const uncompressedSize = zip.readUInt32LE(offset + 24);
+    const nameLength = zip.readUInt16LE(offset + 28);
+    const extraLength = zip.readUInt16LE(offset + 30);
+    const commentLength = zip.readUInt16LE(offset + 32);
+    const localOffset = zip.readUInt32LE(offset + 42);
+    const nextOffset = offset + 46 + nameLength + extraLength + commentLength;
+    if (nextOffset > centralEnd) throw new Error("Invalid ZIP: malformed central directory entry");
+    if ((flags & 1) !== 0) throw new Error("Encrypted ZIP entries are not supported");
+    if (method !== 0 && method !== 8) throw new Error(`Unsupported ZIP compression method: ${method}`);
+
+    const name = safeName(zip.toString("utf8", offset + 46, offset + 46 + nameLength));
+    if (localOffset + 30 > zip.length || zip.readUInt32LE(localOffset) !== 0x04034b50) {
+      throw new Error("Invalid ZIP: local entry not found");
+    }
+    const localNameLength = zip.readUInt16LE(localOffset + 26);
+    const localExtraLength = zip.readUInt16LE(localOffset + 28);
+    const dataOffset = localOffset + 30 + localNameLength + localExtraLength;
+    const dataEnd = dataOffset + compressedSize;
+    if (dataEnd > zip.length) throw new Error("Invalid ZIP: entry data is out of bounds");
+
+    if (name.endsWith("/")) {
+      entries.push({ name });
+    } else {
+      const compressed = zip.subarray(dataOffset, dataEnd);
+      const data = method === 0 ? Buffer.from(compressed) : inflateRawSync(compressed);
+      if (data.length !== uncompressedSize || crc32(data) !== expectedCrc) {
+        throw new Error(`Invalid ZIP entry: ${name}`);
+      }
+      entries.push({ name, data });
+    }
+    offset = nextOffset;
+  }
+  return entries;
+}
+
+export async function extractZip(zip: Buffer, destDir: string): Promise<void> {
+  const entries = parseEntries(zip);
+  await mkdir(destDir, { recursive: true });
+  for (const entry of entries) {
+    const destination = path.join(destDir, ...entry.name.split("/"));
+    if (entry.data === undefined) {
+      await mkdir(destination, { recursive: true });
+    } else {
+      await mkdir(path.dirname(destination), { recursive: true });
+      await writeFile(destination, entry.data);
+    }
+  }
+}

--- a/extensions/proton-pass/src/lib/error-views.tsx
+++ b/extensions/proton-pass/src/lib/error-views.tsx
@@ -39,6 +39,14 @@ interface ErrorConfig {
 
 function getErrorConfig(errorType: PassCliErrorType, contextTitle?: string): ErrorConfig {
   switch (errorType) {
+    case "unsupported_platform":
+      return {
+        icon: Icon.XMarkCircle,
+        title: "Unsupported Platform",
+        description: `Proton Pass supports macOS arm64/x64 and Windows x64. Current platform: ${process.platform}-${process.arch}.`,
+        showDocsLink: false,
+        showRetry: false,
+      };
     case "not_installed":
       return {
         icon: Icon.XMarkCircle,

--- a/extensions/proton-pass/src/lib/pass-cli-normalize.test.ts
+++ b/extensions/proton-pass/src/lib/pass-cli-normalize.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { normalizeItem } from "./pass-cli-normalize";
+import { normalizeItem, normalizeVault } from "./pass-cli-normalize";
+import { PassCliError } from "./types";
 
 test("normalizes a scoped item list entry that omits the vault share id", () => {
   const item = normalizeItem(
@@ -51,4 +52,94 @@ test("keeps an explicit item share id when present", () => {
   assert.equal(item.shareId, "vault-from-item");
   assert.equal(item.vaultName, "Personal");
   assert.equal(item.type, "note");
+});
+
+test("normalizes full login data to exactly the cache-safe Item keys", () => {
+  const item = normalizeItem(
+    {
+      id: "item-secret",
+      password: "outer-secret",
+      totp_uri: "otpauth://totp/outer-secret",
+      content: {
+        title: "Secret Login",
+        content: {
+          Login: {
+            username: "alice",
+            email: "alice@example.com",
+            password: "inner-secret",
+            urls: [{ url: "https://example.com" }],
+            totp_uri: "otpauth://totp/inner-secret",
+          },
+        },
+      },
+    },
+    "Personal",
+    "vault-1",
+  );
+
+  assert.deepEqual(Object.keys(item).sort(), [
+    "email",
+    "hasTotp",
+    "itemId",
+    "shareId",
+    "title",
+    "type",
+    "urls",
+    "username",
+    "vaultName",
+  ]);
+  assert.equal(Object.hasOwn(item, "password"), false);
+  assert.equal(Object.hasOwn(item, "totp_uri"), false);
+  assert.equal(item.hasTotp, true);
+});
+
+test("recognizes note, credit card, and alias items", () => {
+  const cases = [
+    ["note", { Note: {} }],
+    ["credit_card", { CreditCard: {} }],
+    ["alias", { Alias: {} }],
+  ] as const;
+
+  for (const [expectedType, content] of cases) {
+    const item = normalizeItem(
+      { id: `item-${expectedType}`, content: { title: expectedType, content } },
+      "Personal",
+      "vault-1",
+    );
+    assert.equal(item.type, expectedType);
+  }
+});
+
+test("accepts alternate credit-card and SSH-key field names", () => {
+  const creditCard = normalizeItem(
+    { id: "card", content: { title: "Card", content: { credit_card: {} } } },
+    "Personal",
+    "vault-1",
+  );
+  const sshKey = normalizeItem(
+    { id: "ssh", content: { title: "SSH", content: { ssh_key: {} } } },
+    "Personal",
+    "vault-1",
+  );
+
+  assert.equal(creditCard.type, "credit_card");
+  assert.equal(sshKey.type, "ssh_key");
+});
+
+test("rejects malformed item and vault records as invalid output", () => {
+  for (const normalize of [() => normalizeItem({ title: "Missing IDs" }), () => normalizeVault("bad")]) {
+    assert.throws(normalize, (error: unknown) => {
+      assert.equal(error instanceof PassCliError && error.type, "invalid_output");
+      return true;
+    });
+  }
+});
+
+test("does not invent metadata omitted by pass-cli 2.3.3 vault output", () => {
+  assert.deepEqual(normalizeVault({ name: "Work", vault_id: "vault-id-2", share_id: "share-2" }), {
+    shareId: "share-2",
+    name: "Work",
+    itemCount: undefined,
+    role: undefined,
+  });
 });

--- a/extensions/proton-pass/src/lib/pass-cli-normalize.ts
+++ b/extensions/proton-pass/src/lib/pass-cli-normalize.ts
@@ -10,7 +10,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function normalizeVaultRole(value: unknown): VaultRole {
+function normalizeVaultRole(value: unknown): VaultRole | undefined {
   const raw = trimOrUndefined(value)?.toLowerCase();
   switch (raw) {
     case "owner":
@@ -19,7 +19,7 @@ function normalizeVaultRole(value: unknown): VaultRole {
     case "viewer":
       return raw;
     default:
-      return "viewer";
+      return undefined;
   }
 }
 
@@ -31,7 +31,12 @@ export function normalizeVault(raw: unknown): Vault {
   const shareId = trimOrUndefined(raw.share_id ?? raw.shareId ?? raw.shareID ?? raw.id);
   const name = trimOrUndefined(raw.name);
   const itemCountValue = raw.itemCount ?? raw.item_count ?? raw.items_count ?? raw.itemsCount;
-  const itemCount = typeof itemCountValue === "number" ? itemCountValue : Number(itemCountValue ?? 0);
+  const itemCount =
+    itemCountValue === undefined
+      ? undefined
+      : typeof itemCountValue === "number"
+        ? itemCountValue
+        : Number(itemCountValue);
   const role = normalizeVaultRole(raw.role);
 
   if (!shareId || !name) {
@@ -41,7 +46,7 @@ export function normalizeVault(raw: unknown): Vault {
   return {
     shareId,
     name,
-    itemCount: Number.isFinite(itemCount) ? itemCount : 0,
+    itemCount: itemCount !== undefined && Number.isFinite(itemCount) ? itemCount : undefined,
     role,
   };
 }

--- a/extensions/proton-pass/src/lib/pass-cli.ts
+++ b/extensions/proton-pass/src/lib/pass-cli.ts
@@ -1,24 +1,19 @@
-import { getPreferenceValues, environment } from "@raycast/api";
-import { execFile } from "child_process";
-import { homedir } from "os";
-import { delimiter } from "path";
-import { promisify } from "util";
-import { Item, ItemDetail, PassCliError, PassCliErrorType, PasswordOptions, PasswordScore, Vault } from "./types";
-import { MOCK_VAULTS, MOCK_ITEMS, MOCK_ITEM_DETAILS, MOCK_TOTP_CODES } from "./mock-data";
+import { environment, getPreferenceValues, open } from "@raycast/api";
+import { homedir } from "node:os";
+import { delimiter } from "node:path";
 import { clearCache } from "./cache";
 import { ensureCli } from "./cli";
-import { normalizeItem, normalizeItemDetail, normalizeVault } from "./pass-cli-normalize";
+import { createPassCliAdapter, PassCliAdapter } from "./core/adapter";
+import { runBrowserLogin } from "./core/login";
+import { MOCK_ITEM_DETAILS, MOCK_ITEMS, MOCK_TOTP_CODES, MOCK_VAULTS } from "./mock-data";
+import { Item, ItemDetail, PassCliError, PasswordOptions, PasswordScore, Vault } from "./types";
 
-let mockCacheCleared = false;
-
-// Seed the extension with local demo data while running `ray develop` / `npm run dev`.
 const USE_MOCK_DATA = environment.isDevelopment;
 const DEFAULT_CLI_COMMAND = "pass-cli";
+const LOGIN_TIMEOUT_MS = 10 * 60_000;
 type CliPathPreferenceValues = { cliPath?: string };
 
-function useMockData(): boolean {
-  return USE_MOCK_DATA;
-}
+let mockCacheCleared = false;
 
 async function ensureMockCacheCleared(): Promise<void> {
   if (mockCacheCleared) return;
@@ -26,12 +21,10 @@ async function ensureMockCacheCleared(): Promise<void> {
   await clearCache();
 }
 
-const execFileAsync = promisify(execFile);
-
 function trimOrUndefined(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
+  return trimmed || undefined;
 }
 
 function stripSurroundingQuotes(value: string): string {
@@ -42,372 +35,135 @@ function stripSurroundingQuotes(value: string): string {
   return trimmed;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function truncateMiddle(value: string, maxLen: number): string {
-  if (value.length <= maxLen) return value;
-  const head = Math.max(0, Math.floor((maxLen - 1) / 2));
-  const tail = Math.max(0, maxLen - head - 1);
-  return `${value.slice(0, head)}…${value.slice(value.length - tail)}`;
-}
-
 function getEnhancedPath(): string {
-  const home = homedir();
   const currentPath = process.env.PATH || "";
+  if (process.platform === "win32") return currentPath;
 
-  const additionalPaths = [
-    "/opt/homebrew/bin",
-    "/usr/local/bin",
-    `${home}/.local/bin`,
-    `${home}/bin`,
-    "/usr/bin",
-    "/bin",
-  ];
-
-  return [...additionalPaths, currentPath].filter((p) => p.length > 0).join(delimiter);
+  const home = homedir();
+  return ["/opt/homebrew/bin", "/usr/local/bin", `${home}/.local/bin`, `${home}/bin`, "/usr/bin", "/bin", currentPath]
+    .filter(Boolean)
+    .join(delimiter);
 }
 
 function getConfiguredCliPath(): string | undefined {
-  const preferences = getPreferenceValues<CliPathPreferenceValues>();
-  const configured = trimOrUndefined(preferences.cliPath);
-  if (!configured || configured === DEFAULT_CLI_COMMAND) {
-    return undefined;
-  }
+  const configured = trimOrUndefined(getPreferenceValues<CliPathPreferenceValues>().cliPath);
+  if (!configured || configured === DEFAULT_CLI_COMMAND) return undefined;
   return stripSurroundingQuotes(configured);
 }
 
-async function getCliPathAsync(): Promise<string> {
-  // Check if user configured a custom path
-  const configured = getConfiguredCliPath();
-  if (configured) {
-    return configured;
-  }
-
-  // This extension is macOS-only, but keeping a non-throwing fallback here
-  // avoids hard failures when code paths are executed in non-darwin environments.
-  if (process.platform !== "darwin") {
-    return DEFAULT_CLI_COMMAND;
-  }
-
-  // Ensure CLI is installed (auto-download if needed)
-  return ensureCli();
+async function getCliPath(): Promise<string> {
+  return getConfiguredCliPath() ?? ensureCli();
 }
 
-function createExecEnv(): NodeJS.ProcessEnv {
-  return {
-    ...process.env,
-    PATH: getEnhancedPath(),
-  };
-}
-
-function classifyCliError(text: string): PassCliErrorType {
-  const normalized = text.toLowerCase();
-
-  if (normalized.includes("cannot get the encryption key") || normalized.includes("error creating client features")) {
-    return "keyring_error";
-  }
-
-  if (
-    normalized.includes("requires an authenticated client") ||
-    normalized.includes("not authenticated") ||
-    normalized.includes("login required") ||
-    normalized.includes("please login") ||
-    normalized.includes("not logged in")
-  ) {
-    return "not_authenticated";
-  }
-
-  if (
-    normalized.includes("network") ||
-    normalized.includes("timeout") ||
-    normalized.includes("timed out") ||
-    normalized.includes("connection") ||
-    normalized.includes("dns")
-  ) {
-    return "network_error";
-  }
-
-  return "unknown";
-}
-
-async function execPassCli(
-  cliPath: string,
-  args: string[],
-  env: NodeJS.ProcessEnv,
-  timeout = 60_000,
-): Promise<{ stdout: string; stderr: string }> {
-  const baseOptions = {
-    env,
-    timeout,
-    maxBuffer: 20 * 1024 * 1024,
-  };
-
-  const { stdout, stderr } = await execFileAsync(cliPath, args, baseOptions);
-  return { stdout: stdout ?? "", stderr: stderr ?? "" };
-}
-
-async function runCli(args: string[]): Promise<string> {
-  const cliPath = await getCliPathAsync();
-  const env = createExecEnv();
-
-  try {
-    const { stdout } = await execPassCli(cliPath, args, env);
-    return (stdout ?? "").trim();
-  } catch (error: unknown) {
-    throw normalizeCliExecutionError(error, cliPath, "pass-cli timed out. Please try again.");
-  }
-}
-
-function normalizeCliExecutionError(error: unknown, cliPath: string, timeoutMessage: string): PassCliError {
-  const execErr = error as NodeJS.ErrnoException & { killed?: boolean; signal?: string; stderr?: string };
-  if (execErr?.killed && typeof execErr?.signal === "string") {
-    return new PassCliError(timeoutMessage, "timeout");
-  }
-
-  const message = error instanceof Error ? error.message : "";
-  const stderr = typeof execErr?.stderr === "string" ? execErr.stderr : "";
-
-  const isEnoent = execErr?.code === "ENOENT" || execErr?.errno === -2;
-  if (isEnoent) {
-    return new PassCliError(
-      `pass-cli not found at '${cliPath}'. Install it or set the correct path in extension preferences.`,
-      "not_installed",
-    );
-  }
-
-  const combined = [stderr, message]
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0)
-    .join("\n");
-  const type = classifyCliError(combined);
-
-  if (type === "keyring_error") {
-    return new PassCliError(
-      "pass-cli could not access secure key storage. Try: pass-cli logout --force, then set PROTON_PASS_KEY_PROVIDER=fs and login again.",
-      "keyring_error",
-    );
-  }
-
-  if (type === "not_authenticated") {
-    return new PassCliError("Not authenticated. Run pass-cli login to authenticate.", "not_authenticated");
-  }
-
-  if (type === "network_error") {
-    return new PassCliError("Network error. Check your connection and try again.", "network_error");
-  }
-
-  const safeDetails =
-    combined.length > 0 ? truncateMiddle(combined, 600) : "An unknown error occurred while running pass-cli.";
-  return new PassCliError(safeDetails, "unknown");
+async function getAdapter(): Promise<PassCliAdapter> {
+  const cliPath = await getCliPath();
+  return createPassCliAdapter(
+    { file: cliPath, args: [] },
+    {
+      env: { ...process.env, PATH: getEnhancedPath() },
+    },
+  );
 }
 
 export async function loginWithBrowser(): Promise<void> {
-  if (useMockData()) {
+  if (USE_MOCK_DATA) {
     await ensureMockCacheCleared();
     return;
   }
 
-  const cliPath = await getCliPathAsync();
-  const env = createExecEnv();
-
-  try {
-    await execPassCli(cliPath, ["login"], env, 10 * 60_000);
-  } catch (error: unknown) {
-    throw normalizeCliExecutionError(error, cliPath, "Login timed out. Complete browser authentication and try again.");
-  }
-}
-
-function parseJson<T>(text: string, context: string): T {
-  try {
-    return JSON.parse(text) as T;
-  } catch {
-    throw new PassCliError(
-      `Unexpected ${context} output from pass-cli. Please update pass-cli and try again.`,
-      "invalid_output",
-    );
-  }
+  const cliPath = await getCliPath();
+  await runBrowserLogin(
+    { file: cliPath, args: [] },
+    {
+      openUrl: (url) => open(url),
+      timeoutMs: LOGIN_TIMEOUT_MS,
+    },
+  );
 }
 
 export async function checkAuth(): Promise<boolean> {
-  if (useMockData()) {
+  if (USE_MOCK_DATA) {
     await ensureMockCacheCleared();
     return true;
   }
-
-  try {
-    await runCli(["test"]);
-    return true;
-  } catch (error) {
-    if (error instanceof PassCliError && error.type === "not_authenticated") {
-      return false;
-    }
-    throw error;
-  }
+  return (await getAdapter()).checkAuth();
 }
 
 export async function listVaults(): Promise<Vault[]> {
-  if (useMockData()) {
+  if (USE_MOCK_DATA) {
     await ensureMockCacheCleared();
     return MOCK_VAULTS;
   }
-
-  const output = await runCli(["vault", "list", "--output", "json"]);
-  const data = parseJson<unknown>(output, "vault list");
-
-  const vaultsRaw = Array.isArray(data) ? data : isRecord(data) ? (data.vaults as unknown) : undefined;
-  if (!Array.isArray(vaultsRaw)) {
-    throw new PassCliError("Unexpected vault list output from pass-cli.", "invalid_output");
-  }
-
-  return vaultsRaw.map(normalizeVault);
+  return (await getAdapter()).listVaults();
 }
 
 async function listItemsFromVault(shareId: string, vaultName: string): Promise<Item[]> {
-  const args = ["item", "list", "--share-id", shareId, "--output", "json"];
-
-  const output = await runCli(args);
-  const data = parseJson<unknown>(output, "item list");
-
-  const itemsRaw = Array.isArray(data) ? data : isRecord(data) ? (data.items as unknown) : undefined;
-  if (!Array.isArray(itemsRaw)) {
-    throw new PassCliError("Unexpected item list output from pass-cli.", "invalid_output");
-  }
-
-  return itemsRaw
-    .filter((item) => {
-      if (!isRecord(item)) return false;
-      const state = trimOrUndefined(item.state);
-      return state !== "Trashed";
-    })
-    .map((item) => normalizeItem(item, vaultName, shareId));
+  return (await getAdapter()).listItems(shareId, vaultName);
 }
 
 export async function listItems(shareId?: string): Promise<Item[]> {
-  if (useMockData()) {
+  if (USE_MOCK_DATA) {
     await ensureMockCacheCleared();
-    if (shareId) {
-      return MOCK_ITEMS.filter((item) => item.shareId === shareId);
-    }
-    return MOCK_ITEMS;
-  }
-
-  if (shareId) {
-    const vaults = await listVaults();
-    const vault = vaults.find((v) => v.shareId === shareId);
-    return listItemsFromVault(shareId, vault?.name ?? "Unknown Vault");
+    return shareId ? MOCK_ITEMS.filter((item) => item.shareId === shareId) : MOCK_ITEMS;
   }
 
   const vaults = await listVaults();
-  const allItems: Item[] = [];
-
-  for (const vault of vaults) {
-    try {
-      const items = await listItemsFromVault(vault.shareId, vault.name);
-      allItems.push(...items);
-    } catch (error) {
-      const errorType = error instanceof PassCliError ? error.type : "unknown";
-      const message = error instanceof Error ? error.message : "Unknown error";
-      console.error(`Failed to list items from vault ${vault.name} (${errorType}): ${message}`);
-    }
+  if (shareId) {
+    const vault = vaults.find((candidate) => candidate.shareId === shareId);
+    return listItemsFromVault(shareId, vault?.name ?? "Unknown Vault");
   }
 
+  const allItems: Item[] = [];
+  for (const vault of vaults) {
+    try {
+      allItems.push(...(await listItemsFromVault(vault.shareId, vault.name)));
+    } catch (error) {
+      const type = error instanceof PassCliError ? error.type : "unknown";
+      const message = error instanceof Error ? error.message : "Unknown error";
+      console.error(`Failed to list items from vault ${vault.name} (${type}): ${message}`);
+    }
+  }
   return allItems;
 }
 
-function unwrapItemResponse(data: unknown): unknown {
-  if (!isRecord(data)) return data;
-
-  const wrapperKeys = ["item", "data", "result", "response", "payload"];
-  for (const key of wrapperKeys) {
-    if (isRecord(data[key])) {
-      const inner = data[key] as Record<string, unknown>;
-      for (const innerKey of wrapperKeys) {
-        if (isRecord(inner[innerKey])) {
-          return inner[innerKey];
-        }
-      }
-      return inner;
-    }
-  }
-
-  return data;
-}
-
 export async function getItem(shareId: string, itemId: string): Promise<ItemDetail> {
-  if (useMockData()) {
-    const mockDetail = MOCK_ITEM_DETAILS[itemId];
-    if (mockDetail) return mockDetail;
-    const mockItem = MOCK_ITEMS.find((i) => i.itemId === itemId && i.shareId === shareId);
-    if (mockItem) return { ...mockItem, password: "mock-password-123" };
+  if (USE_MOCK_DATA) {
+    const detail = MOCK_ITEM_DETAILS[itemId];
+    if (detail) return detail;
+    const item = MOCK_ITEMS.find((candidate) => candidate.itemId === itemId && candidate.shareId === shareId);
+    if (item) return { ...item, password: "mock-password-123" };
     throw new PassCliError("Item not found", "invalid_output");
   }
-
-  const output = await runCli(["item", "view", "--share-id", shareId, "--item-id", itemId, "--output", "json"]);
-  const data = parseJson<unknown>(output, "item view");
-
-  const rawItem = unwrapItemResponse(data);
-  return normalizeItemDetail(rawItem, undefined, shareId);
+  return (await getAdapter()).getItem(shareId, itemId);
 }
 
 export async function getTotpCodes(shareId: string, itemId: string): Promise<Record<string, string>> {
-  const output = await runCli(["item", "totp", "--share-id", shareId, "--item-id", itemId, "--output", "json"]);
-  const data = parseJson<unknown>(output, "item totp");
-
-  const raw = isRecord(data) && isRecord(data.totps) ? data.totps : data;
-  if (!isRecord(raw)) {
-    throw new PassCliError("Unexpected TOTP output from pass-cli.", "invalid_output");
-  }
-
-  const entries = Object.entries(raw)
-    .map(([k, v]) => [k, trimOrUndefined(v)] as const)
-    .filter((e): e is readonly [string, string] => Boolean(e[1]));
-
-  return Object.fromEntries(entries);
+  return (await getAdapter()).getTotpCodes(shareId, itemId);
 }
 
 export async function getTotp(shareId: string, itemId: string): Promise<string> {
-  if (useMockData()) {
-    const mockCode = MOCK_TOTP_CODES[itemId];
-    if (mockCode) return mockCode;
+  if (USE_MOCK_DATA) {
+    const code = MOCK_TOTP_CODES[itemId];
+    if (code) return code;
     throw new PassCliError("No TOTP fields found for this item.", "invalid_output");
   }
 
   const codes = await getTotpCodes(shareId, itemId);
-  const preferred = codes.totp;
-  if (preferred) return preferred;
-
-  const firstKey = Object.keys(codes).sort()[0];
-  const first = firstKey ? codes[firstKey] : undefined;
-  if (!first) {
-    throw new PassCliError("No TOTP fields found for this item.", "invalid_output");
-  }
+  if (codes.totp) return codes.totp;
+  const first = Object.keys(codes)
+    .sort()
+    .map((key) => codes[key])
+    .find(Boolean);
+  if (!first) throw new PassCliError("No TOTP fields found for this item.", "invalid_output");
   return first;
 }
 
 export async function generatePassword(options: PasswordOptions): Promise<string> {
-  if (options.type === "random") {
-    const args = ["password", "generate", "random"];
-    if (options.length !== undefined) args.push("--length", options.length.toString());
-    if (options.includeNumbers !== undefined) args.push("--numbers", options.includeNumbers ? "true" : "false");
-    if (options.includeUppercase !== undefined) args.push("--uppercase", options.includeUppercase ? "true" : "false");
-    if (options.includeSymbols !== undefined) args.push("--symbols", options.includeSymbols ? "true" : "false");
-    return (await runCli(args)).trim();
-  }
-
-  const args = ["password", "generate", "memorable"];
-  if (options.words !== undefined) args.push("--words", options.words.toString());
-  if (options.separator !== undefined) args.push("--separator", options.separator);
-  if (options.capitalize !== undefined) args.push("--capitalize", options.capitalize ? "true" : "false");
-  if (options.includeNumbers !== undefined) args.push("--numbers", options.includeNumbers ? "true" : "false");
-  return (await runCli(args)).trim();
+  return (await getAdapter()).generatePassword(options);
 }
 
 export async function passwordScore(password: string): Promise<PasswordScore> {
-  // Avoid passing passwords to external process arguments.
   const penalties: string[] = [];
-
   if (password.length < 12) penalties.push("Use at least 12 characters");
   if (!/[a-z]/.test(password)) penalties.push("Add lowercase letters");
   if (!/[A-Z]/.test(password)) penalties.push("Add uppercase letters");
@@ -424,22 +180,7 @@ export async function passwordScore(password: string): Promise<PasswordScore> {
   if (/[^a-zA-Z0-9]/.test(password)) characterPool += 33;
 
   const entropy = characterPool > 0 ? Math.log2(characterPool) * password.length : 0;
-  const penaltyWeight = 7;
-  const rawScore = Math.round(Math.min(100, entropy * 1.2)) - penalties.length * penaltyWeight;
-  const numericScore = Math.max(0, Math.min(100, rawScore));
-
-  let passwordScore = "Weak";
-  if (numericScore >= 80) {
-    passwordScore = "Strong";
-  } else if (numericScore >= 60) {
-    passwordScore = "Good";
-  } else if (numericScore >= 35) {
-    passwordScore = "Fair";
-  }
-
-  return {
-    numericScore,
-    passwordScore,
-    penalties: penalties.length > 0 ? penalties : undefined,
-  };
+  const numericScore = Math.max(0, Math.min(100, Math.round(Math.min(100, entropy * 1.2)) - penalties.length * 7));
+  const score = numericScore >= 80 ? "Strong" : numericScore >= 60 ? "Good" : numericScore >= 35 ? "Fair" : "Weak";
+  return { numericScore, passwordScore: score, penalties: penalties.length ? penalties : undefined };
 }

--- a/extensions/proton-pass/src/lib/shortcuts.test.ts
+++ b/extensions/proton-pass/src/lib/shortcuts.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+import { platformShortcut } from "./shortcuts";
+
+test("maps Command to Control on Windows", () => {
+  assert.deepEqual(platformShortcut(["cmd"], "c"), {
+    macOS: { modifiers: ["cmd"], key: "c" },
+    Windows: { modifiers: ["ctrl"], key: "c" },
+  });
+});
+
+test("maps Command-Option to Control-Alt on Windows", () => {
+  assert.deepEqual(platformShortcut(["cmd", "opt"], "c"), {
+    macOS: { modifiers: ["cmd", "opt"], key: "c" },
+    Windows: { modifiers: ["ctrl", "alt"], key: "c" },
+  });
+});
+
+test("preserves Shift in platform shortcuts", () => {
+  assert.deepEqual(platformShortcut(["cmd", "shift"], "u"), {
+    macOS: { modifiers: ["cmd", "shift"], key: "u" },
+    Windows: { modifiers: ["ctrl", "shift"], key: "u" },
+  });
+});
+
+test("TSX sources contain no macOS-only Command or Option shortcuts", () => {
+  const sourceDir = join(process.cwd(), "src");
+  const files = readdirSync(sourceDir, { recursive: true, encoding: "utf8" }).filter((file) => file.endsWith(".tsx"));
+  const offenders = files.filter((file) =>
+    /modifiers\s*:\s*\[\s*["'](?:cmd|opt)["']/.test(readFileSync(join(sourceDir, file), "utf8")),
+  );
+
+  assert.deepEqual(offenders, []);
+});

--- a/extensions/proton-pass/src/lib/shortcuts.ts
+++ b/extensions/proton-pass/src/lib/shortcuts.ts
@@ -1,0 +1,15 @@
+type MacModifier = "cmd" | "ctrl" | "opt" | "shift";
+type WindowsModifier = "ctrl" | "alt" | "shift";
+
+export function platformShortcut<Key extends string>(modifiers: MacModifier[], key: Key) {
+  const windowsModifiers = modifiers.map((modifier): WindowsModifier => {
+    if (modifier === "cmd") return "ctrl";
+    if (modifier === "opt") return "alt";
+    return modifier;
+  });
+
+  return {
+    macOS: { modifiers, key },
+    Windows: { modifiers: windowsModifiers, key },
+  };
+}

--- a/extensions/proton-pass/src/lib/testing/fake-pass-cli.mjs
+++ b/extensions/proton-pass/src/lib/testing/fake-pass-cli.mjs
@@ -1,0 +1,139 @@
+const mode = process.argv[2];
+const args = process.argv.slice(3);
+const loginUrl = "https://account.proton.me/desktop/login?app=pass#payload=FAKE_PAYLOAD_TOKEN";
+
+const expectedArgs = {
+  "auth-ok": ["info"],
+  "auth-denied": ["info"],
+  "login-ok": ["login"],
+  "login-split-url": ["login"],
+  "login-bad-host": ["login"],
+  "login-garbage": ["login"],
+  "login-hang": ["login"],
+  "login-fail": ["login"],
+  "login-fail-unknown": ["login"],
+  "malformed-json": ["vault", "list", "--output", "json"],
+  "json:vaults-array": ["vault", "list", "--output", "json"],
+  "json:vaults-wrapper": ["vault", "list", "--output", "json"],
+  "json:items-full": ["item", "list", "--share-id", "vault-1", "--output", "json", "--show-secrets"],
+  "json:item-view": ["item", "view", "--share-id", "vault-1", "--item-id", "item-login", "--output", "json"],
+  "json:totps-wrapper": ["item", "totp", "--share-id", "vault-1", "--item-id", "item-1", "--output", "json"],
+  "json:totps-flat": ["item", "totp", "--share-id", "vault-1", "--item-id", "item-1", "--output", "json"],
+};
+
+if (mode in expectedArgs && JSON.stringify(args) !== JSON.stringify(expectedArgs[mode])) {
+  console.error(`Unexpected arguments for ${mode}`);
+  process.exit(3);
+}
+
+// Schema-derived subsets of pass-cli 2.3.3 JSON output (tag 2.3.3, commit 51a4c9b):
+// https://github.com/protonpass/pass-cli/tree/51a4c9b110a0ffe6e81f4f5d3877b9e5a0c24112/pass-cli/src/commands
+const fixtures = {
+  "vaults-array": [{ share_id: "vault-1", name: "Personal", item_count: 3, role: "Owner" }],
+  "vaults-wrapper": {
+    vaults: [{ name: "Work", vault_id: "vault-id-2", share_id: "vault-2" }],
+  },
+  "items-full": {
+    items: [
+      {
+        id: "item-login",
+        state: "Active",
+        content: {
+          title: "Example Login",
+          content: {
+            Login: {
+              username: "alice",
+              email: "alice@example.com",
+              password: "must-never-be-cached",
+              urls: [{ url: "https://example.com/login" }],
+              totp_uri: "otpauth://totp/Example?secret=MUST_NEVER_BE_CACHED",
+            },
+          },
+        },
+      },
+      {
+        id: "item-trashed",
+        state: "Trashed",
+        content: { title: "Deleted", content: { Note: {} } },
+      },
+    ],
+  },
+  "item-view": {
+    item: {
+      id: "item-login",
+      content: {
+        title: "Example Login",
+        content: {
+          Login: {
+            username: "alice",
+            password: "detail-password",
+            urls: [{ url: "https://example.com/login" }],
+          },
+        },
+      },
+    },
+    attachments: [],
+  },
+  "totps-wrapper": { totps: { totp: "123456", recovery: "654321" } },
+  "totps-flat": { primary: "111222", secondary: "333444" },
+};
+
+switch (mode) {
+  case "echo-args":
+    console.log(JSON.stringify(args));
+    break;
+  case "auth-ok":
+    break;
+  case "auth-denied":
+    console.error("Error: This operation requires an authenticated client");
+    process.exitCode = 1;
+    break;
+  case "login-ok":
+    console.log(
+      `\nPlease open the following URL in your browser to complete authentication:\n\n${loginUrl}\n\nWaiting for authentication to complete...`,
+    );
+    break;
+  case "login-split-url": {
+    const splitAt = loginUrl.indexOf("#payload=") + 5;
+    process.stdout.write(`Please open the following URL:\n${loginUrl.slice(0, splitAt)}`);
+    setTimeout(() => {
+      process.stdout.write(`${loginUrl.slice(splitAt)}\nWaiting for authentication to complete...\n`);
+    }, 50);
+    break;
+  }
+  case "login-bad-host":
+    console.log("https://evil.com/desktop/login?app=pass#payload=BAD_HOST_TOKEN");
+    break;
+  case "login-garbage":
+    console.log("Pass CLI changed this message and printed no browser URL.");
+    break;
+  case "login-hang":
+    process.on("SIGTERM", () => process.exit(0));
+    setInterval(() => {}, 1_000);
+    break;
+  case "login-fail":
+    console.error("Error: This operation requires an authenticated client");
+    console.error("payload=FAIL_PAYLOAD_TOKEN");
+    process.exitCode = 1;
+    break;
+  case "login-fail-unknown":
+    console.error("unexpected payload=UNKNOWN_PAYLOAD_TOKEN");
+    process.exitCode = 2;
+    break;
+  case "malformed-json":
+    console.log("{not json");
+    break;
+  default:
+    if (mode?.startsWith("json:")) {
+      const fixture = fixtures[mode.slice(5)];
+      if (fixture === undefined) {
+        console.error(`Unknown fixture: ${mode.slice(5)}`);
+        process.exitCode = 2;
+      } else {
+        console.log(JSON.stringify(fixture));
+      }
+    } else {
+      console.error(`Unknown mode: ${mode ?? "<missing>"}`);
+      process.exitCode = 2;
+    }
+}

--- a/extensions/proton-pass/src/lib/types.ts
+++ b/extensions/proton-pass/src/lib/types.ts
@@ -9,8 +9,8 @@ export type PasswordType = "random" | "passphrase";
 export interface Vault {
   shareId: string;
   name: string;
-  itemCount: number;
-  role: VaultRole;
+  itemCount?: number;
+  role?: VaultRole;
 }
 
 export interface Item {
@@ -56,6 +56,7 @@ export interface PasswordScore {
 }
 
 export type PassCliErrorType =
+  | "unsupported_platform"
   | "not_installed"
   | "not_authenticated"
   | "network_error"

--- a/extensions/proton-pass/src/list-vaults.tsx
+++ b/extensions/proton-pass/src/list-vaults.tsx
@@ -1,10 +1,11 @@
-import { List, ActionPanel, Action, Icon, showToast, Toast, Color, getPreferenceValues } from "@raycast/api";
+import { List, ActionPanel, Action, Icon, showToast, Toast, Color, getPreferenceValues, Keyboard } from "@raycast/api";
 import { useState, useEffect, useRef } from "react";
 import { listVaults, listItems, checkAuth, loginWithBrowser } from "./lib/pass-cli";
 import { Vault, Item, PassCliError, VaultRole, PROTON_PASS_CLI_DOCS } from "./lib/types";
 import { getItemIcon } from "./lib/utils";
 import { getCachedVaults, setCachedVaults, getCachedItemsForVault, setCachedItemsForVault } from "./lib/cache";
 import { openTerminalForLogin } from "./lib/terminal";
+import { platformShortcut } from "./lib/shortcuts";
 
 function VaultItems({ vault, backgroundRefreshEnabled }: { vault: Vault; backgroundRefreshEnabled: boolean }) {
   const [items, setItems] = useState<Item[]>([]);
@@ -68,20 +69,20 @@ function VaultItems({ vault, backgroundRefreshEnabled }: { vault: Vault; backgro
                 <Action.CopyToClipboard
                   title="Copy Title"
                   content={item.title}
-                  shortcut={{ modifiers: ["cmd"], key: "c" }}
+                  shortcut={Keyboard.Shortcut.Common.Copy}
                 />
                 {item.username && (
                   <Action.CopyToClipboard
                     title="Copy Username"
                     content={item.username}
-                    shortcut={{ modifiers: ["cmd", "shift"], key: "u" }}
+                    shortcut={platformShortcut(["cmd", "shift"], "u")}
                   />
                 )}
                 {item.email && (
                   <Action.CopyToClipboard
                     title="Copy Email"
                     content={item.email}
-                    shortcut={{ modifiers: ["cmd", "shift"], key: "e" }}
+                    shortcut={platformShortcut(["cmd", "shift"], "e")}
                   />
                 )}
               </ActionPanel>
@@ -218,16 +219,22 @@ export default function Command() {
         <List.EmptyView
           icon={Icon.Lock}
           title="Not Logged In"
-          description="Use browser login (default pass-cli flow). Terminal login remains available as a fallback."
+          description={
+            process.platform === "darwin"
+              ? "Use browser login (default pass-cli flow). Terminal login remains available as a fallback."
+              : "Use browser login to authenticate with Proton Pass."
+          }
           actions={
             <ActionPanel>
               <Action title="Login with Browser" icon={Icon.Globe} onAction={handleBrowserLogin} />
-              <Action title="Open Terminal Login (Fallback)" icon={Icon.Terminal} onAction={openTerminalForLogin} />
+              {process.platform === "darwin" && (
+                <Action title="Open Terminal Login (Fallback)" icon={Icon.Terminal} onAction={openTerminalForLogin} />
+              )}
               <Action.OpenInBrowser
                 title="View CLI Documentation"
                 url={PROTON_PASS_CLI_DOCS}
                 icon={Icon.Globe}
-                shortcut={{ modifiers: ["cmd"], key: "d" }}
+                shortcut={platformShortcut(["cmd"], "d")}
               />
             </ActionPanel>
           }
@@ -321,16 +328,20 @@ export default function Command() {
             icon={Icon.Folder}
             title={vault.name}
             accessories={[
-              { text: `${vault.itemCount} ${vault.itemCount === 1 ? "item" : "items"}` },
-              {
-                tag: {
-                  value: vault.role,
-                  color: getRoleColor(vault.role),
-                },
-                icon: getRoleIcon(vault.role),
-                tooltip: `Role: ${vault.role}`,
-              },
-            ]}
+              vault.itemCount === undefined
+                ? undefined
+                : { text: `${vault.itemCount} ${vault.itemCount === 1 ? "item" : "items"}` },
+              vault.role === undefined
+                ? undefined
+                : {
+                    tag: {
+                      value: vault.role,
+                      color: getRoleColor(vault.role),
+                    },
+                    icon: getRoleIcon(vault.role),
+                    tooltip: `Role: ${vault.role}`,
+                  },
+            ].filter((accessory) => accessory !== undefined)}
             actions={
               <ActionPanel>
                 <Action.Push
@@ -341,12 +352,12 @@ export default function Command() {
                 <Action.CopyToClipboard
                   title="Copy Vault Name"
                   content={vault.name}
-                  shortcut={{ modifiers: ["cmd"], key: "c" }}
+                  shortcut={Keyboard.Shortcut.Common.Copy}
                 />
                 <Action.CopyToClipboard
                   title="Copy Share ID"
                   content={vault.shareId}
-                  shortcut={{ modifiers: ["cmd", "shift"], key: "i" }}
+                  shortcut={platformShortcut(["cmd", "shift"], "i")}
                 />
               </ActionPanel>
             }

--- a/extensions/proton-pass/src/login.tsx
+++ b/extensions/proton-pass/src/login.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from "react";
 import { checkAuth, loginWithBrowser } from "./lib/pass-cli";
 import { PassCliError, PROTON_PASS_CLI_DOCS } from "./lib/types";
 import { openTerminalForLogin } from "./lib/terminal";
+import { platformShortcut } from "./lib/shortcuts";
 
 type AuthState = "loading" | "not-installed" | "not-authenticated" | "authenticated";
 
@@ -94,21 +95,27 @@ export default function Command() {
         <List.EmptyView
           icon={Icon.Lock}
           title="Not Logged In"
-          description="Use browser login (default pass-cli flow). Terminal login remains available as a fallback."
+          description={
+            process.platform === "darwin"
+              ? "Use browser login (default pass-cli flow). Terminal login remains available as a fallback."
+              : "Use browser login to authenticate with Proton Pass."
+          }
           actions={
             <ActionPanel>
               <Action title="Login with Browser" icon={Icon.Globe} onAction={handleBrowserLogin} />
-              <Action
-                title="Open Terminal Login (Fallback)"
-                icon={Icon.Terminal}
-                onAction={openTerminalForLogin}
-                shortcut={{ modifiers: ["cmd"], key: "t" }}
-              />
+              {process.platform === "darwin" && (
+                <Action
+                  title="Open Terminal Login (Fallback)"
+                  icon={Icon.Terminal}
+                  onAction={openTerminalForLogin}
+                  shortcut={platformShortcut(["cmd"], "t")}
+                />
+              )}
               <Action.OpenInBrowser
                 title="View CLI Documentation"
                 url={PROTON_PASS_CLI_DOCS}
                 icon={Icon.Globe}
-                shortcut={{ modifiers: ["cmd"], key: "d" }}
+                shortcut={platformShortcut(["cmd"], "d")}
               />
             </ActionPanel>
           }
@@ -130,7 +137,7 @@ export default function Command() {
               title="View CLI Documentation"
               url={PROTON_PASS_CLI_DOCS}
               icon={Icon.Globe}
-              shortcut={{ modifiers: ["cmd"], key: "d" }}
+              shortcut={platformShortcut(["cmd"], "d")}
             />
           </ActionPanel>
         }

--- a/extensions/proton-pass/src/search-items.tsx
+++ b/extensions/proton-pass/src/search-items.tsx
@@ -10,6 +10,7 @@ import {
   Detail,
   BrowserExtension,
   environment,
+  Keyboard,
 } from "@raycast/api";
 import { useState, useEffect, useMemo, useRef } from "react";
 import { usePromise } from "@raycast/utils";
@@ -18,6 +19,7 @@ import { Item, ItemDetail as ItemDetailType, PassCliError, PassCliErrorType, Vau
 import { getItemIcon, formatItemSubtitle, maskPassword } from "./lib/utils";
 import { getCachedItems, setCachedItems, getCachedVaults, setCachedVaults } from "./lib/cache";
 import { renderErrorView } from "./lib/error-views";
+import { platformShortcut } from "./lib/shortcuts";
 
 function escapeMarkdown(value: string): string {
   return value.replace(/([\\`*_{}[\]()#+\-.!|>])/g, "\\$1");
@@ -133,7 +135,7 @@ function ItemDetail({ item }: { item: Item }) {
               <Action
                 title="Copy Password"
                 icon={Icon.Key}
-                shortcut={{ modifiers: ["cmd"], key: "c" }}
+                shortcut={Keyboard.Shortcut.Common.Copy}
                 onAction={async () => {
                   await Clipboard.copy(detail.password!, { transient: preferences.copyPasswordTransient ?? true });
                   showToast({ style: Toast.Style.Success, title: "Password Copied" });
@@ -144,7 +146,7 @@ function ItemDetail({ item }: { item: Item }) {
               <Action
                 title="Copy Username"
                 icon={Icon.Person}
-                shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+                shortcut={platformShortcut(["cmd", "shift"], "c")}
                 onAction={async () => {
                   await Clipboard.copy(detail.username!);
                   showToast({ style: Toast.Style.Success, title: "Username Copied" });
@@ -155,7 +157,7 @@ function ItemDetail({ item }: { item: Item }) {
               <Action
                 title="Copy Email"
                 icon={Icon.Envelope}
-                shortcut={{ modifiers: ["cmd", "opt"], key: "c" }}
+                shortcut={platformShortcut(["cmd", "opt"], "c")}
                 onAction={async () => {
                   await Clipboard.copy(detail.email!);
                   showToast({ style: Toast.Style.Success, title: "Email Copied" });
@@ -166,7 +168,7 @@ function ItemDetail({ item }: { item: Item }) {
               <Action
                 title="Copy First URL"
                 icon={Icon.Link}
-                shortcut={{ modifiers: ["cmd"], key: "u" }}
+                shortcut={platformShortcut(["cmd"], "u")}
                 onAction={async () => {
                   await Clipboard.copy(detail.urls![0]);
                   showToast({ style: Toast.Style.Success, title: "URL Copied" });
@@ -177,7 +179,7 @@ function ItemDetail({ item }: { item: Item }) {
               <Action
                 title="Copy TOTP Code"
                 icon={Icon.Clock}
-                shortcut={{ modifiers: ["cmd"], key: "t" }}
+                shortcut={platformShortcut(["cmd"], "t")}
                 onAction={async () => {
                   try {
                     const totp = await getTotp(detail.shareId, detail.itemId);
@@ -194,7 +196,7 @@ function ItemDetail({ item }: { item: Item }) {
               <Action
                 title="Copy Note"
                 icon={Icon.Document}
-                shortcut={{ modifiers: ["cmd"], key: "n" }}
+                shortcut={platformShortcut(["cmd"], "n")}
                 onAction={async () => {
                   await Clipboard.copy(detail.note!);
                   showToast({ style: Toast.Style.Success, title: "Note Copied" });
@@ -211,10 +213,10 @@ function ItemDetail({ item }: { item: Item }) {
                   icon={Icon.Clipboard}
                   shortcut={
                     index < 9
-                      ? {
-                          modifiers: ["cmd", "shift"],
-                          key: String(index + 1) as "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9",
-                        }
+                      ? platformShortcut(
+                          ["cmd", "shift"],
+                          String(index + 1) as "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9",
+                        )
                       : undefined
                   }
                   onAction={async () => {
@@ -236,7 +238,7 @@ function ItemDetail({ item }: { item: Item }) {
             <Action
               title="Copy Item Debug Info"
               icon={Icon.Bug}
-              shortcut={{ modifiers: ["cmd", "shift"], key: "d" }}
+              shortcut={platformShortcut(["cmd", "shift"], "d")}
               onAction={async () => {
                 await Clipboard.copy(
                   JSON.stringify(
@@ -404,7 +406,7 @@ export default function Command() {
                     title="View Details"
                     icon={Icon.Eye}
                     target={<ItemDetail item={item} />}
-                    shortcut={{ modifiers: ["cmd"], key: "d" }}
+                    shortcut={platformShortcut(["cmd"], "d")}
                   />
                 </ActionPanel.Section>
                 <ActionPanel.Section title="Copy">
@@ -412,7 +414,7 @@ export default function Command() {
                     <Action
                       title="Copy Password"
                       icon={Icon.Key}
-                      shortcut={{ modifiers: ["cmd"], key: "c" }}
+                      shortcut={Keyboard.Shortcut.Common.Copy}
                       onAction={async () => {
                         try {
                           const detail = await getItem(item.shareId, item.itemId);
@@ -443,7 +445,7 @@ export default function Command() {
                     <Action
                       title="Copy Username"
                       icon={Icon.Person}
-                      shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+                      shortcut={platformShortcut(["cmd", "shift"], "c")}
                       onAction={async () => {
                         await Clipboard.copy(item.username!);
                         showToast({ style: Toast.Style.Success, title: "Username Copied" });
@@ -454,7 +456,7 @@ export default function Command() {
                     <Action
                       title="Copy Email"
                       icon={Icon.Envelope}
-                      shortcut={{ modifiers: ["cmd", "opt"], key: "c" }}
+                      shortcut={platformShortcut(["cmd", "opt"], "c")}
                       onAction={async () => {
                         await Clipboard.copy(item.email!);
                         showToast({ style: Toast.Style.Success, title: "Email Copied" });
@@ -465,7 +467,7 @@ export default function Command() {
                     <Action
                       title="Copy TOTP Code"
                       icon={Icon.Clock}
-                      shortcut={{ modifiers: ["cmd"], key: "t" }}
+                      shortcut={platformShortcut(["cmd"], "t")}
                       onAction={async () => {
                         try {
                           const totp = await getTotp(item.shareId, item.itemId);

--- a/extensions/proton-pass/tsconfig.test.json
+++ b/extensions/proton-pass/tsconfig.test.json
@@ -6,5 +6,11 @@
     "types": ["node"],
     "jsx": "react-jsx"
   },
-  "include": ["src/lib/pass-cli-normalize.test.ts", "src/lib/pass-cli-normalize.ts", "src/lib/types.ts"]
+  "include": [
+    "src/lib/core/**/*.ts",
+    "src/lib/pass-cli-normalize.test.ts",
+    "src/lib/pass-cli-normalize.ts",
+    "src/lib/shortcuts*.ts",
+    "src/lib/types.ts"
+  ]
 }


### PR DESCRIPTION
## Description

Adds Windows support to the Proton Pass extension while preserving existing macOS behavior.

- Downloads and verifies the Proton Pass CLI artifact for each supported platform.
- Installs the Windows executable with its required companion DLL.
- Uses platform-correct CLI execution, login handling, paths, and keyboard shortcuts.
- Prevents concurrent first-use installation races with single-flight calls, isolated staging, and atomic publication.
- Adds portable tests for artifacts, installation, concurrency, ZIP safety, CLI behavior, authentication errors, and shortcuts.
- Updates setup documentation for macOS and Windows.

Closes #30516

## Verification

- `npm test` — 52 tests passed
- `npm run build` — passed
- `npm run lint` — passed
- Windows-specific installation and execution paths are covered by portable tests. Live Raycast UI testing on Windows was not available in this environment.

## Screencast

Not included; this change adds platform compatibility without changing command UI.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
