### PR TITLE
Language Tool: add a Check Selected Text command

### DIFF
--- a/extensions/language-tool/CHANGELOG.md
+++ b/extensions/language-tool/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Check Selected Text] - {PR_MERGE_DATE}
+## [Check Selected Text] - 2026-09-02
 
 ### Added
 - New "Check Selected Text" command: checks the text selected in any application, lists every correction it found, and replaces the selection once they have been reviewed

--- a/extensions/language-tool/CHANGELOG.md
+++ b/extensions/language-tool/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Check Selected Text] - {PR_MERGE_DATE}
+
+### Added
+- New "Check Selected Text" command: checks the text selected in any application, lists every correction it found, and replaces the selection once they have been reviewed
+- Corrections start out applied and are switched off one at a time, or given a different replacement where LanguageTool offers more than one
+- The result stays in view and is rewritten as corrections are toggled, with the correction in focus marked in place; hovering it shows the word it replaced
+- The checking language can be chosen when auto-detection gets it wrong, and the choice is remembered between runs
+
 ## [Apply All Preferences in Check Text Instant] - 2026-08-26
 
 ### Fixed

--- a/extensions/language-tool/README.md
+++ b/extensions/language-tool/README.md
@@ -6,6 +6,7 @@
 
 - ✅ **Check Text** - Interactive form with detailed results and corrections
 - ⚡ **Check Text Instant** - Quick selected text or clipboard check and paste (background mode)
+- 📝 **Check Selected Text** - Check what you have selected anywhere, review every correction, then replace it
 - 🌍 **30+ Languages** - Auto-detection or manual selection
 - 🎯 **Smart Sorting** - Most used languages appear first (frecency-based)
 - 💾 **Persistent Settings** - Your preferred language is remembered
@@ -67,6 +68,29 @@ npm run build
 **Note:** The command prioritizes selected text over clipboard content. If no text is selected, it uses the clipboard.
 
 Perfect for quick corrections while writing emails, documents, or messages.
+
+### Check Selected Text (Review, Then Replace)
+
+1. Select text in any application
+2. Open Raycast and type "Check Selected Text"
+3. Read the corrected text, with every change marked in place
+4. Press `↵` to replace the selection
+
+Every correction starts out applied. To go through them one at a time, press `⌘R`
+for the corrections list: `↵` switches a correction off and on, the sidebar offers
+the other replacements LanguageTool suggests, and `⌘↵` replaces the selection from
+there.
+
+**Keyboard Shortcuts:**
+- `↵` - Replace the selection with the corrected text
+- `⌘R` - Review the corrections one by one
+- `⌘L` - Check in a different language
+- `⌘⇧R` - Read the selection again and check it afresh
+- `⌘⇧C` - Copy the corrected text
+
+**Note:** Like Check Text Instant, it falls back to the clipboard when nothing is
+selected. Raycast can reopen the command showing the previous run — `⌘⇧R`, or the
+**Check again** button in the sidebar, picks up what is selected now.
 
 ## ⚙️ Configuration
 
@@ -156,16 +180,23 @@ Mother Tongue: Portuguese
 src/
 ├── check-text.tsx                # Main command (interactive form)
 ├── check-text-instant.tsx        # Background command (clipboard)
+├── check-selected-text.tsx       # Selection command (review, then replace)
 ├── components/                   # React components
 │   ├── check-text-result.tsx    # Results screen orchestrator
 │   ├── result-metadata.tsx      # Results metadata display
-│   └── result-actions.tsx       # Action panel with shortcuts
+│   ├── result-actions.tsx       # Action panel with shortcuts
+│   └── corrections-list.tsx     # Correction-by-correction review
 ├── hooks/                        # React hooks
-│   └── use-text-corrections.ts  # Corrections state management
+│   ├── use-text-corrections.ts  # Corrections state management
+│   ├── use-correction-choices.ts # Replacement chosen per correction
+│   └── use-selected-text-check.ts # Reads the selection and checks it
 ├── services/                     # Business logic
 │   └── languagetool-api.ts      # API client (Premium support)
 ├── utils/                        # Pure functions
-│   └── text-correction.ts       # Text correction algorithms
+│   ├── text-correction.ts       # Text correction algorithms
+│   ├── match-filter.ts          # Drops unusable and overlapping matches
+│   ├── match-display.ts         # Marks corrections in the rendered text
+│   └── replace-selection.ts     # Pastes over the selection
 ├── config/                       # Configuration
 │   └── api.ts                   # API endpoints and limits
 └── types.ts                     # TypeScript types

--- a/extensions/language-tool/package.json
+++ b/extensions/language-tool/package.json
@@ -30,6 +30,13 @@
       "description": "Check a text with LanguageTool using the clipboard content and paste the result instantly. The language is detected automatically.",
       "mode": "no-view",
       "icon": "extension-icon.png"
