### PR TITLE
[Herdr] Refresh menu bar in the background

### DIFF
--- a/extensions/herdr/CHANGELOG.md
+++ b/extensions/herdr/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Menu Bar Background Refresh] - {PR_MERGE_DATE}
+## [Menu Bar Background Refresh] - 2026-09-03
 
 - Refresh the menu bar in the background every minute instead of only when it is opened.
 

--- a/extensions/herdr/CHANGELOG.md
+++ b/extensions/herdr/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Menu Bar Background Refresh] - {PR_MERGE_DATE}
+
+- Refresh the menu bar in the background every minute instead of only when it is opened.
+
 ## [Fix Stuck Menu Bar Toast] - 2026-08-29
 
 - Report menu bar failures with a HUD instead of a toast held open across the action. Clicking an item unloads the menu bar command, which left the toast on screen with nothing to resolve it.

--- a/extensions/herdr/README.md
+++ b/extensions/herdr/README.md
@@ -53,6 +53,8 @@ The extension finds Herdr in `PATH`, `~/.local/bin`, `/opt/homebrew/bin`, and `/
 
 Pane navigation, splitting, zoom, and tab creation are available as disabled-by-default commands for custom global hotkeys.
 
+Agent Status in Menu Bar refreshes in the background every minute once Background Refresh is enabled for it. It turns on the first time you open the command, and the toggle lives in Raycast Settings → Extensions → Herdr → Agent Status in Menu Bar.
+
 Start Agent Quicklinks preserve the form configuration except environment variables.
 
 ## Terminal support

--- a/extensions/herdr/package.json
+++ b/extensions/herdr/package.json
@@ -231,7 +231,8 @@
       "name": "menu-bar",
       "title": "Agent Status in Menu Bar",
       "description": "Monitor and control Herdr agents from the menu bar",
-      "mode": "menu-bar"
+      "mode": "menu-bar",
+      "interval": "1m"
     },
     {
       "name": "open-herdr",
@@ -348,7 +349,7 @@
     {
       "name": "refreshInterval",
       "title": "Refresh Interval",
-      "description": "How often visible lists and the menu bar refresh.",
+      "description": "How often visible lists and the open menu bar refresh. The menu bar icon also refreshes in the background every minute.",
       "type": "dropdown",
       "required": false,
       "default": "5",


### PR DESCRIPTION
## Description

The Agent Status in Menu Bar command only updated when clicked. Raycast unloads a menu bar command as soon as `MenuBarExtra` reports `isLoading` false, so the in-process `setInterval` driven by the refresh interval preference never fired once the menu closed. Raycast's log confirmed it: its scheduled-command list never included the Herdr menu bar, and the command exited seconds after each click.

Adds `"interval": "1m"` to the `menu-bar` command's manifest entry so Raycast schedules it directly. One minute is the documented minimum.

The manifest interval has no runtime API, so the refresh interval preference can't drive it. That preference still controls how often the open menu refreshes. Its description and the README now explain the split: the icon refreshes in the background every minute, and Background Refresh turns on the first time the command is opened.

Verified with a dev build in Raycast. After adding the interval, the log's scheduler entry changed to `dev_/vlades/herdr/menu-bar:60000` and the command ran on its own about once a minute with the menu closed.

## Screencast

No visible UI change. The evidence is Raycast's log:

```
[info 23:01:26.762] 🔌 macos-node [extension-host] Scheduling task started {
  commands: "nyatinte/ccusage/menubar-ccusage:300000,dev_/vlades/herdr/menu-bar:60000"
}
[info 23:01:41.943] 🔌 macos-node [extension-host] commandExited { entryPoint: "dev_/vlades/herdr/menu-bar" }
[info 23:02:41.933] 🔌 macos-node [extension-host] commandExited { entryPoint: "dev_/vlades/herdr/menu-bar" }
[info 23:03:36.927] 🔌 macos-node [extension-host] commandExited { entryPoint: "dev_/vlades/herdr/menu-bar" }
[info 23:04:41.930] 🔌 macos-node [extension-host] commandExited { entryPoint: "dev_/vlades/herdr/menu-bar" }
```

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

https://claude.ai/code/session_014oHHLbpd9xYxnrQTmT4YvE
