### PR TITLE
Meme Generator: Live preview while typing

### DIFF
--- a/extensions/meme-generator/CHANGELOG.md
+++ b/extensions/meme-generator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Meme generator Changelog
 
+## [Live Meme Preview] - {PR_MERGE_DATE}
+
+- Selecting a template now opens a live editor that renders the meme while you type
+- Switch between text boxes with ⌘↵ (or ⌘⇧N / ⌘⇧B), the current value of each one is listed next to the preview
+- Memegen previews render instantly from the URL, Imgflip previews are debounced
+- Text case (uppercase / as typed) is a search bar dropdown and is remembered
+- Fix empty Memegen text boxes rendering a literal underscore
+
 ## [Added Memegen API provider] - 2026-01-28
 
 - Refactor Imgflip API provider

--- a/extensions/meme-generator/CHANGELOG.md
+++ b/extensions/meme-generator/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Live Meme Preview] - {PR_MERGE_DATE}
 
 - Selecting a template now opens a live editor that renders the meme while you type
-- Switch between text boxes with ⌘↵ (or ⌘⇧N / ⌘⇧B), the current value of each one is listed next to the preview
+- Switch between text boxes with ⌘↵ / ⌘⇧↵, the current value of each one is listed next to the preview
 - Memegen previews render instantly from the URL, Imgflip previews are debounced
 - Text case (uppercase / as typed) is a search bar dropdown and is remembered
 - Fix empty Memegen text boxes rendering a literal underscore

--- a/extensions/meme-generator/CHANGELOG.md
+++ b/extensions/meme-generator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Meme generator Changelog
 
-## [Live Meme Preview] - {PR_MERGE_DATE}
+## [Live Meme Preview] - 2026-09-01
 
 - Selecting a template now opens a live editor that renders the meme while you type
 - Switch between text boxes with ⌘↵ / ⌘⇧↵, the current value of each one is listed next to the preview

--- a/extensions/meme-generator/README.md
+++ b/extensions/meme-generator/README.md
@@ -5,7 +5,7 @@ Generate memes with the help of Imgflip API using shared user.
 ### Live Preview
 
 Pick a template and the meme is rendered next to the search bar while you type. Templates with more than one
-text box use ⌘↵ (or ⌘⇧N / ⌘⇧B) to move between them, and the current value of every box is listed under the preview.
+text box use ⌘↵ and ⌘⇧↵ to move between them, and the current value of every box is listed under the preview.
 
 ### Custom API User
 

--- a/extensions/meme-generator/README.md
+++ b/extensions/meme-generator/README.md
@@ -2,6 +2,11 @@
 
 Generate memes with the help of Imgflip API using shared user.
 
