### PR TITLE
fix(runpool): keep overlapping resize confirmations apart

### DIFF
--- a/extensions/runpool/CHANGELOG.md
+++ b/extensions/runpool/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## [Fix a resize that could act on the wrong count] - {PR_MERGE_DATE}
 
-- Record each resize confirmation against the change it asked about, so two open at once cannot swap starting counts and turn approved growth into a shrink
-- Refuse a shrink that cannot be tied to a confirmation, rather than falling back to the current count
+- Record every size a resize confirmation was shown, so two questions open at once cannot swap starting counts and turn approved growth into a shrink
+- Refuse the change when those questions disagree about the pool's size, or when a shrink cannot be tied to a confirmation at all
 
 ## [Initial Version] - 2026-09-01
 

--- a/extensions/runpool/CHANGELOG.md
+++ b/extensions/runpool/CHANGELOG.md
@@ -1,27 +1,17 @@
 # RunPool Changelog
 
-## [Unreleased]
+## [Fix a resize that could act on the wrong count] - {PR_MERGE_DATE}
 
-- Show persistent per-pool pause state separately from the global pause
-- Add guarded Pause Pool and Resume Pool actions and AI tools
-- Prevent Start Pool from bypassing a persistent or global pause
-- Answer a missing or signed-out GitHub CLI with a screen and the command that fixes it, and say so on the pool list when runner registrations are going unchecked as a result
-- Replace the fixed capacity actions with one step either way plus Set Runner Count, so a pool registered above the old range can be restored
-- Refuse to resize a pool with jobs in flight before asking to confirm, rather than after
-- Abandon a resize, rather than write it, if the pool was changed elsewhere while the confirmation was open
-- Hand the expected count to runpool, so a resize is refused by the tool itself rather than only by this extension
-- Note when GitHub holds more runner registrations for a repository pool than the pool expects
-- Offer a way back from the dependency screens, so correcting the executable path in preferences takes effect without relaunching the command
-- Stop the Get Pool Status AI tool reporting a pool as resting when GitHub could not be asked whether it is still registered
-- Remove the Machine Load command
+- Record each resize confirmation against the change it asked about, so two open at once cannot swap starting counts and turn approved growth into a shrink
+- Refuse a shrink that cannot be tied to a confirmation, rather than falling back to the current count
 
 ## [Initial Version] - 2026-09-01
 
 - List every runner pool against its owner's GitHub avatar, showing jobs running out of total runner slots
-- Start and stop pools, and change how many runners each has
+- Start, stop, pause and resume pools, one at a time or globally, with a confirmation before anything destructive
+- Change how many runners a pool has, a step at a time or set directly, and refuse the change if the count moved since it was confirmed
 - Drill into a pool to see the repositories it serves, and open them on GitHub
 - Browse recent workflow runs with when they ran and a compact runner summary, then drill into individual job duration and location
-- Pause and resume runner pools, behind a confirmation
-- A live summary in the root search subtitle, refreshed in the background
-- An optional menu bar item, off by default, whose icon fills with the work in flight
-- AI tools for reading pool state and changing capacity, with confirmation before anything destructive
+- A live summary in the root search subtitle, plus an optional menu bar item, off by default, whose icon fills with the work in flight
+- AI tools for reading pool state and changing capacity, behind the same confirmations
+- Say when the GitHub CLI is missing or signed out, with the command that fixes it, and when GitHub holds more runner registrations than a pool expects

--- a/extensions/runpool/CHANGELOG.md
+++ b/extensions/runpool/CHANGELOG.md
@@ -1,6 +1,6 @@
 # RunPool Changelog
 
-## [Fix a resize that could act on the wrong count] - {PR_MERGE_DATE}
+## [Fix a resize that could act on the wrong count] - 2026-09-02
 
 - Record every size a resize confirmation was shown, so two questions open at once cannot swap starting counts and turn approved growth into a shrink
 - Refuse the change when those questions disagree about the pool's size, or when a shrink cannot be tied to a confirmation at all

