### PR TITLE
fix: locale independent output analysis for netstat.exe

### DIFF
--- a/extensions/port-manager/CHANGELOG.md
+++ b/extensions/port-manager/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Port Manager Changelog
 
+## [Windows Support] - 2026-09-01
+
+- Fix "Open Ports" command on non-english windows locales
+
 ## [Windows Support] - 2026-08-13
 
 - Added Windows support for listing and killing processes listening on TCP ports

--- a/extensions/port-manager/package.json
+++ b/extensions/port-manager/package.json
@@ -14,7 +14,8 @@
     "Sheraff",
     "ridemountainpig",
     "pernielsentikaer",
-    "0xdhrv"
+    "0xdhrv",
+    "MaaxGr"
   ],
   "license": "MIT",
   "commands": [

--- a/extensions/port-manager/src/models/Process.ts
+++ b/extensions/port-manager/src/models/Process.ts
@@ -265,14 +265,24 @@ export default class Process implements ProcessInfo {
     return Array.from(valuesByPid.values());
   }
 
+  private static isWindowsListeningForeignAddress(foreignAddress: string) {
+    return foreignAddress === "0.0.0.0:0" || foreignAddress === "[::]:0";
+  }
+
   private static parseWindowsNetstat(stdout: string) {
     const namedPorts = getNamedPorts();
     const valuesByPid = new Map<number, ProcessInfo>();
 
     for (const line of stdout.split("\n")) {
-      const [protocol, localAddress, , state, pidValue] = line.trim().split(/\s+/);
+      const [protocol, localAddress, foreignAddress, , pidValue] = line.trim().split(/\s+/);
       const pid = Number(pidValue);
-      if (protocol !== "TCP" || state !== "LISTENING" || !Number.isFinite(pid) || pid <= 0) continue;
+      if (
+        protocol !== "TCP" ||
+        !Process.isWindowsListeningForeignAddress(foreignAddress) ||
+        !Number.isFinite(pid) ||
+        pid <= 0
+      )
+        continue;
 
       const portInfo = Process.parsePortInfo(localAddress, namedPorts);
       if (portInfo === undefined) continue;


### PR DESCRIPTION
## Description

### Root cause

[`Process.parseWindowsNetstat`](extensions/port-manager/src/models/Process.ts) filters rows with:

```typescript
if (protocol !== "TCP" || state !== "LISTENING" || ...) continue;
```

Windows `netstat.exe` localizes the **Status** column. On your German system, listening sockets show `ABHÖREN` instead of `LISTENING`:

```
TCP    0.0.0.0:8080    0.0.0.0:0    ABHÖREN    42852
```

Every row fails the `LISTENING` check, so `loadFromNetstat()` returns an empty array and the UI shows "No Open Ports".

```mermaid
flowchart LR
  netstat["netstat.exe -ano -p TCP"]
  parse["parseWindowsNetstat"]
  filter["state !== LISTENING"]
  empty["returns []"]
  ui["No Open Ports"]

  netstat --> parse --> filter --> empty --> ui
```

### Fix

Update [`extensions/port-manager/src/models/Process.ts`](extensions/port-manager/src/models/Process.ts) only.

1. Add a small helper, e.g. `isWindowsListeningForeignAddress(foreignAddress: string)`:
   - Return `true` for `0.0.0.0:0` (IPv4 listening)
   - Return `true` for `[::]:0` (IPv6 listening)
   - These values are not localized and reliably indicate a listening socket in Windows netstat output

2. Change `parseWindowsNetstat` to read the foreign-address column explicitly:

```typescript
const [protocol, localAddress, foreignAddress, , pidValue] = line.trim().split(/\s+/);
if (protocol !== "TCP" || !isWindowsListeningForeignAddress(foreignAddress) || ...) continue;
```

3. No changes needed elsewhere — `getListeningPids()` and `loadFromNetstat()` both flow through `parseWindowsNetstat`.


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