+### Live Preview
+
+Pick a template and the meme is rendered next to the search bar while you type. Templates with more than one
+text box use ⌘↵ (or ⌘⇧N / ⌘⇧B) to move between them, and the current value of every box is listed under the preview.
+
 ### Custom API User
 
 By default, this extension uses shared API user. If you wish to use your own API user, you can sign up for a free account for Imgflip at [https://imgflip.com/signup](https://imgflip.com/signup), and provide your credentials keys in the Command Preferences.

--- a/extensions/meme-generator/src/api/memegen/index.ts
+++ b/extensions/meme-generator/src/api/memegen/index.ts
@@ -2,6 +2,7 @@ import fetch, { Response } from "node-fetch";
 import { MemegenTemplatesResponse } from "./types";
 import { ApiModule, Meme } from "../types";
 import { withCache } from "@raycast/utils";
+import buildMemegenImageUrl from "../../lib/buildMemegenImageUrl";
 
 interface GetMemesResult {
   success: true;
@@ -49,33 +50,9 @@ interface GenerateMemeResult {
   url: string;
 }
 
-/**
- * Escapes text for use in memegen URLs according to their special character rules
- */
-function escapeTextForUrl(text: string): string {
-  return text
-    .replace(/_/g, "__") // Underscore → double underscore (must be first)
-    .replace(/-/g, "--") // Dash → double dash
-    .replace(/ /g, "_") // Space → underscore
-    .replace(/\?/g, "~q") // Question mark
-    .replace(/&/g, "~a") // Ampersand
-    .replace(/%/g, "~p") // Percentage
-    .replace(/#/g, "~h") // Hashtag
-    .replace(/\//g, "~s") // Slash
-    .replace(/\\/g, "~b") // Backslash
-    .replace(/</g, "~l") // Less-than
-    .replace(/>/g, "~g") // Greater-than
-    .replace(/"/g, "''"); // Double quote → two single quotes
-}
-
 export async function generateMeme({ id, boxes }: GenerateMemeInput): Promise<GenerateMemeResult> {
   try {
-    // Escape text for each box
-    const escapedTexts = boxes.map((box) => escapeTextForUrl(box.text || "_"));
-
-    // Build the URL path: /images/{template_id}/{text1}/{text2}/...
-    const textsPath = escapedTexts.join("/");
-    const url = `https://api.memegen.link/images/${id}/${textsPath}.png`;
+    const url = buildMemegenImageUrl({ id, boxes });
 
     // Memegen generates images via GET request - the URL itself is the image
     // We just need to verify it's accessible
@@ -109,4 +86,5 @@ export const memegenApi: ApiModule = {
   parseTemplates,
   getMemes,
   generateMeme,
+  previewUrl: buildMemegenImageUrl,
 };

--- a/extensions/meme-generator/src/api/types.ts
+++ b/extensions/meme-generator/src/api/types.ts
@@ -1,6 +1,7 @@
 export interface ApiModule {
   getMemes: () => Promise<{ success: true; memes: Meme[] }>;
   generateMeme: (input: { id: string; boxes: { text: string }[] }) => Promise<{ success: true; url: string }>;
+  previewUrl?: (input: { id: string; boxes: { text: string }[] }) => string;
   templatesUrl: string;
   parseTemplates: (response: Response) => Promise<Meme[]>;
 }

--- a/extensions/meme-generator/src/components/MemeEditor.tsx
+++ b/extensions/meme-generator/src/components/MemeEditor.tsx
@@ -143,7 +143,7 @@ export default function MemeEditor({ id, title, url, boxCount, apiModule }: Meme
                   icon={Icon.ArrowDown}
                   title="Next Text Box"
                   onAction={() => switchBox(1)}
-                  shortcut={{ modifiers: ["cmd", "shift"], key: "n" }}
+                  shortcut={{ modifiers: ["cmd"], key: "return" }}
                 />
               )}
               {boxCount > 1 && (
@@ -151,7 +151,7 @@ export default function MemeEditor({ id, title, url, boxCount, apiModule }: Meme
                   icon={Icon.ArrowUp}
                   title="Previous Text Box"
                   onAction={() => switchBox(-1)}
-                  shortcut={{ modifiers: ["cmd", "shift"], key: "b" }}
+                  shortcut={{ modifiers: ["cmd", "shift"], key: "return" }}
                 />
               )}
             </ActionPanel.Section>

--- a/extensions/meme-generator/src/components/MemeEditor.tsx
+++ b/extensions/meme-generator/src/components/MemeEditor.tsx
@@ -1,0 +1,190 @@
+import { Action, ActionPanel, closeMainWindow, Icon, Keyboard, List, showToast, Toast } from "@raycast/api";
+import { showFailureToast, useCachedPromise } from "@raycast/utils";
+import { useMemo, useState } from "react";
+import { ApiModule, Meme } from "../api/types";
+import useDebouncedValue from "../hooks/useDebouncedValue";
+import copyFileToClipboard from "../lib/copyFileToClipboard";
+import MemeForm from "./MemeForm";
+import MemePreview from "./MemePreview";
+
+const INSTANT_PREVIEW_DEBOUNCE_MS = 200;
+const API_PREVIEW_DEBOUNCE_MS = 500;
+
+interface MemeEditorProps extends Meme {
+  apiModule: ApiModule;
+}
+
+export default function MemeEditor({ id, title, url, boxCount, apiModule }: MemeEditorProps) {
+  const [texts, setTexts] = useState<string[]>(() => Array<string>(boxCount).fill(""));
+  const [activeBox, setActiveBox] = useState(0);
+  const [capitalize, setCapitalize] = useState(true);
+  const [isCopying, setIsCopying] = useState(false);
+
+  const boxes = useMemo(
+    () => texts.map((text) => ({ text: capitalize ? text.toUpperCase() : text })),
+    [texts, capitalize],
+  );
+
+  const debouncedBoxes = useDebouncedValue(
+    boxes,
+    apiModule.previewUrl ? INSTANT_PREVIEW_DEBOUNCE_MS : API_PREVIEW_DEBOUNCE_MS,
+  );
+  const hasText = debouncedBoxes.some((box) => box.text.trim().length > 0);
+
+  const instantPreviewUrl = apiModule.previewUrl && hasText ? apiModule.previewUrl({ id, boxes: debouncedBoxes }) : "";
+  const shouldGeneratePreview = !apiModule.previewUrl && hasText;
+  const {
+    data: generatedPreviewUrl,
+    isLoading: isGeneratingPreview,
+    error: previewError,
+  } = useCachedPromise(
+    async (previewBoxes: { text: string }[]) => {
+      try {
+        return (await apiModule.generateMeme({ id, boxes: previewBoxes })).url;
+      } catch (error) {
+        throw new Error(errorMessage(error) ?? "Could not generate a preview");
+      }
+    },
+    [debouncedBoxes],
+    { execute: shouldGeneratePreview, keepPreviousData: true, failureToastOptions: { title: "Preview failed" } },
+  );
+
+  const previewUrl = instantPreviewUrl || (hasText ? generatedPreviewUrl : undefined) || url;
+  const isPreviewPending = boxes !== debouncedBoxes || (shouldGeneratePreview && isGeneratingPreview);
+  const previewHeight = boxCount > 1 ? 200 : 250;
+
+  const markdown = useMemo(() => {
+    if (previewError) {
+      return `## Preview unavailable\n\n${errorMessage(previewError) ?? "Could not generate a preview."}`;
+    }
+
+    const image = `![${title}](${previewUrl}?raycast-height=${previewHeight})`;
+    return hasText ? image : `${image}\n\nStart typing to see your meme update live.`;
+  }, [previewError, previewUrl, title, hasText, previewHeight]);
+
+  function onSearchTextChange(value: string) {
+    setTexts((current) => current.map((text, index) => (index === activeBox ? value : text)));
+  }
+
+  function switchBox(offset: number) {
+    setActiveBox((current) => (current + offset + boxCount) % boxCount);
+  }
+
+  async function onCopy() {
+    if (!boxes.some((box) => box.text.trim().length > 0)) {
+      await showToast({ style: Toast.Style.Failure, title: "At least one text input has to be filled" });
+      return;
+    }
+
+    const generatingToast = await showToast({ style: Toast.Style.Animated, title: "Generating..." });
+    setIsCopying(true);
+
+    try {
+      const { url: memeUrl } = await apiModule.generateMeme({ id, boxes });
+      await copyFileToClipboard(memeUrl, `${title}.jpg`);
+      await generatingToast.hide();
+      await closeMainWindow();
+      await showToast(Toast.Style.Success, `Meme "${title}" copied to clipboard`);
+    } catch (error) {
+      await generatingToast.hide();
+      await showFailureToast(error, { title: "Could not generate the meme" });
+    } finally {
+      setIsCopying(false);
+    }
+  }
+
+  return (
+    <List
+      isShowingDetail
+      filtering={false}
+      isLoading={isCopying || isPreviewPending}
+      navigationTitle={`Generate meme "${title}"`}
+      searchText={texts[activeBox]}
+      searchBarPlaceholder={
+        boxCount > 1 ? `Text #${activeBox + 1} of ${boxCount} - ⌘↵ for the next one` : "Type the text for your meme"
+      }
+      onSearchTextChange={onSearchTextChange}
+      searchBarAccessory={
+        <List.Dropdown tooltip="Text Case" storeValue onChange={(value) => setCapitalize(value === "uppercase")}>
+          <List.Dropdown.Item title="Uppercase" value="uppercase" />
+          <List.Dropdown.Item title="As Typed" value="as-typed" />
+        </List.Dropdown>
+      }
+    >
+      <List.Item
+        id="preview"
+        icon={Icon.Image}
+        title={boxCount > 1 ? `Text #${activeBox + 1}` : "Preview"}
+        detail={
+          <List.Item.Detail
+            markdown={markdown}
+            metadata={
+              boxCount > 1 ? (
+                <List.Item.Detail.Metadata>
+                  {texts.map((text, index) => (
+                    <List.Item.Detail.Metadata.Label
+                      key={index}
+                      icon={index === activeBox ? Icon.Pencil : Icon.Dot}
+                      title={`Text #${index + 1}`}
+                      text={text || "Empty"}
+                    />
+                  ))}
+                </List.Item.Detail.Metadata>
+              ) : undefined
+            }
+          />
+        }
+        actions={
+          <ActionPanel>
+            <ActionPanel.Section>
+              <Action icon={Icon.Clipboard} title="Generate Meme" onAction={onCopy} />
+              {boxCount > 1 && (
+                <Action
+                  icon={Icon.ArrowDown}
+                  title="Next Text Box"
+                  onAction={() => switchBox(1)}
+                  shortcut={{ modifiers: ["cmd", "shift"], key: "n" }}
+                />
+              )}
+              {boxCount > 1 && (
+                <Action
+                  icon={Icon.ArrowUp}
+                  title="Previous Text Box"
+                  onAction={() => switchBox(-1)}
+                  shortcut={{ modifiers: ["cmd", "shift"], key: "b" }}
+                />
+              )}
+            </ActionPanel.Section>
+            <ActionPanel.Section>
+              <Action.Push
+                icon={Icon.Eye}
+                title="Open Full Preview"
+                target={<MemePreview title={title} url={previewUrl} />}
+                shortcut={Keyboard.Shortcut.Common.Open}
+              />
+              <Action.CopyToClipboard
+                icon={Icon.Link}
+                title="Copy Meme URL"
+                content={previewUrl}
+                shortcut={Keyboard.Shortcut.Common.Copy}
+              />
+              <Action.Push
+                icon={Icon.TextInput}
+                title="Edit in Form"
+                target={<MemeForm id={id} title={title} url={url} boxCount={boxCount} apiModule={apiModule} />}
+                shortcut={Keyboard.Shortcut.Common.Edit}
+              />
+            </ActionPanel.Section>
+          </ActionPanel>
+        }
+      />
+    </List>
+  );
+}
+
+function errorMessage(error: unknown): string | undefined {
+  if (error && typeof error === "object" && "message" in error && typeof error.message === "string") {
+    return error.message;
+  }
+  return undefined;
+}

--- a/extensions/meme-generator/src/components/MemeGrid.tsx
+++ b/extensions/meme-generator/src/components/MemeGrid.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { ActionPanel, Action, Grid, Icon } from "@raycast/api";
 import { useFetch } from "@raycast/utils";
 import { ApiModule, Meme } from "../api/types";
-import MemeForm from "./MemeForm";
+import MemeEditor from "./MemeEditor";
 import MemePreview from "./MemePreview";
 
 interface MemeGridProps {
@@ -75,7 +75,7 @@ export default function MemeGrid({ apiModule }: MemeGridProps) {
                 <Action.Push
                   icon={Icon.CheckCircle}
                   title="Select Template"
-                  target={<MemeForm {...meme} apiModule={apiModule} />}
+                  target={<MemeEditor {...meme} apiModule={apiModule} />}
                 />
                 <Action.Push icon={Icon.Eye} title="Preview Template" target={<MemePreview {...meme} />} />
               </ActionPanel>

--- a/extensions/meme-generator/src/hooks/useDebouncedValue.ts
+++ b/extensions/meme-generator/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+
+export default function useDebouncedValue<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(timeout);
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/extensions/meme-generator/src/lib/buildMemegenImageUrl.ts
+++ b/extensions/meme-generator/src/lib/buildMemegenImageUrl.ts
@@ -1,0 +1,27 @@
+const MEMEGEN_IMAGE_BASE_URL = "https://api.memegen.link/images";
+
+export function escapeTextForUrl(text: string): string {
+  return text
+    .replace(/_/g, "__")
+    .replace(/-/g, "--")
+    .replace(/ /g, "_")
+    .replace(/\?/g, "~q")
+    .replace(/&/g, "~a")
+    .replace(/%/g, "~p")
+    .replace(/#/g, "~h")
+    .replace(/\//g, "~s")
+    .replace(/\\/g, "~b")
+    .replace(/</g, "~l")
+    .replace(/>/g, "~g")
+    .replace(/"/g, "''");
+}
+
+export default function buildMemegenImageUrl({ id, boxes }: { id: string; boxes: { text: string }[] }): string {
+  const textsPath = boxes.map((box) => (box.text ? escapeTextForUrl(box.text) : "_")).join("/");
+
+  if (!textsPath) {
+    return `${MEMEGEN_IMAGE_BASE_URL}/${id}.png`;
+  }
+
+  return `${MEMEGEN_IMAGE_BASE_URL}/${id}/${textsPath}.png`;
+}


### PR DESCRIPTION
## Description

Adds a live preview to the meme generator: picking a template now opens an editor that renders the meme next to the search bar while you type, instead of a form that only previews on demand.

The text boxes share the search bar, since a `Form` cannot render an image. `⌘↵` (or `⌘⇧N` / `⌘⇧B`) moves between them on multi-box templates, and the current value of every box is listed under the preview.

Two preview paths, because the providers differ:

- **Memegen** renders straight from the URL, so previews are built locally with no request. The URL building moved out of `generateMeme` into `buildMemegenImageUrl`, which the API module and the preview share.
- **Imgflip** needs a `caption_image` call per render, so those go through `useCachedPromise` behind a debounce, keeping the previous image while the next one generates.

Also fixes a small Memegen bug this surfaced: an empty text box was escaped from `_` into `__`, which renders a literal underscore in the image. An empty box now stays a bare `_`, i.e. a blank line.

The original form is still reachable from the editor with `⌘E`.

## Screencast

_To be added._

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
