### PR TITLE
Transfer OpenQR extension ownership to the OpenQR organisation

### DIFF
--- a/.github/public_raycast_extensions.txt
+++ b/.github/public_raycast_extensions.txt
@@ -76,3 +76,4 @@ globalping
 mymind
 buffer
 nocal
+openqr

--- a/extensions/openqr/CHANGELOG.md
+++ b/extensions/openqr/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OpenQR Changelog
 
+## [Ownership Transfer] - 2026-08-30
+
+- Extension ownership transferred to the OpenQR organisation.
+
 ## [Fixes] - 2026-08-28
 
 - Manage Dynamic QR Codes: a failed load (invalid API key, network error) now shows the error on the list with a Retry action, instead of looking like an empty account.

--- a/extensions/openqr/CHANGELOG.md
+++ b/extensions/openqr/CHANGELOG.md
@@ -1,6 +1,6 @@
 # OpenQR Changelog
 
-## [Ownership Transfer] - {PR_MERGE_DATE}
+## [Ownership Transfer] - 2026-09-08
 
 - Extension ownership transferred to the OpenQR organisation.
 

--- a/extensions/openqr/CHANGELOG.md
+++ b/extensions/openqr/CHANGELOG.md
@@ -1,6 +1,6 @@
 # OpenQR Changelog
 
-## [Ownership Transfer] - 2026-08-30
+## [Ownership Transfer] - {PR_MERGE_DATE}
 
 - Extension ownership transferred to the OpenQR organisation.
 

--- a/extensions/openqr/package.json
+++ b/extensions/openqr/package.json
@@ -6,6 +6,8 @@
   "description": "Generate QR codes and manage dynamic (editable) QR codes with scan analytics, straight from Raycast.",
   "icon": "openqr-icon.png",
   "author": "sam_moreton",
+  "owner": "openqr",
+  "access": "public",
   "categories": [
     "Data",
     "Productivity",


### PR DESCRIPTION
Set `owner` to `openqr` with `access: public`, so the store listing is published under the OpenQR organisation instead of my personal handle. The organisation already exists at https://www.raycast.com/openqr. I am the current author of this extension, so no previous-owner confirmation is needed.

## Description

OpenQR (https://openqr.uk, open source at https://github.com/open-qr/openqr) is now published under its own organisation. Nothing else in the extension changes: same code, same `author` handle, same version.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)