### PR TITLE
Update granite extension

### DIFF
--- a/extensions/granite/CHANGELOG.md
+++ b/extensions/granite/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Granite Changelog
 
-<!-- {PR_MERGE_DATE} belongs ONLY on a new, unshipped heading — Raycast's bot replaces
+<!-- 2026-09-02 belongs ONLY on a new, unshipped heading — Raycast's bot replaces
      it on merge. Leaving it on a shipped heading re-stamps that release with the next
      merge date. Shipped versions carry their real date. See docs/ops/api.md. -->
 
-## [Copy Value] - {PR_MERGE_DATE}
+## [Copy Value] - 2026-09-02
 
 - New Copy Value action on Ask answers: when a question is answered straight from an extracted field (an SSN, a policy number), copy the bare value without the surrounding answer text.
 - Fixed stray blank lines in Ask answers.

--- a/extensions/granite/CHANGELOG.md
+++ b/extensions/granite/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Granite Changelog
 
+<!-- {PR_MERGE_DATE} belongs ONLY on a new, unshipped heading — Raycast's bot replaces
+     it on merge. Leaving it on a shipped heading re-stamps that release with the next
+     merge date. Shipped versions carry their real date. See docs/ops/api.md. -->
+
+## [Copy Value] - {PR_MERGE_DATE}
+
+- New Copy Value action on Ask answers: when a question is answered straight from an extracted field (an SSN, a policy number), copy the bare value in one keystroke.
+- Fixed stray blank lines in Ask answers.
+- Ask now shows the retrieval summary when no direct answer is found, instead of an empty view.
+
 ## [Initial Version] - 2026-07-15
 
 - Search your vault and open any document with its full details.

--- a/extensions/granite/CHANGELOG.md
+++ b/extensions/granite/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## [Copy Value] - {PR_MERGE_DATE}
 
-- New Copy Value action on Ask answers: when a question is answered straight from an extracted field (an SSN, a policy number), copy the bare value in one keystroke.
+- New Copy Value action on Ask answers: when a question is answered straight from an extracted field (an SSN, a policy number), copy the bare value without the surrounding answer text.
 - Fixed stray blank lines in Ask answers.
 - Ask now shows the retrieval summary when no direct answer is found, instead of an empty view.
 

