### PR TITLE
Remove outdated screenshots from Contrast Lab README

### DIFF
--- a/extensions/contrast-lab/CHANGELOG.md
+++ b/extensions/contrast-lab/CHANGELOG.md
@@ -1,3 +1,7 @@
 # Contrast Lab Changelog
 
+## [README Cleanup] - {PR_MERGE_DATE}
+
+- Removed outdated screenshots from the README
+
 ## [Initial Version] - 2026-08-25

--- a/extensions/contrast-lab/CHANGELOG.md
+++ b/extensions/contrast-lab/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Contrast Lab Changelog
 
-## [README Cleanup] - {PR_MERGE_DATE}
+## [README Cleanup] - 2026-09-02
 
 - Removed outdated screenshots from the README
 

--- a/extensions/contrast-lab/README.md
+++ b/extensions/contrast-lab/README.md
@@ -2,13 +2,10 @@
 
 A Raycast extension for checking color contrast. It does both WCAG 2 and the newer APCA model, takes colors in hex, RGB, HSL, or OKLCH, and when a pair fails it suggests the nearest passing color.
 
-<img width="1000" height="625" alt="contrast-lab-1" src="https://github.com/user-attachments/assets/d8b8a0a9-2314-4c54-9dee-7f25ca8d6b61" />
-<img width="1000" height="625" alt="contrast-lab-2" src="https://github.com/user-attachments/assets/16b955c5-efd2-4dfc-9a91-93bcdafa3852" />
 
 ## Install
 
-[Install from the Raycast Store](https://www.raycast.com/fracazo/contrast-lab) - _link goes live once the listing is approved._
-
+[Install from the Raycast Store](https://www.raycast.com/fracazo/contrast-lab)
 ## Status
 
 Shipped as one command: a form for the foreground and background colors (plus font size and weight) with a live readout that updates as you type, and a result view with a preview swatch, the WCAG AA/AAA tags, the APCA Lc, and a one-tap nearest-passing fix you can copy when the pair fails. It all wires into the pure, fully tested `analyze()` core below.


### PR DESCRIPTION
## Description

README-only cleanup for Contrast Lab (merged in #29066): removes the two embedded screenshots, which were stale pre-review uploads that contradict the store's metadata gallery shown above the README, and drops the "link goes live once approved" note now that the listing is live.

## Screencast

Not applicable: README-only change, no functional or visual changes to the extension.

## Checklist

- [x] I read the extension guidelines
- [x] I read the documentation about publishing
- [ ] I ran `npm run build` (not applicable, README-only)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder