### PR TITLE
Update stealth-ai-tool extension

### DIFF
--- a/extensions/stealth-ai-tool/.gitignore
+++ b/extensions/stealth-ai-tool/.gitignore
@@ -16,3 +16,4 @@ compiled_raycast_rust
 node_modules
 dist
 .DS_Store
+.serena

--- a/extensions/stealth-ai-tool/CHANGELOG.md
+++ b/extensions/stealth-ai-tool/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Stealth AI Changelog
 
+## [Local Models: LM Studio & Ollama] - {PR_MERGE_DATE}
+
+- Add LM Studio and Ollama as providers, so prompts can run entirely on your own machine
+- Add an editable Server URL per local provider (defaults: `http://localhost:1234`, `http://localhost:11434`)
+- Accept pasted URLs in any common shape (`localhost:1234`, `http://127.0.0.1:1234/v1/`)
+- LM Studio model list uses the native `/api/v0/models` endpoint, hiding embedding models and marking the loaded one
+- Ollama model list shows parameter size and quantization
+- HTTP endpoints are now supported (previously every request was forced through HTTPS)
+- All requests now time out instead of hanging: 60s for cloud providers, 180s for local ones
+- Clearer failures: unreachable server, missing key and missing model each explain the fix and link to "Configure AI Model"
+- Anthropic responses are no longer truncated at 1024 tokens
+- Gemini API key moved out of the request URL into a header
+- Fix model dropdown breaking when a saved model is missing from the fetched list
+- Debounce is now per action, so one action no longer blocks a different one for 3 seconds
+
 ## [In-App AI Configuration] - 2026-02-09
 
 - Add in-app AI provider and model configuration (no more Raycast Settings)

--- a/extensions/stealth-ai-tool/README.md
+++ b/extensions/stealth-ai-tool/README.md
@@ -28,13 +28,43 @@ https://github.com/user-attachments/assets/3072d252-adf8-4272-906c-02434c9817d6
 
 ## ⚙️ Configuration & Customization
 
-### 1. AI Model Selection
+### 1. AI Provider & Model
 
-You can change which AI model is used for these actions globally:
+Run the **Configure AI Model** command to pick a provider and model. Everything is stored locally, per provider, so you can switch back and forth without re-entering keys.
 
-- Open **Raycast Settings** (`Command + ,` on macOS, `Ctrl + ,` on Windows)
-- Navigate to the **AI** tab
-- Change the **Quick AI Model** selection.
+| Provider | Needs API key | Notes |
+| --- | --- | --- |
+| Raycast AI (default) | No | Uses the model from Raycast Settings > AI. Requires Raycast Pro. |
+| OpenAI | Yes | |
+| Anthropic | Yes | |
+| Gemini | Yes | |
+| OpenRouter | Yes | |
+| **LM Studio (local)** | No | Runs on your machine. Default `http://localhost:1234` |
+| **Ollama (local)** | No | Runs on your machine. Default `http://localhost:11434` |
+
+Press `Cmd + R` in the configure view to fetch the model list, then pick one and save.
+
+### 1a. Running Local Models (LM Studio / Ollama)
+
+Local providers keep your text on your own machine - nothing is sent to a cloud API.
+
+**LM Studio**
+
+1. Open LM Studio and go to the **Developer** tab.
+2. Toggle the server to **Running** (default port `1234`) and load a model.
+3. In Raycast, run **Configure AI Model**, choose **LM Studio (Local)**, press `Cmd + R`, select your model and save.
+
+**Ollama**
+
+1. Make sure Ollama is running (`ollama serve`) and you have a model pulled, e.g. `ollama pull gemma3:1b`.
+2. In Raycast, run **Configure AI Model**, choose **Ollama (Local)**, press `Cmd + R`, select your model and save.
+
+Notes:
+
+- The **Server URL** field accepts any common shape - `localhost:1234`, `http://127.0.0.1:1234/v1/` and `http://localhost:1234` all work.
+- Point it at another machine on your network (e.g. `http://192.168.1.20:11434`) to use a model hosted elsewhere.
+- The **API Key** field is optional for local providers; fill it in only if you put your server behind auth.
+- Local requests are given up to 180 seconds, since a cold model may need to load first.
 
 ### 2. Hotkeys & Aliases
 
@@ -44,13 +74,16 @@ To make these actions truly "stealth", it is highly recommended to set up custom
 - Search for **Stealth AI**
 - Set a **Hotkey** (e.g., `Control + F` for Fix Grammar) or an **Alias** (e.g., `fx`) for each command.
 
-### 3. Custom Prompts (Multiline)
+### 3. Custom Prompts
 
-If you want to tweak the prompt for an action:
+Each action's title and prompt are Raycast preferences:
 
-- Run the action **without selecting any text**.
-- Or, click the **"Edit Prompt"** button/shortcut (`Cmd + Shift + E`) in the notification that appears while an action is running.
-- This opens a multiline editor where you can customize the prompt to your liking.
+- Open **Raycast Settings** > **Extensions** > **Stealth AI**
+- Pick the action and edit its **Action Title** and **AI Prompt**
+
+Actions 6-9 ship with empty prompts and are meant for your own.
+
+> Note: the in-app multiline prompt editor described in earlier versions is not currently implemented - prompts are single-line preference fields for now.
 
 ## 🛠️ Included Actions
 

--- a/extensions/stealth-ai-tool/package.json
+++ b/extensions/stealth-ai-tool/package.json
@@ -2,8 +2,8 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "stealth-ai-tool",
   "title": "Stealth AI",
-  "description": "In-line AI formatting. Configure your AI provider via the 'Configure AI Model' command. Set custom Hotkey & Alias per action in Settings.",
-  "version": "1.1.0",
+  "description": "In-line AI formatting. Use Raycast AI, a cloud provider, or a local model via LM Studio or Ollama. Configure via the 'Configure AI Model' command, and set a custom Hotkey & Alias per action in Settings.",
+  "version": "1.2.0",
   "icon": "icon.png",
   "author": "ahmed",
   "categories": [
@@ -26,7 +26,7 @@
       "name": "configure-model",
       "title": "Configure AI Model",
       "subtitle": "Stealth AI",
-      "description": "Fetch and select models for your provider",
+      "description": "Choose a provider (cloud or local) and select a model",
       "mode": "view",
       "icon": "icon.png"
     },

