### PR TITLE
Update logos-launcher extension

### DIFF
--- a/extensions/logos-launcher/CHANGELOG.md
+++ b/extensions/logos-launcher/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Logos Search Changelog
 
-## [Unreleased] - 2026-06-25
+## [1.3.0] - 2026-08-30
+
+### Added
+
+- Added an "Open in Floating Window" action to the Logos Tools Launcher on macOS and Windows.
+- Uses Logos' documented floating-panel shortcuts after opening the selected tool with a native Logos URI.
 
 ### Fixed
 

--- a/extensions/logos-launcher/CHANGELOG.md
+++ b/extensions/logos-launcher/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Logos Search Changelog
 
-## [1.3.0] - 2026-08-30
+## [Floating Window Action & Scheme Priorities] - {PR_MERGE_DATE}
 
-### Added
+- Added an "Open in Floating Window" action to the Logos Tools Launcher on macOS and Windows using Logos' documented shortcuts (`Option+Command+F` on macOS and `Ctrl+F11` on Windows).
+- Prioritized native Logos deep-link schemes (`logos4:...`, `logosres:...`) over `https://ref.ly/...` URLs in the tools launcher so tools open directly within Logos without opening the browser.
 
-- Added an "Open in Floating Window" action to the Logos Tools Launcher on macOS and Windows.
-- Uses Logos' documented floating-panel shortcuts after opening the selected tool with a native Logos URI.
+## [Unreleased] - 2026-06-25
 
 ### Fixed
 

--- a/extensions/logos-launcher/CHANGELOG.md
+++ b/extensions/logos-launcher/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Logos Search Changelog
 
-## [Floating Window Action & Scheme Priorities] - {PR_MERGE_DATE}
+## [Floating Window Action & Scheme Priorities] - 2026-08-31
 
 - Added an "Open in Floating Window" action to the Logos Tools Launcher on macOS and Windows using Logos' documented shortcuts (`Option+Command+F` on macOS and `Ctrl+F11` on Windows).
 - Prioritized native Logos deep-link schemes (`logos4:...`, `logosres:...`) over `https://ref.ly/...` URLs in the tools launcher so tools open directly within Logos without opening the browser.

--- a/extensions/logos-launcher/src/tools-launcher.tsx
+++ b/extensions/logos-launcher/src/tools-launcher.tsx
@@ -47,6 +47,8 @@ function ToolActions({ tool }: { tool: LogosTool }) {
           await launchTool(tool, uris);
         }}
       />
+      <Action.CopyToClipboard title="Copy Command Text" content={primaryCommand} />
+      {primaryUri ? <Action.CopyToClipboard title="Copy Launch URI" content={primaryUri} /> : null}
       {floatingUris.length > 0 ? (
         <Action
           title="Open in Floating Window"
@@ -56,8 +58,6 @@ function ToolActions({ tool }: { tool: LogosTool }) {
           }}
         />
       ) : null}
-      <Action.CopyToClipboard title="Copy Command Text" content={primaryCommand} />
-      {primaryUri ? <Action.CopyToClipboard title="Copy Launch URI" content={primaryUri} /> : null}
     </ActionPanel>
   );
 }

--- a/extensions/logos-launcher/src/tools-launcher.tsx
+++ b/extensions/logos-launcher/src/tools-launcher.tsx
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import { LOGOS_TOOL_GROUPS, type LogosTool } from "./data/logos-tools";
 import { extractErrorMessage } from "./utils/errors";
 import { LOGOS_BUNDLE_ID } from "./logos/constants";