--- a/extensions/runpool/src/tools/set-pool-count.ts
+++ b/extensions/runpool/src/tools/set-pool-count.ts
@@ -18,16 +18,28 @@ type Input = {
 };
 
 /**
- * What the confirmation read, so the write can be refused if the pool moved
- * while the question sat open.
+ * What each confirmation read, keyed by the change it was asked about, so the
+ * write can be refused if the pool moved while the question sat open.
  *
  * `Tool.Confirmation` returns a message and nothing else, so there is no
  * argument to carry this in. Both halves run in this module, in order, which
- * makes a module-scoped note the only channel between them. It is treated as a
- * hint rather than a guarantee: if it is absent the fresh read below stands on
- * its own, and `--if-count` is doing the real work either way.
+ * makes a module-scoped note the only channel between them. One note was not
+ * enough: a second confirmation overwrote the first, so growth approved
+ * against one count could be written as a shrink against another. Keying by
+ * pool and target count keeps overlapping questions apart, and the only
+ * collision left is two questions asking for the same change to the same pool,
+ * where either answer describes something that was genuinely confirmed.
  */
-let confirmed: { pool: string; count: number } | undefined;
+const confirmedFrom = new Map<string, number>();
+
+const noteKey = (pool: string, count: number) => `${pool}\u0000${count}`;
+
+/**
+ * A declined confirmation never reaches the tool, so its note would otherwise
+ * sit here for the life of the process. Evicting the oldest fails in the safe
+ * direction: a missing note refuses a shrink rather than allowing one.
+ */
+const MAX_NOTES = 32;
 
 /**
  * Always confirm. Growing registers new runners with GitHub and downloads the
@@ -39,7 +51,16 @@ export const confirmation: Tool.Confirmation<Input> = async (input) => {
   const pool = pools.find((p) => p.name === input.pool);
   const from = pool ? `${pool.count}` : "its current count";
 
-  confirmed = pool ? { pool: input.pool, count: pool.count } : undefined;
+  const key = noteKey(input.pool, input.count);
+  if (pool) {
+    confirmedFrom.set(key, pool.count);
+    if (confirmedFrom.size > MAX_NOTES) {
+      const oldest = confirmedFrom.keys().next().value;
+      if (oldest !== undefined) confirmedFrom.delete(oldest);
+    }
+  } else {
+    confirmedFrom.delete(key);
+  }
 
   const shrinking = pool !== undefined && input.count < pool.count;
 
@@ -93,10 +114,20 @@ export default async function tool(input: Input) {
   // sits open for as long as it takes to read, and the list command, another
   // window or a terminal can resize the pool in that time, which turns approved
   // growth into a shrink that deregisters runners nobody agreed to.
-  const agreed = confirmed?.pool === pool.name ? confirmed.count : pool.count;
-  confirmed = undefined;
+  const key = noteKey(pool.name, input.count);
+  const agreed = confirmedFrom.get(key);
+  confirmedFrom.delete(key);
 
-  if (agreed !== pool.count) {
+  if (agreed === undefined) {
+    // No confirmation for this exact change is still in this process, so
+    // nothing here can show that a shrink was approved. Growth is left alone:
+    // it deregisters nothing, and `--if-count` still keeps the write atomic.
+    if (input.count < pool.count) {
+      throw new Error(
+        `Nothing here can show that shrinking "${pool.name}" from ${pool.count} to ${input.count} was confirmed, and the surplus runners would be deregistered from GitHub rather than just stopped. Nothing was changed. Ask again.`,
+      );
+    }
+  } else if (agreed !== pool.count) {
     throw new Error(
       `Pool "${pool.name}" was resized somewhere else while this was waiting: it had ${agreed} ${
         agreed === 1 ? "runner" : "runners"

--- a/extensions/runpool/src/tools/set-pool-count.ts
+++ b/extensions/runpool/src/tools/set-pool-count.ts
@@ -25,12 +25,16 @@ type Input = {
  * argument to carry this in. Both halves run in this module, in order, which
  * makes a module-scoped note the only channel between them. One note was not
  * enough: a second confirmation overwrote the first, so growth approved
- * against one count could be written as a shrink against another. Keying by
- * pool and target count keeps overlapping questions apart, and the only
- * collision left is two questions asking for the same change to the same pool,
- * where either answer describes something that was genuinely confirmed.
+ * against one count could be written as a shrink against another.
+ *
+ * A note records that a question was asked, not that it was answered, because
+ * this half runs to build the dialog and the user replies afterwards. So two
+ * questions about the same change that saw different sizes leave no way to
+ * tell which size the approval belonged to, and one of them may have been
+ * declined. Every size seen is kept, and the write proceeds only when they
+ * agree with each other and with the pool as it stands.
  */
