### PR TITLE
Capacities: pop to root search after a successful capture

### DIFF
--- a/extensions/capacities/CHANGELOG.md
+++ b/extensions/capacities/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Capacities Changelog
 
+## [Return to root search after capturing] - {PR_MERGE_DATE}
+
+- Fixed the Create Task, Save Weblink and Save to Daily Note commands leaving the form on the navigation stack after a successful save, so reopening Raycast returned to the filled-in form instead of the root search.
+- Replaced the redundant `showHUD` + `closeMainWindow` pair with a single `showHUD(..., { clearRootSearch: true, popToRootType: PopToRootType.Immediate })` call.
+
 ## [Add Deadline to Create Task] - 2026-07-21
 
 - Add "Deadline" date picker to the Create Task command, mirroring Capacities' native two-date task creation (Date + Deadline).

--- a/extensions/capacities/CHANGELOG.md
+++ b/extensions/capacities/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Capacities Changelog
 
-## [Return to root search after capturing] - {PR_MERGE_DATE}
+## [Return to root search after capturing] - 2026-09-03
 
 - Fixed the Create Task, Save Weblink and Save to Daily Note commands leaving the form on the navigation stack after a successful save, so reopening Raycast returned to the filled-in form instead of the root search.
 - Replaced the redundant `showHUD` + `closeMainWindow` pair with a single `showHUD(..., { clearRootSearch: true, popToRootType: PopToRootType.Immediate })` call.

--- a/extensions/capacities/package.json
+++ b/extensions/capacities/package.json
@@ -6,7 +6,8 @@
   "icon": "capacities.png",
   "author": "steffenble",
   "contributors": [
-    "xmok"
+    "xmok",
+    "mikolaj_adamowicz"
   ],
   "categories": [
     "Productivity",

--- a/extensions/capacities/src/create-task.tsx
+++ b/extensions/capacities/src/create-task.tsx
@@ -1,4 +1,4 @@
-import { ActionPanel, Action, Form, Icon, closeMainWindow, showToast, Toast, showHUD } from "@raycast/api";
+import { ActionPanel, Action, Form, Icon, PopToRootType, showToast, Toast, showHUD } from "@raycast/api";
 import { FormValidation, useForm } from "@raycast/utils";
 import { useEffect, useRef } from "react";
 import { getInitialSpaceId, setStoredSpaceId } from "./helpers/spaces";
@@ -84,12 +84,10 @@ export default function Command() {
           return;
         }
 
-        showToast({
-          style: Toast.Style.Success,
-          title: "Saved",
+        await showHUD("Task created", {
+          clearRootSearch: true,
+          popToRootType: PopToRootType.Immediate,
         });
-        showHUD("Task created");
-        closeMainWindow();
       } catch (e) {
         if (e instanceof Error) {
           handleUnexpectedError(e);

--- a/extensions/capacities/src/create-weblink.tsx
+++ b/extensions/capacities/src/create-weblink.tsx
@@ -1,4 +1,4 @@
-import { ActionPanel, Action, Form, Icon, closeMainWindow, Clipboard, showToast, Toast, showHUD } from "@raycast/api";
+import { ActionPanel, Action, Form, Icon, PopToRootType, Clipboard, showToast, Toast, showHUD } from "@raycast/api";
 import { FormValidation, useForm } from "@raycast/utils";
 import { useEffect, useRef } from "react";
 import { useActiveTab } from "./helpers/useActiveTab";
@@ -56,12 +56,10 @@ export default function Command() {
           return;
         }
 
-        showToast({
-          style: Toast.Style.Success,
-          title: "Saved",
+        await showHUD("Weblink created", {
+          clearRootSearch: true,
+          popToRootType: PopToRootType.Immediate,
         });
-        showHUD("Weblink created");
-        closeMainWindow();
       } catch (e) {
         if (e instanceof Error) {
           handleUnexpectedError(e);

--- a/extensions/capacities/src/save-to-daily-note.tsx
+++ b/extensions/capacities/src/save-to-daily-note.tsx
@@ -1,4 +1,4 @@
-import { ActionPanel, Action, Form, Icon, showToast, Toast, closeMainWindow, showHUD } from "@raycast/api";
+import { ActionPanel, Action, Form, Icon, showToast, Toast, PopToRootType, showHUD } from "@raycast/api";
 import { FormValidation, useForm } from "@raycast/utils";
 import { useEffect, useRef } from "react";
 import { getInitialSpaceId, setStoredSpaceId } from "./helpers/spaces";
@@ -42,13 +42,10 @@ export default function Command() {
           return;
         }
         setValue("mdText", "");
-        showToast({
-          style: Toast.Style.Success,
-          title: "Saved",
+        await showHUD("Notes saved to daily note", {
+          clearRootSearch: true,
+          popToRootType: PopToRootType.Immediate,
         });
-
-        showHUD("Notes saved to daily note");
-        closeMainWindow();
       } catch (e) {
         if (e instanceof Error) {
           handleUnexpectedError(e);


### PR DESCRIPTION
## Description

The Create Task, Save Weblink and Save to Daily Note commands ended their submit handler with an unawaited `showHUD(...)` followed by a bare `closeMainWindow()`. With no options `closeMainWindow()` uses `PopToRootType.Default` which follows the user's **Pop to Root Search** preference. The window hid, but the command's navigation stack stayed on the form. Reopening Raycast inside that window landed back on the Capacities form, still holding the values just submitted, which makes a duplicate save easy to trigger.

Each handler now ends with a single awaited call:

```ts
await showHUD("Notes saved to daily note", {
  clearRootSearch: true,
  popToRootType: PopToRootType.Immediate,
});
```

`showHUD` closes the main window itself and accepts the same options, so the old pair was redundant with no guaranteed ordering. This also removes a `Toast.Style.Success` toast that fired immediately before the close and was never visible.

No change to the API calls, validation, or space selection.

Tested on macOS. The extension also declares Windows support, which I had no way to verify.

## Screencast

<!-- paste the recording here -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

