### PR TITLE
[Google Cloud CLI] Add Cloud SQL

### DIFF
--- a/extensions/g-cloud/CHANGELOG.md
+++ b/extensions/g-cloud/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### New Features
 - Added **Cloud SQL** to the service hub — browse instances with engine, machine type, region, high-availability and running state
 - Added an instance detail view covering connectivity (connection name, IP addresses, authorized networks, SSL mode), backup configuration, and the maintenance window
-- Added per-instance **databases** and **users** listings, and a **backups** view that lists backup runs and can trigger an on-demand backup
+- Added per-instance **databases** and **users** listings, and a **backups** view that lists backup runs and can trigger an on-demand backup with a custom description
 - Added copy actions for the instance name, connection name, public IP, and a ready-to-run `gcloud sql connect` command
 
 ## [Fix Empty Project Dropdown on Accounts with Many Projects] - 2026-09-02

--- a/extensions/g-cloud/CHANGELOG.md
+++ b/extensions/g-cloud/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Google Cloud CLI Changelog
 
+## [Fix Silent Empty Lists When gcloud Credentials Expire] - {PR_MERGE_DATE}
+
+- Fixed an expired gcloud session being treated as authenticated. `gcloud auth list` keeps reporting an account as `ACTIVE` after its refresh token has expired, so the extension stayed on the hub and every list — including the project dropdown — silently came back empty with no explanation. It now confirms the credentials still work and shows a **Session Expired** screen wired to the existing sign-in action. Failures that are not credential-related (a timeout, a network blip) are left alone so they still surface as real errors.
+
 ## [Add Cloud SQL] - {PR_MERGE_DATE}
 
 ### New Features

--- a/extensions/g-cloud/CHANGELOG.md
+++ b/extensions/g-cloud/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Google Cloud CLI Changelog
 
+## [Add Cloud SQL] - {PR_MERGE_DATE}
+
+### New Features
+- Added **Cloud SQL** to the service hub — browse instances with engine, machine type, region, high-availability and running state
+- Added an instance detail view covering connectivity (connection name, IP addresses, authorized networks, SSL mode), backup configuration, and the maintenance window
+- Added per-instance **databases** and **users** listings, and a **backups** view that lists backup runs and can trigger an on-demand backup
+- Added copy actions for the instance name, connection name, public IP, and a ready-to-run `gcloud sql connect` command
+
 ## [Fix Empty Project Dropdown on Accounts with Many Projects] - 2026-09-02
 
 - Fixed the project dropdown showing "No projects found" when `gcloud projects list` output exceeds 1 MB (roughly 3,500+ projects). `getProjects` relied on Node's default `execFile` `maxBuffer`, so the process was killed with `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` and the rejection was swallowed into an empty list. It now passes an explicit 64 MiB `maxBuffer`.

--- a/extensions/g-cloud/CHANGELOG.md
+++ b/extensions/g-cloud/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Google Cloud CLI Changelog
 
-## [Fix Silent Empty Lists When gcloud Credentials Expire] - {PR_MERGE_DATE}
+## [Fix Silent Empty Lists When gcloud Credentials Expire] - 2026-09-09
 
 - Fixed an expired gcloud session being treated as authenticated. `gcloud auth list` keeps reporting an account as `ACTIVE` after its refresh token has expired, so the extension stayed on the hub and every list — including the project dropdown — silently came back empty with no explanation. It now confirms the credentials still work and shows a **Session Expired** screen wired to the existing sign-in action. Failures that are not credential-related (a timeout, a network blip) are left alone so they still surface as real errors.
 
-## [Add Cloud SQL] - {PR_MERGE_DATE}
+## [Add Cloud SQL] - 2026-09-09
 
 ### New Features
 - Added **Cloud SQL** to the service hub — browse instances with engine, machine type, region, high-availability and running state

