### PR TITLE
Update dovetail extension

### DIFF
--- a/extensions/dovetail/CHANGELOG.md
+++ b/extensions/dovetail/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Dovetail Changelog
 
+## [Fix store build] - {PR_MERGE_DATE}
+
+- Pin `react`/`@types/react` to the exact versions `@raycast/api` nests internally, fixing a TypeScript type-checking failure in the automated store build caused by two incompatible copies of React's type definitions
+
 ## [Workspace search, projects, and AI tools] - 2026-08-28
 
 - Migrate the insights search command to the `/v1/docs` endpoint (renamed to "Search Docs"); `/v1/insights` is deprecated

--- a/extensions/dovetail/CHANGELOG.md
+++ b/extensions/dovetail/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Dovetail Changelog
 
-## [Fix store build] - {PR_MERGE_DATE}
+## [Fix store build] - 2026-08-31
 
 - Pin `react`/`@types/react` to the exact versions `@raycast/api` nests internally, fixing a TypeScript type-checking failure in the automated store build caused by two incompatible copies of React's type definitions
 

--- a/extensions/dovetail/package-lock.json
+++ b/extensions/dovetail/package-lock.json
@@ -18,9 +18,10 @@
         "@types/node": "20.8.10",
         "@types/node-fetch": "^2.6.12",
         "@types/qs": "^6.9.18",
-        "@types/react": "18.3.3",
+        "@types/react": "19.0.10",
         "eslint": "^8.57.0",
         "prettier": "^3.3.3",
+        "react": "19.0.0",
         "typescript": "^5.4.5"
       }
     },
@@ -1122,15 +1123,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@raycast/api/node_modules/@types/react": {
-      "version": "19.0.10",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
-      "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.0.2"
-      }
-    },
     "node_modules/@raycast/api/node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -1221,13 +1213,6 @@
         "form-data": "^4.0.4"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/qs": {
       "version": "6.15.1",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
@@ -1236,13 +1221,11 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.3.3",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-      "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-      "dev": true,
+      "version": "19.0.10",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
+      "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.0.2"
       }
     },
@@ -2465,9 +2448,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.2.tgz",
-      "integrity": "sha512-UpGiiODyCGprM8EPP6JodP6jC9Rws6TCuiDOD+nn0CJhR8guI3g/ozo4ugL0vJ+Yz1UtJuuRPqvQuybVOF1VQA==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.3.tgz",
+      "integrity": "sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3468,9 +3451,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/extensions/dovetail/package.json
+++ b/extensions/dovetail/package.json
@@ -97,9 +97,10 @@
     "@types/node": "20.8.10",
     "@types/node-fetch": "^2.6.12",
     "@types/qs": "^6.9.18",
-    "@types/react": "18.3.3",
+    "@types/react": "19.0.10",
     "eslint": "^8.57.0",
     "prettier": "^3.3.3",
+    "react": "19.0.0",
     "typescript": "^5.4.5"
   },
   "overrides": {


### PR DESCRIPTION
## Description

Follow-up to #30604, which merged but failed the automated store build ([failed run](https://github.com/raycast/extensions/actions/runs/33162593649/job/98820366842)) with cascading Type 'bigint' is not assignable to type 'ReactNode' / cannot be used as a JSX component TypeScript errors in search-workspace.tsx.

Root cause: package.json had an exact pin on @types/react@18.3.3 with no room to move, while @raycast/api's own dependency tree resolves to React 19 internally. A fresh install (as CI does) let two incompatible copies of React's type definitions coexist, which broke type-checking. Pinning react/@types/react to the exact versions @raycast/api nests (19.0.0/19.0.10) lets npm dedupe them into a single instance.

Verified locally with the same tsc, ray lint, and ray build commands the store CI runs — all pass now.

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