+    },
+    {
+      "name": "check-selected-text",
+      "title": "Check Selected Text",
+      "description": "Check the selected text, review each correction with the result in view, then replace the selection.",
+      "mode": "view",
+      "icon": "extension-icon.png"
     }
   ],
   "preferences": [

--- a/extensions/language-tool/src/check-selected-text.tsx
+++ b/extensions/language-tool/src/check-selected-text.tsx
@@ -12,7 +12,10 @@ import { API_ENDPOINTS } from "./config/api";
 import { useCorrectionChoices } from "./hooks/use-correction-choices";
 import { useSelectedTextCheck } from "./hooks/use-selected-text-check";
 import { resultWithAllMarked } from "./utils/match-display";
-import { replaceSelectionWith } from "./utils/replace-selection";
+import {
+  replaceActionTitle,
+  replaceSelectionWith,
+} from "./utils/replace-selection";
 import { onBothPlatforms } from "./utils/shortcuts";
 import type { Language } from "./types";
 
@@ -119,7 +122,9 @@ export default function Command() {
                 can come back showing the previous run, and a view has no way
                 to notice, so the way to refresh is put in reach of the mouse
                 as well as of Cmd+Shift+R. */}
-            <Detail.Metadata.TagList title="Selection">
+            <Detail.Metadata.TagList
+              title={fromSelection ? "Selection" : "Clipboard"}
+            >
               <Detail.Metadata.TagList.Item
                 text="Check again"
                 color={Color.Blue}
@@ -133,7 +138,7 @@ export default function Command() {
         canReplace ? (
           <ActionPanel>
             <Action
-              title="Replace Selection"
+              title={replaceActionTitle(fromSelection)}
               icon={Icon.Text}
               onAction={replaceSelection}
             />
@@ -167,7 +172,11 @@ export default function Command() {
               ))}
             </ActionPanel.Submenu>
             <Action
-              title="Check the Selection Again"
+              title={
+                fromSelection
+                  ? "Check the Selection Again"
+                  : "Check the Clipboard Again"
+              }
               icon={Icon.ArrowClockwise}
               onAction={rereadSelection}
               shortcut={onBothPlatforms("r", "shift")}

--- a/extensions/language-tool/src/check-selected-text.tsx
+++ b/extensions/language-tool/src/check-selected-text.tsx
@@ -1,0 +1,192 @@
+import {
+  Action,
+  ActionPanel,
+  Clipboard,
+  Color,
+  Detail,
+  Icon,
+  PopToRootType,
+  Toast,
+  closeMainWindow,
+  showToast,
+  useNavigation,
+} from "@raycast/api";
+import { useCachedState, useFetch } from "@raycast/utils";
+import { CorrectionsList } from "./components/corrections-list";
+import { API_ENDPOINTS } from "./config/api";
+import { useCorrectionChoices } from "./hooks/use-correction-choices";
+import {
+  readInputText,
+  useSelectedTextCheck,
+} from "./hooks/use-selected-text-check";
+import { resultWithAllMarked } from "./utils/match-display";
+import { onBothPlatforms } from "./utils/shortcuts";
+import type { Language } from "./types";
+
+const AUTO_DETECT = "auto";
+
+/**
+ * Checks the text selected in any application and shows the result, ready to
+ * be put back in place of the selection.
+ *
+ * Two screens rather than one: Raycast binds Enter to the first action of the
+ * panel and shows that action in the footer, so a single screen would always
+ * leave one of "replace everything" and "skip this correction" unannounced.
+ * Split in two, each screen gives Enter to the obvious thing — replacing here,
+ * toggling in the list — and neither needs explaining.
+ */
+export default function Command() {
+  const { push } = useNavigation();
+  const [language, setLanguage] = useCachedState<string>(
+    "selected-text-language",
+    AUTO_DETECT,
+  );
+
+  const { data: languages } = useFetch<Language[]>(API_ENDPOINTS.LANGUAGES);
+  const { textChecked, result, isLoading, error, rereadSelection } =
+    useSelectedTextCheck(language);
+  const { matches, applied, correctedText } = useCorrectionChoices(
+    textChecked,
+    result,
+    { resetOnMount: true },
+  );
+
+  // Raycast can bring a dismissed command back exactly as it was, and gives a
+  // view no way to notice. Reading the selection again here is the one place
+  // it matters: it stops a stale result from being pasted over whatever the
+  // user has selected now.
+  async function replaceSelection() {
+    const current = await readInputText();
+    if (current.text && current.text !== textChecked) {
+      await rereadSelection();
+      await showToast({
+        style: Toast.Style.Success,
+        title: "The selection changed",
+        message: "Checked it again — press Enter to replace it",
+      });
+      return;
+    }
+
+    await Clipboard.paste(correctedText);
+    // Pop to root as well as closing: the text has been placed and this run is
+    // over, so reopening Raycast should start from the search bar rather than
+    // resume this command on a selection that is no longer there.
+    await closeMainWindow({ popToRootType: PopToRootType.Immediate });
+  }
+
+  // The API returns variants such as "English (US)"; one entry per code is enough
+  const languageOptions = Array.from(
+    new Map((languages ?? []).map((item) => [item.longCode, item])).values(),
+  ).sort((a, b) => a.name.localeCompare(b.name));
+
+  function reviewCorrections() {
+    push(<CorrectionsList textChecked={textChecked} result={result} />);
+  }
+
+  function body(): string {
+    if (error) return `# Could Not Check the Text\n\n${error.message}`;
+    if (isLoading) return "";
+    if (!textChecked) {
+      return "# No Text Found\n\nSelect some text, or copy it to the clipboard, then run this command again.";
+    }
+    return resultWithAllMarked(textChecked, result, applied);
+  }
+
+  // Nothing may be pasted over the selection unless the check actually came
+  // back: on failure the result is just the untouched text, and replacing it
+  // would look like the command had worked
+  const canReplace = Boolean(textChecked) && !error && !isLoading;
+
+  const detected = result.language?.detectedLanguage?.name;
+  const skipped = matches.length - applied.size;
+
+  return (
+    <Detail
+      isLoading={isLoading}
+      markdown={body()}
+      metadata={
+        canReplace ? (
+          <Detail.Metadata>
+            <Detail.Metadata.Label
+              title="Corrections"
+              text={
+                matches.length === 0
+                  ? "None found"
+                  : skipped === 0
+                    ? `All ${matches.length} applied`
+                    : `${applied.size} of ${matches.length} applied`
+              }
+            />
+            <Detail.Metadata.Label
+              title="Language"
+              text={result.language?.name ?? "…"}
+            />
+            <Detail.Metadata.Separator />
+            {/* Clickable, which the labels above are not. A dismissed command
+                can come back showing the previous run, and a view has no way
+                to notice, so the way to refresh is put in reach of the mouse
+                as well as of Cmd+Shift+R. */}
+            <Detail.Metadata.TagList title="Selection">
+              <Detail.Metadata.TagList.Item
+                text="Check again"
+                color={Color.Blue}
+                onAction={rereadSelection}
+              />
+            </Detail.Metadata.TagList>
+          </Detail.Metadata>
+        ) : undefined
+      }
+      actions={
+        canReplace ? (
+          <ActionPanel>
+            <Action
+              title="Replace Selection"
+              icon={Icon.Text}
+              onAction={replaceSelection}
+            />
+            {matches.length > 0 && (
+              <Action
+                title="Review Corrections"
+                icon={Icon.BulletPoints}
+                onAction={reviewCorrections}
+                shortcut={onBothPlatforms("r")}
+              />
+            )}
+            {/* The language belongs on this screen because this is where the
+                check runs: changing it from the pushed list could not re-run
+                anything. */}
+            <ActionPanel.Submenu
+              title="Change Language…"
+              icon={Icon.Globe}
+              shortcut={onBothPlatforms("l")}
+            >
+              <Action
+                title={detected ? `Auto-Detect — ${detected}` : "Auto-Detect"}
+                icon={Icon.MagnifyingGlass}
+                onAction={() => setLanguage(AUTO_DETECT)}
+              />
+              {languageOptions.map((item) => (
+                <Action
+                  key={item.longCode}
+                  title={item.name}
+                  onAction={() => setLanguage(item.longCode)}
+                />
+              ))}
+            </ActionPanel.Submenu>
+            <Action
+              title="Check the Selection Again"
+              icon={Icon.ArrowClockwise}
+              onAction={rereadSelection}
+              shortcut={onBothPlatforms("r", "shift")}
+            />
+            <Action.CopyToClipboard
+              title="Copy Result"
+              content={correctedText}
+              shortcut={onBothPlatforms("c", "shift")}
+            />
+          </ActionPanel>
+        ) : undefined
+      }
+    />
+  );
+}

--- a/extensions/language-tool/src/check-selected-text.tsx
+++ b/extensions/language-tool/src/check-selected-text.tsx
@@ -1,25 +1,18 @@
 import {
   Action,
   ActionPanel,
-  Clipboard,
   Color,
   Detail,
   Icon,
-  PopToRootType,
-  Toast,
-  closeMainWindow,
-  showToast,
   useNavigation,
 } from "@raycast/api";
 import { useCachedState, useFetch } from "@raycast/utils";
 import { CorrectionsList } from "./components/corrections-list";
 import { API_ENDPOINTS } from "./config/api";
 import { useCorrectionChoices } from "./hooks/use-correction-choices";
-import {
-  readInputText,
-  useSelectedTextCheck,
-} from "./hooks/use-selected-text-check";
+import { useSelectedTextCheck } from "./hooks/use-selected-text-check";
 import { resultWithAllMarked } from "./utils/match-display";
+import { replaceSelectionWith } from "./utils/replace-selection";
 import { onBothPlatforms } from "./utils/shortcuts";
 import type { Language } from "./types";
 
@@ -43,35 +36,29 @@ export default function Command() {
   );
 
   const { data: languages } = useFetch<Language[]>(API_ENDPOINTS.LANGUAGES);
-  const { textChecked, result, isLoading, error, rereadSelection } =
-    useSelectedTextCheck(language);
+  const {
+    textChecked,
+    fromSelection,
+    result,
+    isLoading,
+    error,
+    rereadSelection,
+  } = useSelectedTextCheck(language);
   const { matches, applied, correctedText } = useCorrectionChoices(
     textChecked,
     result,
     { resetOnMount: true },
   );
 
-  // Raycast can bring a dismissed command back exactly as it was, and gives a
-  // view no way to notice. Reading the selection again here is the one place
-  // it matters: it stops a stale result from being pasted over whatever the
-  // user has selected now.
+  // The helper refuses when the selection is no longer the text that was
+  // checked; checking it again here is what makes that refusal recoverable
+  // rather than a dead end.
   async function replaceSelection() {
-    const current = await readInputText();
-    if (current.text && current.text !== textChecked) {
-      await rereadSelection();
-      await showToast({
-        style: Toast.Style.Success,
-        title: "The selection changed",
-        message: "Checked it again — press Enter to replace it",
-      });
-      return;
-    }
-
-    await Clipboard.paste(correctedText);
-    // Pop to root as well as closing: the text has been placed and this run is
-    // over, so reopening Raycast should start from the search bar rather than
-    // resume this command on a selection that is no longer there.
-    await closeMainWindow({ popToRootType: PopToRootType.Immediate });
+    const replaced = await replaceSelectionWith(correctedText, {
+      textChecked,
+      fromSelection,
+    });
+    if (!replaced) await rereadSelection();
   }
 
   // The API returns variants such as "English (US)"; one entry per code is enough
@@ -80,7 +67,13 @@ export default function Command() {
   ).sort((a, b) => a.name.localeCompare(b.name));
 
   function reviewCorrections() {
-    push(<CorrectionsList textChecked={textChecked} result={result} />);
+    push(
+      <CorrectionsList
+        textChecked={textChecked}
+        fromSelection={fromSelection}
+        result={result}
+      />,
+    );
   }
 
   function body(): string {

--- a/extensions/language-tool/src/components/corrections-list.tsx
+++ b/extensions/language-tool/src/components/corrections-list.tsx
@@ -17,6 +17,7 @@ const AUTO_DETECT = "auto";
 
 type CorrectionsListProps = {
   textChecked: string;
+  fromSelection: boolean;
   result: CheckTextResponse;
 };
 
@@ -25,7 +26,11 @@ type CorrectionsListProps = {
  * acts on the row being reviewed, as it does everywhere else in Raycast; the
  * text is replaced from the screen this was opened from.
  */
-export function CorrectionsList({ textChecked, result }: CorrectionsListProps) {
+export function CorrectionsList({
+  textChecked,
+  fromSelection,
+  result,
+}: CorrectionsListProps) {
   // Read the shared state rather than take it as props: this view is pushed
   // onto the navigation stack, so props captured at push time never update.
   const {
@@ -37,7 +42,12 @@ export function CorrectionsList({ textChecked, result }: CorrectionsListProps) {
     toggleChoice,
   } = useCorrectionChoices(textChecked, result);
 
-  const onReplaceSelection = () => replaceSelectionWith(correctedText);
+  // The same guard as the screen this was opened from: this path used to
+  // paste without checking that the selection was still the text reviewed.
+  // Refusing here leaves the reader on the list, where Escape goes back to the
+  // screen that can check the selection again.
+  const onReplaceSelection = () =>
+    replaceSelectionWith(correctedText, { textChecked, fromSelection });
 
   const { pop } = useNavigation();
   const { data: languages } = useFetch<Language[]>(API_ENDPOINTS.LANGUAGES);

--- a/extensions/language-tool/src/components/corrections-list.tsx
+++ b/extensions/language-tool/src/components/corrections-list.tsx
@@ -10,7 +10,10 @@ import { useCachedState, useFetch } from "@raycast/utils";
 import { API_ENDPOINTS } from "../config/api";
 import { useCorrectionChoices } from "../hooks/use-correction-choices";
 import { fragmentOf, resultWithMatchLinked } from "../utils/match-display";
-import { replaceSelectionWith } from "../utils/replace-selection";
+import {
+  replaceActionTitle,
+  replaceSelectionWith,
+} from "../utils/replace-selection";
 import type { CheckTextResponse, Language } from "../types";
 
 const AUTO_DETECT = "auto";
@@ -102,7 +105,7 @@ export function CorrectionsList({
         actions={
           <ActionPanel>
             <Action
-              title="Replace Selection"
+              title={replaceActionTitle(fromSelection)}
               icon={Icon.Text}
               onAction={onReplaceSelection}
             />
@@ -201,7 +204,7 @@ export function CorrectionsList({
                     that slot — going back a screen just to accept the text
                     would be a poor exit. */}
                 <Action
-                  title="Replace Selection"
+                  title={replaceActionTitle(fromSelection)}
                   icon={Icon.Text}
                   onAction={onReplaceSelection}
                 />

--- a/extensions/language-tool/src/components/corrections-list.tsx
+++ b/extensions/language-tool/src/components/corrections-list.tsx
@@ -1,0 +1,225 @@
+import {
+  Action,
+  ActionPanel,
+  Color,
+  Icon,
+  List,
+  useNavigation,
+} from "@raycast/api";
+import { useCachedState, useFetch } from "@raycast/utils";
+import { API_ENDPOINTS } from "../config/api";
+import { useCorrectionChoices } from "../hooks/use-correction-choices";
+import { fragmentOf, resultWithMatchLinked } from "../utils/match-display";
+import { replaceSelectionWith } from "../utils/replace-selection";
+import type { CheckTextResponse, Language } from "../types";
+
+const AUTO_DETECT = "auto";
+
+type CorrectionsListProps = {
+  textChecked: string;
+  result: CheckTextResponse;
+};
+
+/**
+ * The corrections, one per row, with the running result beside them. Enter
+ * acts on the row being reviewed, as it does everywhere else in Raycast; the
+ * text is replaced from the screen this was opened from.
+ */
+export function CorrectionsList({ textChecked, result }: CorrectionsListProps) {
+  // Read the shared state rather than take it as props: this view is pushed
+  // onto the navigation stack, so props captured at push time never update.
+  const {
+    matches,
+    applied,
+    correctedText,
+    chosenFor,
+    setChoice,
+    toggleChoice,
+  } = useCorrectionChoices(textChecked, result);
+
+  const onReplaceSelection = () => replaceSelectionWith(correctedText);
+
+  const { pop } = useNavigation();
+  const { data: languages } = useFetch<Language[]>(API_ENDPOINTS.LANGUAGES);
+  const [language, setLanguage] = useCachedState<string>(
+    "selected-text-language",
+    AUTO_DETECT,
+  );
+
+  // The check runs on the screen this was opened from, so a new language means
+  // going back to it: these corrections belong to the old one and popping is
+  // both the honest outcome and what re-runs the check.
+  function changeLanguage(next: string) {
+    if (next === language) return;
+    setLanguage(next);
+    pop();
+  }
+
+  const detected = result.language?.detectedLanguage?.name;
+  const languageOptions = Array.from(
+    new Map((languages ?? []).map((item) => [item.longCode, item])).values(),
+  ).sort((a, b) => a.name.localeCompare(b.name));
+
+  return (
+    <List
+      isShowingDetail={matches.length > 0}
+      navigationTitle="Corrections"
+      searchBarPlaceholder="Type to narrow the corrections"
+      searchBarAccessory={
+        <List.Dropdown
+          tooltip="Language"
+          value={language}
+          onChange={changeLanguage}
+        >
+          <List.Dropdown.Item
+            value={AUTO_DETECT}
+            title={detected ? `Auto-detect — ${detected}` : "Auto-detect"}
+          />
+          {languageOptions.map((item) => (
+            <List.Dropdown.Item
+              key={item.longCode}
+              value={item.longCode}
+              title={item.name}
+            />
+          ))}
+        </List.Dropdown>
+      }
+    >
+      <List.EmptyView
+        icon={{ source: Icon.CheckCircle, tintColor: Color.Green }}
+        title="No Issues Found"
+        description="The text is already fine."
+        actions={
+          <ActionPanel>
+            <Action
+              title="Replace Selection"
+              icon={Icon.Text}
+              onAction={onReplaceSelection}
+            />
+          </ActionPanel>
+        }
+      />
+
+      {matches.map((match, index) => {
+        const chosen = chosenFor(index);
+        const isApplied = chosen !== null;
+        const fragment = fragmentOf(match);
+
+        const alternatives = Array.from(
+          new Set(
+            match.replacements
+              .map((replacement) => replacement.value)
+              .filter((value): value is string => Boolean(value)),
+          ),
+        );
+
+        return (
+          <List.Item
+            key={index}
+            icon={
+              isApplied
+                ? { source: Icon.CheckCircle, tintColor: Color.Green }
+                : Icon.Circle
+            }
+            title={fragment}
+            subtitle={isApplied ? `→ ${chosen}` : "Kept as is"}
+            accessories={[{ text: match.shortMessage || match.message }]}
+            detail={
+              <List.Item.Detail
+                markdown={resultWithMatchLinked(
+                  textChecked,
+                  result,
+                  applied,
+                  index,
+                )}
+                metadata={
+                  <List.Item.Detail.Metadata>
+                    <List.Item.Detail.Metadata.Label
+                      title="Original"
+                      text={{ value: fragment, color: Color.Red }}
+                    />
+                    <List.Item.Detail.Metadata.Label
+                      title="Becomes"
+                      text={
+                        isApplied
+                          ? { value: chosen, color: Color.Green }
+                          : { value: "Unchanged", color: Color.SecondaryText }
+                      }
+                    />
+                    <List.Item.Detail.Metadata.Label
+                      title="Issue"
+                      text={match.message}
+                    />
+                    {match.rule?.category?.name && (
+                      <List.Item.Detail.Metadata.Label
+                        title="Category"
+                        text={match.rule.category.name}
+                      />
+                    )}
+                    <List.Item.Detail.Metadata.Separator />
+                    <List.Item.Detail.Metadata.TagList title="Replacement">
+                      {alternatives.map((value) => (
+                        <List.Item.Detail.Metadata.TagList.Item
+                          key={value}
+                          text={value}
+                          color={value === chosen ? Color.Green : undefined}
+                          onAction={() => setChoice(index, value)}
+                        />
+                      ))}
+                      <List.Item.Detail.Metadata.TagList.Item
+                        text={`Keep "${fragment}"`}
+                        color={isApplied ? undefined : Color.Orange}
+                        onAction={() => setChoice(index, null)}
+                      />
+                    </List.Item.Detail.Metadata.TagList>
+                  </List.Item.Detail.Metadata>
+                }
+              />
+            }
+            actions={
+              <ActionPanel>
+                <Action
+                  title={
+                    isApplied ? "Skip This Correction" : "Apply This Correction"
+                  }
+                  icon={isApplied ? Icon.Undo : Icon.Check}
+                  onAction={() => toggleChoice(index)}
+                />
+                {/* Second on purpose: Raycast gives the second action Cmd
+                    Enter automatically, and no shortcut written here can take
+                    it back. Finishing from this screen matters enough to claim
+                    that slot — going back a screen just to accept the text
+                    would be a poor exit. */}
+                <Action
+                  title="Replace Selection"
+                  icon={Icon.Text}
+                  onAction={onReplaceSelection}
+                />
+                {alternatives.length > 1 && (
+                  <ActionPanel.Submenu
+                    title="Use Another Replacement…"
+                    icon={Icon.List}
+                  >
+                    {alternatives.map((value) => (
+                      <Action
+                        key={value}
+                        title={value}
+                        onAction={() => setChoice(index, value)}
+                      />
+                    ))}
+                  </ActionPanel.Submenu>
+                )}
+                {match.rule?.urls?.[0]?.value && (
+                  <Action.OpenInBrowser
+                    title="Why Is This Flagged?"
+                    url={match.rule.urls[0].value}
+                  />
+                )}
+              </ActionPanel>
+            }
+          />
+        );
+      })}
+    </List>
+  );
+}

--- a/extensions/language-tool/src/components/result-actions.tsx
+++ b/extensions/language-tool/src/components/result-actions.tsx
@@ -1,9 +1,9 @@
 import { ActionPanel, Action, Icon } from "@raycast/api";
-import type { CheckTextResponse } from "../types";
+import type { AppliedCorrections, CheckTextResponse } from "../types";
 
 type ResultActionsProps = {
   result: CheckTextResponse;
-  appliedSuggestions: Set<number>;
+  appliedSuggestions: AppliedCorrections;
   applyAllAndPaste: () => Promise<void>;
   pasteText: () => Promise<void>;
   copyToClipboard: () => Promise<void>;

--- a/extensions/language-tool/src/components/result-metadata.tsx
+++ b/extensions/language-tool/src/components/result-metadata.tsx
@@ -1,9 +1,9 @@
 import { Detail, Icon, Color } from "@raycast/api";
-import type { CheckTextResponse } from "../types";
+import type { AppliedCorrections, CheckTextResponse } from "../types";
 
 type ResultMetadataProps = {
   result: CheckTextResponse;
-  appliedSuggestions: Set<number>;
+  appliedSuggestions: AppliedCorrections;
 };
 
 /**
@@ -62,7 +62,10 @@ export function ResultMetadata({
 
           {result.matches.map((match, index) => {
             const isApplied = appliedSuggestions.has(index);
-            const replacement = match.replacements[0]?.value || "";
+            const replacement =
+              appliedSuggestions.get(index) ??
+              match.replacements[0]?.value ??
+              "";
             const original = match.context.text.slice(
               match.context.offset,
               match.context.offset + match.context.length,

--- a/extensions/language-tool/src/hooks/use-correction-choices.ts
+++ b/extensions/language-tool/src/hooks/use-correction-choices.ts
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCachedState } from "@raycast/utils";
+import { calculateCorrectedText } from "../utils/text-correction";
+import type { AppliedCorrections, CheckTextResponse } from "../types";
+
+type StoredChoices = {
+  /** Which response these choices belong to */
+  signature: string;
+  /** Index of the match, and the replacement chosen for it; null means keep */
+  entries: [number, string | null][];
+};
+
+const EMPTY: StoredChoices = { signature: "", entries: [] };
+
+/**
+ * A cheap, stable hash. Not a checksum: it only has to make two different
+ * strings produce different output often enough to be relied on.
+ */
+function hashOf(input: string): string {
+  let value = 2166136261;
+  for (let index = 0; index < input.length; index += 1) {
+    value ^= input.charCodeAt(index);
+    value = Math.imul(value, 16777619);
+  }
+  return (value >>> 0).toString(36);
+}
+
+/**
+ * Identifies a response, so choices made against an older one are dropped.
+ *
+ * The text itself is part of it, not just its length: two different sentences
+ * of the same length flagged in the same places would otherwise look like the
+ * same response, and the previous run's choices would be applied to words they
+ * were never made for.
+ */
+function signatureOf(textChecked: string, result: CheckTextResponse): string {
+  const matches = result.matches ?? [];
+  const shape = matches
+    .map(
+      (match) =>
+        `${match.offset}.${match.length}.${match.replacements[0]?.value ?? ""}`,
+    )
+    .join("|");
+  return `${hashOf(textChecked)}.${textChecked.length}:${hashOf(shape)}.${matches.length}`;
+}
+
+/**
+ * Tracks which replacement is used for each match, with every match corrected
+ * by default.
+ *
+ * Only the choices that differ from the default are stored, and null means
+ * "keep the original". Deriving the default rather than seeding it into state
+ * is what keeps the form controls stable: a control whose value never changes
+ * after mount cannot echo an outdated value back at us.
+ *
+ * The state is cached rather than local because the corrections screen is
+ * pushed onto the navigation stack: a pushed view keeps the props it was
+ * created with, so plain state in the caller would never reach it. A cached
+ * key is shared by every component that reads it, in either direction.
+ */
+export function useCorrectionChoices(
+  textChecked: string,
+  result: CheckTextResponse,
+  options: { resetOnMount?: boolean } = {},
+) {
+  const matches = useMemo(() => result.matches ?? [], [result]);
+  const signature = signatureOf(textChecked, result);
+
+  const [stored, setStored] = useCachedState<StoredChoices>(
+    "correction-choices",
+    EMPTY,
+  );
+
+  // The cache outlives the command, so the screen that starts a run clears it:
+  // otherwise checking the same text again would come back with the previous
+  // run's choices already applied, and every run has to start from scratch.
+  //
+  // Clearing can only happen in an effect, which is one render too late, so
+  // until it has run the stored choices are treated as absent. Ignoring them
+  // for one frame is what stops the old run from showing through.
+  const [cleared, setCleared] = useState(!options.resetOnMount);
+  useEffect(() => {
+    if (cleared) return;
+    setStored(EMPTY);
+    setCleared(true);
+  }, [cleared, setStored]);
+
+  // Choices made against a previous response no longer line up with these
+  // matches, so they are ignored rather than misapplied
+  const choices = useMemo(
+    () =>
+      new Map<number, string | null>(
+        cleared && stored.signature === signature ? stored.entries : [],
+      ),
+    [cleared, stored, signature],
+  );
+
+  const chosenFor = useCallback(
+    (index: number): string | null => {
+      if (choices.has(index)) return choices.get(index) ?? null;
+      return matches[index]?.replacements[0]?.value ?? null;
+    },
+    [choices, matches],
+  );
+
+  const applied: AppliedCorrections = useMemo(() => {
+    const map = new Map<number, string>();
+    matches.forEach((match, index) => {
+      const chosen = choices.has(index)
+        ? (choices.get(index) ?? null)
+        : (match.replacements[0]?.value ?? null);
+      if (chosen !== null) map.set(index, chosen);
+    });
+    return map;
+  }, [matches, choices]);
+
+  const correctedText = useMemo(
+    () => calculateCorrectedText(textChecked, result, applied),
+    [textChecked, result, applied],
+  );
+
+  const write = useCallback(
+    (next: Map<number, string | null>) =>
+      setStored({ signature, entries: Array.from(next.entries()) }),
+    [setStored, signature],
+  );
+
+  const setChoice = useCallback(
+    (index: number, value: string | null) => {
+      const next = new Map(choices);
+      next.set(index, value);
+      write(next);
+    },
+    [choices, write],
+  );
+
+  const toggleChoice = useCallback(
+    (index: number) => {
+      const match = matches[index];
+      if (!match) return;
+
+      const fallback = match.replacements[0]?.value ?? null;
+      const current = choices.has(index)
+        ? (choices.get(index) ?? null)
+        : fallback;
+
+      const next = new Map(choices);
+      next.set(index, current === null ? fallback : null);
+      write(next);
+    },
+    [choices, matches, write],
+  );
+
+  return {
+    matches,
+    applied,
+    correctedText,
+    chosenFor,
+    setChoice,
+    toggleChoice,
+  };
+}

--- a/extensions/language-tool/src/hooks/use-selected-text-check.ts
+++ b/extensions/language-tool/src/hooks/use-selected-text-check.ts
@@ -1,0 +1,96 @@
+import { Clipboard, getPreferenceValues, getSelectedText } from "@raycast/api";
+import { usePromise } from "@raycast/utils";
+import { checkTextWithAPI } from "../services/languagetool-api";
+import {
+  filterValidMatches,
+  withoutOverlappingMatches,
+} from "../utils/match-filter";
+import type { CheckTextResponse } from "../types";
+
+const EMPTY_RESULT: CheckTextResponse = {};
+
+/**
+ * The text to work on, and where it came from.
+ *
+ * Kept verbatim, never trimmed: what gets pasted back replaces the whole
+ * selection, so trimming here would silently eat the leading and trailing
+ * whitespace the user had.
+ */
+type InputText = { text: string; fromSelection: boolean };
+
+export async function readInputText(): Promise<InputText> {
+  try {
+    const selected = await getSelectedText();
+    if (selected.trim()) return { text: selected, fromSelection: true };
+  } catch {
+    // Nothing selected, or the selection could not be read; fall back below
+  }
+
+  const clipboard = (await Clipboard.readText()) ?? "";
+  return {
+    text: clipboard.trim() ? clipboard : "",
+    fromSelection: false,
+  };
+}
+
+/**
+ * Reads the selected text once, then checks it in the given language. Changing
+ * the language re-runs the check on the same text: the original selection is
+ * no longer reachable once Raycast is in front.
+ */
+export function useSelectedTextCheck(language: string) {
+  const preferences = getPreferenceValues<Preferences>();
+
+  const {
+    data: input,
+    isLoading: isReadingText,
+    revalidate: rereadSelection,
+  } = usePromise(readInputText, []);
+  const textChecked = input?.text ?? "";
+
+  const {
+    data: result,
+    isLoading: isChecking,
+    error,
+  } = usePromise(
+    async (text: string, languageCode: string) => {
+      if (!text) return EMPTY_RESULT;
+
+      const response = await checkTextWithAPI({
+        text,
+        language: languageCode,
+        motherTongue: preferences.motherTongue,
+        preferredVariants: preferences.preferredVariants,
+        level: preferences.level,
+        enabledRules: preferences.enabledRules,
+        disabledRules: preferences.disabledRules,
+        enabledCategories: preferences.enabledCategories,
+        disabledCategories: preferences.disabledCategories,
+        enabledOnly: preferences.enabledOnly,
+        enableHiddenRules: preferences.enableHiddenRules,
+        noopLanguages: preferences.noopLanguages,
+        abtest: preferences.abtest,
+        mode: preferences.mode,
+        allowIncompleteResults: preferences.allowIncompleteResults,
+        useragent: preferences.useragent,
+      });
+
+      // Overlaps are dropped here rather than downstream so that every
+      // screen counts, marks and applies exactly the same set
+      return withoutOverlappingMatches(filterValidMatches(response));
+    },
+    [textChecked ?? "", language],
+    { execute: Boolean(textChecked) },
+  );
+
+  return {
+    textChecked: textChecked ?? "",
+    result: result ?? EMPTY_RESULT,
+    isLoading: isReadingText || isChecking,
+    error,
+    // Raycast can bring a dismissed command back with everything as it was,
+    // and gives a view no way to notice. This lets the reader ask for the
+    // current selection instead of acting on the previous one.
+    rereadSelection,
+  };
+}

--- a/extensions/language-tool/src/hooks/use-selected-text-check.ts
+++ b/extensions/language-tool/src/hooks/use-selected-text-check.ts
@@ -47,6 +47,7 @@ export function useSelectedTextCheck(language: string) {
     revalidate: rereadSelection,
   } = usePromise(readInputText, []);
   const textChecked = input?.text ?? "";
+  const fromSelection = input?.fromSelection ?? false;
 
   const {
     data: result,
@@ -84,7 +85,10 @@ export function useSelectedTextCheck(language: string) {
   );
 
   return {
-    textChecked: textChecked ?? "",
+    textChecked,
+    // Where the text came from, which the replacement has to match: pasting
+    // over a selection that is no longer there lands at the cursor instead.
+    fromSelection,
     result: result ?? EMPTY_RESULT,
     isLoading: isReadingText || isChecking,
     error,

--- a/extensions/language-tool/src/hooks/use-text-corrections.ts
+++ b/extensions/language-tool/src/hooks/use-text-corrections.ts
@@ -1,7 +1,11 @@
 import { useState, useMemo, useCallback } from "react";
 import { Clipboard, showToast, Toast } from "@raycast/api";
-import type { CheckTextResponse } from "../types";
-import { calculateCorrectedText } from "../utils/text-correction";
+import type { AppliedCorrections, CheckTextResponse } from "../types";
+import {
+  allDefaultCorrections,
+  calculateCorrectedText,
+  defaultReplacement,
+} from "../utils/text-correction";
 
 /**
  * Hook to manage text corrections
@@ -10,58 +14,55 @@ export function useTextCorrections(
   textChecked: string,
   result: CheckTextResponse,
 ) {
-  const [appliedSuggestions, setAppliedSuggestions] = useState<Set<number>>(
-    new Set(),
-  );
+  const [appliedSuggestions, setAppliedSuggestions] =
+    useState<AppliedCorrections>(new Map());
 
   // Current corrected text
   const correctedText = useMemo(() => {
     return calculateCorrectedText(textChecked, result, appliedSuggestions);
   }, [textChecked, result, appliedSuggestions]);
 
-  // Apply an individual suggestion
+  // Apply an individual suggestion, optionally with a specific replacement
   const applySuggestion = useCallback(
-    async (index: number) => {
-      const newApplied = new Set(appliedSuggestions);
-      newApplied.add(index);
-      setAppliedSuggestions(newApplied);
+    async (index: number, replacement?: string) => {
+      const match = result.matches?.[index];
+      if (!match) return;
+
+      const chosen = replacement ?? defaultReplacement(match);
+
+      setAppliedSuggestions((current) => new Map(current).set(index, chosen));
 
       await showToast({
         style: Toast.Style.Success,
         title: "Suggestion applied",
       });
     },
-    [appliedSuggestions],
+    [result.matches],
   );
 
   // Apply all suggestions
   const applyAllSuggestions = useCallback(async () => {
     if (!result.matches) return;
 
-    const allIndexes = new Set(result.matches.map((_, index) => index));
-    setAppliedSuggestions(allIndexes);
+    setAppliedSuggestions(allDefaultCorrections(result));
 
     await showToast({
       style: Toast.Style.Success,
       title: `Applied ${result.matches.length} suggestions`,
     });
-  }, [result.matches]);
+  }, [result]);
 
   // Apply all and paste
   const applyAllAndPaste = useCallback(async () => {
-    const allIndexes = new Set(result.matches?.map((_, index) => index) || []);
-    const fullyCorrectedText = calculateCorrectedText(
-      textChecked,
-      result,
-      allIndexes,
-    );
+    const all = allDefaultCorrections(result);
+    const fullyCorrectedText = calculateCorrectedText(textChecked, result, all);
 
-    setAppliedSuggestions(allIndexes);
+    setAppliedSuggestions(all);
     await Clipboard.paste(fullyCorrectedText);
 
     await showToast({
       style: Toast.Style.Success,
-      title: `Applied ${allIndexes.size} suggestions and pasted`,
+      title: `Applied ${all.size} suggestions and pasted`,
     });
   }, [textChecked, result]);
 
@@ -85,7 +86,7 @@ export function useTextCorrections(
 
   // Reset corrections
   const resetCorrections = useCallback(() => {
-    setAppliedSuggestions(new Set());
+    setAppliedSuggestions(new Map());
     showToast({
       style: Toast.Style.Success,
       title: "Reset",

--- a/extensions/language-tool/src/types.ts
+++ b/extensions/language-tool/src/types.ts
@@ -65,3 +65,10 @@ export interface Match {
 export interface Replacement {
   value?: string;
 }
+
+/**
+ * Corrections the user has accepted: index of the match in the response, mapped
+ * to the replacement chosen for it. A match can offer several replacements, so
+ * the choice has to be stored alongside the index.
+ */
+export type AppliedCorrections = Map<number, string>;

--- a/extensions/language-tool/src/utils/match-display.ts
+++ b/extensions/language-tool/src/utils/match-display.ts
@@ -1,0 +1,125 @@
+import type { AppliedCorrections, CheckTextResponse, Match } from "../types";
+import { calculateCorrectedText } from "./text-correction";
+
+/** The offending fragment, as delimited inside the match's context */
+export function fragmentOf(match: Match): string {
+  return match.context.text.slice(
+    match.context.offset,
+    match.context.offset + match.context.length,
+  );
+}
+
+/**
+ * Escapes the characters CommonMark gives meaning to, so a selection that
+ * happens to contain `#`, `*`, `_` or backticks is shown as written instead of
+ * being rendered as a heading, italics or code.
+ */
+function escapeMarkdown(text: string): string {
+  return text.replace(/([\\`*_{}[\]()#+\-.!|>~])/g, "\\$1");
+}
+
+/**
+ * Escapes a word so it can sit inside a link label without closing it early.
+ * A replacement containing `](...)` would otherwise inject a real link.
+ */
+function escapeLinkLabel(text: string): string {
+  return text.replace(/([\\[\]])/g, "\\$1");
+}
+
+/**
+ * The result as it currently stands, with the selected correction marked as a
+ * markdown link.
+ *
+ * A link is the one thing in this renderer that both colours and underlines
+ * text without changing the glyphs: bold, italic and code all alter the width
+ * of the word, which makes the paragraph shift as the selection moves.
+ *
+ * The address is an empty fragment: these marks exist to be seen, not
+ * followed. What each correction did, and why the rule fired, belongs to the
+ * corrections screen.
+ */
+export function resultWithMatchLinked(
+  textChecked: string,
+  result: CheckTextResponse,
+  applied: AppliedCorrections,
+  index: number,
+): string {
+  const matches = result.matches ?? [];
+  const target = matches[index];
+  if (!target) return textChecked;
+
+  const corrected = calculateCorrectedText(textChecked, result, applied);
+  const original = textChecked.slice(
+    target.offset,
+    target.offset + target.length,
+  );
+
+  let shift = 0;
+  matches.forEach((match, position) => {
+    const replacement = applied.get(position);
+    if (replacement === undefined || match.offset >= target.offset) return;
+    shift += replacement.length - match.length;
+  });
+
+  const chosen = applied.get(index);
+  const start = target.offset + shift;
+  const end = start + (chosen !== undefined ? chosen.length : target.length);
+
+  // An empty fragment: nowhere to go, which is the point. The rule
+  // explanation is reachable from the action panel instead.
+  const href = "#";
+
+  // The link title becomes a tooltip: hovering the corrected word shows what
+  // was there before, which is the one thing the reader cannot see any more
+  const tooltip =
+    chosen !== undefined ? `${original} → ${chosen}` : target.message;
+  const escapedTooltip = tooltip.replace(/"/g, "'");
+
+  const before = escapeMarkdown(corrected.slice(0, start));
+  const after = escapeMarkdown(corrected.slice(end));
+  const label = escapeLinkLabel(chosen ?? original);
+
+  return `${before}[${label}](${href} "${escapedTooltip}")${after}`;
+}
+
+/**
+ * The result, with every applied correction marked in place. Walking the
+ * matches in order sidesteps the offset arithmetic: the text between them is
+ * copied across untouched.
+ *
+ * The mark is a link, the only colour this renderer offers; hovering it shows
+ * the word that used to be there, which is the one thing the result no longer
+ * says. What each correction did in detail belongs to the corrections screen.
+ */
+export function resultWithAllMarked(
+  textChecked: string,
+  result: CheckTextResponse,
+  applied: AppliedCorrections,
+): string {
+  const matches = result.matches ?? [];
+
+  const ordered = matches
+    .map((match, index) => ({ match, replacement: applied.get(index) }))
+    .filter(
+      (entry): entry is { match: Match; replacement: string } =>
+        entry.replacement !== undefined,
+    )
+    .sort((a, b) => a.match.offset - b.match.offset);
+
+  let output = "";
+  let cursor = 0;
+
+  for (const { match, replacement } of ordered) {
+    const original = textChecked.slice(
+      match.offset,
+      match.offset + match.length,
+    );
+    const tooltip = `${original} → ${replacement}`.replace(/"/g, "'");
+
+    output += escapeMarkdown(textChecked.slice(cursor, match.offset));
+    output += `[${escapeLinkLabel(replacement)}](# "${tooltip}")`;
+    cursor = match.offset + match.length;
+  }
+
+  return output + escapeMarkdown(textChecked.slice(cursor));
+}

--- a/extensions/language-tool/src/utils/match-filter.ts
+++ b/extensions/language-tool/src/utils/match-filter.ts
@@ -32,3 +32,35 @@ export function filterValidMatches(
     matches: validMatches,
   };
 }
+
+/**
+ * Drops every match that overlaps one kept before it.
+ *
+ * LanguageTool can flag the same words twice — a spelling rule and a grammar
+ * rule reaching for the same span. Applying both would splice the second
+ * replacement into the middle of the first and corrupt every offset after it,
+ * so only one of an overlapping pair can survive. The leftmost wins, and the
+ * longer one where two start together: that is the match whose replacement the
+ * reader sees marked in the text.
+ */
+export function withoutOverlappingMatches(
+  result: CheckTextResponse,
+): CheckTextResponse {
+  const matches = result.matches ?? [];
+  if (matches.length < 2) return result;
+
+  const ordered = [...matches].sort(
+    (a, b) => a.offset - b.offset || b.length - a.length,
+  );
+
+  const kept: Match[] = [];
+  let end = -1;
+
+  for (const match of ordered) {
+    if (match.offset < end) continue;
+    kept.push(match);
+    end = match.offset + match.length;
+  }
+
+  return kept.length === matches.length ? result : { ...result, matches: kept };
+}

--- a/extensions/language-tool/src/utils/replace-selection.ts
+++ b/extensions/language-tool/src/utils/replace-selection.ts
@@ -1,13 +1,56 @@
-import { Clipboard, PopToRootType, closeMainWindow } from "@raycast/api";
+import {
+  Clipboard,
+  PopToRootType,
+  Toast,
+  closeMainWindow,
+  showToast,
+} from "@raycast/api";
+import { readInputText } from "../hooks/use-selected-text-check";
+
+type Checked = {
+  /** The text the corrections were computed from */
+  textChecked: string;
+  /** Whether that text came from a selection rather than the clipboard */
+  fromSelection: boolean;
+};
 
 /**
- * Puts the text back where the selection was and ends the run.
+ * Puts the corrected text back, but only if what is in front of the user is
+ * still what was checked.
  *
- * Popping to root as well as closing matters: without it Raycast keeps the
- * command alive, and reopening it resumes a review of text that has already
- * been replaced, against a selection that is no longer there.
+ * Raycast can bring a dismissed command back with everything as it was, and
+ * gives a view no way to notice. By then the selection may be gone, or be
+ * different text entirely — and pasting is destructive: it overwrites whatever
+ * is selected now, or inserts at the cursor when nothing is. So the input is
+ * read again and has to match on both counts. The source matters as much as
+ * the characters: text that was checked as a selection must still be a live
+ * selection, or the paste lands somewhere it was never meant to.
+ *
+ * Returns whether the text was replaced, so the caller can re-check.
  */
-export async function replaceSelectionWith(text: string): Promise<void> {
+export async function replaceSelectionWith(
+  text: string,
+  checked: Checked,
+): Promise<boolean> {
+  const current = await readInputText();
+
+  if (
+    !current.text ||
+    current.text !== checked.textChecked ||
+    current.fromSelection !== checked.fromSelection
+  ) {
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "The selection is no longer the text that was checked",
+      message: "Select the text again and check it afresh",
+    });
+    return false;
+  }
+
   await Clipboard.paste(text);
+  // Popping to root as well as closing matters: without it Raycast keeps the
+  // command alive, and reopening it resumes a review of text that has already
+  // been replaced, against a selection that is no longer there.
   await closeMainWindow({ popToRootType: PopToRootType.Immediate });
+  return true;
 }

--- a/extensions/language-tool/src/utils/replace-selection.ts
+++ b/extensions/language-tool/src/utils/replace-selection.ts
@@ -41,8 +41,12 @@ export async function replaceSelectionWith(
   ) {
     await showToast({
       style: Toast.Style.Failure,
-      title: "The selection is no longer the text that was checked",
-      message: "Select the text again and check it afresh",
+      title: checked.fromSelection
+        ? "The selection is no longer the text that was checked"
+        : "The clipboard is no longer the text that was checked",
+      message: checked.fromSelection
+        ? "Select the text again and check it afresh"
+        : "Copy the text again and check it afresh",
     });
     return false;
   }
@@ -53,4 +57,16 @@ export async function replaceSelectionWith(
   // been replaced, against a selection that is no longer there.
   await closeMainWindow({ popToRootType: PopToRootType.Immediate });
   return true;
+}
+
+/**
+ * What the replacement will actually do, in the reader's words.
+ *
+ * The text is not always a selection: with nothing selected the command falls
+ * back to the clipboard, as Check Text Instant does, and then there is nothing
+ * to replace — the result is pasted wherever the cursor is. Calling that
+ * "Replace Selection" would promise something the command cannot deliver.
+ */
+export function replaceActionTitle(fromSelection: boolean): string {
+  return fromSelection ? "Replace Selection" : "Paste Corrected Text";
 }

--- a/extensions/language-tool/src/utils/replace-selection.ts
+++ b/extensions/language-tool/src/utils/replace-selection.ts
@@ -1,0 +1,13 @@
+import { Clipboard, PopToRootType, closeMainWindow } from "@raycast/api";
+
+/**
+ * Puts the text back where the selection was and ends the run.
+ *
+ * Popping to root as well as closing matters: without it Raycast keeps the
+ * command alive, and reopening it resumes a review of text that has already
+ * been replaced, against a selection that is no longer there.
+ */
+export async function replaceSelectionWith(text: string): Promise<void> {
+  await Clipboard.paste(text);
+  await closeMainWindow({ popToRootType: PopToRootType.Immediate });
+}

--- a/extensions/language-tool/src/utils/shortcuts.ts
+++ b/extensions/language-tool/src/utils/shortcuts.ts
@@ -1,0 +1,18 @@
+import type { Keyboard } from "@raycast/api";
+
+/**
+ * The same chord on both platforms: Command on macOS, Control on Windows.
+ *
+ * A shortcut written with a bare `cmd` is not translated on Windows, it is
+ * ignored, so an extension that declares both platforms has to spell both out.
+ * See https://developers.raycast.com/api-reference/keyboard
+ */
+export function onBothPlatforms(
+  key: Keyboard.KeyEquivalent,
+  ...alsoHeld: Keyboard.KeyModifier[]
+): Keyboard.Shortcut {
+  return {
+    macOS: { modifiers: ["cmd", ...alsoHeld], key },
+    Windows: { modifiers: ["ctrl", ...alsoHeld], key },
+  };
+}

--- a/extensions/language-tool/src/utils/text-correction.ts
+++ b/extensions/language-tool/src/utils/text-correction.ts
@@ -1,4 +1,4 @@
-import type { CheckTextResponse } from "../types";
+import type { AppliedCorrections, CheckTextResponse, Match } from "../types";
 
 /**
  * Extracts newline characters from the end of a string
@@ -48,9 +48,17 @@ function adjustReplacementForNewline(
 }
 
 /**
+ * Returns the replacement a match suggests by default
+ */
+export function defaultReplacement(match: Match): string {
+  return match.replacements[0]?.value || "";
+}
+
+/**
  * Applies a single correction to the text
  * @param text - The current text state
  * @param match - The match to apply
+ * @param chosenReplacement - The replacement selected for this match
  * @param offset - Current offset adjustment from previous corrections
  * @returns Object with updated text and new offset
  */
@@ -59,11 +67,11 @@ function applySingleCorrection(
   match: {
     offset: number;
     length: number;
-    replacements: Array<{ value?: string }>;
   },
+  chosenReplacement: string,
   offset: number,
 ): { updatedText: string; newOffset: number } {
-  let replacement = match.replacements[0]?.value || "";
+  let replacement = chosenReplacement;
   const start = match.offset + offset;
   const end = start + match.length;
 
@@ -87,31 +95,37 @@ function applySingleCorrection(
  *
  * @param textChecked - Original text
  * @param result - API response with matches
- * @param appliedIndexes - Set of indexes of suggestions to apply
+ * @param applied - Chosen replacement per match index
  * @returns Text with corrections applied
  */
 export function calculateCorrectedText(
   textChecked: string,
   result: CheckTextResponse,
-  appliedIndexes: Set<number>,
+  applied: AppliedCorrections,
 ): string {
-  if (!result.matches || appliedIndexes.size === 0) {
+  if (!result.matches || applied.size === 0) {
     return textChecked;
   }
 
-  // Filter and sort matches by offset (must apply in order)
-  const sortedMatches = result.matches
-    .filter((_, index) => appliedIndexes.has(index))
-    .sort((a, b) => a.offset - b.offset);
+  // Keep each match paired with its chosen replacement, sorted by offset
+  // (corrections must be applied in order for the running offset to hold)
+  const sortedCorrections = result.matches
+    .map((match, index) => ({ match, replacement: applied.get(index) }))
+    .filter(
+      (entry): entry is { match: Match; replacement: string } =>
+        entry.replacement !== undefined,
+    )
+    .sort((a, b) => a.match.offset - b.match.offset);
 
   // Apply each correction sequentially
   let text = textChecked;
   let offset = 0;
 
-  for (const match of sortedMatches) {
+  for (const { match, replacement } of sortedCorrections) {
     const { updatedText, newOffset } = applySingleCorrection(
       text,
       match,
+      replacement,
       offset,
     );
     text = updatedText;
@@ -122,7 +136,21 @@ export function calculateCorrectedText(
 }
 
 /**
- * Applies ALL corrections from an API response
+ * Every match paired with the replacement it suggests by default
+ */
+export function allDefaultCorrections(
+  result: CheckTextResponse,
+): AppliedCorrections {
+  return new Map(
+    (result.matches || []).map((match, index) => [
+      index,
+      defaultReplacement(match),
+    ]),
+  );
+}
+
+/**
+ * Applies ALL corrections from an API response, each with its first replacement
  *
  * @param textChecked - Original text
  * @param result - API response
@@ -136,8 +164,9 @@ export function applyAllCorrections(
     return textChecked;
   }
 
-  // Create set with all indexes
-  const allIndexes = new Set(result.matches.map((_, index) => index));
-
-  return calculateCorrectedText(textChecked, result, allIndexes);
+  return calculateCorrectedText(
+    textChecked,
+    result,
+    allDefaultCorrections(result),
+  );
 }


### PR DESCRIPTION
## Description

A third command, **Check Selected Text**. It checks whatever is selected in any application, shows the corrected text with every change marked in place, and replaces the selection once the corrections have been reviewed.

### Why

*Check Text Instant* applies every suggestion blindly, always taking `replacements[0]`. On technical writing in a language other than English, that is destructive rather than helpful. Measured against the live API:

| Selected | Pasted back |
|---|---|
| Ho fatto il **commit** e poi il **deploy** sul server, ma il **build** fallisce per un problema di **caching**. | Ho fatto il **commi** e poi il **dello** sul server, ma il **Tuili** fallisce per un problema di **bachino**. |

All four come from `MORFOLOGIK_RULE_IT_IT`. The language was detected correctly — the problem is not detection, it is applying without looking. *Check Text* avoids this but needs the text pasted into a form by hand, which loses the selection.

The new command sits between the two: the speed of the instant one, with a look at the result before it lands.

### How it works

Two screens. The first shows the corrected text, every correction applied, with each change marked so it can be seen at a glance; `↵` replaces the selection. `⌘R` opens the second screen, one row per correction, where `↵` switches a correction off and on and the sidebar offers the other replacements LanguageTool suggests; `⌘↵` replaces the selection from there.

Two screens rather than one because Raycast gives `↵` to the first action of a panel and shows it in the footer. On a single screen, one of "replace everything" and "skip this correction" would always go unannounced. Split, each screen gives `↵` to the obvious thing.

### Changes to existing code

Applied corrections were a `Set<number>` of indices, with the replacement always `replacements[0]`. Choosing among alternatives needs a `Map<number, string>`. `applyAllCorrections` builds that map from `replacements[0]` for every match, so **both existing commands behave exactly as before**.

### Notes for the reviewer

- Matches that overlap one already kept are dropped, in the new command only. LanguageTool can flag the same span twice, and applying both splices the second replacement into the middle of the first — `commit` came out as `cmmit`. The existing commands are left untouched.
- Shortcuts are written per platform. The extension declares Windows, where a bare `cmd` is ignored rather than translated.
- The selection is read again before replacing: Raycast can reopen a dismissed command with the previous run still on screen, and a view has no way to notice. If the selection changed, the command re-checks instead of pasting something stale.

## Screencast

The result, every correction applied and marked in place. `↵` replaces the selection.

<img width="862" height="587" alt="1-result" src="https://github.com/user-attachments/assets/dbc806f5-75a2-4e24-8a87-2966cee5f029" />

`⌘R` opens the corrections. Here `oncall` and the comma splice have been switched off with `↵` — LanguageTool is right about neither — and only `recieve` → `receive` is left applied. `⌘↵` replaces the selection.

<img width="862" height="587" alt="2-review" src="https://github.com/user-attachments/assets/4d0266c0-cc54-4678-8fc2-893f93bd8ccb" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