+import { floatActiveLogosPanel } from "./utils/floating-window";
 
 export default function Command() {
   return (
@@ -33,6 +34,7 @@ function ToolListItem({ tool }: { tool: LogosTool }) {
 
 function ToolActions({ tool }: { tool: LogosTool }) {
   const uris = useMemo(() => buildToolUris(tool), [tool]);
+  const floatingUris = useMemo(() => uris.filter((uri) => !isHttpUri(uri)), [uris]);
   const primaryCommand = getPrimaryCommand(tool);
   const primaryUri = uris[0];
 
@@ -45,13 +47,22 @@ function ToolActions({ tool }: { tool: LogosTool }) {
           await launchTool(tool, uris);
         }}
       />
+      {floatingUris.length > 0 ? (
+        <Action
+          title="Open in Floating Window"
+          icon={Icon.AppWindow}
+          onAction={async () => {
+            await launchTool(tool, floatingUris, { floating: true });
+          }}
+        />
+      ) : null}
       <Action.CopyToClipboard title="Copy Command Text" content={primaryCommand} />
       {primaryUri ? <Action.CopyToClipboard title="Copy Launch URI" content={primaryUri} /> : null}
     </ActionPanel>
   );
 }
 
-async function launchTool(tool: LogosTool, uris?: string[]) {
+async function launchTool(tool: LogosTool, uris?: string[], options: { floating?: boolean } = {}) {
   const candidates = uris?.length ? uris : buildToolUris(tool);
   if (candidates.length === 0) {
     await showToast({
@@ -65,9 +76,20 @@ async function launchTool(tool: LogosTool, uris?: string[]) {
   let lastError: unknown;
   for (const uri of candidates) {
     try {
-      const isHttp = uri.startsWith("http://") || uri.startsWith("https://");
-      await open(uri, isHttp ? undefined : LOGOS_BUNDLE_ID);
-      await showHUD(`Opening ${tool.name}`);
+      await open(uri, isHttpUri(uri) ? undefined : LOGOS_BUNDLE_ID);
+      if (options.floating) {
+        try {
+          await floatActiveLogosPanel();
+        } catch (error) {
+          await showToast({
+            style: Toast.Style.Failure,
+            title: "Opened tool, but could not float panel",
+            message: `${extractErrorMessage(error)} Check automation or accessibility permissions and try again.`,
+          });
+          return;
+        }
+      }
+      await showHUD(options.floating ? `Opening ${tool.name} in a floating window` : `Opening ${tool.name}`);
       return;
     } catch (error) {
       lastError = error;
@@ -80,6 +102,10 @@ async function launchTool(tool: LogosTool, uris?: string[]) {
     title: "Could not open Logos",
     message: `${extractErrorMessage(lastError)} — Tried ${previewList}${candidates.length > 3 ? ", …" : ""}`,
   });
+}
+
+function isHttpUri(uri: string) {
+  return uri.startsWith("http://") || uri.startsWith("https://");
 }
 
 function buildToolUris(tool: LogosTool) {

--- a/extensions/logos-launcher/src/tools-launcher.tsx
+++ b/extensions/logos-launcher/src/tools-launcher.tsx
@@ -79,7 +79,7 @@ async function launchTool(tool: LogosTool, uris?: string[], options: { floating?
       await open(uri, isHttpUri(uri) ? undefined : LOGOS_BUNDLE_ID);
       if (options.floating) {
         try {
-          await floatActiveLogosPanel();
+          await floatActiveLogosPanel(tool.name);
         } catch (error) {
           await showToast({
             style: Toast.Style.Failure,

--- a/extensions/logos-launcher/src/tools-launcher.tsx
+++ b/extensions/logos-launcher/src/tools-launcher.tsx
@@ -109,8 +109,10 @@ function isHttpUri(uri: string) {
 }
 
 function buildToolUris(tool: LogosTool) {
-  const uris: string[] = [];
+  const nativeUris: string[] = [];
+  const httpUris: string[] = [];
   const seen = new Set<string>();
+
   const add = (uri?: string) => {
     if (!uri) {
       return;
@@ -119,7 +121,11 @@ function buildToolUris(tool: LogosTool) {
       return;
     }
     seen.add(uri);
-    uris.push(uri);
+    if (isHttpUri(uri)) {
+      httpUris.push(uri);
+    } else {
+      nativeUris.push(uri);
+    }
   };
 
   tool.uriHints?.forEach(add);
@@ -130,10 +136,6 @@ function buildToolUris(tool: LogosTool) {
       continue;
     }
     const encodedKind = encodeURIComponent(trimmed);
-    add(`https://ref.ly/logos4/${encodedKind}`);
-    add(`https://ref.ly/logos4/Tools?kind=${encodedKind}`);
-    add(`https://ref.ly/logos4/Tool?kind=${encodedKind}`);
-    add(`https://ref.ly/logos4/Tools?kind=${encodedKind}&name=${encodedKind}`);
     add(`logos4:${trimmed}`);
     add(`logos4:${trimmed};Name=${trimmed}`);
     add(`logos4:Tools;Kind=${trimmed}`);
@@ -141,6 +143,10 @@ function buildToolUris(tool: LogosTool) {
     add(`logos4:Tool;Kind=${trimmed}`);
     add(`logos4:Tools;Name=${trimmed}`);
     add(`logos4:Tools;Tool=${trimmed}`);
+    add(`https://ref.ly/logos4/${encodedKind}`);
+    add(`https://ref.ly/logos4/Tools?kind=${encodedKind}`);
+    add(`https://ref.ly/logos4/Tool?kind=${encodedKind}`);
+    add(`https://ref.ly/logos4/Tools?kind=${encodedKind}&name=${encodedKind}`);
   }
 
   const interactiveSlugCandidates = new Set<string>();
@@ -158,10 +164,10 @@ function buildToolUris(tool: LogosTool) {
   }
   for (const slug of interactiveSlugCandidates) {
     const encodedSlug = encodeURIComponent(slug);
-    add(`https://ref.ly/logosres/interactive:${encodedSlug}`);
-    add(`https://ref.ly/logosres/interactive:${encodedSlug}?pos=index.html`);
     add(`logosres:interactive:${slug}`);
     add(`logosres:interactive:${slug}?pos=index.html`);
+    add(`https://ref.ly/logosres/interactive:${encodedSlug}`);
+    add(`https://ref.ly/logosres/interactive:${encodedSlug}?pos=index.html`);
   }
 
   for (const interactiveId of tool.interactiveIds ?? []) {
@@ -170,24 +176,24 @@ function buildToolUris(tool: LogosTool) {
       continue;
     }
     const encodedInteractive = encodeURIComponent(trimmed);
-    add(`https://ref.ly/logos4/Interactive?name=${encodedInteractive}`);
     add(`logos4:Interactive;Name=${trimmed}`);
     add(`logos4:Interactive;name=${trimmed}`);
     add(`logos4:Interactive;Id=${trimmed}`);
+    add(`https://ref.ly/logos4/Interactive?name=${encodedInteractive}`);
   }
 
   for (const command of buildCommandCandidates(tool)) {
     const encodedCommand = encodeURIComponent(command);
-    add(`https://ref.ly/logos4/Command?q=${encodedCommand}`);
-    add(`https://ref.ly/logos4/Command?text=${encodedCommand}`);
     add(`logos4:Command?text=${encodedCommand}`);
     add(`logos4:Command;Command=${command}`);
     add(`logos4:Command;Name=Open;Text=${encodedCommand}`);
     add(`logos4-command://command/open?text=${encodedCommand}`);
     add(`logos4-command://command?text=${encodedCommand}`);
+    add(`https://ref.ly/logos4/Command?q=${encodedCommand}`);
+    add(`https://ref.ly/logos4/Command?text=${encodedCommand}`);
   }
 
-  return uris;
+  return [...nativeUris, ...httpUris];
 }
 
 function getPrimaryCommand(tool: LogosTool) {

--- a/extensions/logos-launcher/src/utils/floating-window.test.ts
+++ b/extensions/logos-launcher/src/utils/floating-window.test.ts
@@ -17,13 +17,17 @@ describe("floating window automation", () => {
     expect(WINDOWS_FLOAT_PANEL_SCRIPT).toContain("$shell.SendKeys('^{F11}')");
   });
 
-  it("includes tool-specific window readiness check when tool name is provided", () => {
+  it("gates shortcut delivery on tool panel readiness and errors on timeout", () => {
     const macScript = getMacOSFloatPanelScript("Atlas");
     expect(macScript).toContain('set targetTool to "Atlas"');
-    expect(macScript).toContain("if currentTitle contains targetTool then exit repeat");
+    expect(macScript).toContain("if not panelReady then");
+    expect(macScript).toContain('error "Timed out waiting for " & targetTool & " panel to become active in Logos."');
+    expect(macScript).toContain('keystroke "f" using {command down, option down}');
 
     const winScript = getWindowsFloatPanelScript("Atlas");
     expect(winScript).toContain('$targetName = "Atlas"');
-    expect(winScript).toContain('$currentTitle -like "*$targetName*"');
+    expect(winScript).toContain("if (-not $panelReady)");
+    expect(winScript).toContain('throw "Timed out waiting for $targetName panel to become active in Logos."');
+    expect(winScript).toContain("$shell.SendKeys('^{F11}')");
   });
 });

--- a/extensions/logos-launcher/src/utils/floating-window.test.ts
+++ b/extensions/logos-launcher/src/utils/floating-window.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { MACOS_FLOAT_PANEL_SCRIPT, WINDOWS_FLOAT_PANEL_SCRIPT } from "./floating-window";
+
+describe("floating window automation", () => {
+  it("uses Logos' documented macOS floating-panel shortcut", () => {
+    expect(MACOS_FLOAT_PANEL_SCRIPT).toContain('tell application id "com.logos.desktop.logos" to activate');
+    expect(MACOS_FLOAT_PANEL_SCRIPT).toContain('keystroke "f" using {command down, option down}');
+  });
+
+  it("uses Logos' documented Windows floating-panel shortcut", () => {
+    expect(WINDOWS_FLOAT_PANEL_SCRIPT).toContain('Get-Process -Name "Logos"');
+    expect(WINDOWS_FLOAT_PANEL_SCRIPT).toContain("$shell.SendKeys('^{F11}')");
+  });
+});

--- a/extensions/logos-launcher/src/utils/floating-window.test.ts
+++ b/extensions/logos-launcher/src/utils/floating-window.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { MACOS_FLOAT_PANEL_SCRIPT, WINDOWS_FLOAT_PANEL_SCRIPT } from "./floating-window";
+import {
+  MACOS_FLOAT_PANEL_SCRIPT,
+  WINDOWS_FLOAT_PANEL_SCRIPT,
+  getMacOSFloatPanelScript,
+  getWindowsFloatPanelScript,
+} from "./floating-window";
 
 describe("floating window automation", () => {
   it("uses Logos' documented macOS floating-panel shortcut", () => {
@@ -10,5 +15,15 @@ describe("floating window automation", () => {
   it("uses Logos' documented Windows floating-panel shortcut", () => {
     expect(WINDOWS_FLOAT_PANEL_SCRIPT).toContain('Get-Process -Name "Logos"');
     expect(WINDOWS_FLOAT_PANEL_SCRIPT).toContain("$shell.SendKeys('^{F11}')");
+  });
+
+  it("includes tool-specific window readiness check when tool name is provided", () => {
+    const macScript = getMacOSFloatPanelScript("Atlas");
+    expect(macScript).toContain('set targetTool to "Atlas"');
+    expect(macScript).toContain("if currentTitle contains targetTool then exit repeat");
+
+    const winScript = getWindowsFloatPanelScript("Atlas");
+    expect(winScript).toContain('$targetName = "Atlas"');
+    expect(winScript).toContain('$currentTitle -like "*$targetName*"');
   });
 });

--- a/extensions/logos-launcher/src/utils/floating-window.test.ts
+++ b/extensions/logos-launcher/src/utils/floating-window.test.ts
@@ -20,12 +20,19 @@ describe("floating window automation", () => {
   it("gates shortcut delivery on tool panel readiness and errors on timeout", () => {
     const macScript = getMacOSFloatPanelScript("Atlas");
     expect(macScript).toContain('set targetTool to "Atlas"');
+    expect(macScript).toContain("if frontmost and focused of w then");
+    expect(macScript).not.toContain("set currentTitle");
     expect(macScript).toContain("if not panelReady then");
     expect(macScript).toContain('error "Timed out waiting for " & targetTool & " panel to become active in Logos."');
     expect(macScript).toContain('keystroke "f" using {command down, option down}');
 
     const winScript = getWindowsFloatPanelScript("Atlas");
     expect(winScript).toContain('$targetName = "Atlas"');
+    expect(winScript).toContain("function Test-PanelOwnsFocus");
+    expect(winScript).toContain("[System.Windows.Automation.Automation]::Compare($focused, $panel)");
+    expect(winScript).toContain("Test-PanelOwnsFocus $elem");
+    expect(winScript).not.toContain("MainWindowTitle");
+    expect(winScript).not.toContain("$focused.Current.Name");
     expect(winScript).toContain("if (-not $panelReady)");
     expect(winScript).toContain('throw "Timed out waiting for $targetName panel to become active in Logos."');
     expect(winScript).toContain("$shell.SendKeys('^{F11}')");

--- a/extensions/logos-launcher/src/utils/floating-window.ts
+++ b/extensions/logos-launcher/src/utils/floating-window.ts
@@ -14,15 +14,22 @@ repeat with attempt from 1 to 20
   tell application "System Events"
     tell process "Logos"
       try
-        set currentTitle to name of front window
-        if currentTitle contains targetTool then
-          set panelReady to true
-          exit repeat
+        if exists front window then
+          set currentTitle to name of front window
+          if currentTitle contains targetTool then
+            set panelReady to true
+            exit repeat
+          end if
         end if
         repeat with w in windows
           if name of w contains targetTool then
-            set panelReady to true
-            exit repeat
+            perform action "AXRaise" of w
+            set frontmost of process "Logos" to true
+            delay 0.1
+            if (name of front window) contains targetTool then
+              set panelReady to true
+              exit repeat
+            end if
           end if
         end repeat
         if panelReady then exit repeat

--- a/extensions/logos-launcher/src/utils/floating-window.ts
+++ b/extensions/logos-launcher/src/utils/floating-window.ts
@@ -5,7 +5,22 @@ const execFileAsync = promisify(execFile);
 
 export const MACOS_FLOAT_PANEL_SCRIPT = `
 tell application id "com.logos.desktop.logos" to activate
-delay 1
+
+-- Wait for Logos process to be running and accessible
+repeat with attempt from 1 to 20
+  if application "Logos" is running then
+    tell application "System Events"
+      if exists (process "Logos") then
+        exit repeat
+      end if
+    end tell
+  end if
+  delay 0.5
+end repeat
+
+-- Allow Logos time to process the deep link and focus the newly opened panel
+delay 1.5
+
 tell application "System Events"
   tell process "Logos"
     keystroke "f" using {command down, option down}
@@ -14,10 +29,26 @@ end tell
 `;
 
 export const WINDOWS_FLOAT_PANEL_SCRIPT = `
-$logos = Get-Process -Name "Logos" -ErrorAction Stop | Select-Object -First 1
+$timeout = 10
+$elapsed = 0
+$logos = $null
+
+while ($elapsed -lt $timeout) {
+  $logos = Get-Process -Name "Logos" -ErrorAction SilentlyContinue | Where-Object { $_.MainWindowHandle -ne 0 } | Select-Object -First 1
+  if ($null -ne $logos) { break }
+  $logos = Get-Process -Name "Logos" -ErrorAction SilentlyContinue | Select-Object -First 1
+  if ($null -ne $logos) { break }
+  Start-Sleep -Milliseconds 500
+  $elapsed += 0.5
+}
+
+if ($null -eq $logos) {
+  throw "Logos process not found."
+}
+
 $shell = New-Object -ComObject WScript.Shell
 [void] $shell.AppActivate($logos.Id)
-Start-Sleep -Milliseconds 1000
+Start-Sleep -Milliseconds 1500
 $shell.SendKeys('^{F11}')
 `;
 

--- a/extensions/logos-launcher/src/utils/floating-window.ts
+++ b/extensions/logos-launcher/src/utils/floating-window.ts
@@ -28,11 +28,9 @@ export async function floatActiveLogosPanel(platform: NodeJS.Platform = process.
   }
 
   if (platform === "win32") {
-    await execFileAsync(
-      "powershell.exe",
-      ["-NoProfile", "-NonInteractive", "-Command", WINDOWS_FLOAT_PANEL_SCRIPT],
-      { windowsHide: true },
-    );
+    await execFileAsync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", WINDOWS_FLOAT_PANEL_SCRIPT], {
+      windowsHide: true,
+    });
     return;
   }
 

--- a/extensions/logos-launcher/src/utils/floating-window.ts
+++ b/extensions/logos-launcher/src/utils/floating-window.ts
@@ -1,0 +1,40 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export const MACOS_FLOAT_PANEL_SCRIPT = `
+tell application id "com.logos.desktop.logos" to activate
+delay 1
+tell application "System Events"
+  tell process "Logos"
+    keystroke "f" using {command down, option down}
+  end tell
+end tell
+`;
+
+export const WINDOWS_FLOAT_PANEL_SCRIPT = `
+$logos = Get-Process -Name "Logos" -ErrorAction Stop | Select-Object -First 1
+$shell = New-Object -ComObject WScript.Shell
+[void] $shell.AppActivate($logos.Id)
+Start-Sleep -Milliseconds 1000
+$shell.SendKeys('^{F11}')
+`;
+
+export async function floatActiveLogosPanel(platform: NodeJS.Platform = process.platform) {
+  if (platform === "darwin") {
+    await execFileAsync("/usr/bin/osascript", ["-e", MACOS_FLOAT_PANEL_SCRIPT]);
+    return;
+  }
+
+  if (platform === "win32") {
+    await execFileAsync(
+      "powershell.exe",
+      ["-NoProfile", "-NonInteractive", "-Command", WINDOWS_FLOAT_PANEL_SCRIPT],
+      { windowsHide: true },
+    );
+    return;
+  }
+
+  throw new Error("Floating Logos panels are supported only on macOS and Windows.");
+}

--- a/extensions/logos-launcher/src/utils/floating-window.ts
+++ b/extensions/logos-launcher/src/utils/floating-window.ts
@@ -74,6 +74,9 @@ end tell
 export function getWindowsFloatPanelScript(toolName?: string): string {
   const toolCheck = toolName
     ? `
+Add-Type -AssemblyName UIAutomationClient -ErrorAction SilentlyContinue
+Add-Type -AssemblyName UIAutomationTypes -ErrorAction SilentlyContinue
+
 $targetName = "${toolName.replace(/"/g, '`"')}"
 $panelReady = $false
 
@@ -83,6 +86,22 @@ for ($i = 0; $i -lt 20; $i++) {
     $panelReady = $true
     break
   }
+
+  try {
+    if ($logos.MainWindowHandle -ne [IntPtr]::Zero) {
+      $root = [System.Windows.Automation.AutomationElement]::FromHandle($logos.MainWindowHandle)
+      if ($root -ne $null) {
+        $cond = New-Object System.Windows.Automation.PropertyCondition([System.Windows.Automation.AutomationElement]::NameProperty, $targetName)
+        $elem = $root.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $cond)
+        if ($elem -ne $null) {
+          try { [void] $elem.SetFocus() } catch {}
+          $panelReady = $true
+          break
+        }
+      }
+    }
+  } catch {}
+
   Start-Sleep -Milliseconds 250
 }
 

--- a/extensions/logos-launcher/src/utils/floating-window.ts
+++ b/extensions/logos-launcher/src/utils/floating-window.ts
@@ -3,7 +3,29 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
-export const MACOS_FLOAT_PANEL_SCRIPT = `
+export function getMacOSFloatPanelScript(toolName?: string): string {
+  const toolCheck = toolName
+    ? `
+-- Wait for the requested tool panel to receive focus if window title reflects it
+set targetTool to "${toolName.replace(/"/g, '\\"')}"
+repeat with attempt from 1 to 10
+  tell application "System Events"
+    tell process "Logos"
+      try
+        set currentTitle to name of front window
+        if currentTitle contains targetTool then exit repeat
+      end try
+    end tell
+  end tell
+  delay 0.3
+end repeat
+`
+    : `
+-- Allow Logos time to process the deep link and focus the newly opened panel
+delay 1.5
+`;
+
+  return `
 tell application id "com.logos.desktop.logos" to activate
 
 -- Wait for Logos process to be running and accessible
@@ -11,24 +33,38 @@ repeat with attempt from 1 to 20
   if application "Logos" is running then
     tell application "System Events"
       if exists (process "Logos") then
-        exit repeat
+        if frontmost of process "Logos" then exit repeat
       end if
     end tell
   end if
-  delay 0.5
+  delay 0.25
 end repeat
-
--- Allow Logos time to process the deep link and focus the newly opened panel
-delay 1.5
-
+${toolCheck}
 tell application "System Events"
   tell process "Logos"
     keystroke "f" using {command down, option down}
   end tell
 end tell
 `;
+}
 
-export const WINDOWS_FLOAT_PANEL_SCRIPT = `
+export function getWindowsFloatPanelScript(toolName?: string): string {
+  const toolCheck = toolName
+    ? `
+$targetName = "${toolName.replace(/"/g, '`"')}"
+for ($i = 0; $i -lt 10; $i++) {
+  $currentTitle = (Get-Process -Id $logos.Id -ErrorAction SilentlyContinue).MainWindowTitle
+  if ($targetName -and $currentTitle -and $currentTitle -like "*$targetName*") {
+    break
+  }
+  Start-Sleep -Milliseconds 300
+}
+`
+    : `
+Start-Sleep -Milliseconds 1500
+`;
+
+  return `
 $timeout = 10
 $elapsed = 0
 $logos = $null
@@ -46,20 +82,42 @@ if ($null -eq $logos) {
   throw "Logos process not found."
 }
 
+try { [void] $logos.WaitForInputIdle(5000) } catch {}
+
 $shell = New-Object -ComObject WScript.Shell
 [void] $shell.AppActivate($logos.Id)
-Start-Sleep -Milliseconds 1500
+${toolCheck}
 $shell.SendKeys('^{F11}')
 `;
+}
 
-export async function floatActiveLogosPanel(platform: NodeJS.Platform = process.platform) {
-  if (platform === "darwin") {
-    await execFileAsync("/usr/bin/osascript", ["-e", MACOS_FLOAT_PANEL_SCRIPT]);
+export const MACOS_FLOAT_PANEL_SCRIPT = getMacOSFloatPanelScript();
+export const WINDOWS_FLOAT_PANEL_SCRIPT = getWindowsFloatPanelScript();
+
+export async function floatActiveLogosPanel(
+  toolName?: string | NodeJS.Platform,
+  platform: NodeJS.Platform = process.platform,
+) {
+  let resolvedToolName: string | undefined;
+  let resolvedPlatform = platform;
+
+  if (typeof toolName === "string") {
+    if (toolName === "darwin" || toolName === "win32" || toolName === "linux") {
+      resolvedPlatform = toolName;
+    } else {
+      resolvedToolName = toolName;
+    }
+  }
+
+  if (resolvedPlatform === "darwin") {
+    const script = getMacOSFloatPanelScript(resolvedToolName);
+    await execFileAsync("/usr/bin/osascript", ["-e", script]);
     return;
   }
 
-  if (platform === "win32") {
-    await execFileAsync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", WINDOWS_FLOAT_PANEL_SCRIPT], {
+  if (resolvedPlatform === "win32") {
+    const script = getWindowsFloatPanelScript(resolvedToolName);
+    await execFileAsync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script], {
       windowsHide: true,
     });
     return;

--- a/extensions/logos-launcher/src/utils/floating-window.ts
+++ b/extensions/logos-launcher/src/utils/floating-window.ts
@@ -81,12 +81,6 @@ $targetName = "${toolName.replace(/"/g, '`"')}"
 $panelReady = $false
 
 for ($i = 0; $i -lt 20; $i++) {
-  $currentTitle = (Get-Process -Id $logos.Id -ErrorAction SilentlyContinue).MainWindowTitle
-  if ($targetName -and $currentTitle -and $currentTitle -like "*$targetName*") {
-    $panelReady = $true
-    break
-  }
-
   try {
     if ($logos.MainWindowHandle -ne [IntPtr]::Zero) {
       $root = [System.Windows.Automation.AutomationElement]::FromHandle($logos.MainWindowHandle)
@@ -94,11 +88,24 @@ for ($i = 0; $i -lt 20; $i++) {
         $cond = New-Object System.Windows.Automation.PropertyCondition([System.Windows.Automation.AutomationElement]::NameProperty, $targetName)
         $elem = $root.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $cond)
         if ($elem -ne $null) {
-          try { [void] $elem.SetFocus() } catch {}
-          $panelReady = $true
-          break
+          $elem.SetFocus()
+          Start-Sleep -Milliseconds 100
+          $focused = [System.Windows.Automation.AutomationElement]::FocusedElement
+          if ($focused -ne $null -and ($focused.Current.Name -like "*$targetName*" -or $elem.Current.HasKeyboardFocus)) {
+            $panelReady = $true
+            break
+          }
         }
       }
+    }
+  } catch {}
+
+  try {
+    $proc = Get-Process -Id $logos.Id -ErrorAction SilentlyContinue
+    if ($proc -and $proc.MainWindowTitle -like "*$targetName*") {
+      [void] $shell.AppActivate($logos.Id)
+      $panelReady = $true
+      break
     }
   } catch {}
 

--- a/extensions/logos-launcher/src/utils/floating-window.ts
+++ b/extensions/logos-launcher/src/utils/floating-window.ts
@@ -8,17 +8,33 @@ export function getMacOSFloatPanelScript(toolName?: string): string {
     ? `
 -- Wait for the requested tool panel to receive focus if window title reflects it
 set targetTool to "${toolName.replace(/"/g, '\\"')}"
-repeat with attempt from 1 to 10
+set panelReady to false
+
+repeat with attempt from 1 to 20
   tell application "System Events"
     tell process "Logos"
       try
         set currentTitle to name of front window
-        if currentTitle contains targetTool then exit repeat
+        if currentTitle contains targetTool then
+          set panelReady to true
+          exit repeat
+        end if
+        repeat with w in windows
+          if name of w contains targetTool then
+            set panelReady to true
+            exit repeat
+          end if
+        end repeat
+        if panelReady then exit repeat
       end try
     end tell
   end tell
-  delay 0.3
+  delay 0.25
 end repeat
+
+if not panelReady then
+  error "Timed out waiting for " & targetTool & " panel to become active in Logos."
+end if
 `
     : `
 -- Allow Logos time to process the deep link and focus the newly opened panel
@@ -52,12 +68,19 @@ export function getWindowsFloatPanelScript(toolName?: string): string {
   const toolCheck = toolName
     ? `
 $targetName = "${toolName.replace(/"/g, '`"')}"
-for ($i = 0; $i -lt 10; $i++) {
+$panelReady = $false
+
+for ($i = 0; $i -lt 20; $i++) {
   $currentTitle = (Get-Process -Id $logos.Id -ErrorAction SilentlyContinue).MainWindowTitle
   if ($targetName -and $currentTitle -and $currentTitle -like "*$targetName*") {
+    $panelReady = $true
     break
   }
-  Start-Sleep -Milliseconds 300
+  Start-Sleep -Milliseconds 250
+}
+
+if (-not $panelReady) {
+  throw "Timed out waiting for $targetName panel to become active in Logos."
 }
 `
     : `

--- a/extensions/logos-launcher/src/utils/floating-window.ts
+++ b/extensions/logos-launcher/src/utils/floating-window.ts
@@ -6,7 +6,7 @@ const execFileAsync = promisify(execFile);
 export function getMacOSFloatPanelScript(toolName?: string): string {
   const toolCheck = toolName
     ? `
--- Wait for the requested tool panel to receive focus if window title reflects it
+-- Wait for the requested tool panel itself to receive focus.
 set targetTool to "${toolName.replace(/"/g, '\\"')}"
 set panelReady to false
 
@@ -14,19 +14,12 @@ repeat with attempt from 1 to 20
   tell application "System Events"
     tell process "Logos"
       try
-        if exists front window then
-          set currentTitle to name of front window
-          if currentTitle contains targetTool then
-            set panelReady to true
-            exit repeat
-          end if
-        end if
         repeat with w in windows
           if name of w contains targetTool then
             perform action "AXRaise" of w
             set frontmost of process "Logos" to true
             delay 0.1
-            if (name of front window) contains targetTool then
+            if frontmost and focused of w then
               set panelReady to true
               exit repeat
             end if
@@ -80,6 +73,22 @@ Add-Type -AssemblyName UIAutomationTypes -ErrorAction SilentlyContinue
 $targetName = "${toolName.replace(/"/g, '`"')}"
 $panelReady = $false
 
+function Test-PanelOwnsFocus {
+  param($panel)
+
+  try {
+    $focused = [System.Windows.Automation.AutomationElement]::FocusedElement
+    while ($focused -ne $null) {
+      if ([System.Windows.Automation.Automation]::Compare($focused, $panel)) {
+        return $true
+      }
+      $focused = [System.Windows.Automation.TreeWalker]::RawViewWalker.GetParent($focused)
+    }
+  } catch {}
+
+  return $false
+}
+
 for ($i = 0; $i -lt 20; $i++) {
   try {
     if ($logos.MainWindowHandle -ne [IntPtr]::Zero) {
@@ -90,22 +99,12 @@ for ($i = 0; $i -lt 20; $i++) {
         if ($elem -ne $null) {
           $elem.SetFocus()
           Start-Sleep -Milliseconds 100
-          $focused = [System.Windows.Automation.AutomationElement]::FocusedElement
-          if ($focused -ne $null -and ($focused.Current.Name -like "*$targetName*" -or $elem.Current.HasKeyboardFocus)) {
+          if (Test-PanelOwnsFocus $elem) {
             $panelReady = $true
             break
           }
         }
       }
-    }
-  } catch {}
-
-  try {
-    $proc = Get-Process -Id $logos.Id -ErrorAction SilentlyContinue
-    if ($proc -and $proc.MainWindowTitle -like "*$targetName*") {
-      [void] $shell.AppActivate($logos.Id)
-      $panelReady = $true
-      break
     }
   } catch {}
 


### PR DESCRIPTION
## Description

- Added an **Open in Floating Window** action to the Logos Tools Launcher on macOS and Windows using Logos' documented floating-panel shortcuts (`Option+Command+F` on macOS and `Ctrl+F11` on Windows).
- Prioritized native Logos deep-link schemes (`logos4:...`, `logosres:...`) over `https://ref.ly/...` URLs in the tools launcher so tools open directly within Logos without opening the browser.
- Fixed the verse feature to open directly in Logos Bible Software instead of the browser.
- Changed default open method to use the `logosres` scheme.
- Added unit test coverage for floating window automation scripts.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)