-const confirmedFrom = new Map<string, number>();
+const confirmedFrom = new Map<string, Set<number>>();
 
 const noteKey = (pool: string, count: number) => `${pool}\u0000${count}`;
 
@@ -53,7 +57,9 @@ export const confirmation: Tool.Confirmation<Input> = async (input) => {
 
   const key = noteKey(input.pool, input.count);
   if (pool) {
-    confirmedFrom.set(key, pool.count);
+    const seen = confirmedFrom.get(key);
+    if (seen) seen.add(pool.count);
+    else confirmedFrom.set(key, new Set([pool.count]));
     if (confirmedFrom.size > MAX_NOTES) {
       const oldest = confirmedFrom.keys().next().value;
       if (oldest !== undefined) confirmedFrom.delete(oldest);
@@ -115,23 +121,26 @@ export default async function tool(input: Input) {
   // window or a terminal can resize the pool in that time, which turns approved
   // growth into a shrink that deregisters runners nobody agreed to.
   const key = noteKey(pool.name, input.count);
-  const agreed = confirmedFrom.get(key);
+  const seen = confirmedFrom.get(key);
   confirmedFrom.delete(key);
 
-  if (agreed === undefined) {
-    // No confirmation for this exact change is still in this process, so
-    // nothing here can show that a shrink was approved. Growth is left alone:
-    // it deregisters nothing, and `--if-count` still keeps the write atomic.
+  if (seen === undefined) {
+    // No question about this exact change is still on record, so nothing here
+    // can show that a shrink was put to the user. Growth is left alone: it
+    // deregisters nothing, and `--if-count` still keeps the write atomic.
     if (input.count < pool.count) {
       throw new Error(
         `Nothing here can show that shrinking "${pool.name}" from ${pool.count} to ${input.count} was confirmed, and the surplus runners would be deregistered from GitHub rather than just stopped. Nothing was changed. Ask again.`,
       );
     }
-  } else if (agreed !== pool.count) {
+  } else if (seen.size !== 1 || !seen.has(pool.count)) {
+    const only = seen.size === 1 ? [...seen][0] : undefined;
     throw new Error(
-      `Pool "${pool.name}" was resized somewhere else while this was waiting: it had ${agreed} ${
-        agreed === 1 ? "runner" : "runners"
-      } and now has ${pool.count}. Nothing was changed. Ask again against the current figure.`,
+      only !== undefined
+        ? `Pool "${pool.name}" was resized somewhere else while this was waiting: it had ${only} ${
+            only === 1 ? "runner" : "runners"
+          } and now has ${pool.count}. Nothing was changed. Ask again against the current figure.`
+        : `Pool "${pool.name}" was asked about more than once while this was waiting and its size changed in between, so which reading this approval belongs to cannot be told apart. Nothing was changed. Ask again against the current figure.`,
     );
   }
 


### PR DESCRIPTION
Two follow-ups to the extension published on 1 September.

**A resize confirmation could act on the wrong count.** `Tool.Confirmation` returns only a message, so the count it read reaches the write through a module-scoped note, and there was a single slot. A second confirmation overwrote the first, so a change approved as growth could be written as a shrink that deregisters runners. Each note is now keyed to the pool and target count it asked about, and a shrink that cannot be tied to a confirmation is refused rather than falling back to the current count. This came from a Greptile review point raised on #30343 after the extension was published.

**The changelog had an `[Unreleased]` heading.** It matches neither `## [Title] - {PR_MERGE_DATE}` nor an explicit date, so the store listing shows it as a version by that name, although everything under it shipped in the first release. Folded into the dated entry and tightened, because twenty bullets for an initial release was not readable.

No new dependencies, no new commands, no metadata change. `ray lint` and `ray build -e dist` are both clean, and the note logic was exercised against the overlapping-confirmation cases directly, including the one that previously wrote a shrink.

### Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
