### PR TITLE
Audio Device: Add optional volume argument for setting volume silently

### DIFF
--- a/extensions/audio-device/CHANGELOG.md
+++ b/extensions/audio-device/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Audio Device Changelog
 
+## [Update] - {PR_MERGE_DATE}
+
+- Added an optional `volume` argument to the Set Output Volume and Set Input Volume commands, so a volume can be set silently from a hotkey or deeplink (e.g. `raycast://extensions/benvp/audio-device/set-volume?arguments=%7B%22volume%22%3A%2220%22%7D`)
+
 ## [Fix] - 2026-08-21
 
 - Reduce background device enforcement refreshes from every 10 seconds to every minute.

--- a/extensions/audio-device/package.json
+++ b/extensions/audio-device/package.json
@@ -50,14 +50,30 @@
       "title": "Set Output Volume",
       "subtitle": "Audio Device",
       "description": "Set the volume of an output device.",
-      "mode": "view"
+      "mode": "view",
+      "arguments": [
+        {
+          "name": "volume",
+          "placeholder": "0-100",
+          "type": "text",
+          "required": false
+        }
+      ]
     },
     {
       "name": "set-input-volume",
       "title": "Set Input Volume",
       "subtitle": "Audio Device",
       "description": "Set the volume of an input device.",
-      "mode": "view"
+      "mode": "view",
+      "arguments": [
+        {
+          "name": "volume",
+          "placeholder": "0-100",
+          "type": "text",
+          "required": false
+        }
+      ]
     },
     {
       "name": "auto-switch-input",

--- a/extensions/audio-device/src/set-input-volume.tsx
+++ b/extensions/audio-device/src/set-input-volume.tsx
@@ -1,5 +1,12 @@
-import { VolumeForm } from "./volume-form";
+import { LaunchProps } from "@raycast/api";
+import { SilentVolume, VolumeForm } from "./volume-form";
 
-export default function Command() {
+interface Arguments {
+  volume?: string;
+}
+
+export default function Command({ arguments: args }: LaunchProps<{ arguments: Arguments }>) {
+  const volume = args?.volume?.trim();
+  if (volume) return <SilentVolume ioType="input" level={volume} />;
   return <VolumeForm ioType="input" />;
 }

--- a/extensions/audio-device/src/set-volume.tsx
+++ b/extensions/audio-device/src/set-volume.tsx
@@ -1,5 +1,12 @@
-import { VolumeForm } from "./volume-form";
+import { LaunchProps } from "@raycast/api";
+import { SilentVolume, VolumeForm } from "./volume-form";
 
-export default function Command() {
+interface Arguments {
+  volume?: string;
+}
+
+export default function Command({ arguments: args }: LaunchProps<{ arguments: Arguments }>) {
+  const volume = args?.volume?.trim();
+  if (volume) return <SilentVolume ioType="output" level={volume} />;
   return <VolumeForm ioType="output" />;
 }

--- a/extensions/audio-device/src/volume-form.tsx
+++ b/extensions/audio-device/src/volume-form.tsx
@@ -1,4 +1,15 @@
-import { showToast, Toast, Form, ActionPanel, Action, Icon, launchCommand, LaunchType } from "@raycast/api";
+import {
+  showToast,
+  showHUD,
+  Toast,
+  Detail,
+  Form,
+  ActionPanel,
+  Action,
+  Icon,
+  launchCommand,
+  LaunchType,
+} from "@raycast/api";
 import { usePromise, useForm } from "@raycast/utils";
 import {
   type AudioDevice,
@@ -15,7 +26,7 @@ import {
   setInputDeviceMute,
 } from "./audio-device";
 import { getPinnedVolume, setPinnedVolume, clearPinnedVolume } from "./device-preferences";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 const ioConfig = {
   output: {
@@ -202,4 +213,32 @@ export function VolumeForm({ ioType }: { ioType: IOType }) {
       />
     </Form>
   );
+}
+
+export function SilentVolume({ ioType, level }: { ioType: IOType; level: string }) {
+  useEffect(() => {
+    (async () => {
+      const config = ioConfig[ioType];
+      const parsed = parseInt(level, 10);
+
+      if (isNaN(parsed)) {
+        await showToast(Toast.Style.Failure, "Invalid volume", `"${level}" is not a number between 0 and 100`);
+        return;
+      }
+
+      const clamped = Math.max(0, Math.min(100, parsed));
+
+      try {
+        const device = await config.getDefault();
+        const deviceId = String(device.id);
+        if (clamped > 0) await config.setMute(deviceId, false).catch(() => {});
+        await config.setVolume(deviceId, clamped / 100);
+        await showHUD(`${device.name}: ${clamped}%`);
+      } catch (error) {
+        await showToast(Toast.Style.Failure, `Failed to set ${ioType} volume`, String(error));
+      }
+    })();
+  }, [ioType, level]);
+
+  return <Detail isLoading markdown="" />;
 }

--- a/extensions/audio-device/src/volume-form.tsx
+++ b/extensions/audio-device/src/volume-form.tsx
@@ -231,11 +231,25 @@ export function SilentVolume({ ioType, level }: { ioType: IOType; level: string 
       try {
         const device = await config.getDefault();
         const deviceId = String(device.id);
+
+        if ((await config.getVolume(deviceId)) == null) {
+          await showToast(
+            Toast.Style.Failure,
+            "Volume not supported",
+            `${device.name} does not support volume control`,
+          );
+          return;
+        }
+
         if (clamped > 0) await config.setMute(deviceId, false).catch(() => {});
         await config.setVolume(deviceId, clamped / 100);
         await showHUD(`${device.name}: ${clamped}%`);
       } catch (error) {
-        await showToast(Toast.Style.Failure, `Failed to set ${ioType} volume`, String(error));
+        await showToast(
+          Toast.Style.Failure,
+          `Failed to set ${ioType} volume`,
+          error instanceof Error ? error.message : String(error),
+        );
       }
     })();
   }, [ioType, level]);


### PR DESCRIPTION
## Description

Adds an optional `volume` argument to the **Set Output Volume** and **Set Input Volume** commands, so a specific level can be set silently — without opening the form — from a hotkey, a Quicklink, or a deeplink.

This implements the request in #30674: the reporter wants to drive volume from a launcher such as Leader Key, and [confirmed](https://github.com/raycast/extensions/issues/30674#issuecomment-5485701830) they weren't planning to open a PR themselves.

```
raycast://extensions/benvp/audio-device/set-volume?arguments=%7B%22volume%22%3A%2220%22%7D
```

Behavior:

- **Argument supplied** — the level is applied to the current default output/input device and confirmed with a HUD. Values are clamped to 0–100, and a non-zero level unmutes the device first, matching what the form already does on submit.
- **Argument empty** — the form opens exactly as before, so nothing changes for existing users.
- **Non-numeric input** — a failure toast explains that a number between 0 and 100 is expected.

The silent path reuses the existing `ioConfig` in `volume-form.tsx`, so output and input share one implementation.

## Screencast

<!-- Add a short recording of the deeplink setting the volume. -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#test-the-extension-in-raycast)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