--- a/extensions/stealth-ai-tool/src/configure-model.tsx
+++ b/extensions/stealth-ai-tool/src/configure-model.tsx
@@ -8,97 +8,69 @@ import {
   open,
 } from "@raycast/api";
 import { useEffect, useState } from "react";
-import { LLMService, Model } from "./utils/llm-service";
-
-const PROVIDERS = [
-  { value: "raycast", title: "Raycast AI (Default)" },
-  { value: "openai", title: "OpenAI" },
-  { value: "anthropic", title: "Anthropic" },
-  { value: "gemini", title: "Gemini" },
-  { value: "openrouter", title: "OpenRouter" },
-];
-
-const PROVIDER_URLS: Record<string, string> = {
-  openai: "https://platform.openai.com/docs/models",
-  anthropic: "https://docs.anthropic.com/en/docs/models-overview",
-  gemini: "https://ai.google.dev/gemini-api/docs/models/gemini",
-  openrouter: "https://openrouter.ai/models",
-  raycast: "https://raycast.com",
-};
-
-const STORAGE_KEYS = {
-  provider: "configured_provider",
-  apiKey: (p: string) => `api_key_${p}`,
-  model: (p: string) => `selected_model_${p}`,
-};
+import {
+  LLMService,
+  Model,
+  PROVIDERS,
+  STORAGE_KEYS,
+  defaultBaseUrl,
+  getProviderInfo,
+  isLocalProvider,
+  requiresApiKey,
+} from "./utils/llm-service";
 
 export default function ConfigureModelCommand() {
   const [ready, setReady] = useState(false);
   const [provider, setProvider] = useState("raycast");
   const [apiKey, setApiKey] = useState("");
+  const [baseUrl, setBaseUrl] = useState("");
   const [models, setModels] = useState<Model[]>([]);
   const [selectedModel, setSelectedModel] = useState("");
   const [isLoading, setIsLoading] = useState(true);
 
-  // Load all saved data on mount
   useEffect(() => {
     (async () => {
       const p =
         (await LocalStorage.getItem<string>(STORAGE_KEYS.provider)) ||
         "raycast";
-      const key =
-        (await LocalStorage.getItem<string>(STORAGE_KEYS.apiKey(p))) || "";
-      const model =
-        (await LocalStorage.getItem<string>(STORAGE_KEYS.model(p))) || "";
-
-      setProvider(p);
-      setApiKey(key);
-      setSelectedModel(model);
-
-      if (p !== "raycast" && key) {
-        try {
-          const fetched = await LLMService.fetchModelsWithKey(p, key);
-          setModels(fetched);
-        } catch (e) {
-          console.error("Failed to fetch models on load", e);
-        }
-      }
-
-      setIsLoading(false);
+      await loadProvider(p);
       setReady(true);
     })();
   }, []);
 
-  async function onProviderChange(newProvider: string) {
-    setProvider(newProvider);
+  /** Pull the stored settings for a provider and, when possible, its model list. */
+  async function loadProvider(p: string) {
+    setProvider(p);
     setModels([]);
     setSelectedModel("");
     setIsLoading(true);
 
     try {
       const key =
-        (await LocalStorage.getItem<string>(
-          STORAGE_KEYS.apiKey(newProvider),
-        )) || "";
+        (await LocalStorage.getItem<string>(STORAGE_KEYS.apiKey(p))) || "";
       const model =
-        (await LocalStorage.getItem<string>(STORAGE_KEYS.model(newProvider))) ||
-        "";
+        (await LocalStorage.getItem<string>(STORAGE_KEYS.model(p))) || "";
+      const url =
+        (await LocalStorage.getItem<string>(STORAGE_KEYS.baseUrl(p))) ||
+        defaultBaseUrl(p);
+
       setApiKey(key);
+      setBaseUrl(url);
       setSelectedModel(model);
 
-      if (newProvider !== "raycast" && key) {
-        const fetched = await LLMService.fetchModelsWithKey(newProvider, key);
-        setModels(fetched);
+      // Local providers need no key, so their list can be loaded straight away.
+      if (p !== "raycast" && (key || isLocalProvider(p))) {
+        setModels(await LLMService.fetchModelsWithKey(p, key, url));
       }
     } catch (e) {
-      console.error("Failed to load provider data", e);
+      console.error(`Failed to load models for ${p}`, e);
     } finally {
       setIsLoading(false);
     }
   }
 
   async function handleFetchModels() {
-    if (!apiKey && provider !== "raycast") {
+    if (requiresApiKey(provider) && !apiKey) {
       await showToast({
         style: Toast.Style.Failure,
         title: "API Key Required",
@@ -106,16 +78,34 @@ export default function ConfigureModelCommand() {
       });
       return;
     }
+
     setIsLoading(true);
     try {
-      const fetched = await LLMService.fetchModelsWithKey(provider, apiKey);
+      const fetched = await LLMService.fetchModelsWithKey(
+        provider,
+        apiKey,
+        baseUrl,
+      );
       setModels(fetched);
-      await showToast({ style: Toast.Style.Success, title: "Models Loaded" });
+      if (fetched.length === 0) {
+        await showToast({
+          style: Toast.Style.Failure,
+          title: "No models found",
+          message: isLocalProvider(provider)
+            ? "The server is reachable but has no models available"
+            : "Provider returned an empty list",
+        });
+        return;
+      }
+      await showToast({
+        style: Toast.Style.Success,
+        title: `Loaded ${fetched.length} model${fetched.length === 1 ? "" : "s"}`,
+      });
     } catch (e) {
       await showToast({
         style: Toast.Style.Failure,
         title: "Failed to fetch models",
-        message: String(e),
+        message: (e as Error).message,
       });
       setModels([]);
     } finally {
@@ -123,44 +113,63 @@ export default function ConfigureModelCommand() {
     }
   }
 
-  async function handleSubmit(values: {
-    provider: string;
-    apiKey: string;
-    modelId: string;
-  }) {
-    const p = values.provider;
-    const key = values.apiKey?.trim() || "";
+  async function handleSubmit(values: { modelId: string }) {
     const finalModel = values.modelId;
+    await LocalStorage.setItem(STORAGE_KEYS.provider, provider);
 
-    await LocalStorage.setItem(STORAGE_KEYS.provider, p);
-
-    if (p !== "raycast") {
-      if (key) {
-        await LocalStorage.setItem(STORAGE_KEYS.apiKey(p), key);
-      }
-      if (!finalModel) {
-        await showToast({
-          style: Toast.Style.Failure,
-          title: "No Model",
-          message: "Please select a model",
-        });
-        return;
-      }
-      await LocalStorage.setItem(STORAGE_KEYS.model(p), finalModel);
+    if (provider === "raycast") {
+      await showToast({
+        style: Toast.Style.Success,
+        title: "Configuration Saved",
+        message: "Using Raycast AI",
+      });
+      return;
     }
+
+    const key = apiKey.trim();
+    if (requiresApiKey(provider) && !key) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "API Key Required",
+        message: `${provider} needs an API key`,
+      });
+      return;
+    }
+    if (!finalModel) {
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "No Model",
+        message: "Fetch models (Cmd+R) and select one",
+      });
+      return;
+    }
+
+    await LocalStorage.setItem(STORAGE_KEYS.apiKey(provider), key);
+    if (isLocalProvider(provider)) {
+      await LocalStorage.setItem(
+        STORAGE_KEYS.baseUrl(provider),
+        baseUrl.trim(),
+      );
+    }
+    await LocalStorage.setItem(STORAGE_KEYS.model(provider), finalModel);
 
     await showToast({
       style: Toast.Style.Success,
       title: "Configuration Saved",
-      message: p === "raycast" ? "Using Raycast AI" : `${p}: ${finalModel}`,
+      message: `${provider}: ${finalModel}`,
     });
   }
 
-  if (!ready) {
-    return <Form isLoading={true} />;
-  }
+  if (!ready) return <Form isLoading={true} />;
 
+  const info = getProviderInfo(provider);
   const showModelFields = provider !== "raycast";
+  const local = isLocalProvider(provider);
+  // Guard against a stored model that is no longer in the fetched list, which
+  // would leave the dropdown with a value it cannot render.
+  const dropdownValue = models.some((m) => m.id === selectedModel)
+    ? selectedModel
+    : "";
 
   return (
     <Form
@@ -173,7 +182,7 @@ export default function ConfigureModelCommand() {
           />
           {showModelFields && (
             <Action
-              title="Fetch Models"
+              title={local ? "Connect and Fetch Models" : "Fetch Models"}
               onAction={handleFetchModels}
               shortcut={{ modifiers: ["cmd"], key: "r" }}
             />
@@ -181,7 +190,7 @@ export default function ConfigureModelCommand() {
           {showModelFields && (
             <Action
               title="Open Provider Docs"
-              onAction={() => open(PROVIDER_URLS[provider] || "")}
+              onAction={() => open(info?.docsUrl || "")}
               shortcut={{ modifiers: ["cmd"], key: "o" }}
             />
           )}
@@ -192,7 +201,7 @@ export default function ConfigureModelCommand() {
         id="provider"
         title="AI Provider"
         value={provider}
-        onChange={onProviderChange}
+        onChange={loadProvider}
       >
         {PROVIDERS.map((p) => (
           <Form.Dropdown.Item key={p.value} value={p.value} title={p.title} />
@@ -206,33 +215,63 @@ export default function ConfigureModelCommand() {
       {showModelFields && (
         <>
           <Form.Separator />
+
+          {local && (
+            <Form.TextField
+              id="baseUrl"
+              title="Server URL"
+              placeholder={defaultBaseUrl(provider)}
+              value={baseUrl}
+              onChange={setBaseUrl}
+              info="Base address of your local server. A trailing /v1 or /api is optional."
+            />
+          )}
+
           <Form.PasswordField
             id="apiKey"
-            title="API Key"
-            placeholder="Enter your API key"
+            title={local ? "API Key (optional)" : "API Key"}
+            placeholder={
+              local ? "Only if your server requires auth" : "Enter your API key"
+            }
             value={apiKey}
             onChange={setApiKey}
-            info="Your key is stored locally."
+            info="Stored locally on this machine."
           />
+
           <Form.Separator />
+
           <Form.Dropdown
             id="modelId"
             title="Select Model"
-            value={selectedModel}
+            value={dropdownValue}
             onChange={setSelectedModel}
           >
-            {models.length === 0 && !isLoading && (
-              <Form.Dropdown.Item value="" title="No models loaded" />
-            )}
+            <Form.Dropdown.Item
+              value=""
+              title={
+                models.length === 0 ? "No models loaded" : "Select a model…"
+              }
+            />
             {models.map((model) => (
               <Form.Dropdown.Item
                 key={model.id}
                 value={model.id}
-                title={`${model.name} (${model.id})`}
+                title={
+                  model.description
+                    ? `${model.name} — ${model.description}`
+                    : model.name
+                }
               />
             ))}
           </Form.Dropdown>
-          <Form.Description text="Press Cmd+R (or Ctrl+R) to refresh the models list." />
+
+          <Form.Description
+            text={
+              info?.hint
+                ? `${info.hint}\nPress Cmd+R to refresh the model list.`
+                : "Press Cmd+R (or Ctrl+R) to refresh the models list."
+            }
+          />
         </>
       )}
     </Form>

--- a/extensions/stealth-ai-tool/src/configure-model.tsx
+++ b/extensions/stealth-ai-tool/src/configure-model.tsx
@@ -113,11 +113,13 @@ export default function ConfigureModelCommand() {
     }
   }
 
+  // Validate before persisting anything: switching the active provider on a
+  // rejected form would leave every action pointing at an unusable config.
   async function handleSubmit(values: { modelId: string }) {
     const finalModel = values.modelId;
-    await LocalStorage.setItem(STORAGE_KEYS.provider, provider);
 
     if (provider === "raycast") {
+      await LocalStorage.setItem(STORAGE_KEYS.provider, provider);
       await showToast({
         style: Toast.Style.Success,
         title: "Configuration Saved",
@@ -152,6 +154,8 @@ export default function ConfigureModelCommand() {
       );
     }
     await LocalStorage.setItem(STORAGE_KEYS.model(provider), finalModel);
+    // Switch the active provider only once its config is complete.
+    await LocalStorage.setItem(STORAGE_KEYS.provider, provider);
 
     await showToast({
       style: Toast.Style.Success,

--- a/extensions/stealth-ai-tool/src/utils/action-runner.ts
+++ b/extensions/stealth-ai-tool/src/utils/action-runner.ts
@@ -12,7 +12,7 @@ import {
 } from "@raycast/api";
 
 import { execSync } from "child_process";
-import { LLMService } from "./llm-service";
+import { LLMConfigError, LLMService } from "./llm-service";
 
 interface ActionConfig {
   title: string;
@@ -49,7 +49,10 @@ const DEFAULT_CONFIGS: Record<string, ActionConfig> = {
 
 // In-memory lock to prevent concurrent executions
 let isRunning = false;
-let lastRunTime = 0;
+// Debounce is tracked per action so a hotkey double-fire is swallowed without
+// one action blocking a different one.
+const lastRunTimes = new Map<string, number>();
+const DEBOUNCE_MS = 3000;
 
 export async function runStealthAction(
   actionId: string,
@@ -64,16 +67,17 @@ export async function runStealthAction(
     return;
   }
 
-  // Debounce: don't run if last run was less than 3 seconds ago
-  if (now - lastRunTime < 3000) {
+  // Debounce: don't re-run the same action within the debounce window
+  const lastRun = lastRunTimes.get(actionId) ?? 0;
+  if (now - lastRun < DEBOUNCE_MS) {
     console.log(
-      `[DEBOUNCE] Last run was ${now - lastRunTime}ms ago. Aborting.`,
+      `[DEBOUNCE] ${actionId} last ran ${now - lastRun}ms ago. Aborting.`,
     );
     return;
   }
 
   isRunning = true;
-  lastRunTime = now;
+  lastRunTimes.set(actionId, now);
 
   try {
     await runStealthActionInternal(actionId, forceEditor);
@@ -83,24 +87,22 @@ export async function runStealthAction(
   }
 }
 
+/** Surfaces a configuration problem with a one-press route to the fix. */
 async function showModelErrorToast(errorMsg: string) {
-  const isModelError = /model/i.test(errorMsg);
   const toast = await showToast({
     style: Toast.Style.Failure,
-    title: isModelError ? "Model Error" : "AI Call Failed",
-    message: isModelError ? "Run 'Configure AI Model' to fix this" : errorMsg,
+    title: "AI Not Configured",
+    message: errorMsg,
   });
-  if (isModelError) {
-    toast.primaryAction = {
-      title: "Configure AI Model",
-      onAction: () => {
-        launchCommand({
-          name: "configure-model",
-          type: LaunchType.UserInitiated,
-        });
-      },
-    };
-  }
+  toast.primaryAction = {
+    title: "Configure AI Model",
+    onAction: () => {
+      launchCommand({
+        name: "configure-model",
+        type: LaunchType.UserInitiated,
+      });
+    },
+  };
   return toast;
 }
 
@@ -209,21 +211,6 @@ async function runStealthActionInternal(
     console.log(`[DEBUG] environment.canAccess(AI) failed with error: ${e}`);
   }
 
-  try {
-    console.log("AI.Model Keys: " + Object.keys(AI.Model).join(", "));
-    const mapping: Record<string, string> = {};
-    for (const key of Object.keys(AI.Model)) {
-      try {
-        mapping[key] = (AI.Model as Record<string, string>)[key];
-      } catch (_e) {
-        // ignore
-      }
-    }
-    console.log("[DEBUG] AI.Model Mapping:", JSON.stringify(mapping, null, 2));
-  } catch (e) {
-    console.log(`[DEBUG] AI.Model logging failed: ${e}`);
-  }
-
   // 3. Get selected text using Raycast's native cross-platform API
   let selectedText = "";
   let hasRealSelection = false;
@@ -275,7 +262,9 @@ async function runStealthActionInternal(
     // 5. Final AI access check
     const currentProvider = await LLMService.getProvider();
     if (!canAccessAI && currentProvider === "raycast") {
-      throw new Error("Raycast AI is required. Please upgrade to Raycast Pro.");
+      throw new LLMConfigError(
+        "Raycast AI is required. Upgrade to Raycast Pro, or pick another provider.",
+      );
     }
 
     // 6. Call AI (using new LLM Service)
@@ -291,14 +280,9 @@ async function runStealthActionInternal(
 
       const errorMsg = (e as Error).message;
 
-      // Check for model-related errors
-      if (/model/i.test(errorMsg)) {
-        await showModelErrorToast(errorMsg);
-        return;
-      }
-
-      // Special handling for Raycast AI limitation
-      if (errorMsg.includes("Raycast AI is not supported")) {
+      // Misconfiguration (missing key/model, unreachable local server) gets a
+      // toast that links straight to the configuration command.
+      if (e instanceof LLMConfigError) {
         await showModelErrorToast(errorMsg);
         return;
       }
@@ -354,8 +338,8 @@ async function runStealthActionInternal(
     toast.title = "Done!";
   } catch (error) {
     console.error("Error:", error);
-    const errorMsg = String(error);
-    if (/model/i.test(errorMsg)) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    if (error instanceof LLMConfigError) {
       await showModelErrorToast(errorMsg);
     } else {
       toast.style = Toast.Style.Failure;

--- a/extensions/stealth-ai-tool/src/utils/llm-service.ts
+++ b/extensions/stealth-ai-tool/src/utils/llm-service.ts
@@ -1,16 +1,121 @@
-import { AI, getPreferenceValues, LocalStorage } from "@raycast/api";
+import { AI, LocalStorage } from "@raycast/api";
+import http from "http";
 import https from "https";
-
-export interface AIPreferences {
-  aiProvider?: string;
-  apiKey?: string;
-}
 
 export interface Model {
   id: string;
   name: string;
   description?: string;
 }
+
+export interface ProviderInfo {
+  value: string;
+  title: string;
+  /** Local providers talk to a server on the user's own machine. */
+  local: boolean;
+  /** Whether an API key must be supplied before the provider can be used. */
+  requiresApiKey: boolean;
+  /** Default endpoint for local providers, editable by the user. */
+  defaultBaseUrl?: string;
+  docsUrl: string;
+  hint?: string;
+}
+
+export const PROVIDERS: ProviderInfo[] = [
+  {
+    value: "raycast",
+    title: "Raycast AI (Default)",
+    local: false,
+    requiresApiKey: false,
+    docsUrl: "https://raycast.com",
+  },
+  {
+    value: "openai",
+    title: "OpenAI",
+    local: false,
+    requiresApiKey: true,
+    docsUrl: "https://platform.openai.com/docs/models",
+  },
+  {
+    value: "anthropic",
+    title: "Anthropic",
+    local: false,
+    requiresApiKey: true,
+    docsUrl: "https://docs.anthropic.com/en/docs/about-claude/models",
+  },
+  {
+    value: "gemini",
+    title: "Gemini",
+    local: false,
+    requiresApiKey: true,
+    docsUrl: "https://ai.google.dev/gemini-api/docs/models/gemini",
+  },
+  {
+    value: "openrouter",
+    title: "OpenRouter",
+    local: false,
+    requiresApiKey: true,
+    docsUrl: "https://openrouter.ai/models",
+  },
+  {
+    value: "lmstudio",
+    title: "LM Studio (Local)",
+    local: true,
+    requiresApiKey: false,
+    defaultBaseUrl: "http://localhost:1234",
+    docsUrl: "https://lmstudio.ai/docs/app/api/endpoints/rest",
+    hint: "Start the server in LM Studio: Developer tab -> Status: Running (default port 1234).",
+  },
+  {
+    value: "ollama",
+    title: "Ollama (Local)",
+    local: true,
+    requiresApiKey: false,
+    defaultBaseUrl: "http://localhost:11434",
+    docsUrl: "https://github.com/ollama/ollama/blob/main/docs/api.md",
+    hint: "Make sure Ollama is running (`ollama serve`) and you have pulled at least one model.",
+  },
+];
+
+export function getProviderInfo(provider: string): ProviderInfo | undefined {
+  return PROVIDERS.find((p) => p.value === provider);
+}
+
+export function isLocalProvider(provider: string): boolean {
+  return getProviderInfo(provider)?.local ?? false;
+}
+
+export function requiresApiKey(provider: string): boolean {
+  return getProviderInfo(provider)?.requiresApiKey ?? false;
+}
+
+export function defaultBaseUrl(provider: string): string {
+  return getProviderInfo(provider)?.defaultBaseUrl ?? "";
+}
+
+/**
+ * Raised when the extension is misconfigured (missing key/model, unreachable
+ * local server). The action runner turns these into a toast that links straight
+ * to the "Configure AI Model" command.
+ */
+export class LLMConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LLMConfigError";
+  }
+}
+
+export const STORAGE_KEYS = {
+  provider: "configured_provider",
+  apiKey: (p: string) => `api_key_${p}`,
+  model: (p: string) => `selected_model_${p}`,
+  baseUrl: (p: string) => `base_url_${p}`,
+};
+
+/** Remote calls get a short leash; local models may need to warm up first. */
+const REMOTE_TIMEOUT_MS = 60_000;
+const LOCAL_TIMEOUT_MS = 180_000;
+const MAX_TOKENS = 4096;
 
 interface ModelEntry {
   id: string;
@@ -24,62 +129,106 @@ interface GeminiModel {
   displayName: string;
 }
 
-export class LLMService {
-  public static get config(): AIPreferences {
-    return getPreferenceValues<AIPreferences>();
-  }
+interface LMStudioModel {
+  id: string;
+  type?: string;
+  arch?: string;
+  quantization?: string;
+  state?: string;
+  max_context_length?: number;
+}
 
+interface OllamaModel {
+  name: string;
+  model?: string;
+  details?: { parameter_size?: string; quantization_level?: string };
+}
+
+/**
+ * Accepts anything the user is likely to paste ("localhost:1234",
+ * "http://127.0.0.1:1234/v1/", "http://host:11434/api") and reduces it to a
+ * bare origin that the per-provider paths below can be appended to.
+ */
+export function normalizeBaseUrl(raw: string, provider: string): string {
+  let value = (raw || "").trim();
+  if (!value) return defaultBaseUrl(provider);
+  if (!/^https?:\/\//i.test(value)) value = `http://${value}`;
+  try {
+    const url = new URL(value);
+    const path = url.pathname
+      .replace(/\/+$/, "")
+      .replace(/\/(v1|api(\/v\d+)?)$/i, "");
+    return `${url.origin}${path}`;
+  } catch {
+    return value.replace(/\/+$/, "");
+  }
+}
+
+export class LLMService {
   public static async getProvider(): Promise<string> {
-    const saved = await LocalStorage.getItem<string>("configured_provider");
-    return saved || this.config.aiProvider || "raycast";
+    const saved = await LocalStorage.getItem<string>(STORAGE_KEYS.provider);
+    return saved || "raycast";
   }
 
   public static async getApiKey(provider: string): Promise<string> {
-    const saved = await LocalStorage.getItem<string>(`api_key_${provider}`);
-    if (saved) return saved;
-    return this.config.apiKey || "";
+    return (
+      (await LocalStorage.getItem<string>(STORAGE_KEYS.apiKey(provider))) || ""
+    );
   }
 
-  public static async getSelectedModel(): Promise<string> {
-    const provider = await this.getProvider();
-    const key = `selected_model_${provider}`;
-    const saved = await LocalStorage.getItem<string>(key);
-    if (saved) return saved;
-    return "";
+  public static async getSelectedModel(provider?: string): Promise<string> {
+    const p = provider ?? (await this.getProvider());
+    return (await LocalStorage.getItem<string>(STORAGE_KEYS.model(p))) || "";
   }
+
+  public static async getBaseUrl(provider: string): Promise<string> {
+    const saved = await LocalStorage.getItem<string>(
+      STORAGE_KEYS.baseUrl(provider),
+    );
+    return normalizeBaseUrl(saved || "", provider);
+  }
+
+  // ---------------------------------------------------------------- models
 
   public static async fetchModelsWithKey(
     provider: string,
     key: string,
+    baseUrl?: string,
   ): Promise<Model[]> {
+    const base = normalizeBaseUrl(baseUrl || "", provider);
+
     if (provider === "openai") {
       const oai = await this.request(
         "https://api.openai.com/v1/models",
         "GET",
-        { Authorization: `Bearer ${key}` },
-        null,
+        {
+          Authorization: `Bearer ${key}`,
+        },
       );
       return oai.data
         .map((m: ModelEntry) => ({ id: m.id, name: m.id }))
         .sort((a: Model, b: Model) => a.id.localeCompare(b.id));
     }
+
     if (provider === "anthropic") {
       const ant = await this.request(
         "https://api.anthropic.com/v1/models",
         "GET",
-        { "x-api-key": key, "anthropic-version": "2023-06-01" },
-        null,
+        {
+          "x-api-key": key,
+          "anthropic-version": "2023-06-01",
+        },
       );
       return ant.data
         .map((m: ModelEntry) => ({ id: m.id, name: m.display_name || m.id }))
         .sort((a: Model, b: Model) => a.id.localeCompare(b.id));
     }
+
     if (provider === "gemini") {
       const gem = await this.request(
-        `https://generativelanguage.googleapis.com/v1beta/models?key=${key}`,
+        "https://generativelanguage.googleapis.com/v1beta/models",
         "GET",
-        {},
-        null,
+        { "x-goog-api-key": key },
       );
       return gem.models
         .filter((m: GeminiModel) => m.name.includes("gemini"))
@@ -88,52 +237,155 @@ export class LLMService {
           name: m.displayName,
         }));
     }
+
     if (provider === "openrouter") {
       const or = await this.request(
         "https://openrouter.ai/api/v1/models",
         "GET",
         {},
-        null,
       );
       return or.data.map((m: ModelEntry) => ({
         id: m.id,
         name: m.name || m.id,
       }));
     }
+
+    if (provider === "lmstudio") return this.fetchLMStudioModels(base, key);
+    if (provider === "ollama") return this.fetchOllamaModels(base, key);
+
     return [];
   }
 
-  public static async fetchModels(): Promise<Model[]> {
-    const { aiProvider, apiKey } = this.config;
-    if (!apiKey && aiProvider !== "raycast")
-      throw new Error("API Key required");
-    return this.fetchModelsWithKey(aiProvider || "raycast", apiKey || "");
+  /**
+   * Prefers LM Studio's native /api/v0/models, which reports model type and
+   * load state, and falls back to the OpenAI-compatible listing on older builds.
+   */
+  private static async fetchLMStudioModels(
+    base: string,
+    key: string,
+  ): Promise<Model[]> {
+    const headers = this.localHeaders(key);
+    try {
+      const res = await this.request(
+        `${base}/api/v0/models`,
+        "GET",
+        headers,
+        null,
+        LOCAL_TIMEOUT_MS,
+      );
+      const entries: LMStudioModel[] = res.data || [];
+      return entries
+        .filter((m) => m.type !== "embeddings")
+        .map((m) => ({
+          id: m.id,
+          name: m.state === "loaded" ? `${m.id} (loaded)` : m.id,
+          description:
+            [m.arch, m.quantization].filter(Boolean).join(" · ") || undefined,
+        }))
+        .sort((a, b) => a.id.localeCompare(b.id));
+    } catch {
+      const res = await this.request(
+        `${base}/v1/models`,
+        "GET",
+        headers,
+        null,
+        LOCAL_TIMEOUT_MS,
+      );
+      const entries: ModelEntry[] = res.data || [];
+      return entries
+        .map((m) => ({ id: m.id, name: m.id }))
+        .sort((a, b) => a.id.localeCompare(b.id));
+    }
   }
 
+  private static async fetchOllamaModels(
+    base: string,
+    key: string,
+  ): Promise<Model[]> {
+    const res = await this.request(
+      `${base}/api/tags`,
+      "GET",
+      this.localHeaders(key),
+      null,
+      LOCAL_TIMEOUT_MS,
+    );
+    const entries: OllamaModel[] = res.models || [];
+    return entries
+      .map((m) => ({
+        id: m.model || m.name,
+        name: m.name,
+        description:
+          [m.details?.parameter_size, m.details?.quantization_level]
+            .filter(Boolean)
+            .join(" · ") || undefined,
+      }))
+      .sort((a, b) => a.id.localeCompare(b.id));
+  }
+
+  // ------------------------------------------------------------ completion
+
   public static async askAI(prompt: string): Promise<string> {
-    const aiProvider = await this.getProvider();
-    const model = await this.getSelectedModel();
-    const apiKey = await this.getApiKey(aiProvider);
+    const provider = await this.getProvider();
 
-    if (aiProvider === "raycast") {
-      return await this.callRaycastAI(prompt);
+    if (provider === "raycast") return this.callRaycastAI(prompt);
+
+    const model = await this.getSelectedModel(provider);
+    const apiKey = await this.getApiKey(provider);
+
+    if (requiresApiKey(provider) && !apiKey) {
+      throw new LLMConfigError(
+        `API key required for ${provider}. Set it in "Configure AI Model".`,
+      );
     }
-
-    if (!apiKey) {
-      throw new Error(
-        `API Key is required for ${aiProvider}. Configure it via "Configure AI Model" command.`,
+    if (!model) {
+      throw new LLMConfigError(
+        `No model selected for ${provider}. Pick one in "Configure AI Model".`,
       );
     }
 
-    if (aiProvider === "openai")
-      return await this.callOpenAI(apiKey, model, prompt);
-    if (aiProvider === "anthropic")
-      return await this.callAnthropic(apiKey, model, prompt);
-    if (aiProvider === "gemini")
-      return await this.callGemini(apiKey, model, prompt);
-    if (aiProvider === "openrouter")
-      return await this.callOpenRouter(apiKey, model, prompt);
-    throw new Error(`Unknown Provider: ${aiProvider}`);
+    switch (provider) {
+      case "openai":
+        return this.callOpenAICompatible(
+          "https://api.openai.com/v1/chat/completions",
+          { Authorization: `Bearer ${apiKey}` },
+          model,
+          prompt,
+          REMOTE_TIMEOUT_MS,
+        );
+      case "anthropic":
+        return this.callAnthropic(apiKey, model, prompt);
+      case "gemini":
+        return this.callGemini(apiKey, model, prompt);
+      case "openrouter":
+        return this.callOpenAICompatible(
+          "https://openrouter.ai/api/v1/chat/completions",
+          {
+            Authorization: `Bearer ${apiKey}`,
+            "HTTP-Referer": "https://raycast.com",
+            "X-Title": "Raycast Stealth AI",
+          },
+          model,
+          prompt,
+          REMOTE_TIMEOUT_MS,
+        );
+      case "lmstudio":
+        return this.callOpenAICompatible(
+          `${await this.getBaseUrl(provider)}/v1/chat/completions`,
+          this.localHeaders(apiKey),
+          model,
+          prompt,
+          LOCAL_TIMEOUT_MS,
+        );
+      case "ollama":
+        return this.callOllama(
+          await this.getBaseUrl(provider),
+          apiKey,
+          model,
+          prompt,
+        );
+      default:
+        throw new LLMConfigError(`Unknown provider: ${provider}`);
+    }
   }
 
   private static async callRaycastAI(prompt: string): Promise<string> {
@@ -142,28 +394,32 @@ export class LLMService {
     } catch (e) {
       const msg = (e as Error).message;
       if (msg.includes("Model is not supported")) {
-        throw new Error(
-          "Raycast AI is not supported on this device. Please select OpenAI/Gemini in Settings.",
+        throw new LLMConfigError(
+          'Raycast AI is not available on this account. Pick another provider in "Configure AI Model".',
         );
       }
       throw e;
     }
   }
 
-  private static async callOpenAI(
-    key: string,
+  /** OpenAI, OpenRouter and LM Studio all speak the same chat-completions dialect. */
+  private static async callOpenAICompatible(
+    url: string,
+    headers: Record<string, string>,
     model: string,
     prompt: string,
+    timeoutMs: number,
   ): Promise<string> {
-    const body = {
-      model,
-      messages: [{ role: "user", content: prompt }],
-      temperature: 0.7,
-    };
-    const response = await this.post(
-      "https://api.openai.com/v1/chat/completions",
-      key,
-      body,
+    const response = await this.request(
+      url,
+      "POST",
+      { "Content-Type": "application/json", ...headers },
+      {
+        model,
+        messages: [{ role: "user", content: prompt }],
+        temperature: 0.7,
+      },
+      timeoutMs,
     );
     return response.choices?.[0]?.message?.content?.trim() || "";
   }
@@ -173,21 +429,20 @@ export class LLMService {
     model: string,
     prompt: string,
   ): Promise<string> {
-    const body = {
-      model,
-      messages: [{ role: "user", content: prompt }],
-      max_tokens: 1024,
-    };
-    const headers = {
-      "x-api-key": key,
-      "anthropic-version": "2023-06-01",
-      "content-type": "application/json",
-    };
     const response = await this.request(
       "https://api.anthropic.com/v1/messages",
       "POST",
-      headers,
-      body,
+      {
+        "x-api-key": key,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      {
+        model,
+        messages: [{ role: "user", content: prompt }],
+        max_tokens: MAX_TOKENS,
+      },
+      REMOTE_TIMEOUT_MS,
     );
     return response.content?.[0]?.text?.trim() || "";
   }
@@ -197,91 +452,155 @@ export class LLMService {
     model: string,
     prompt: string,
   ): Promise<string> {
-    const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${key}`;
-    const body = {
-      contents: [{ parts: [{ text: prompt }] }],
-    };
     const response = await this.request(
-      url,
+      `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`,
       "POST",
-      { "Content-Type": "application/json" },
-      body,
+      { "Content-Type": "application/json", "x-goog-api-key": key },
+      { contents: [{ parts: [{ text: prompt }] }] },
+      REMOTE_TIMEOUT_MS,
     );
     return response.candidates?.[0]?.content?.parts?.[0]?.text?.trim() || "";
   }
 
-  private static async callOpenRouter(
+  private static async callOllama(
+    base: string,
     key: string,
     model: string,
     prompt: string,
   ): Promise<string> {
-    const body = {
-      model,
-      messages: [{ role: "user", content: prompt }],
-    };
-    const headers = {
-      Authorization: `Bearer ${key}`,
-      "HTTP-Referer": "https://raycast.com",
-      "X-Title": "Raycast Stealth AI",
-      "Content-Type": "application/json",
-    };
     const response = await this.request(
-      "https://openrouter.ai/api/v1/chat/completions",
+      `${base}/api/chat`,
       "POST",
-      headers,
-      body,
+      { "Content-Type": "application/json", ...this.localHeaders(key) },
+      {
+        model,
+        messages: [{ role: "user", content: prompt }],
+        stream: false,
+        options: { temperature: 0.7 },
+      },
+      LOCAL_TIMEOUT_MS,
     );
-    return response.choices?.[0]?.message?.content?.trim() || "";
+    return response.message?.content?.trim() || "";
   }
 
-  private static post(
-    url: string,
-    apiKey: string,
-    body: Record<string, unknown>,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ): Promise<any> {
-    return this.request(
-      url,
-      "POST",
-      {
-        Authorization: `Bearer ${apiKey}`,
-        "Content-Type": "application/json",
-      },
-      body,
-    );
+  /** Local servers usually need no auth, but both accept a bearer token when secured. */
+  private static localHeaders(key: string): Record<string, string> {
+    return key ? { Authorization: `Bearer ${key}` } : {};
   }
+
+  // --------------------------------------------------------------- transport
 
   private static request(
     url: string,
     method: string,
     headers: Record<string, string>,
-    body: Record<string, unknown> | null,
+    body: Record<string, unknown> | null = null,
+    timeoutMs: number = REMOTE_TIMEOUT_MS,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<any> {
     return new Promise((resolve, reject) => {
-      const req = https.request(url, { method, headers }, (res) => {
-        let data = "";
-        res.on("data", (chunk) => (data += chunk));
-        res.on("end", () => {
-          try {
-            if (
-              res.statusCode &&
-              res.statusCode >= 200 &&
-              res.statusCode < 300
-            ) {
-              resolve(JSON.parse(data));
-            } else {
-              reject(new Error(`API Auth Error (${res.statusCode}): ${data}`));
-            }
-          } catch (_e) {
-            reject(new Error(`Failed to parse response: ${data}`));
-          }
-        });
-      });
+      let target: URL;
+      try {
+        target = new URL(url);
+      } catch {
+        reject(new LLMConfigError(`Invalid endpoint URL: ${url}`));
+        return;
+      }
 
-      req.on("error", (e) => reject(e));
-      if (body) req.write(JSON.stringify(body));
+      // Local providers are served over plain HTTP, so pick the module per scheme.
+      const transport = target.protocol === "http:" ? http : https;
+      const payload = body ? JSON.stringify(body) : null;
+
+      const req = transport.request(
+        target,
+        {
+          method,
+          headers: {
+            Accept: "application/json",
+            ...headers,
+            ...(payload
+              ? { "Content-Length": Buffer.byteLength(payload) }
+              : {}),
+          },
+        },
+        (res) => {
+          let data = "";
+          res.setEncoding("utf8");
+          res.on("data", (chunk) => (data += chunk));
+          res.on("end", () => {
+            const status = res.statusCode ?? 0;
+            if (status >= 200 && status < 300) {
+              try {
+                resolve(data ? JSON.parse(data) : {});
+              } catch {
+                reject(
+                  new Error(
+                    `Could not parse response from ${target.host}: ${data.slice(0, 200)}`,
+                  ),
+                );
+              }
+            } else {
+              reject(this.httpError(status, data, target));
+            }
+          });
+        },
+      );
+
+      req.setTimeout(timeoutMs, () => {
+        req.destroy(
+          new Error(
+            `Request to ${target.host} timed out after ${timeoutMs / 1000}s`,
+          ),
+        );
+      });
+      req.on("error", (e) => reject(this.networkError(e, target)));
+      if (payload) req.write(payload);
       req.end();
     });
+  }
+
+  private static httpError(status: number, data: string, target: URL): Error {
+    const detail = this.extractErrorMessage(data);
+    if (status === 401 || status === 403) {
+      return new LLMConfigError(
+        `Authentication failed (${status}). Check your API key. ${detail}`.trim(),
+      );
+    }
+    if (status === 404 && this.isLoopback(target)) {
+      return new LLMConfigError(
+        `${target.host} returned 404 for ${target.pathname}. Check the base URL and that the model is available.`,
+      );
+    }
+    return new Error(
+      `Request failed (${status}): ${detail || data.slice(0, 200)}`,
+    );
+  }
+
+  private static networkError(e: NodeJS.ErrnoException, target: URL): Error {
+    if (
+      e.code === "ECONNREFUSED" ||
+      e.code === "ECONNRESET" ||
+      e.code === "EHOSTUNREACH"
+    ) {
+      return new LLMConfigError(
+        `Cannot reach the local server at ${target.origin}. Make sure it is running and the base URL is correct.`,
+      );
+    }
+    return e;
+  }
+
+  private static extractErrorMessage(data: string): string {
+    try {
+      const parsed = JSON.parse(data);
+      return parsed?.error?.message || parsed?.error || parsed?.message || "";
+    } catch {
+      return "";
+    }
+  }
+
+  private static isLoopback(target: URL): boolean {
+    return ["localhost", "127.0.0.1", "0.0.0.0", "::1"].includes(
+      target.hostname,
+    );
   }
 }


### PR DESCRIPTION
## Description

Adds **LM Studio** and **Ollama** as providers, so Stealth AI actions can run entirely against a local model with no cloud API key.

Local support was previously impossible: the request layer imported only `node:https`, so any `http://localhost` endpoint failed outright. The transport now selects `http` or `https` per URL scheme.

**Providers**

| | Chat | Model list |
| --- | --- | --- |
| LM Studio (default `http://localhost:1234`) | `/v1/chat/completions` | `/api/v0/models`, falling back to `/v1/models` |
| Ollama (default `http://localhost:11434`) | `/api/chat` (`stream: false`) | `/api/tags` |

Both need no API key and expose an editable **Server URL** that normalizes what users paste — `localhost:1234`, `http://127.0.0.1:1234/v1/` and LAN addresses all resolve correctly. The optional API key field is there only for servers placed behind auth.

LM Studio models are listed via the native `/api/v0/models` because the OpenAI-compatible `/v1/models` does not report model **type** — without it, embedding models appear in the picker as selectable chat models. The native endpoint also reports load state, so the loaded model is marked. Older builds without `/api/v0` fall back automatically. Ollama models show parameter size and quantization.

**Reliability and correctness fixes found while working in this code**

- Requests had no timeout and could hang indefinitely — now 60s for cloud providers, 180s for local ones, since a cold local model may need to load first
- Error handling keyed off `/model/i.test(message)`, so unrelated failures mentioning "model" were reported as misconfiguration while genuine ones were not — replaced with a typed `LLMConfigError`
- Anthropic responses were truncated at `max_tokens: 1024` — raised to 4096
- Gemini API key moved out of the request URL into the `x-goog-api-key` header
- Model dropdown could hold a value absent from the fetched list after switching providers
- Debounce was global, so one action blocked every other action for 3 seconds — now tracked per action
- Removed dead code: `aiProvider`/`apiKey` preference fallbacks reading preferences that are not declared in the manifest, an unused `fetchModels()`, and a full `AI.Model` dump logged on every run

**Docs**

The README documented a multiline prompt editor that no longer exists in the code (`forceEditor` is never set, and nothing writes the `action-configs` key that was read on every run). Corrected to describe the actual preference fields rather than re-adding the feature.

## Testing

Verified against live LM Studio and Ollama servers running locally:

- Model listing for both, including the LM Studio `/api/v0` → `/v1` fallback (exercised against a stub server) and the filtering of embedding models
- Server URL normalization across the URL shapes above
- End-to-end completions through `askAI` for both providers, returning correct output for the Fix Grammar prompt
- Error paths: unreachable server, missing API key and missing model each raise `LLMConfigError` with an actionable message

`ray lint` and `ray build` are clean.

Note: the checklist item about testing the distribution build inside Raycast is left unchecked — the provider layer was verified directly against live local servers rather than by exercising the packaged build in the Raycast client.

## Screencast

No new commands or UI surfaces were added. The existing **Configure AI Model** command gains two entries in the provider dropdown and a Server URL field when a local provider is selected.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