--- a/extensions/g-cloud/src/components/ApiErrorView.tsx
+++ b/extensions/g-cloud/src/components/ApiErrorView.tsx
@@ -13,6 +13,7 @@ const API_INFO: Record<string, { name: string; service: string }> = {
   compute: { name: "Compute Engine", service: "compute.googleapis.com" },
   storage: { name: "Cloud Storage", service: "storage.googleapis.com" },
   secretmanager: { name: "Secret Manager", service: "secretmanager.googleapis.com" },
+  sqladmin: { name: "Cloud SQL Admin", service: "sqladmin.googleapis.com" },
   logging: { name: "Cloud Logging", service: "logging.googleapis.com" },
   iam: { name: "IAM", service: "iam.googleapis.com" },
   container: { name: "Kubernetes Engine", service: "container.googleapis.com" },

--- a/extensions/g-cloud/src/gcloud.ts
+++ b/extensions/g-cloud/src/gcloud.ts
@@ -341,6 +341,7 @@ export async function fetchResourceCounts(
   secrets: number;
   cloudrun: number;
   cloudfunctions: number;
+  cloudsql: number;
   cloudbuild: number;
 }> {
   // Import REST API functions dynamically to avoid circular dependencies
@@ -352,6 +353,7 @@ export async function fetchResourceCounts(
     listSecrets,
     listCloudRunServices,
     listCloudFunctions,
+    listCloudSqlInstances,
     listBuildTriggers,
   } = await import("./utils/gcpApi");
 
@@ -367,6 +369,7 @@ export async function fetchResourceCounts(
     secretsResult,
     cloudrunResult,
     cloudfunctionsResult,
+    cloudsqlResult,
     cloudbuildResult,
   ] = await Promise.allSettled([
     listComputeInstances(gcloudPath, projectId, undefined, {
@@ -385,6 +388,7 @@ export async function fetchResourceCounts(
     listSecrets(gcloudPath, projectId, { pageSize: countLimit }),
     listCloudRunServices(gcloudPath, projectId, { pageSize: countLimit }),
     listCloudFunctions(gcloudPath, projectId, undefined, { pageSize: countLimit }),
+    listCloudSqlInstances(gcloudPath, projectId, { fields: "items/name", maxResults: countLimit }),
     listBuildTriggers(gcloudPath, projectId, { pageSize: countLimit }),
   ]);
 
@@ -410,6 +414,7 @@ export async function fetchResourceCounts(
     secrets: getArrayCount(secretsResult as PromiseSettledResult<unknown[]>),
     cloudrun: getArrayCount(cloudrunResult as PromiseSettledResult<unknown[]>),
     cloudfunctions: getArrayCount(cloudfunctionsResult as PromiseSettledResult<unknown[]>),
+    cloudsql: getArrayCount(cloudsqlResult as PromiseSettledResult<unknown[]>),
     cloudbuild: getArrayCount(cloudbuildResult as PromiseSettledResult<unknown[]>),
   };
 }

--- a/extensions/g-cloud/src/gcloud.ts
+++ b/extensions/g-cloud/src/gcloud.ts
@@ -406,6 +406,13 @@ export async function fetchResourceCounts(
     iamCount = policy.bindings?.length || 0;
   }
 
+  // Cloud SQL returns { items, truncated } rather than a bare array.
+  let cloudsqlCount = 0;
+  if (cloudsqlResult.status === "fulfilled") {
+    const page = cloudsqlResult.value as { items?: unknown[] };
+    cloudsqlCount = page.items?.length || 0;
+  }
+
   return {
     compute: getArrayCount(computeResult as PromiseSettledResult<unknown[]>),
     storage: getArrayCount(storageResult as PromiseSettledResult<unknown[]>),
@@ -414,7 +421,7 @@ export async function fetchResourceCounts(
     secrets: getArrayCount(secretsResult as PromiseSettledResult<unknown[]>),
     cloudrun: getArrayCount(cloudrunResult as PromiseSettledResult<unknown[]>),
     cloudfunctions: getArrayCount(cloudfunctionsResult as PromiseSettledResult<unknown[]>),
-    cloudsql: getArrayCount(cloudsqlResult as PromiseSettledResult<unknown[]>),
+    cloudsql: cloudsqlCount,
     cloudbuild: getArrayCount(cloudbuildResult as PromiseSettledResult<unknown[]>),
   };
 }

--- a/extensions/g-cloud/src/index.tsx
+++ b/extensions/g-cloud/src/index.tsx
@@ -16,6 +16,7 @@ import { promisify } from "util";
 import { ProjectDropdown } from "./components/ProjectDropdown";
 import { CacheManager, RecentResource, ResourceType, ServiceCounts } from "./utils/CacheManager";
 import { authenticateWithBrowser, fetchResourceCounts } from "./gcloud";
+import { clearTokenCache } from "./utils/gcpApi";
 import { detectGcloudPath, getInstallInstructions, getPlatform } from "./utils/gcloudDetect";
 import DoctorView from "./components/DoctorView";
 
@@ -90,6 +91,7 @@ export default function GoogleCloudHub({ initialService }: GoogleCloudHubProps =
   const [viewMode, setViewMode] = useState<ViewMode>(initialService || "hub");
   const [isLoading, setIsLoading] = useState(true);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [sessionExpired, setSessionExpired] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [gcloudPath, setGcloudPath] = useState<string>(configuredGcloudPath || "gcloud");
 
@@ -186,21 +188,42 @@ export default function GoogleCloudHub({ initialService }: GoogleCloudHubProps =
       );
       if (mountCancelledRef.current) return;
 
-      if (stdout.trim()) {
-        setIsAuthenticated(true);
-        CacheManager.saveAuthStatus(true, stdout.trim());
-
-        // Load cached project
-        const cachedProject = CacheManager.getSelectedProject();
-        if (cachedProject) {
-          setSelectedProject(cachedProject.projectId);
-        }
-
-        setIsLoading(false);
-      } else {
+      if (!stdout.trim()) {
         setIsAuthenticated(false);
         setIsLoading(false);
+        return;
       }
+
+      // An account keeps being listed as ACTIVE after its refresh token expires, so
+      // confirm the credentials still work. Without this an expired session looks
+      // authenticated and every list silently comes back empty.
+      try {
+        await execFilePromise(pathToUse, ["auth", "print-access-token"], { timeout: 15000 });
+      } catch (err) {
+        if (mountCancelledRef.current) return;
+        if (isReauthRequired(err)) {
+          CacheManager.clearAuthCache();
+          clearTokenCache();
+          setSessionExpired(true);
+          setIsAuthenticated(false);
+          setIsLoading(false);
+          return;
+        }
+        // Anything else — a network blip, a timeout — is not proof the session is gone,
+        // so fall through and let the individual views surface the real error.
+      }
+
+      setIsAuthenticated(true);
+      setSessionExpired(false);
+      CacheManager.saveAuthStatus(true, stdout.trim());
+
+      // Load cached project
+      const cachedProject = CacheManager.getSelectedProject();
+      if (cachedProject) {
+        setSelectedProject(cachedProject.projectId);
+      }
+
+      setIsLoading(false);
     } catch {
       if (mountCancelledRef.current) return;
       setIsAuthenticated(false);
@@ -334,9 +357,16 @@ export default function GoogleCloudHub({ initialService }: GoogleCloudHubProps =
     return (
       <List>
         <List.EmptyView
-          title="Not authenticated"
-          description="Please authenticate with Google Cloud"
-          icon={{ source: Icon.Person, tintColor: Color.Blue }}
+          title={sessionExpired ? "Session Expired" : "Not authenticated"}
+          description={
+            sessionExpired
+              ? "Your gcloud credentials need to be refreshed — sign in again to continue"
+              : "Please authenticate with Google Cloud"
+          }
+          icon={{
+            source: sessionExpired ? Icon.Clock : Icon.Person,
+            tintColor: sessionExpired ? Color.Orange : Color.Blue,
+          }}
           actions={
             <ActionPanel>
               <Action title="Authenticate" icon={Icon.Key} onAction={authenticate} />
@@ -532,6 +562,25 @@ function AuthenticationView({ gcloudPath, onAuthenticated }: AuthenticationViewP
         }
       />
     </Form>
+  );
+}
+
+/**
+ * `gcloud auth list` keeps reporting an account as ACTIVE after its refresh token has
+ * expired, so an expired session is only detectable from the error a real credential
+ * call returns. gcloud always points at `gcloud auth login` when a re-login is needed.
+ */
+function isReauthRequired(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  // execFile surfaces the CLI's stderr on the error object as well as in the message.
+  const stderr = (error as Error & { stderr?: string }).stderr ?? "";
+  const detail = `${error.message} ${stderr}`.toLowerCase();
+
+  return (
+    detail.includes("reauthentication failed") ||
+    detail.includes("invalid_grant") ||
+    detail.includes("valid credentials") ||
+    detail.includes("gcloud auth login")
   );
 }
 

--- a/extensions/g-cloud/src/index.tsx
+++ b/extensions/g-cloud/src/index.tsx
@@ -27,13 +27,15 @@ import NetworkView from "./services/network/NetworkView";
 import SecretListView from "./services/secrets/SecretListView";
 import { CloudRunView } from "./services/cloudrun";
 import { CloudFunctionsView } from "./services/cloudfunctions";
+import { CloudSqlView } from "./services/cloudsql";
 import { LogsView } from "./services/logs-service";
 import { StreamerModeAction } from "./components/StreamerModeAction";
 import { CloudShellAction } from "./components/CloudShellAction";
 
 const execFilePromise = promisify(execFile);
 
-type ViewMode = "hub" | "compute" | "storage" | "iam" | "network" | "secrets" | "cloudrun" | "cloudfunctions" | "logs";
+type ViewMode =
+  "hub" | "compute" | "storage" | "iam" | "network" | "secrets" | "cloudrun" | "cloudfunctions" | "cloudsql" | "logs";
 
 interface ServiceInfo {
   id: ResourceType;
@@ -59,6 +61,13 @@ const SERVICES: ServiceInfo[] = [
     description: "Serverless functions",
     icon: Icon.Code,
     color: Color.Orange,
+  },
+  {
+    id: "cloudsql",
+    name: "Cloud SQL",
+    description: "Managed databases",
+    icon: Icon.HardDrive,
+    color: Color.Magenta,
   },
   {
     id: "iam",
@@ -349,6 +358,8 @@ export default function GoogleCloudHub({ initialService }: GoogleCloudHubProps =
         return <CloudRunView projectId={selectedProject} gcloudPath={gcloudPath} />;
       case "cloudfunctions":
         return <CloudFunctionsView projectId={selectedProject} gcloudPath={gcloudPath} />;
+      case "cloudsql":
+        return <CloudSqlView projectId={selectedProject} gcloudPath={gcloudPath} />;
       case "iam":
         return <IAMView projectId={selectedProject} gcloudPath={gcloudPath} />;
       case "network":

--- a/extensions/g-cloud/src/services/cloudsql/CloudSqlView.tsx
+++ b/extensions/g-cloud/src/services/cloudsql/CloudSqlView.tsx
@@ -28,12 +28,20 @@ interface StatusInfo {
 }
 
 /**
- * A stopped instance still reports state RUNNABLE; the stop is expressed as
+ * "stopped" is deliberately narrower than "not running": only a stopped instance can be
+ * started again with an activation-policy change, so only it should be offered that.
+ * A creating, failed or under-maintenance instance is transitional — it also cannot serve
+ * database and user listings, but telling someone to start it would be wrong.
+ *
+ * Note a stopped instance still reports state RUNNABLE; the stop is expressed as
  * settings.activationPolicy NEVER, which is what gcloud's own STATUS column reflects.
  */
-function isInstanceStopped(instance: CloudSqlInstance): boolean {
-  if (instance.settings?.activationPolicy === "NEVER") return true;
-  return instance.state !== undefined && instance.state !== "RUNNABLE";
+type InstanceAvailability = "running" | "stopped" | "transitional";
+
+function getInstanceAvailability(instance: CloudSqlInstance): InstanceAvailability {
+  if (instance.settings?.activationPolicy === "NEVER" || instance.state === "STOPPED") return "stopped";
+  if (instance.state === undefined || instance.state === "RUNNABLE") return "running";
+  return "transitional";
 }
 
 function getInstanceStatus(instance: CloudSqlInstance): StatusInfo {
@@ -124,31 +132,13 @@ function InstanceNavigationSection({ instance, projectId, gcloudPath, onViewDeta
         title="View Databases"
         icon={Icon.List}
         shortcut={{ modifiers: ["cmd"], key: "d" }}
-        onAction={() =>
-          push(
-            <DatabasesView
-              projectId={projectId}
-              gcloudPath={gcloudPath}
-              instanceName={instance.name}
-              instanceStopped={isInstanceStopped(instance)}
-            />,
-          )
-        }
+        onAction={() => push(<DatabasesView projectId={projectId} gcloudPath={gcloudPath} instance={instance} />)}
       />
       <Action
         title="View Users"
         icon={Icon.Person}
         shortcut={{ modifiers: ["cmd"], key: "u" }}
-        onAction={() =>
-          push(
-            <UsersView
-              projectId={projectId}
-              gcloudPath={gcloudPath}
-              instanceName={instance.name}
-              instanceStopped={isInstanceStopped(instance)}
-            />,
-          )
-        }
+        onAction={() => push(<UsersView projectId={projectId} gcloudPath={gcloudPath} instance={instance} />)}
       />
       <Action
         title="View Backups"
@@ -433,8 +423,13 @@ interface SubViewProps {
   projectId: string;
   gcloudPath: string;
   instanceName: string;
-  /** Databases and users can only be listed while the instance is actually running. */
-  instanceStopped?: boolean;
+}
+
+/** Databases and users can only be listed while the instance is actually running. */
+interface InstanceSubViewProps {
+  projectId: string;
+  gcloudPath: string;
+  instance: CloudSqlInstance;
 }
 
 /** The API rejects databases/users listings on a stopped instance with a 400. */
@@ -446,46 +441,68 @@ function isInstanceNotRunningError(message: string): boolean {
  * A stopped instance is an ordinary state, not a failure, so it gets an explanation
  * and a way forward rather than the generic API error screen.
  */
-function InstanceStoppedView({
-  instanceName,
+function InstanceNotRunningView({
+  instance,
   projectId,
   resource,
 }: {
-  instanceName: string;
+  instance: CloudSqlInstance;
   projectId: string;
   resource: string;
 }) {
+  const availability = getInstanceAvailability(instance);
+  const status = getInstanceStatus(instance);
+
+  // The third case is reached only via the error fallback, when the cached state still
+  // says RUNNABLE but the API has already rejected the request.
+  const { title, reason } =
+    availability === "stopped"
+      ? { title: "Instance Is Stopped", reason: "is stopped. Start the instance to see them." }
+      : availability === "transitional"
+        ? {
+            title: `Instance Is ${status.text}`,
+            reason: `is ${status.text.toLowerCase()}. Try again once it is running.`,
+          }
+        : { title: "Instance Is Not Running", reason: "is not running. Try again once it is running." };
+
   return (
     <List.EmptyView
-      title="Instance Is Stopped"
-      description={`Cloud SQL cannot list ${resource} while "${instanceName}" is stopped. Start the instance to see them.`}
-      icon={{ source: Icon.Stop, tintColor: Color.SecondaryText }}
+      title={title}
+      description={`Cloud SQL cannot list ${resource} while "${instance.name}" ${reason}`}
+      icon={{
+        source: availability === "stopped" ? Icon.Stop : Icon.Clock,
+        tintColor: availability === "stopped" ? Color.SecondaryText : status.color,
+      }}
       actions={
         <ActionPanel>
           <Action.OpenInBrowser
             title="Open in Console"
-            url={`https://console.cloud.google.com/sql/instances/${instanceName}/overview?project=${projectId}`}
+            url={`https://console.cloud.google.com/sql/instances/${instance.name}/overview?project=${projectId}`}
             shortcut={{ modifiers: ["cmd", "shift"], key: "o" }}
           />
-          <Action.CopyToClipboard
-            title="Copy Start Command"
-            content={`gcloud sql instances patch ${instanceName} --project=${projectId} --activation-policy=ALWAYS`}
-          />
+          {/* Only a stopped instance can be brought back with an activation-policy change. */}
+          {availability === "stopped" && (
+            <Action.CopyToClipboard
+              title="Copy Start Command"
+              content={`gcloud sql instances patch ${instance.name} --project=${projectId} --activation-policy=ALWAYS`}
+            />
+          )}
         </ActionPanel>
       }
     />
   );
 }
 
-function DatabasesView({ projectId, gcloudPath, instanceName, instanceStopped }: SubViewProps) {
+function DatabasesView({ projectId, gcloudPath, instance }: InstanceSubViewProps) {
+  const instanceName = instance.name;
   const [isLoading, setIsLoading] = useState(true);
   const [databases, setDatabases] = useState<CloudSqlDatabase[]>([]);
   const [error, setError] = useState<string | null>(null);
-  const isStopped = instanceStopped === true;
+  const isRunning = getInstanceAvailability(instance) === "running";
 
   useEffect(() => {
     // Skip the request entirely when we already know it will be rejected.
-    if (isStopped) {
+    if (!isRunning) {
       setIsLoading(false);
       return;
     }
@@ -508,10 +525,10 @@ function DatabasesView({ projectId, gcloudPath, instanceName, instanceStopped }:
     }
   }
 
-  if (isStopped || (error && isInstanceNotRunningError(error))) {
+  if (!isRunning || (error && isInstanceNotRunningError(error))) {
     return (
       <List navigationTitle={`Databases - ${instanceName}`}>
-        <InstanceStoppedView instanceName={instanceName} projectId={projectId} resource="databases" />
+        <InstanceNotRunningView instance={instance} projectId={projectId} resource="databases" />
       </List>
     );
   }
@@ -564,16 +581,17 @@ function DatabasesView({ projectId, gcloudPath, instanceName, instanceStopped }:
   );
 }
 
-function UsersView({ projectId, gcloudPath, instanceName, instanceStopped }: SubViewProps) {
+function UsersView({ projectId, gcloudPath, instance }: InstanceSubViewProps) {
+  const instanceName = instance.name;
   const [isLoading, setIsLoading] = useState(true);
   const [users, setUsers] = useState<CloudSqlUser[]>([]);
   const [error, setError] = useState<string | null>(null);
   const { isEnabled: isStreamerMode } = useStreamerMode();
-  const isStopped = instanceStopped === true;
+  const isRunning = getInstanceAvailability(instance) === "running";
 
   useEffect(() => {
     // Skip the request entirely when we already know it will be rejected.
-    if (isStopped) {
+    if (!isRunning) {
       setIsLoading(false);
       return;
     }
@@ -596,10 +614,10 @@ function UsersView({ projectId, gcloudPath, instanceName, instanceStopped }: Sub
     }
   }
 
-  if (isStopped || (error && isInstanceNotRunningError(error))) {
+  if (!isRunning || (error && isInstanceNotRunningError(error))) {
     return (
       <List navigationTitle={`Users - ${instanceName}`}>
-        <InstanceStoppedView instanceName={instanceName} projectId={projectId} resource="users" />
+        <InstanceNotRunningView instance={instance} projectId={projectId} resource="users" />
       </List>
     );
   }

--- a/extensions/g-cloud/src/services/cloudsql/CloudSqlView.tsx
+++ b/extensions/g-cloud/src/services/cloudsql/CloudSqlView.tsx
@@ -1,0 +1,824 @@
+import {
+  ActionPanel,
+  Action,
+  List,
+  showToast,
+  Toast,
+  Icon,
+  Color,
+  Detail,
+  useNavigation,
+  confirmAlert,
+  Alert,
+} from "@raycast/api";
+import { useState, useEffect } from "react";
+import {
+  listCloudSqlInstances,
+  listCloudSqlDatabases,
+  listCloudSqlUsers,
+  listCloudSqlBackupRuns,
+  createCloudSqlBackupRun,
+  CloudSqlInstance,
+  CloudSqlDatabase,
+  CloudSqlUser,
+  CloudSqlBackupRun,
+} from "../../utils/gcpApi";
+import { ServiceViewBar } from "../../utils/ServiceViewBar";
+import { initializeQuickLink } from "../../utils/QuickLinks";
+import { ApiErrorView } from "../../components/ApiErrorView";
+import { CloudShellAction } from "../../components/CloudShellAction";
+import { friendlyErrorMessage } from "../../utils/errorMessages";
+import { useStreamerMode } from "../../utils/useStreamerMode";
+import { maskIPIfEnabled, maskEmailIfEnabled } from "../../utils/maskSensitiveData";
+
+const MAINTENANCE_DAYS = ["Any", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
+
+interface StatusInfo {
+  icon: Icon;
+  color: Color;
+  text: string;
+}
+
+/**
+ * A stopped instance still reports state RUNNABLE; the stop is expressed as
+ * settings.activationPolicy NEVER, which is what gcloud's own STATUS column reflects.
+ */
+function isInstanceStopped(instance: CloudSqlInstance): boolean {
+  if (instance.settings?.activationPolicy === "NEVER") return true;
+  return instance.state !== undefined && instance.state !== "RUNNABLE";
+}
+
+function getInstanceStatus(instance: CloudSqlInstance): StatusInfo {
+  if (instance.state === "RUNNABLE" && instance.settings?.activationPolicy === "NEVER") {
+    return { icon: Icon.Stop, color: Color.SecondaryText, text: "Stopped" };
+  }
+
+  switch (instance.state) {
+    case "RUNNABLE":
+      return { icon: Icon.CheckCircle, color: Color.Green, text: "Running" };
+    case "STOPPED":
+      return { icon: Icon.Stop, color: Color.SecondaryText, text: "Stopped" };
+    case "PENDING_CREATE":
+      return { icon: Icon.Clock, color: Color.Yellow, text: "Creating" };
+    case "PENDING_DELETE":
+      return { icon: Icon.Clock, color: Color.Yellow, text: "Deleting" };
+    case "MAINTENANCE":
+      return { icon: Icon.Clock, color: Color.Yellow, text: "Maintenance" };
+    case "FAILED":
+      return { icon: Icon.XMarkCircle, color: Color.Red, text: "Failed" };
+    case "SUSPENDED":
+      return { icon: Icon.XMarkCircle, color: Color.Red, text: "Suspended" };
+    default:
+      return { icon: Icon.Circle, color: Color.SecondaryText, text: instance.state || "Unknown" };
+  }
+}
+
+/**
+ * Turns MYSQL_5_7 / POSTGRES_18 / SQLSERVER_2019_STANDARD into "MySQL 5.7", "PostgreSQL 18",
+ * "SQL Server 2019 Standard". Falls back to the raw value for engines we do not know about.
+ */
+function formatDatabaseVersion(version?: string): string {
+  if (!version) return "Unknown";
+
+  const engines: Array<[string, string]> = [
+    ["POSTGRES_", "PostgreSQL "],
+    ["MYSQL_", "MySQL "],
+    ["SQLSERVER_", "SQL Server "],
+  ];
+
+  for (const [prefix, label] of engines) {
+    if (version.startsWith(prefix)) {
+      // Version numbers are underscore-separated (MYSQL_5_7 -> 5.7); anything after the
+      // leading numeric run is an edition name (SQLSERVER_2019_STANDARD -> 2019 Standard).
+      const parts = version.slice(prefix.length).split("_");
+      const versionEnd = parts.findIndex((part) => !/^\d+$/.test(part));
+      const numericParts = versionEnd === -1 ? parts : parts.slice(0, versionEnd);
+      const edition =
+        versionEnd === -1
+          ? ""
+          : parts
+              .slice(versionEnd)
+              .map((part) => part.charAt(0) + part.slice(1).toLowerCase())
+              .join(" ");
+      return `${label}${numericParts.join(".")}${edition ? ` ${edition}` : ""}`;
+    }
+  }
+
+  return version;
+}
+
+function getPrimaryIp(instance: CloudSqlInstance): string | undefined {
+  return instance.ipAddresses?.find((ip) => ip.type === "PRIMARY")?.ipAddress;
+}
+
+function formatTimestamp(value?: string): string {
+  if (!value) return "—";
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? value : parsed.toLocaleString();
+}
+
+interface InstanceSectionProps {
+  instance: CloudSqlInstance;
+  projectId: string;
+  gcloudPath: string;
+  /** Omitted when already on the detail view, which has nowhere further to go. */
+  onViewDetails?: () => void;
+}
+
+/** Shared by the instance list and the instance detail view so both offer the same actions. */
+function InstanceNavigationSection({ instance, projectId, gcloudPath, onViewDetails }: InstanceSectionProps) {
+  const { push } = useNavigation();
+
+  return (
+    <ActionPanel.Section title="Instance">
+      {onViewDetails && <Action title="View Details" icon={Icon.Eye} onAction={onViewDetails} />}
+      <Action
+        title="View Databases"
+        icon={Icon.List}
+        shortcut={{ modifiers: ["cmd"], key: "d" }}
+        onAction={() =>
+          push(
+            <DatabasesView
+              projectId={projectId}
+              gcloudPath={gcloudPath}
+              instanceName={instance.name}
+              instanceStopped={isInstanceStopped(instance)}
+            />,
+          )
+        }
+      />
+      <Action
+        title="View Users"
+        icon={Icon.Person}
+        shortcut={{ modifiers: ["cmd"], key: "u" }}
+        onAction={() =>
+          push(
+            <UsersView
+              projectId={projectId}
+              gcloudPath={gcloudPath}
+              instanceName={instance.name}
+              instanceStopped={isInstanceStopped(instance)}
+            />,
+          )
+        }
+      />
+      <Action
+        title="View Backups"
+        icon={Icon.Clock}
+        shortcut={{ modifiers: ["cmd"], key: "b" }}
+        onAction={() =>
+          push(<BackupsView projectId={projectId} gcloudPath={gcloudPath} instanceName={instance.name} />)
+        }
+      />
+      <Action.OpenInBrowser
+        title="Open in Console"
+        url={`https://console.cloud.google.com/sql/instances/${instance.name}/overview?project=${projectId}`}
+        shortcut={{ modifiers: ["cmd", "shift"], key: "o" }}
+      />
+    </ActionPanel.Section>
+  );
+}
+
+function InstanceCopySection({ instance, projectId }: { instance: CloudSqlInstance; projectId: string }) {
+  const primaryIp = getPrimaryIp(instance);
+
+  return (
+    <ActionPanel.Section title="Copy">
+      <Action.CopyToClipboard
+        title="Copy Instance Name"
+        content={instance.name}
+        shortcut={{ modifiers: ["cmd"], key: "c" }}
+      />
+      {instance.connectionName && (
+        <Action.CopyToClipboard
+          title="Copy Connection Name"
+          content={instance.connectionName}
+          shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+        />
+      )}
+      {primaryIp && <Action.CopyToClipboard title="Copy Public IP" content={primaryIp} />}
+      <Action.CopyToClipboard
+        title="Copy Connect Command"
+        content={`gcloud sql connect ${instance.name} --project=${projectId}`}
+      />
+    </ActionPanel.Section>
+  );
+}
+
+interface CloudSqlViewProps {
+  projectId: string;
+  gcloudPath: string;
+}
+
+export default function CloudSqlView({ projectId, gcloudPath }: CloudSqlViewProps) {
+  const [isLoading, setIsLoading] = useState(true);
+  const [instances, setInstances] = useState<CloudSqlInstance[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const { push } = useNavigation();
+  const { isEnabled: isStreamerMode } = useStreamerMode();
+
+  useEffect(() => {
+    initializeQuickLink(projectId);
+    fetchInstances();
+  }, []);
+
+  async function fetchInstances() {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const instanceList = await listCloudSqlInstances(gcloudPath, projectId);
+      setInstances(instanceList);
+
+      if (instanceList.length === 0) {
+        showToast({
+          style: Toast.Style.Success,
+          title: "No Cloud SQL instances found",
+          message: "Create an instance to get started",
+        });
+      } else {
+        showToast({
+          style: Toast.Style.Success,
+          title: "Instances loaded",
+          message: `Found ${instanceList.length} instances`,
+        });
+      }
+    } catch (err) {
+      console.error("Error fetching Cloud SQL instances:", err);
+      const friendly = friendlyErrorMessage(err, "Failed to fetch instances");
+      setError(friendly.message);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  function viewInstanceDetails(instance: CloudSqlInstance) {
+    const status = getInstanceStatus(instance);
+    const settings = instance.settings;
+    const backup = settings?.backupConfiguration;
+    const maintenance = settings?.maintenanceWindow;
+    const primaryIp = getPrimaryIp(instance);
+
+    const ipRows =
+      instance.ipAddresses && instance.ipAddresses.length > 0
+        ? instance.ipAddresses
+            .map((ip) => `- **${ip.type}:** \`${maskIPIfEnabled(ip.ipAddress, isStreamerMode)}\``)
+            .join("\n")
+        : "- No IP addresses assigned";
+
+    const authorizedNetworks = settings?.ipConfiguration?.authorizedNetworks;
+    const authorizedRows =
+      authorizedNetworks && authorizedNetworks.length > 0
+        ? authorizedNetworks
+            .map((net) => `- ${net.name ? `**${net.name}:** ` : ""}\`${maskIPIfEnabled(net.value, isStreamerMode)}\``)
+            .join("\n")
+        : "- None";
+
+    const markdown = `# ${instance.name}
+
+## Overview
+- **Status:** ${status.text}
+- **Engine:** ${formatDatabaseVersion(instance.databaseVersion)}${
+      instance.databaseInstalledVersion && instance.databaseInstalledVersion !== instance.databaseVersion
+        ? ` (running ${formatDatabaseVersion(instance.databaseInstalledVersion)})`
+        : ""
+    }
+- **Region:** ${instance.region || "—"}${instance.gceZone ? ` (${instance.gceZone})` : ""}
+- **Availability:** ${settings?.availabilityType === "REGIONAL" ? "Regional (HA)" : "Zonal"}${
+      instance.secondaryGceZone ? ` · secondary ${instance.secondaryGceZone}` : ""
+    }
+- **Tier:** ${settings?.tier || "—"}${settings?.edition ? ` · ${settings.edition}` : ""}
+- **Storage:** ${settings?.dataDiskSizeGb ? `${settings.dataDiskSizeGb} GB` : "—"}${
+      settings?.dataDiskType ? ` (${settings.dataDiskType})` : ""
+    }
+- **Created:** ${formatTimestamp(instance.createTime)}
+- **Deletion protection:** ${settings?.deletionProtectionEnabled ? "Enabled" : "Disabled"}
+
+## Connectivity
+- **Connection name:** \`${instance.connectionName || "—"}\`
+- **Public IP:** ${settings?.ipConfiguration?.ipv4Enabled ? "Enabled" : "Disabled"}
+- **Private network:** ${settings?.ipConfiguration?.privateNetwork ? `\`${settings.ipConfiguration.privateNetwork}\`` : "None"}
+- **SSL mode:** ${settings?.ipConfiguration?.sslMode || (settings?.ipConfiguration?.requireSsl ? "Required" : "—")}
+
+### IP addresses
+${ipRows}
+
+### Authorized networks
+${authorizedRows}
+
+## Backups
+- **Automated backups:** ${backup?.enabled ? "Enabled" : "Disabled"}
+- **Backup window:** ${backup?.startTime ? `${backup.startTime} UTC` : "—"}
+- **Backup location:** ${backup?.location || "—"}
+- **Retained backups:** ${backup?.backupRetentionSettings?.retainedBackups ?? "—"}
+- **Point-in-time recovery:** ${backup?.pointInTimeRecoveryEnabled ? "Enabled" : "Disabled"}${
+      backup?.transactionLogRetentionDays ? ` · ${backup.transactionLogRetentionDays}d transaction logs` : ""
+    }
+
+## Maintenance
+- **Window:** ${
+      maintenance?.day !== undefined || maintenance?.hour !== undefined
+        ? `${MAINTENANCE_DAYS[maintenance?.day ?? 0]} at ${String(maintenance?.hour ?? 0).padStart(2, "0")}:00 UTC`
+        : "Any window"
+    }
+- **Update track:** ${maintenance?.updateTrack || "—"}
+
+${
+  instance.serviceAccountEmailAddress
+    ? `## Service account
+\`${maskEmailIfEnabled(instance.serviceAccountEmailAddress, isStreamerMode)}\``
+    : ""
+}
+${
+  primaryIp
+    ? `
+> Connect with: \`gcloud sql connect ${instance.name} --project=${projectId}\``
+    : ""
+}
+`;
+
+    push(
+      <Detail
+        markdown={markdown}
+        navigationTitle={instance.name}
+        actions={
+          <ActionPanel>
+            <InstanceNavigationSection instance={instance} projectId={projectId} gcloudPath={gcloudPath} />
+            <InstanceCopySection instance={instance} projectId={projectId} />
+            <ActionPanel.Section title="Cloud Shell">
+              <CloudShellAction projectId={projectId} />
+            </ActionPanel.Section>
+          </ActionPanel>
+        }
+      />,
+    );
+  }
+
+  if (error) {
+    return (
+      <List>
+        <ApiErrorView error={error} projectId={projectId} apiName="sqladmin" onRetry={fetchInstances} />
+      </List>
+    );
+  }
+
+  return (
+    <List
+      isLoading={isLoading}
+      searchBarPlaceholder="Search Cloud SQL instances..."
+      navigationTitle={`Cloud SQL - ${projectId}`}
+      searchBarAccessory={<ServiceViewBar projectId={projectId} gcloudPath={gcloudPath} serviceName="cloudsql" />}
+      actions={
+        <ActionPanel>
+          <Action title="Refresh" icon={Icon.RotateClockwise} onAction={fetchInstances} />
+          <Action.OpenInBrowser
+            title="Open Cloud SQL Console"
+            url={`https://console.cloud.google.com/sql/instances?project=${projectId}`}
+          />
+          <ActionPanel.Section title="Cloud Shell">
+            <CloudShellAction projectId={projectId} />
+          </ActionPanel.Section>
+        </ActionPanel>
+      }
+    >
+      {instances.length === 0 && !isLoading ? (
+        <List.EmptyView
+          title="No Cloud SQL Instances"
+          description="Create an instance to get started"
+          icon={{ source: Icon.HardDrive }}
+          actions={
+            <ActionPanel>
+              <Action.OpenInBrowser
+                title="Open Cloud SQL Console"
+                url={`https://console.cloud.google.com/sql/instances?project=${projectId}`}
+              />
+              <Action title="Refresh" icon={Icon.RotateClockwise} onAction={fetchInstances} />
+              <ActionPanel.Section title="Cloud Shell">
+                <CloudShellAction projectId={projectId} />
+              </ActionPanel.Section>
+            </ActionPanel>
+          }
+        />
+      ) : (
+        instances.map((instance) => {
+          const status = getInstanceStatus(instance);
+          const isHighAvailability = instance.settings?.availabilityType === "REGIONAL";
+
+          return (
+            <List.Item
+              key={instance.name}
+              title={instance.name}
+              subtitle={formatDatabaseVersion(instance.databaseVersion)}
+              icon={{ source: Icon.HardDrive, tintColor: status.color }}
+              accessories={[
+                ...(isHighAvailability ? [{ icon: Icon.Layers, tooltip: "Regional (HA)" }] : []),
+                ...(instance.settings?.tier ? [{ text: instance.settings.tier, tooltip: "Machine type" }] : []),
+                ...(instance.region ? [{ text: instance.region }] : []),
+                { tag: { value: status.text, color: status.color } },
+              ]}
+              actions={
+                <ActionPanel>
+                  <InstanceNavigationSection
+                    instance={instance}
+                    projectId={projectId}
+                    gcloudPath={gcloudPath}
+                    onViewDetails={() => viewInstanceDetails(instance)}
+                  />
+                  <InstanceCopySection instance={instance} projectId={projectId} />
+                  <ActionPanel.Section>
+                    <Action title="Refresh" icon={Icon.RotateClockwise} onAction={fetchInstances} />
+                  </ActionPanel.Section>
+                  <ActionPanel.Section title="Cloud Shell">
+                    <CloudShellAction projectId={projectId} />
+                  </ActionPanel.Section>
+                </ActionPanel>
+              }
+            />
+          );
+        })
+      )}
+    </List>
+  );
+}
+
+interface SubViewProps {
+  projectId: string;
+  gcloudPath: string;
+  instanceName: string;
+  /** Databases and users can only be listed while the instance is actually running. */
+  instanceStopped?: boolean;
+}
+
+/** The API rejects databases/users listings on a stopped instance with a 400. */
+function isInstanceNotRunningError(message: string): boolean {
+  return message.toLowerCase().includes("instance is not running");
+}
+
+/**
+ * A stopped instance is an ordinary state, not a failure, so it gets an explanation
+ * and a way forward rather than the generic API error screen.
+ */
+function InstanceStoppedView({
+  instanceName,
+  projectId,
+  resource,
+}: {
+  instanceName: string;
+  projectId: string;
+  resource: string;
+}) {
+  return (
+    <List.EmptyView
+      title="Instance Is Stopped"
+      description={`Cloud SQL cannot list ${resource} while "${instanceName}" is stopped. Start the instance to see them.`}
+      icon={{ source: Icon.Stop, tintColor: Color.SecondaryText }}
+      actions={
+        <ActionPanel>
+          <Action.OpenInBrowser
+            title="Open in Console"
+            url={`https://console.cloud.google.com/sql/instances/${instanceName}/overview?project=${projectId}`}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "o" }}
+          />
+          <Action.CopyToClipboard
+            title="Copy Start Command"
+            content={`gcloud sql instances patch ${instanceName} --project=${projectId} --activation-policy=ALWAYS`}
+          />
+        </ActionPanel>
+      }
+    />
+  );
+}
+
+function DatabasesView({ projectId, gcloudPath, instanceName, instanceStopped }: SubViewProps) {
+  const [isLoading, setIsLoading] = useState(true);
+  const [databases, setDatabases] = useState<CloudSqlDatabase[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const isStopped = instanceStopped === true;
+
+  useEffect(() => {
+    // Skip the request entirely when we already know it will be rejected.
+    if (isStopped) {
+      setIsLoading(false);
+      return;
+    }
+    fetchDatabases();
+  }, []);
+
+  async function fetchDatabases() {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const databaseList = await listCloudSqlDatabases(gcloudPath, projectId, instanceName);
+      setDatabases(databaseList);
+    } catch (err) {
+      console.error("Error fetching databases:", err);
+      const friendly = friendlyErrorMessage(err, "Failed to fetch databases");
+      setError(friendly.message);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  if (isStopped || (error && isInstanceNotRunningError(error))) {
+    return (
+      <List navigationTitle={`Databases - ${instanceName}`}>
+        <InstanceStoppedView instanceName={instanceName} projectId={projectId} resource="databases" />
+      </List>
+    );
+  }
+
+  if (error) {
+    return (
+      <List>
+        <ApiErrorView error={error} projectId={projectId} apiName="sqladmin" onRetry={fetchDatabases} />
+      </List>
+    );
+  }
+
+  return (
+    <List
+      isLoading={isLoading}
+      searchBarPlaceholder="Search databases..."
+      navigationTitle={`Databases - ${instanceName}`}
+    >
+      {databases.length === 0 && !isLoading ? (
+        <List.EmptyView
+          title="No Databases"
+          description="This instance has no databases"
+          icon={{ source: Icon.List }}
+        />
+      ) : (
+        databases.map((database) => (
+          <List.Item
+            key={database.name}
+            title={database.name}
+            icon={{ source: Icon.List, tintColor: Color.Magenta }}
+            accessories={[
+              ...(database.charset ? [{ text: database.charset }] : []),
+              ...(database.collation ? [{ text: database.collation, tooltip: "Collation" }] : []),
+            ]}
+            actions={
+              <ActionPanel>
+                <Action.CopyToClipboard title="Copy Database Name" content={database.name} />
+                <Action.OpenInBrowser
+                  title="Open in Console"
+                  url={`https://console.cloud.google.com/sql/instances/${instanceName}/databases?project=${projectId}`}
+                  shortcut={{ modifiers: ["cmd", "shift"], key: "o" }}
+                />
+                <Action title="Refresh" icon={Icon.RotateClockwise} onAction={fetchDatabases} />
+              </ActionPanel>
+            }
+          />
+        ))
+      )}
+    </List>
+  );
+}
+
+function UsersView({ projectId, gcloudPath, instanceName, instanceStopped }: SubViewProps) {
+  const [isLoading, setIsLoading] = useState(true);
+  const [users, setUsers] = useState<CloudSqlUser[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const { isEnabled: isStreamerMode } = useStreamerMode();
+  const isStopped = instanceStopped === true;
+
+  useEffect(() => {
+    // Skip the request entirely when we already know it will be rejected.
+    if (isStopped) {
+      setIsLoading(false);
+      return;
+    }
+    fetchUsers();
+  }, []);
+
+  async function fetchUsers() {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const userList = await listCloudSqlUsers(gcloudPath, projectId, instanceName);
+      setUsers(userList);
+    } catch (err) {
+      console.error("Error fetching users:", err);
+      const friendly = friendlyErrorMessage(err, "Failed to fetch users");
+      setError(friendly.message);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  if (isStopped || (error && isInstanceNotRunningError(error))) {
+    return (
+      <List navigationTitle={`Users - ${instanceName}`}>
+        <InstanceStoppedView instanceName={instanceName} projectId={projectId} resource="users" />
+      </List>
+    );
+  }
+
+  if (error) {
+    return (
+      <List>
+        <ApiErrorView error={error} projectId={projectId} apiName="sqladmin" onRetry={fetchUsers} />
+      </List>
+    );
+  }
+
+  return (
+    <List isLoading={isLoading} searchBarPlaceholder="Search users..." navigationTitle={`Users - ${instanceName}`}>
+      {users.length === 0 && !isLoading ? (
+        <List.EmptyView title="No Users" description="This instance has no users" icon={{ source: Icon.Person }} />
+      ) : (
+        users.map((user) => {
+          const isIamUser = Boolean(user.iamStatus) || user.type?.startsWith("CLOUD_IAM");
+          const displayName = user.name.includes("@")
+            ? maskEmailIfEnabled(user.name, isStreamerMode)
+            : maskIPIfEnabled(user.name, isStreamerMode);
+
+          return (
+            <List.Item
+              key={`${user.name}@${user.host || "%"}`}
+              title={displayName}
+              subtitle={user.host ? `host: ${user.host}` : undefined}
+              icon={{ source: isIamUser ? Icon.Key : Icon.Person, tintColor: isIamUser ? Color.Yellow : Color.Blue }}
+              accessories={isIamUser ? [{ tag: { value: "IAM", color: Color.Yellow } }] : []}
+              actions={
+                <ActionPanel>
+                  <Action.CopyToClipboard title="Copy User Name" content={user.name} />
+                  <Action.OpenInBrowser
+                    title="Open in Console"
+                    url={`https://console.cloud.google.com/sql/instances/${instanceName}/users?project=${projectId}`}
+                    shortcut={{ modifiers: ["cmd", "shift"], key: "o" }}
+                  />
+                  <Action title="Refresh" icon={Icon.RotateClockwise} onAction={fetchUsers} />
+                </ActionPanel>
+              }
+            />
+          );
+        })
+      )}
+    </List>
+  );
+}
+
+function getBackupStatus(backup: CloudSqlBackupRun): StatusInfo {
+  switch (backup.status) {
+    case "SUCCESSFUL":
+      return { icon: Icon.CheckCircle, color: Color.Green, text: "Successful" };
+    case "RUNNING":
+      return { icon: Icon.Clock, color: Color.Yellow, text: "Running" };
+    case "ENQUEUED":
+      return { icon: Icon.Clock, color: Color.Yellow, text: "Enqueued" };
+    case "PENDING":
+      return { icon: Icon.Clock, color: Color.Yellow, text: "Pending" };
+    case "FAILED":
+      return { icon: Icon.XMarkCircle, color: Color.Red, text: "Failed" };
+    case "DELETED":
+      return { icon: Icon.Circle, color: Color.SecondaryText, text: "Deleted" };
+    default:
+      return { icon: Icon.Circle, color: Color.SecondaryText, text: backup.status || "Unknown" };
+  }
+}
+
+function BackupsView({ projectId, gcloudPath, instanceName }: SubViewProps) {
+  const [isLoading, setIsLoading] = useState(true);
+  const [backups, setBackups] = useState<CloudSqlBackupRun[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchBackups();
+  }, []);
+
+  async function fetchBackups() {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const backupList = await listCloudSqlBackupRuns(gcloudPath, projectId, instanceName);
+      setBackups(backupList);
+    } catch (err) {
+      console.error("Error fetching backups:", err);
+      const friendly = friendlyErrorMessage(err, "Failed to fetch backups");
+      setError(friendly.message);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function handleCreateBackup() {
+    const confirmed = await confirmAlert({
+      title: "Create On-Demand Backup",
+      message: `Start a backup of "${instanceName}" now? On-demand backups are retained until you delete them and are billed as storage.`,
+      primaryAction: {
+        title: "Create Backup",
+        style: Alert.ActionStyle.Default,
+      },
+    });
+
+    if (!confirmed) return;
+
+    const toast = await showToast({
+      style: Toast.Style.Animated,
+      title: "Starting backup...",
+      message: instanceName,
+    });
+
+    try {
+      await createCloudSqlBackupRun(gcloudPath, projectId, instanceName, "On-demand backup from Raycast");
+      toast.style = Toast.Style.Success;
+      toast.title = "Backup started";
+      toast.message = "It may take a few minutes to complete";
+      fetchBackups();
+    } catch (err) {
+      console.error("Error creating backup:", err);
+      const friendly = friendlyErrorMessage(err, "Failed to create backup");
+      toast.style = Toast.Style.Failure;
+      toast.title = friendly.title;
+      toast.message = friendly.message;
+    }
+  }
+
+  if (error) {
+    return (
+      <List>
+        <ApiErrorView error={error} projectId={projectId} apiName="sqladmin" onRetry={fetchBackups} />
+      </List>
+    );
+  }
+
+  return (
+    <List
+      isLoading={isLoading}
+      searchBarPlaceholder="Search backups..."
+      navigationTitle={`Backups - ${instanceName}`}
+      actions={
+        <ActionPanel>
+          <Action
+            title="Create Backup"
+            icon={Icon.Plus}
+            shortcut={{ modifiers: ["cmd"], key: "n" }}
+            onAction={handleCreateBackup}
+          />
+          <Action title="Refresh" icon={Icon.RotateClockwise} onAction={fetchBackups} />
+        </ActionPanel>
+      }
+    >
+      {backups.length === 0 && !isLoading ? (
+        <List.EmptyView
+          title="No Backups"
+          description="This instance has no backup runs yet"
+          icon={{ source: Icon.Clock }}
+          actions={
+            <ActionPanel>
+              <Action
+                title="Create Backup"
+                icon={Icon.Plus}
+                shortcut={{ modifiers: ["cmd"], key: "n" }}
+                onAction={handleCreateBackup}
+              />
+              <Action title="Refresh" icon={Icon.RotateClockwise} onAction={fetchBackups} />
+            </ActionPanel>
+          }
+        />
+      ) : (
+        backups.map((backup) => {
+          const status = getBackupStatus(backup);
+          const isOnDemand = backup.type === "ON_DEMAND";
+
+          return (
+            <List.Item
+              key={backup.id}
+              title={formatTimestamp(backup.startTime)}
+              subtitle={backup.description || undefined}
+              icon={{ source: Icon.Clock, tintColor: status.color }}
+              accessories={[
+                ...(backup.location ? [{ text: backup.location }] : []),
+                {
+                  tag: { value: isOnDemand ? "On-demand" : "Automated", color: isOnDemand ? Color.Blue : Color.Purple },
+                },
+                { tag: { value: status.text, color: status.color } },
+              ]}
+              actions={
+                <ActionPanel>
+                  <Action
+                    title="Create Backup"
+                    icon={Icon.Plus}
+                    shortcut={{ modifiers: ["cmd"], key: "n" }}
+                    onAction={handleCreateBackup}
+                  />
+                  <Action.CopyToClipboard title="Copy Backup ID" content={backup.id} />
+                  <Action.OpenInBrowser
+                    title="Open in Console"
+                    url={`https://console.cloud.google.com/sql/instances/${instanceName}/backups?project=${projectId}`}
+                    shortcut={{ modifiers: ["cmd", "shift"], key: "o" }}
+                  />
+                  <Action title="Refresh" icon={Icon.RotateClockwise} onAction={fetchBackups} />
+                </ActionPanel>
+              }
+            />
+          );
+        })
+      )}
+    </List>
+  );
+}

--- a/extensions/g-cloud/src/services/cloudsql/CloudSqlView.tsx
+++ b/extensions/g-cloud/src/services/cloudsql/CloudSqlView.tsx
@@ -1,16 +1,4 @@
-import {
-  ActionPanel,
-  Action,
-  List,
-  showToast,
-  Toast,
-  Icon,
-  Color,
-  Detail,
-  useNavigation,
-  confirmAlert,
-  Alert,
-} from "@raycast/api";
+import { ActionPanel, Action, List, showToast, Toast, Icon, Color, Detail, useNavigation, Form } from "@raycast/api";
 import { useState, useEffect } from "react";
 import {
   listCloudSqlInstances,
@@ -684,6 +672,7 @@ function BackupsView({ projectId, gcloudPath, instanceName }: SubViewProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [backups, setBackups] = useState<CloudSqlBackupRun[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const { push } = useNavigation();
 
   useEffect(() => {
     fetchBackups();
@@ -705,37 +694,15 @@ function BackupsView({ projectId, gcloudPath, instanceName }: SubViewProps) {
     }
   }
 
-  async function handleCreateBackup() {
-    const confirmed = await confirmAlert({
-      title: "Create On-Demand Backup",
-      message: `Start a backup of "${instanceName}" now? On-demand backups are retained until you delete them and are billed as storage.`,
-      primaryAction: {
-        title: "Create Backup",
-        style: Alert.ActionStyle.Default,
-      },
-    });
-
-    if (!confirmed) return;
-
-    const toast = await showToast({
-      style: Toast.Style.Animated,
-      title: "Starting backup...",
-      message: instanceName,
-    });
-
-    try {
-      await createCloudSqlBackupRun(gcloudPath, projectId, instanceName, "On-demand backup from Raycast");
-      toast.style = Toast.Style.Success;
-      toast.title = "Backup started";
-      toast.message = "It may take a few minutes to complete";
-      fetchBackups();
-    } catch (err) {
-      console.error("Error creating backup:", err);
-      const friendly = friendlyErrorMessage(err, "Failed to create backup");
-      toast.style = Toast.Style.Failure;
-      toast.title = friendly.title;
-      toast.message = friendly.message;
-    }
+  function handleCreateBackup() {
+    push(
+      <CreateBackupForm
+        projectId={projectId}
+        gcloudPath={gcloudPath}
+        instanceName={instanceName}
+        onCreated={fetchBackups}
+      />,
+    );
   }
 
   if (error) {
@@ -820,5 +787,70 @@ function BackupsView({ projectId, gcloudPath, instanceName }: SubViewProps) {
         })
       )}
     </List>
+  );
+}
+
+interface CreateBackupFormProps {
+  projectId: string;
+  gcloudPath: string;
+  instanceName: string;
+  onCreated: () => void;
+}
+
+function CreateBackupForm({ projectId, gcloudPath, instanceName, onCreated }: CreateBackupFormProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const { pop } = useNavigation();
+
+  async function handleSubmit(values: { description: string }) {
+    setIsLoading(true);
+    const toast = await showToast({
+      style: Toast.Style.Animated,
+      title: "Starting backup...",
+      message: instanceName,
+    });
+
+    try {
+      // An empty description is valid; send none rather than an empty string.
+      const description = values.description.trim();
+      await createCloudSqlBackupRun(gcloudPath, projectId, instanceName, description || undefined);
+      toast.style = Toast.Style.Success;
+      toast.title = "Backup started";
+      toast.message = "It may take a few minutes to complete";
+      onCreated();
+      pop();
+    } catch (err) {
+      console.error("Error creating backup:", err);
+      const friendly = friendlyErrorMessage(err, "Failed to create backup");
+      toast.style = Toast.Style.Failure;
+      toast.title = friendly.title;
+      toast.message = friendly.message;
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <Form
+      isLoading={isLoading}
+      navigationTitle={`Create Backup - ${instanceName}`}
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Create Backup" icon={Icon.Plus} onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.Description
+        title="Instance"
+        text={`${instanceName}\n\nOn-demand backups are retained until you delete them and are billed as storage.`}
+      />
+      <Form.TextField
+        id="description"
+        title="Description"
+        placeholder="e.g. before schema migration"
+        defaultValue="On-demand backup from Raycast"
+        info="Shown in the backup list — use it to tell on-demand backups apart later"
+        autoFocus
+      />
+    </Form>
   );
 }

--- a/extensions/g-cloud/src/services/cloudsql/CloudSqlView.tsx
+++ b/extensions/g-cloud/src/services/cloudsql/CloudSqlView.tsx
@@ -6,6 +6,7 @@ import {
   listCloudSqlUsers,
   listCloudSqlBackupRuns,
   createCloudSqlBackupRun,
+  SQLADMIN_MAX_PAGES,
   CloudSqlInstance,
   CloudSqlDatabase,
   CloudSqlUser,
@@ -183,6 +184,26 @@ function InstanceCopySection({ instance, projectId }: { instance: CloudSqlInstan
   );
 }
 
+/**
+ * A toast is easy to miss, and a truncated list otherwise looks complete — so the
+ * shortfall also gets a row that stays on screen, pointing at the console for the rest.
+ */
+function TruncatedNoticeItem({ resource, consoleUrl }: { resource: string; consoleUrl: string }) {
+  return (
+    <List.Item
+      title={`Some ${resource} are not shown`}
+      subtitle={`Stopped after ${SQLADMIN_MAX_PAGES} pages of results`}
+      icon={{ source: Icon.Warning, tintColor: Color.Orange }}
+      accessories={[{ tag: { value: "Partial", color: Color.Orange } }]}
+      actions={
+        <ActionPanel>
+          <Action.OpenInBrowser title="Open in Console" url={consoleUrl} />
+        </ActionPanel>
+      }
+    />
+  );
+}
+
 interface CloudSqlViewProps {
   projectId: string;
   gcloudPath: string;
@@ -191,6 +212,7 @@ interface CloudSqlViewProps {
 export default function CloudSqlView({ projectId, gcloudPath }: CloudSqlViewProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [instances, setInstances] = useState<CloudSqlInstance[]>([]);
+  const [isTruncated, setIsTruncated] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const { push } = useNavigation();
   const { isEnabled: isStreamerMode } = useStreamerMode();
@@ -205,10 +227,17 @@ export default function CloudSqlView({ projectId, gcloudPath }: CloudSqlViewProp
     setError(null);
 
     try {
-      const instanceList = await listCloudSqlInstances(gcloudPath, projectId);
-      setInstances(instanceList);
+      const { items, truncated } = await listCloudSqlInstances(gcloudPath, projectId);
+      setInstances(items);
+      setIsTruncated(truncated);
 
-      if (instanceList.length === 0) {
+      if (truncated) {
+        showToast({
+          style: Toast.Style.Failure,
+          title: "Showing partial results",
+          message: `Stopped after ${SQLADMIN_MAX_PAGES} pages — some instances are not listed`,
+        });
+      } else if (items.length === 0) {
         showToast({
           style: Toast.Style.Success,
           title: "No Cloud SQL instances found",
@@ -218,7 +247,7 @@ export default function CloudSqlView({ projectId, gcloudPath }: CloudSqlViewProp
         showToast({
           style: Toast.Style.Success,
           title: "Instances loaded",
-          message: `Found ${instanceList.length} instances`,
+          message: `Found ${items.length} instances`,
         });
       }
     } catch (err) {
@@ -378,42 +407,53 @@ ${
           }
         />
       ) : (
-        instances.map((instance) => {
-          const status = getInstanceStatus(instance);
-          const isHighAvailability = instance.settings?.availabilityType === "REGIONAL";
+        [
+          ...instances.map((instance) => {
+            const status = getInstanceStatus(instance);
+            const isHighAvailability = instance.settings?.availabilityType === "REGIONAL";
 
-          return (
-            <List.Item
-              key={instance.name}
-              title={instance.name}
-              subtitle={formatDatabaseVersion(instance.databaseVersion)}
-              icon={{ source: Icon.HardDrive, tintColor: status.color }}
-              accessories={[
-                ...(isHighAvailability ? [{ icon: Icon.Layers, tooltip: "Regional (HA)" }] : []),
-                ...(instance.settings?.tier ? [{ text: instance.settings.tier, tooltip: "Machine type" }] : []),
-                ...(instance.region ? [{ text: instance.region }] : []),
-                { tag: { value: status.text, color: status.color } },
-              ]}
-              actions={
-                <ActionPanel>
-                  <InstanceNavigationSection
-                    instance={instance}
-                    projectId={projectId}
-                    gcloudPath={gcloudPath}
-                    onViewDetails={() => viewInstanceDetails(instance)}
-                  />
-                  <InstanceCopySection instance={instance} projectId={projectId} />
-                  <ActionPanel.Section>
-                    <Action title="Refresh" icon={Icon.RotateClockwise} onAction={fetchInstances} />
-                  </ActionPanel.Section>
-                  <ActionPanel.Section title="Cloud Shell">
-                    <CloudShellAction projectId={projectId} />
-                  </ActionPanel.Section>
-                </ActionPanel>
-              }
-            />
-          );
-        })
+            return (
+              <List.Item
+                key={instance.name}
+                title={instance.name}
+                subtitle={formatDatabaseVersion(instance.databaseVersion)}
+                icon={{ source: Icon.HardDrive, tintColor: status.color }}
+                accessories={[
+                  ...(isHighAvailability ? [{ icon: Icon.Layers, tooltip: "Regional (HA)" }] : []),
+                  ...(instance.settings?.tier ? [{ text: instance.settings.tier, tooltip: "Machine type" }] : []),
+                  ...(instance.region ? [{ text: instance.region }] : []),
+                  { tag: { value: status.text, color: status.color } },
+                ]}
+                actions={
+                  <ActionPanel>
+                    <InstanceNavigationSection
+                      instance={instance}
+                      projectId={projectId}
+                      gcloudPath={gcloudPath}
+                      onViewDetails={() => viewInstanceDetails(instance)}
+                    />
+                    <InstanceCopySection instance={instance} projectId={projectId} />
+                    <ActionPanel.Section>
+                      <Action title="Refresh" icon={Icon.RotateClockwise} onAction={fetchInstances} />
+                    </ActionPanel.Section>
+                    <ActionPanel.Section title="Cloud Shell">
+                      <CloudShellAction projectId={projectId} />
+                    </ActionPanel.Section>
+                  </ActionPanel>
+                }
+              />
+            );
+          }),
+          ...(isTruncated
+            ? [
+                <TruncatedNoticeItem
+                  key="cloudsql-truncated"
+                  resource="instances"
+                  consoleUrl={`https://console.cloud.google.com/sql/instances?project=${projectId}`}
+                />,
+              ]
+            : []),
+        ]
       )}
     </List>
   );
@@ -689,6 +729,7 @@ function getBackupStatus(backup: CloudSqlBackupRun): StatusInfo {
 function BackupsView({ projectId, gcloudPath, instanceName }: SubViewProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [backups, setBackups] = useState<CloudSqlBackupRun[]>([]);
+  const [isTruncated, setIsTruncated] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const { push } = useNavigation();
 
@@ -701,8 +742,17 @@ function BackupsView({ projectId, gcloudPath, instanceName }: SubViewProps) {
     setError(null);
 
     try {
-      const backupList = await listCloudSqlBackupRuns(gcloudPath, projectId, instanceName);
-      setBackups(backupList);
+      const { items, truncated } = await listCloudSqlBackupRuns(gcloudPath, projectId, instanceName);
+      setBackups(items);
+      setIsTruncated(truncated);
+
+      if (truncated) {
+        showToast({
+          style: Toast.Style.Failure,
+          title: "Showing partial results",
+          message: `Stopped after ${SQLADMIN_MAX_PAGES} pages — older backups are not listed`,
+        });
+      }
     } catch (err) {
       console.error("Error fetching backups:", err);
       const friendly = friendlyErrorMessage(err, "Failed to fetch backups");
@@ -766,43 +816,57 @@ function BackupsView({ projectId, gcloudPath, instanceName }: SubViewProps) {
           }
         />
       ) : (
-        backups.map((backup) => {
-          const status = getBackupStatus(backup);
-          const isOnDemand = backup.type === "ON_DEMAND";
+        [
+          ...backups.map((backup) => {
+            const status = getBackupStatus(backup);
+            const isOnDemand = backup.type === "ON_DEMAND";
 
-          return (
-            <List.Item
-              key={backup.id}
-              title={formatTimestamp(backup.startTime)}
-              subtitle={backup.description || undefined}
-              icon={{ source: Icon.Clock, tintColor: status.color }}
-              accessories={[
-                ...(backup.location ? [{ text: backup.location }] : []),
-                {
-                  tag: { value: isOnDemand ? "On-demand" : "Automated", color: isOnDemand ? Color.Blue : Color.Purple },
-                },
-                { tag: { value: status.text, color: status.color } },
-              ]}
-              actions={
-                <ActionPanel>
-                  <Action
-                    title="Create Backup"
-                    icon={Icon.Plus}
-                    shortcut={{ modifiers: ["cmd"], key: "n" }}
-                    onAction={handleCreateBackup}
-                  />
-                  <Action.CopyToClipboard title="Copy Backup ID" content={backup.id} />
-                  <Action.OpenInBrowser
-                    title="Open in Console"
-                    url={`https://console.cloud.google.com/sql/instances/${instanceName}/backups?project=${projectId}`}
-                    shortcut={{ modifiers: ["cmd", "shift"], key: "o" }}
-                  />
-                  <Action title="Refresh" icon={Icon.RotateClockwise} onAction={fetchBackups} />
-                </ActionPanel>
-              }
-            />
-          );
-        })
+            return (
+              <List.Item
+                key={backup.id}
+                title={formatTimestamp(backup.startTime)}
+                subtitle={backup.description || undefined}
+                icon={{ source: Icon.Clock, tintColor: status.color }}
+                accessories={[
+                  ...(backup.location ? [{ text: backup.location }] : []),
+                  {
+                    tag: {
+                      value: isOnDemand ? "On-demand" : "Automated",
+                      color: isOnDemand ? Color.Blue : Color.Purple,
+                    },
+                  },
+                  { tag: { value: status.text, color: status.color } },
+                ]}
+                actions={
+                  <ActionPanel>
+                    <Action
+                      title="Create Backup"
+                      icon={Icon.Plus}
+                      shortcut={{ modifiers: ["cmd"], key: "n" }}
+                      onAction={handleCreateBackup}
+                    />
+                    <Action.CopyToClipboard title="Copy Backup ID" content={backup.id} />
+                    <Action.OpenInBrowser
+                      title="Open in Console"
+                      url={`https://console.cloud.google.com/sql/instances/${instanceName}/backups?project=${projectId}`}
+                      shortcut={{ modifiers: ["cmd", "shift"], key: "o" }}
+                    />
+                    <Action title="Refresh" icon={Icon.RotateClockwise} onAction={fetchBackups} />
+                  </ActionPanel>
+                }
+              />
+            );
+          }),
+          ...(isTruncated
+            ? [
+                <TruncatedNoticeItem
+                  key="cloudsql-backups-truncated"
+                  resource="backups"
+                  consoleUrl={`https://console.cloud.google.com/sql/instances/${instanceName}/backups?project=${projectId}`}
+                />,
+              ]
+            : []),
+        ]
       )}
     </List>
   );

--- a/extensions/g-cloud/src/services/cloudsql/CloudSqlView.tsx
+++ b/extensions/g-cloud/src/services/cloudsql/CloudSqlView.tsx
@@ -18,7 +18,7 @@ import { ApiErrorView } from "../../components/ApiErrorView";
 import { CloudShellAction } from "../../components/CloudShellAction";
 import { friendlyErrorMessage } from "../../utils/errorMessages";
 import { useStreamerMode } from "../../utils/useStreamerMode";
-import { maskIPIfEnabled, maskEmailIfEnabled } from "../../utils/maskSensitiveData";
+import { maskIPIfEnabled, maskEmailIfEnabled, maskSecretIfEnabled } from "../../utils/maskSensitiveData";
 
 const MAINTENANCE_DAYS = ["Any", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
 
@@ -677,15 +677,19 @@ function UsersView({ projectId, gcloudPath, instance }: InstanceSubViewProps) {
       ) : (
         users.map((user) => {
           const isIamUser = Boolean(user.iamStatus) || user.type?.startsWith("CLOUD_IAM");
+          // An IAM user's name is an email; a built-in user's is an opaque account name,
+          // which maskSecret hides without dressing it up as an address.
           const displayName = user.name.includes("@")
             ? maskEmailIfEnabled(user.name, isStreamerMode)
-            : maskIPIfEnabled(user.name, isStreamerMode);
+            : maskSecretIfEnabled(user.name, isStreamerMode);
+          // host is routinely an IP or CIDR, so it leaks just as readily as the name.
+          const displayHost = user.host ? maskIPIfEnabled(user.host, isStreamerMode) : undefined;
 
           return (
             <List.Item
               key={`${user.name}@${user.host || "%"}`}
               title={displayName}
-              subtitle={user.host ? `host: ${user.host}` : undefined}
+              subtitle={displayHost ? `host: ${displayHost}` : undefined}
               icon={{ source: isIamUser ? Icon.Key : Icon.Person, tintColor: isIamUser ? Color.Yellow : Color.Blue }}
               accessories={isIamUser ? [{ tag: { value: "IAM", color: Color.Yellow } }] : []}
               actions={

--- a/extensions/g-cloud/src/services/cloudsql/index.ts
+++ b/extensions/g-cloud/src/services/cloudsql/index.ts
@@ -1,0 +1,1 @@
+export { default as CloudSqlView } from "./CloudSqlView";

--- a/extensions/g-cloud/src/utils/CacheManager.ts
+++ b/extensions/g-cloud/src/utils/CacheManager.ts
@@ -26,7 +26,7 @@ export const CACHE_TTL = {
 };
 
 export type ResourceType =
-  "compute" | "storage" | "iam" | "network" | "secrets" | "cloudrun" | "cloudfunctions" | "logs";
+  "compute" | "storage" | "iam" | "network" | "secrets" | "cloudrun" | "cloudfunctions" | "cloudsql" | "logs";
 
 export interface RecentResource {
   id: string;
@@ -46,6 +46,7 @@ export interface ServiceCounts {
   secrets: number;
   cloudrun: number;
   cloudfunctions: number;
+  cloudsql: number;
   cloudbuild: number;
   timestamp: number;
 }

--- a/extensions/g-cloud/src/utils/gcpApi.ts
+++ b/extensions/g-cloud/src/utils/gcpApi.ts
@@ -1595,3 +1595,167 @@ export async function invokeCloudFunction(
   const body = await response.text();
   return { statusCode: response.status, body };
 }
+
+// ============================================================================
+// Cloud SQL Admin API
+// ============================================================================
+
+export const SQLADMIN_API = "https://sqladmin.googleapis.com/v1";
+
+export interface CloudSqlBackupConfiguration {
+  enabled?: boolean;
+  startTime?: string;
+  location?: string;
+  pointInTimeRecoveryEnabled?: boolean;
+  transactionLogRetentionDays?: number;
+  backupRetentionSettings?: {
+    retentionUnit?: string;
+    retainedBackups?: number;
+  };
+}
+
+export interface CloudSqlInstance {
+  name: string;
+  project?: string;
+  region?: string;
+  state?: string;
+  databaseVersion?: string;
+  databaseInstalledVersion?: string;
+  instanceType?: string;
+  backendType?: string;
+  connectionName?: string;
+  gceZone?: string;
+  secondaryGceZone?: string;
+  createTime?: string;
+  serviceAccountEmailAddress?: string;
+  ipAddresses?: Array<{ type: string; ipAddress: string; timeToRetire?: string }>;
+  settings?: {
+    tier?: string;
+    edition?: string;
+    availabilityType?: string;
+    activationPolicy?: string;
+    dataDiskSizeGb?: string;
+    dataDiskType?: string;
+    deletionProtectionEnabled?: boolean;
+    backupConfiguration?: CloudSqlBackupConfiguration;
+    maintenanceWindow?: {
+      day?: number;
+      hour?: number;
+      updateTrack?: string;
+    };
+    ipConfiguration?: {
+      ipv4Enabled?: boolean;
+      privateNetwork?: string;
+      sslMode?: string;
+      requireSsl?: boolean;
+      authorizedNetworks?: Array<{ name?: string; value: string }>;
+    };
+    userLabels?: Record<string, string>;
+  };
+}
+
+export async function listCloudSqlInstances(
+  gcloudPath: string,
+  projectId: string,
+  options?: { fields?: string; maxResults?: number },
+): Promise<CloudSqlInstance[]> {
+  const params = new URLSearchParams();
+  if (options?.fields) params.set("fields", options.fields);
+  if (options?.maxResults) params.set("maxResults", options.maxResults.toString());
+  const qs = params.toString() ? `?${params.toString()}` : "";
+  const url = `${SQLADMIN_API}/projects/${projectId}/instances${qs}`;
+  const response = await gcpFetch<{ items?: CloudSqlInstance[] }>(gcloudPath, url);
+  return response.items || [];
+}
+
+export async function getCloudSqlInstance(
+  gcloudPath: string,
+  projectId: string,
+  instanceId: string,
+): Promise<CloudSqlInstance> {
+  const url = `${SQLADMIN_API}/projects/${projectId}/instances/${instanceId}`;
+  return gcpFetch<CloudSqlInstance>(gcloudPath, url);
+}
+
+export interface CloudSqlDatabase {
+  name: string;
+  charset?: string;
+  collation?: string;
+  instance?: string;
+  project?: string;
+}
+
+export async function listCloudSqlDatabases(
+  gcloudPath: string,
+  projectId: string,
+  instanceId: string,
+): Promise<CloudSqlDatabase[]> {
+  const url = `${SQLADMIN_API}/projects/${projectId}/instances/${instanceId}/databases`;
+  const response = await gcpFetch<{ items?: CloudSqlDatabase[] }>(gcloudPath, url);
+  return response.items || [];
+}
+
+export interface CloudSqlUser {
+  name: string;
+  host?: string;
+  instance?: string;
+  project?: string;
+  type?: string;
+  iamStatus?: string;
+}
+
+export async function listCloudSqlUsers(
+  gcloudPath: string,
+  projectId: string,
+  instanceId: string,
+): Promise<CloudSqlUser[]> {
+  const url = `${SQLADMIN_API}/projects/${projectId}/instances/${instanceId}/users`;
+  const response = await gcpFetch<{ items?: CloudSqlUser[] }>(gcloudPath, url);
+  return response.items || [];
+}
+
+export interface CloudSqlBackupRun {
+  id: string;
+  status?: string;
+  type?: string;
+  backupKind?: string;
+  description?: string;
+  location?: string;
+  databaseVersion?: string;
+  enqueuedTime?: string;
+  startTime?: string;
+  endTime?: string;
+  windowStartTime?: string;
+  error?: { code?: number; message?: string };
+}
+
+export async function listCloudSqlBackupRuns(
+  gcloudPath: string,
+  projectId: string,
+  instanceId: string,
+  options?: { maxResults?: number },
+): Promise<CloudSqlBackupRun[]> {
+  const params = new URLSearchParams();
+  if (options?.maxResults) params.set("maxResults", options.maxResults.toString());
+  const qs = params.toString() ? `?${params.toString()}` : "";
+  const url = `${SQLADMIN_API}/projects/${projectId}/instances/${instanceId}/backupRuns${qs}`;
+  const response = await gcpFetch<{ items?: CloudSqlBackupRun[] }>(gcloudPath, url);
+  return response.items || [];
+}
+
+export interface CloudSqlOperation {
+  name?: string;
+  status?: string;
+  operationType?: string;
+  error?: { errors?: Array<{ code?: string; message?: string }> };
+}
+
+export async function createCloudSqlBackupRun(
+  gcloudPath: string,
+  projectId: string,
+  instanceId: string,
+  description?: string,
+): Promise<CloudSqlOperation> {
+  const url = `${SQLADMIN_API}/projects/${projectId}/instances/${instanceId}/backupRuns`;
+  return gcpPost<CloudSqlOperation>(gcloudPath, url, description ? { description } : {});
+}

--- a/extensions/g-cloud/src/utils/gcpApi.ts
+++ b/extensions/g-cloud/src/utils/gcpApi.ts
@@ -1654,18 +1654,38 @@ export interface CloudSqlInstance {
   };
 }
 
+/** Guards against a malformed response looping forever; far above any realistic page count. */
+const SQLADMIN_MAX_PAGES = 50;
+
+/**
+ * `maxResults` means "cap the work" — the hub's bounded resource counts rely on that and
+ * stay a single page. Without it every page is followed, so nothing is silently truncated.
+ */
 export async function listCloudSqlInstances(
   gcloudPath: string,
   projectId: string,
   options?: { fields?: string; maxResults?: number },
 ): Promise<CloudSqlInstance[]> {
-  const params = new URLSearchParams();
-  if (options?.fields) params.set("fields", options.fields);
-  if (options?.maxResults) params.set("maxResults", options.maxResults.toString());
-  const qs = params.toString() ? `?${params.toString()}` : "";
-  const url = `${SQLADMIN_API}/projects/${projectId}/instances${qs}`;
-  const response = await gcpFetch<{ items?: CloudSqlInstance[] }>(gcloudPath, url);
-  return response.items || [];
+  const paginate = !options?.maxResults;
+  const instances: CloudSqlInstance[] = [];
+  let pageToken: string | undefined;
+  let page = 0;
+
+  do {
+    const params = new URLSearchParams();
+    // A `fields` mask drops nextPageToken unless it is asked for explicitly.
+    if (options?.fields) params.set("fields", paginate ? `${options.fields},nextPageToken` : options.fields);
+    if (options?.maxResults) params.set("maxResults", options.maxResults.toString());
+    if (pageToken) params.set("pageToken", pageToken);
+    const qs = params.toString() ? `?${params.toString()}` : "";
+    const url = `${SQLADMIN_API}/projects/${projectId}/instances${qs}`;
+    const response = await gcpFetch<{ items?: CloudSqlInstance[]; nextPageToken?: string }>(gcloudPath, url);
+
+    instances.push(...(response.items || []));
+    pageToken = paginate ? response.nextPageToken : undefined;
+  } while (pageToken && ++page < SQLADMIN_MAX_PAGES);
+
+  return instances;
 }
 
 export async function getCloudSqlInstance(
@@ -1729,18 +1749,31 @@ export interface CloudSqlBackupRun {
   error?: { code?: number; message?: string };
 }
 
+/** Follows every page unless `maxResults` caps the request — see listCloudSqlInstances. */
 export async function listCloudSqlBackupRuns(
   gcloudPath: string,
   projectId: string,
   instanceId: string,
   options?: { maxResults?: number },
 ): Promise<CloudSqlBackupRun[]> {
-  const params = new URLSearchParams();
-  if (options?.maxResults) params.set("maxResults", options.maxResults.toString());
-  const qs = params.toString() ? `?${params.toString()}` : "";
-  const url = `${SQLADMIN_API}/projects/${projectId}/instances/${instanceId}/backupRuns${qs}`;
-  const response = await gcpFetch<{ items?: CloudSqlBackupRun[] }>(gcloudPath, url);
-  return response.items || [];
+  const paginate = !options?.maxResults;
+  const backupRuns: CloudSqlBackupRun[] = [];
+  let pageToken: string | undefined;
+  let page = 0;
+
+  do {
+    const params = new URLSearchParams();
+    if (options?.maxResults) params.set("maxResults", options.maxResults.toString());
+    if (pageToken) params.set("pageToken", pageToken);
+    const qs = params.toString() ? `?${params.toString()}` : "";
+    const url = `${SQLADMIN_API}/projects/${projectId}/instances/${instanceId}/backupRuns${qs}`;
+    const response = await gcpFetch<{ items?: CloudSqlBackupRun[]; nextPageToken?: string }>(gcloudPath, url);
+
+    backupRuns.push(...(response.items || []));
+    pageToken = paginate ? response.nextPageToken : undefined;
+  } while (pageToken && ++page < SQLADMIN_MAX_PAGES);
+
+  return backupRuns;
 }
 
 export interface CloudSqlOperation {

--- a/extensions/g-cloud/src/utils/gcpApi.ts
+++ b/extensions/g-cloud/src/utils/gcpApi.ts
@@ -1655,21 +1655,31 @@ export interface CloudSqlInstance {
 }
 
 /** Guards against a malformed response looping forever; far above any realistic page count. */
-const SQLADMIN_MAX_PAGES = 50;
+export const SQLADMIN_MAX_PAGES = 50;
+
+/**
+ * A capped listing can stop with results still outstanding, so callers are told when that
+ * happened rather than being handed a partial list that looks complete.
+ */
+export interface CloudSqlListResult<T> {
+  items: T[];
+  /** True when the page cap was reached while a nextPageToken was still outstanding. */
+  truncated: boolean;
+}
 
 /**
  * `maxResults` means "cap the work" — the hub's bounded resource counts rely on that and
- * stay a single page. Without it every page is followed, so nothing is silently truncated.
+ * stay a single page. Without it every page is followed, up to SQLADMIN_MAX_PAGES.
  */
 export async function listCloudSqlInstances(
   gcloudPath: string,
   projectId: string,
   options?: { fields?: string; maxResults?: number },
-): Promise<CloudSqlInstance[]> {
+): Promise<CloudSqlListResult<CloudSqlInstance>> {
   const paginate = !options?.maxResults;
   const instances: CloudSqlInstance[] = [];
   let pageToken: string | undefined;
-  let page = 0;
+  let pages = 0;
 
   do {
     const params = new URLSearchParams();
@@ -1683,9 +1693,11 @@ export async function listCloudSqlInstances(
 
     instances.push(...(response.items || []));
     pageToken = paginate ? response.nextPageToken : undefined;
-  } while (pageToken && ++page < SQLADMIN_MAX_PAGES);
+    pages += 1;
+  } while (pageToken && pages < SQLADMIN_MAX_PAGES);
 
-  return instances;
+  // A token still in hand means the cap stopped the walk, not the server.
+  return { items: instances, truncated: Boolean(pageToken) };
 }
 
 export async function getCloudSqlInstance(
@@ -1755,11 +1767,11 @@ export async function listCloudSqlBackupRuns(
   projectId: string,
   instanceId: string,
   options?: { maxResults?: number },
-): Promise<CloudSqlBackupRun[]> {
+): Promise<CloudSqlListResult<CloudSqlBackupRun>> {
   const paginate = !options?.maxResults;
   const backupRuns: CloudSqlBackupRun[] = [];
   let pageToken: string | undefined;
-  let page = 0;
+  let pages = 0;
 
   do {
     const params = new URLSearchParams();
@@ -1771,9 +1783,10 @@ export async function listCloudSqlBackupRuns(
 
     backupRuns.push(...(response.items || []));
     pageToken = paginate ? response.nextPageToken : undefined;
-  } while (pageToken && ++page < SQLADMIN_MAX_PAGES);
+    pages += 1;
+  } while (pageToken && pages < SQLADMIN_MAX_PAGES);
 
-  return backupRuns;
+  return { items: backupRuns, truncated: Boolean(pageToken) };
 }
 
 export interface CloudSqlOperation {


### PR DESCRIPTION
## Description

Adds **Cloud SQL** to the service hub, and fixes a related failure mode found while building it — an expired gcloud session silently rendering empty lists.

### Cloud SQL

Cloud SQL sits alongside Compute, Storage, Cloud Run and Cloud Functions in the hub, with an instance count like the others. The instance list shows engine, machine type, region, high-availability and running state:

```
example-primary-db   PostgreSQL 18    ⧉  db-custom-2-8192   us-central1   Running
example-staging-db   MySQL 5.7           db-n1-standard-1   us-central1   Stopped
```

Per instance: a detail view (connection name, IP addresses, authorized networks, SSL mode, backup configuration, maintenance window), plus **databases** `⌘D`, **users** `⌘U` and **backups** `⌘B`. Backups lists runs and can trigger an on-demand backup with a description. Copy actions cover the instance name, connection name, public IP, and a ready-to-run `gcloud sql connect` command.

Reads go through the existing `gcpApi` helpers, so there is no new auth or transport code. IP addresses and the service account email respect Streamer Mode, consistent with the Compute and Network views.

Scope was kept deliberately narrow: **no** instance start/stop/restart and **no** backup restore. Those are destructive or high-blast-radius operations that felt wrong to put one keystroke away in a launcher, and the console handles them well.

### Two API behaviours worth flagging to reviewers

Both were found against a real project and are the kind of thing that looks like a bug later if undocumented.

**1. A stopped instance reports `state: RUNNABLE`.**

The stop is expressed as `settings.activationPolicy: "NEVER"`, and gcloud's own `STATUS` column derives "STOPPED" from that combination:

```
INSTANCE              API state    activationPolicy     gcloud STATUS
example-primary-db    RUNNABLE     ALWAYS               RUNNABLE
example-staging-db    RUNNABLE     NEVER                STOPPED
```

Reading `state` alone reports a stopped instance as running. Status is derived from both fields so the badge matches `gcloud sql instances list`.

**2. Databases and users cannot be listed while an instance is stopped.**

The API returns a 400:

```
HTTP 400  Invalid request: Invalid request since instance is not running.
```

Backup runs are unaffected and still list fine, since they are stored artifacts. A stopped instance is an ordinary state rather than a failure, so it gets a "Instance Is Stopped" screen naming the instance and offering a start command, instead of the generic API error view — which would otherwise have offered a useless "Enable API" button. The request is skipped when the state is already known, with the error text matched as a fallback in case that state is stale.

### Fix: expired credentials showed empty lists with no explanation

`gcloud auth list` keeps reporting an account as `ACTIVE` after its refresh token has expired. `checkAuthStatus` treated that as a live session, so the hub rendered normally and every subsequent call failed the same quiet way:

```
ERROR: (gcloud.projects.list) There was a problem refreshing your current auth tokens:
Reauthentication failed. cannot prompt during non-interactive execution.
```

The project dropdown came back empty — indistinguishable from an account that genuinely has no projects, with nothing on screen explaining why. Since org policies commonly enforce periodic reauth, this recurs.

After confirming an active account, the extension now verifies the credentials actually work via `auth print-access-token`. On a credential failure it clears the cached auth status and access token and shows a **Session Expired** screen wired to the existing sign-in action.

| | Before | After |
|---|---|---|
| Expired refresh token | Hub renders, dropdown empty, no error | "Session Expired" + Authenticate action |
| Network blip / timeout | — | Falls through; views surface the real error |

Only credential failures are treated as a lost session. A timeout or network error deliberately falls through, so a flaky connection does not throw you into a pointless re-login.

This fix is independent of Cloud SQL and could be split out, but it touches `index.tsx`, which Cloud SQL also modifies, so separating it would mean stacked PRs and a conflict. Happy to split if you would prefer it.

## Screencast

The **Session Expired** screen introduced by the credentials fix — what previously appeared as an empty list with no explanation:
<img width="878" height="563" alt="Screenshot 2026-09-02 at 10 25 27 PM" src="https://github.com/user-attachments/assets/cd7112b8-3133-48a9-948c-dafdc045e103" />

The Cloud SQL views follow the existing service-view layout, and the behavioural specifics are documented above alongside the API responses that produce them.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

<sub>On testing: `npm run lint` and `npm run build` pass. Exercised against a live project with five Cloud SQL instances — status badges verified against `gcloud sql instances list`, on-demand backup creation confirmed, the stopped-instance path confirmed against the real 400, and the Session Expired screen confirmed in Raycast. No assets or README content are touched.</sub>

<sub>Note on lint warnings: `ray lint` reports 258 warnings (0 errors) across this extension, from the shortcut-hygiene rules in the recent eslint 9→10 bump. 227 are in files this PR does not touch. The new view is consistent with the existing service views rather than uniquely at fault; happy to address them extension-wide in a separate PR if wanted.</sub>