--- a/extensions/granite/README.md
+++ b/extensions/granite/README.md
@@ -3,7 +3,7 @@
 Search, browse, and ask your [Granite](https://granite.co) document vault from
 [Raycast](https://raycast.com) — without leaving your keyboard.
 
-It's a thin client over the read-only [Granite Agent API](https://api.granite.co/v1).
+It's a thin client over the read-only [Granite Agent API](https://granite.co/docs/api).
 All auth, per-user scoping, prompt-injection sanitization, audit logging, and rate
 limiting happen server-side in the API; this extension just renders the endpoints.
 
@@ -24,49 +24,31 @@ These three work entirely on their own — **no Raycast AI / Pro required.**
 The extension also ships four **AI tools** (`search-vault`, `list-documents`,
 `get-document`, `ask-vault`). These only matter if you have **Raycast Pro**: once
 installed, `@granite` in Quick AI / AI Chat lets Raycast's AI search, read, and ask
-your vault. They're the same idea as the Granite [MCP server](https://api.granite.co)
+your vault. They're the same idea as the Granite [MCP server](https://granite.co/docs/mcp)
 for Claude/Cursor. Dropping them changes nothing about the three commands above.
 
 ## Setup
 
 1. **Granite plan:** the API is paid-only. Free/canceled accounts get a clear
    "needs a paid plan" message.
-2. **Mint a token:** in Granite, go to **Settings → Developer → Access tokens**, create
+2. **Mint a token:** in Granite, go to **Settings → Apps & API → Access tokens**, create
    a token with the scopes you want (`documents:read`, and `vault:ask` for Ask Vault),
    and copy the `gra_live_…` value — it's shown **once**. Treat it like a password: it
    can read everything in your vault, including sensitive documents.
 3. **Paste it into the extension's preferences** (`API Token`). The `API Base URL`
    preference defaults to `https://api.granite.co/v1` — override it only for development.
 
-## Develop
+## Troubleshooting
 
-```bash
-npm install
-npm run dev      # ray develop — loads the extension into Raycast
-npm run build    # ray build — bundle + typecheck
-npm run lint     # ray lint — eslint + prettier + manifest validation
-npm test         # node --test — client unit tests (mocked fetch, no network)
-```
+| what you see | what it means |
+|---|---|
+| "Missing API token" | No token set. Paste your `gra_live_…` value into the extension's preferences. |
+| "This needs a paid Granite plan" | The Agent API is part of Granite Paid. Your account is Free or canceled. |
+| "Invalid or expired token" | The token is wrong, revoked, or past its 1-year expiry. Mint a fresh one and re-paste it. |
+| "Your token is missing the `vault:ask` scope" | Search works, Ask doesn't. Scopes are fixed at creation — make a new token with both. |
+| "Rate limited" | 60 requests/min, 500 reads/day, 200 asks/day. Give it a minute. |
 
-The network/error-mapping logic lives in `src/lib/granite.ts` (no `@raycast/api`
-import, so it's unit-tested directly). `src/lib/preferences.ts` is the only seam that
-reads Raycast preferences. Commands live in `src/*.tsx`; AI tools in `src/tools/*.ts`.
+## Links
 
-## Store screenshots
-
-Screenshots in `metadata/` become the gallery on the Raycast Store listing (max 6,
-aim for 3–5). Capture them with Raycast's built-in Window Capture so they're the
-exact 2000×1250 the Store expects:
-
-1. Raycast → Settings → Advanced → **Window Capture**: assign a hotkey (e.g. `⌘⇧⌥M`).
-2. Run `npm run dev` so the extension is in development mode (Window Capture hides dev
-   menus and icons). A clean, high-contrast wallpaper reads best behind the window.
-3. Open each command, press the hotkey, and tick **Save to Metadata** — it writes a
-   correctly-sized PNG into `metadata/` (named `granite-N.png`).
-
-Suggested shots, in listing order:
-
-1. **Search Vault** with the detail pane open on a result (the core "find anything" view).
-2. **Ask Vault** showing an answer with the Sources panel.
-3. **Browse Documents** — the full vault list.
-4. *(optional)* a document detail view with its fields.
+- [Setup guide](https://granite.co/docs/raycast) — install + token, start to finish
+- [Agent API reference](https://granite.co/docs/api) — endpoints, scopes, limits

--- a/extensions/granite/README.md
+++ b/extensions/granite/README.md
@@ -13,11 +13,11 @@ limiting happen server-side in the API; this extension just renders the endpoint
 
 These three work entirely on their own — **no Raycast AI / Pro required.**
 
-| command | what it does |
-|---|---|
-| **Search Vault** | ranked search (hybrid / keyword / semantic) → open any result with its full fields |
-| **Ask Vault** | ask a question → a synthesized answer with sources (Granite's own AI, not Raycast's) |
-| **Browse Documents** | scroll your whole vault, paginated, newest pages loaded on demand |
+| command              | what it does                                                                         |
+| -------------------- | ------------------------------------------------------------------------------------ |
+| **Search Vault**     | ranked search (hybrid / keyword / semantic) → open any result with its full fields   |
+| **Ask Vault**        | ask a question → a synthesized answer with sources (Granite's own AI, not Raycast's) |
+| **Browse Documents** | scroll your whole vault, paginated, newest pages loaded on demand                    |
 
 ## AI tools (optional)
 
@@ -40,13 +40,13 @@ for Claude/Cursor. Dropping them changes nothing about the three commands above.
 
 ## Troubleshooting
 
-| what you see | what it means |
-|---|---|
-| "Missing API token" | No token set. Paste your `gra_live_…` value into the extension's preferences. |
-| "This needs a paid Granite plan" | The Agent API is part of Granite Paid. Your account is Free or canceled. |
-| "Invalid or expired token" | The token is wrong, revoked, or past its 1-year expiry. Mint a fresh one and re-paste it. |
-| "Your token is missing the `vault:ask` scope" | Search works, Ask doesn't. Scopes are fixed at creation — make a new token with both. |
-| "Rate limited" | 60 requests/min, 500 reads/day, 200 asks/day. Give it a minute. |
+| what you see                                  | what it means                                                                             |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| "Missing API token"                           | No token set. Paste your `gra_live_…` value into the extension's preferences.             |
+| "This needs a paid Granite plan"              | The Agent API is part of Granite Paid. Your account is Free or canceled.                  |
+| "Invalid or expired token"                    | The token is wrong, revoked, or past its 1-year expiry. Mint a fresh one and re-paste it. |
+| "Your token is missing the `vault:ask` scope" | Search works, Ask doesn't. Scopes are fixed at creation — make a new token with both.     |
+| "Rate limited"                                | 60 requests/min, 500 reads/day, 200 asks/day. Give it a minute.                           |
 
 ## Links
 

--- a/extensions/granite/package.json
+++ b/extensions/granite/package.json
@@ -10,7 +10,6 @@
     "Documentation"
   ],
   "license": "MIT",
-  "platforms": ["macOS"],
   "commands": [
     {
       "name": "search-vault",

--- a/extensions/granite/package.json
+++ b/extensions/granite/package.json
@@ -10,6 +10,7 @@
     "Documentation"
   ],
   "license": "MIT",
+  "platforms": ["macOS"],
   "commands": [
     {
       "name": "search-vault",
@@ -86,7 +87,7 @@
     {
       "name": "apiKey",
       "title": "API Token",
-      "description": "Your gra_live_… Personal Access Token from Granite → Settings → Developer → Access tokens. Treat it like a password.",
+      "description": "Your gra_live_… Personal Access Token from Granite → Settings → Apps & API → Access tokens. Treat it like a password.",
       "type": "password",
       "required": true
     },

--- a/extensions/granite/src/ask-vault.tsx
+++ b/extensions/granite/src/ask-vault.tsx
@@ -78,10 +78,10 @@ function AnswerView({ question }: { question: string }) {
       }
       actions={
         <ActionPanel>
+          {data?.answer ? <Action.CopyToClipboard title="Copy Answer" content={data.answer} /> : null}
           {data?.answer_value ? (
             <Action.CopyToClipboard title="Copy Value" content={data.answer_value} concealed />
           ) : null}
-          {data?.answer ? <Action.CopyToClipboard title="Copy Answer" content={data.answer} /> : null}
           {sources.length ? (
             <ActionPanel.Section title="Sources">
               {sources.map((s) => (

--- a/extensions/granite/src/ask-vault.tsx
+++ b/extensions/granite/src/ask-vault.tsx
@@ -78,6 +78,9 @@ function AnswerView({ question }: { question: string }) {
       }
       actions={
         <ActionPanel>
+          {data?.answer_value ? (
+            <Action.CopyToClipboard title="Copy Value" content={data.answer_value} concealed />
+          ) : null}
           {data?.answer ? <Action.CopyToClipboard title="Copy Answer" content={data.answer} /> : null}
           {sources.length ? (
             <ActionPanel.Section title="Sources">

--- a/extensions/granite/src/lib/granite.ts
+++ b/extensions/granite/src/lib/granite.ts
@@ -88,12 +88,12 @@ function mapError(res: Response, raw: unknown): ApiError {
       return new ApiError("Invalid or expired token — check the API token in the Granite extension preferences.", 401);
     case 402:
       return new ApiError(
-        `This needs a paid Granite plan${body.feature ? ` (feature: ${body.feature})` : ""}. Upgrade at granite.co/settings/billing.`,
+        `This needs a paid Granite plan${body.feature ? ` (feature: ${body.feature})` : ""}. Upgrade at app.granite.co/settings/billing.`,
         402,
       );
     case 403:
       return new ApiError(
-        `Your token is missing the \`${body.required ?? "required"}\` scope. Mint a new token with it at Granite → Settings → Developer → Access tokens.`,
+        `Your token is missing the \`${body.required ?? "required"}\` scope. Mint a new token with it at Granite → Settings → Apps & API → Access tokens.`,
         403,
       );
     case 404:

--- a/extensions/granite/src/lib/types.ts
+++ b/extensions/granite/src/lib/types.ts
@@ -63,6 +63,7 @@ export interface DocumentDetail {
   summary: string | null;
   created_at: string;
   understood_at: string | null;
+  due_handled_at: string | null;
   entities: Entity[];
   collections: Collection[];
   extracted_fields: ExtractedField[];
@@ -121,6 +122,7 @@ export interface AskResponse {
   query: string;
   status: string;
   answer: string | null;
+  answer_value?: string | null;
   citations: Citation[];
   documents: AskDocument[];
   aggregation?: Aggregation | null;


### PR DESCRIPTION
## Description

Update to the Granite extension:

- New **Copy Value** action on Ask Vault answers: when a question is answered directly from an extracted document field (an SSN, a policy number, an account number), the exact value can be copied in one keystroke (copied concealed, since these are sensitive values). Backed by a new optional `answer_value` field on Granite's API — absent responses behave exactly as before.
- Fixed stray blank lines in Ask answers (server-side formatting fix; the extension now renders clean single-paragraph answers).
- Ask now shows the retrieval summary when no direct answer is found, instead of an empty view.
- README/package.json refresh: settings path renamed to **Apps & API** in Granite, docs links now point at public docs pages, and a Troubleshooting section replaces dev notes in the README.

No new commands, no new preferences, no dependency changes.

## Screencast

Straightforward change to an existing extension (one conditional action in an existing ActionPanel + copy updates); no new UI surfaces.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder