### PR TITLE
Link Commands: keep a typed sigil out of the package name

### DIFF
--- a/extensions/link-commands/CHANGELOG.md
+++ b/extensions/link-commands/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Link Commands Changelog
 
+## [Sigils and Shared Icons] - {PR_MERGE_DATE}
+
+### Fixed
+
+- A `@scope` or `#category` typed into **Package** now moves to the control that owns it, instead of being taken as part of the brand. `Linear · @work` used to make a brand called literally that: it slugged into `linear-work.my-issues.sh` rather than `work.linear.my-issues.sh`, and the list read it back as a brand rather than a scope. A control you have already set is never overridden — a conflicting sigil is reported as dropped instead — and the move is confirmed in a line beneath the field, because the filename preview shows the outcome but never the edit.
+- Icons are stored under the package rather than the command, and an icon already in your script directory is used before the network is asked. A private or intranet host is invisible to any public favicon service, so a command for one fell back to a generic link glyph even when the right mark was already sitting beside it; storing per command also re-fetched the same image for every new command of a service.
+
+### Changed
+
+- Example values in source comments are neutral placeholders rather than names taken from one contributor's own command collection.
+
 ## [Surface Routers] - 2026-08-30
 
 ### Added

--- a/extensions/link-commands/CHANGELOG.md
+++ b/extensions/link-commands/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Link Commands Changelog
 
-## [Sigils and Shared Icons] - {PR_MERGE_DATE}
+## [Sigils and Shared Icons] - 2026-09-12
 
 ### Fixed
 

--- a/extensions/link-commands/src/create-link-command.tsx
+++ b/extensions/link-commands/src/create-link-command.tsx
@@ -15,11 +15,11 @@ import { access, chmod, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { useState } from "react";
 import { discoverScriptCommands, parseDirectoryPreference } from "./lib/discover-script-commands";
-import { facetCounts } from "./lib/convention";
+import { facetCounts, splitTypedPackage } from "./lib/convention";
 import { learnedPackages, packageForTarget } from "./lib/link-command";
 import { collapseHome } from "./lib/home-path";
 import { fetchFavicon } from "./lib/fetch-icon";
-import { brandFor, buildScript, domainOf, findPlaceholder, scriptFilename } from "./lib/generate-script";
+import { brandFor, buildScript, domainOf, findPlaceholder, scriptFilename, slugify } from "./lib/generate-script";
 
 /** Sentinel for the "New…" dropdown entry — a value no real environment or category can hold. */
 const NEW_VALUE = "\u0000new";
@@ -43,6 +43,14 @@ type CreateInput = {
   author?: string;
   authorURL?: string;
 };
+
+/**
+ * The mark a sibling command already fetched. Checked before the network: a private or intranet host is
+ * invisible to any public favicon service, so without this the second command for such a service falls to
+ * the generic link glyph even though the right icon already sits in the script directory.
+ */
+const brandIcon = async (directory: string, slug: string) =>
+  (await exists(join(directory, "assets", slug, "index.png"))) ? `./assets/${slug}/index.png` : undefined;
 
 const writeIcon = async (directory: string, slug: string, domain: string) => {
   const buffer = await fetchFavicon(domain);
@@ -72,12 +80,18 @@ const createScript = async (input: CreateInput) => {
   const destination = join(input.directory, filename);
   if (await exists(destination)) throw new Error(`${filename} already exists — edit it directly`);
 
-  // Keyed on the script's own filename rather than its title: two commands can share a title while
-  // differing in verb or tag, and a title-keyed asset folder would let the second overwrite the first's icon.
-  const assetKey = filename.replace(/\.[^.]+$/, "");
+  // Keyed on the brand, so every command for a service shares one mark. Keying on the title would let a
+  // second command overwrite the first's icon; keying on the filename, as this did, went too far the other
+  // way and gave each command a private copy — so a service's icon was re-fetched every time and
+  // byte-identical duplicates accumulated. Falls back to the filename where there is no brand to key on.
+  const brandSlug = draft.packageName ? slugify(draft.packageName) : "";
+  const assetKey = brandSlug || filename.replace(/\.[^.]+$/, "");
   const domain = domainOf(draft.target);
   const chosenIcon = input.icon.trim();
-  const iconReference = chosenIcon || (domain ? await writeIcon(input.directory, assetKey, domain) : undefined);
+  const iconReference =
+    chosenIcon ||
+    (await brandIcon(input.directory, assetKey)) ||
+    (domain ? await writeIcon(input.directory, assetKey, domain) : undefined);
 
   const { contents } = buildScript({ ...draft, iconReference });
 
@@ -101,6 +115,7 @@ const Command = () => {
   const [application, setApplication] = useState("");
   const [desktopApplication, setDesktopApplication] = useState("");
   const [icon, setIcon] = useState("");
+  const [hoisted, setHoisted] = useState("");
   const [directory, setDirectory] = useState(directories[0] ?? "");
 
   const { data: applications } = usePromise(getApplications);
@@ -127,6 +142,64 @@ const Command = () => {
   const chosenEnvironment = chosen(environment, newEnvironment);
   const chosenCategory = chosen(category, newCategory);
 
+  // Resolved once, here, and passed explicitly from now on. The brand keys the icon asset as well as the
+  // filename's brand segment, so two sides deriving it independently would file the mark under one slug
+  // while the subtitle claimed another.
+  const resolvedPackage = packageName.trim() || suggestedPackage || "";
+
+  /**
+   * A hoisted value this collection has never seen has no dropdown item to select, so it goes through the
+   * same "New…" sentinel a user would reach for by hand. Selecting a value with no matching item would
+   * leave the control showing nothing at all.
+   */
+  const selectOrCreate = (
+    value: string,
+    known: { value: string }[],
+    setValue: (next: string) => void,
+    setTyped: (next: string) => void,
+  ) => {
+    if (known.some((entry) => entry.value === value)) {
+      setValue(value);
+      return;
+    }
+
+    setValue(NEW_VALUE);
+    setTyped(value);
+  };
+
+  /**
+   * Package is the one field that drives the filename, and a sigil typed into it is someone reaching for a
+   * control that already exists a few rows away. Left alone, `Linear · @work` becomes a brand by that
+   * literal name: it slugs to `linear-work.` rather than the `work.linear.` the convention specifies, and
+   * the list reads it back as part of the brand rather than as a scope.
+   *
+   * The sigil therefore always leaves the brand. Where it lands defers to the user: a control they have
+   * already set is never overridden, and a conflicting sigil is reported as dropped instead. On blur rather
+   * than on change, because `@w` already matches and a per-keystroke hoist would swallow the token as it
+   * was being typed.
+   */
+  const hoistPackageFields = (typed: string) => {
+    const fields = splitTypedPackage(typed);
+    if (!fields.environment && !fields.category) return;
+
+    const notes: string[] = [];
+
+    if (fields.environment && environment) notes.push(`dropped @${fields.environment}, Environment is already set`);
+    if (fields.environment && !environment) {
+      selectOrCreate(fields.environment, facets.environments, setEnvironment, setNewEnvironment);
+      notes.push(`moved @${fields.environment} to Environment`);
+    }
+
+    if (fields.category && category) notes.push(`dropped #${fields.category}, Category is already set`);
+    if (fields.category && !category) {
+      selectOrCreate(fields.category, facets.categories, setCategory, setNewCategory);
+      notes.push(`moved #${fields.category} to Category`);
+    }
+
+    setPackageName(fields.brand ?? "");
+    setHoisted(`${notes.join(", ").replace(/^./, (first) => first.toUpperCase())}.`);
+  };
+
   const placeholder = findPlaceholder(target);
   const filename =
     title.trim() && target.trim()
@@ -134,7 +207,7 @@ const Command = () => {
           title,
           target,
           environment: chosenEnvironment || undefined,
-          packageName: packageName.trim() || suggestedPackage || undefined,
+          packageName: resolvedPackage || undefined,
         })
       : "";
   const preview = filename && placeholder ? `${filename} — prompts for “${placeholder}”` : filename;
@@ -158,7 +231,7 @@ const Command = () => {
         title,
         target,
         environment: chosenEnvironment,
-        packageName: packageName.trim() || suggestedPackage || "",
+        packageName: resolvedPackage,
         category: chosenCategory,
         application,
         desktopApplication,
@@ -238,8 +311,14 @@ Put {query} anywhere in a URL to make it a search command: Raycast prompts for t
         placeholder={suggestedPackage ?? "Netflix"}
         info="The app or service this belongs to, shown as the subtitle. Left empty it is taken from the target's domain. Commands sharing a package sit together in the list."
         value={packageName}
-        onChange={setPackageName}
+        onChange={(next) => {
+          setPackageName(next);
+          setHoisted("");
+        }}
+        onBlur={(event) => hoistPackageFields(event.target.value ?? "")}
       />
+
+      {hoisted ? <Form.Description text={hoisted} /> : null}
 
       <Form.Dropdown
         id="category"

--- a/extensions/link-commands/src/create-link-command.tsx
+++ b/extensions/link-commands/src/create-link-command.tsx
@@ -17,6 +17,7 @@ import { useState } from "react";
 import { discoverScriptCommands, parseDirectoryPreference } from "./lib/discover-script-commands";
 import { facetCounts, splitTypedPackage } from "./lib/convention";
 import { learnedPackages, packageForTarget } from "./lib/link-command";
+import { reusableIcon } from "./lib/reuse-icon";
 import { collapseHome } from "./lib/home-path";
 import { fetchFavicon } from "./lib/fetch-icon";
 import { brandFor, buildScript, domainOf, findPlaceholder, scriptFilename, slugify } from "./lib/generate-script";
@@ -40,6 +41,8 @@ type CreateInput = {
   application: string;
   desktopApplication: string;
   icon: string;
+  /** A mark a command of this package already shows, resolved against the collection before submit. */
+  reuseIcon?: string;
   author?: string;
   authorURL?: string;
 };
@@ -88,8 +91,16 @@ const createScript = async (input: CreateInput) => {
   const assetKey = brandSlug || filename.replace(/\.[^.]+$/, "");
   const domain = domainOf(draft.target);
   const chosenIcon = input.icon.trim();
+
+  // A sibling's declared mark comes before the package's own asset path: it is what the list already shows
+  // for this brand, hand-set icons included, whereas a bare file under the key may be a stale auto-fetch.
+  // Re-checked here rather than trusted, since a header can point at a file that has since been deleted.
+  const reusable =
+    input.reuseIcon && (await exists(join(input.directory, input.reuseIcon))) ? input.reuseIcon : undefined;
+
   const iconReference =
     chosenIcon ||
+    reusable ||
     (await brandIcon(input.directory, assetKey)) ||
     (domain ? await writeIcon(input.directory, assetKey, domain) : undefined);
 
@@ -184,17 +195,23 @@ const Command = () => {
 
     const notes: string[] = [];
 
-    if (fields.environment && environment) notes.push(`dropped @${fields.environment}, Environment is already set`);
-    if (fields.environment && !environment) {
+    // Tested against the resolved value, not the raw control: "New…" holds a sentinel that is truthy while
+    // its text field is still empty, so reading the control directly would call an unset field set and
+    // report the sigil dropped rather than moving it.
+    if (fields.environment && chosenEnvironment)
+      notes.push(`dropped @${fields.environment}, Environment is already set`);
+    if (fields.environment && !chosenEnvironment) {
       selectOrCreate(fields.environment, facets.environments, setEnvironment, setNewEnvironment);
       notes.push(`moved @${fields.environment} to Environment`);
     }
 
-    if (fields.category && category) notes.push(`dropped #${fields.category}, Category is already set`);
-    if (fields.category && !category) {
+    if (fields.category && chosenCategory) notes.push(`dropped #${fields.category}, Category is already set`);
+    if (fields.category && !chosenCategory) {
       selectOrCreate(fields.category, facets.categories, setCategory, setNewCategory);
       notes.push(`moved #${fields.category} to Category`);
     }
+
+    for (const extra of fields.extras) notes.push(`dropped ${extra}, only the first of each sigil is used`);
 
     setPackageName(fields.brand ?? "");
     setHoisted(`${notes.join(", ").replace(/^./, (first) => first.toUpperCase())}.`);
@@ -230,6 +247,7 @@ const Command = () => {
         directory,
         title,
         target,
+        reuseIcon: await reusableIcon(discovered?.commands ?? [], directory, resolvedPackage),
         environment: chosenEnvironment,
         packageName: resolvedPackage,
         category: chosenCategory,

--- a/extensions/link-commands/src/lib/convention.ts
+++ b/extensions/link-commands/src/lib/convention.ts
@@ -5,8 +5,8 @@ import type { ScriptCommand } from "./types";
  * brand or category. Encoding three axes into those two strings is therefore a naming convention
  * rather than a schema, and this module is the one place that knows it:
  *
- *     title        @work · Abacus Board
- *     packageName  Jira
+ *     title        @work · Sprint Board
+ *     packageName  Linear
  *
  *     title        Watch Later
  *     packageName  YouTube · #media
@@ -57,6 +57,49 @@ export const facetsOf = (command: Pick<ScriptCommand, "title" | "packageName">):
   };
 };
 
+/**
+ * A whole field inside `packageName` that is nothing but a sigil and a token. Anchored as a complete
+ * field, so `Chat @ Mozilla` stays a brand.
+ */
+const TYPED_SIGIL_FIELD = /^([@#])([\p{L}\p{N}][\p{L}\p{N}_-]*)$/u;
+
+export type TypedPackage = {
+  /** What is left once any sigil field has been lifted out. Undefined when nothing remains. */
+  brand?: string;
+  environment?: string;
+  category?: string;
+};
+
+/**
+ * Splits a hand-typed `packageName` into the axes it is actually carrying, for the create form only.
+ * `Linear · @work` is someone reaching for the Environment control through the wrong field: taken
+ * literally it is a brand named `Linear · @work`, which slugs into a `linear-work.` filename the
+ * convention has no name for, and which the list view then reads back as a brand rather than a scope.
+ *
+ * Read-side parsing is deliberately untouched — `facetsOf` still takes the scope from the title, as
+ * the convention says. This describes what a person typed, never how a command on disk is interpreted.
+ */
+export const splitTypedPackage = (packageName: string | undefined): TypedPackage => {
+  const fields = (clean(packageName) ?? "")
+    .split(SEPARATOR)
+    .map((field) => field.trim())
+    .filter(Boolean);
+
+  const sigils = fields.map((field) => field.match(TYPED_SIGIL_FIELD)).filter((match) => match !== null);
+  const valueOf = (sigil: string) => sigils.find((match) => match[1] === sigil)?.[2].toLowerCase();
+
+  // The looser `Brand #category` form is honoured here too, because `facetsOf` honours it — a shape the
+  // reader accepts and the filename does not is the same disagreement in a smaller costume.
+  const rawBrand = fields.filter((field) => !TYPED_SIGIL_FIELD.test(field)).join(` ${SEPARATOR} `);
+  const categoryMatch = rawBrand.match(CATEGORY_PATTERN);
+
+  return {
+    brand: clean(categoryMatch ? categoryMatch[1] : rawBrand),
+    environment: valueOf("@"),
+    category: valueOf("#") ?? categoryMatch?.[2].toLowerCase(),
+  };
+};
+
 const titleCase = (value: string) =>
   value.replace(/[-_]+/g, " ").replace(/\p{L}+/gu, (word) => word[0].toUpperCase() + word.slice(1));
 
@@ -69,7 +112,7 @@ export const environmentName = (environment: string) => titleCase(environment);
 export const categoryName = (category: string) => titleCase(category);
 
 /**
- * A package is written by hand and carries its own capitalisation — `YouTube`, `The Orchard`, `npm`,
+ * A package is written by hand and carries its own capitalisation — `YouTube`, `The Guardian`, `npm`,
  * `france.tv` — so it is shown verbatim. Title-casing it would produce `Npm`. Environments and
  * categories are parsed lowercase out of a sigil, which is why only those two get cased.
  */

--- a/extensions/link-commands/src/lib/convention.ts
+++ b/extensions/link-commands/src/lib/convention.ts
@@ -68,6 +68,13 @@ export type TypedPackage = {
   brand?: string;
   environment?: string;
   category?: string;
+  /**
+   * Sigil fields beyond the first of their kind, as typed. Each axis holds one value, so a second `@` has
+   * nowhere to go — but it still has to leave the brand, or it reaches the filename. Returned rather than
+   * discarded so the form can say so: a token removed from the field with no note is the silent loss this
+   * whole split exists to prevent.
+   */
+  extras: string[];
 };
 
 /**
@@ -86,7 +93,9 @@ export const splitTypedPackage = (packageName: string | undefined): TypedPackage
     .filter(Boolean);
 
   const sigils = fields.map((field) => field.match(TYPED_SIGIL_FIELD)).filter((match) => match !== null);
-  const valueOf = (sigil: string) => sigils.find((match) => match[1] === sigil)?.[2].toLowerCase();
+  const firstOf = (sigil: string) => sigils.find((match) => match[1] === sigil);
+  const valueOf = (sigil: string) => firstOf(sigil)?.[2].toLowerCase();
+  const extras = sigils.filter((match) => match !== firstOf(match[1])).map((match) => match[0]);
 
   // The looser `Brand #category` form is honoured here too, because `facetsOf` honours it — a shape the
   // reader accepts and the filename does not is the same disagreement in a smaller costume.
@@ -97,6 +106,7 @@ export const splitTypedPackage = (packageName: string | undefined): TypedPackage
     brand: clean(categoryMatch ? categoryMatch[1] : rawBrand),
     environment: valueOf("@"),
     category: valueOf("#") ?? categoryMatch?.[2].toLowerCase(),
+    extras,
   };
 };
 

--- a/extensions/link-commands/src/lib/generate-script.ts
+++ b/extensions/link-commands/src/lib/generate-script.ts
@@ -21,7 +21,7 @@ export type ScriptDraft = {
   target: string;
   /** `work` becomes a `@work · ` prefix on the title and a `work.` prefix on the filename. */
   environment?: string;
-  /** The brand — `YouTube`, `The Orchard`. Defaults to the target's domain, humanised. */
+  /** The brand — `YouTube`, `The Guardian`. Defaults to the target's domain, humanised. */
   packageName?: string;
   /** `media` becomes ` · #media` on the subtitle. Never on the title. */
   category?: string;

--- a/extensions/link-commands/src/lib/link-command.ts
+++ b/extensions/link-commands/src/lib/link-command.ts
@@ -101,7 +101,7 @@ export const learnedPackages = (commands: ScriptCommand[]) => {
   return learned;
 };
 
-/** Walks up the domain, so `sonymusic-pde.datadoghq.com` finds what `datadoghq.com` was filed under. */
+/** Walks up the domain, so `app.raindrop.io` finds what `raindrop.io` was filed under. */
 export const packageForTarget = (target: string, learned: Map<string, string>) => {
   const host = hostOf(target);
   if (!host) return undefined;

--- a/extensions/link-commands/src/lib/resolve-icon.ts
+++ b/extensions/link-commands/src/lib/resolve-icon.ts
@@ -8,6 +8,22 @@ const FILE_PATH_PATTERN = /\.(png|jpe?g|gif|svg|webp|pdf|icns)$/i;
 const isRaycastIconName = (value: string): value is keyof typeof Icon => value in Icon;
 
 /**
+ * Whether `@raycast.icon` is naming a file kept beside the script, as opposed to the three other things
+ * that field accepts. Exported so nothing else has to re-derive it: the four cases are told apart only by
+ * the order they are tested in, and a second copy of that order elsewhere is a copy that drifts.
+ */
+export const isRelativeIconFile = (raw: string | undefined) => {
+  const value = raw?.trim();
+  if (!value) return false;
+
+  if (/^https?:\/\//i.test(value)) return false;
+  if (isRaycastIconName(value)) return false;
+  if (isAbsolute(value) || value.startsWith("~")) return false;
+
+  return FILE_PATH_PATTERN.test(value);
+};
+
+/**
  * `@raycast.icon` accepts four unrelated things — a remote URL, a built-in Raycast icon name, a file
  * path relative to the script, or a bare emoji — with no marker distinguishing them. Order matters
  * here: emoji is the fallback rather than a case, because there is no reliable test for "is an emoji"

--- a/extensions/link-commands/src/lib/reuse-icon.ts
+++ b/extensions/link-commands/src/lib/reuse-icon.ts
@@ -1,0 +1,55 @@
+import { access, realpath } from "node:fs/promises";
+import { join } from "node:path";
+import { facetsOf } from "./convention";
+import { slugify } from "./generate-script";
+import { isRelativeIconFile } from "./resolve-icon";
+import type { ScriptCommand } from "./types";
+
+const exists = (path: string) =>
+  access(path).then(
+    () => true,
+    () => false,
+  );
+
+const canonical = async (path: string) => realpath(path).catch(() => path);
+
+/**
+ * The icon a command of this package already shows, if there is one.
+ *
+ * Probing for a file under the package's own asset key only finds icons this version wrote — a collection
+ * that predates the package-level key filed each mark under the creating command's filename, which is not
+ * derivable from the draft in hand. Asking the commands instead sidesteps the key entirely: whatever a
+ * sibling declares is by definition the mark the list already shows for that brand, whether it was written
+ * under the old scheme, the new one, or set by hand.
+ *
+ * Restricted to siblings in the same directory as the write target, because the reference is relative and
+ * discovery recurses: a command found in a subdirectory resolves its own `./assets/…` against that
+ * subdirectory, so copying its reference verbatim into a script one level up points at nothing. Both sides
+ * are canonicalised first — discovery calls `realpath` and the directory preference does not, so a synced
+ * or symlinked folder compares unequal as plain strings and the reuse silently never fires.
+ */
+export const reusableIcon = async (commands: ScriptCommand[], directory: string, packageName: string) => {
+  const wanted = slugify(packageName);
+  if (!wanted) return undefined;
+
+  const target = await canonical(directory);
+
+  const counts = new Map<string, number>();
+  for (const command of commands) {
+    if (slugify(facetsOf(command).brand ?? "") !== wanted) continue;
+    if (!isRelativeIconFile(command.icon)) continue;
+    if ((await canonical(command.directory)) !== target) continue;
+
+    const reference = command.icon!.trim();
+    counts.set(reference, (counts.get(reference) ?? 0) + 1);
+  }
+
+  // Most-used wins, as `learnedPackages` settles a host with more than one package: a brand whose commands
+  // disagree about their mark has one the collection has actually converged on.
+  const ranked = [...counts.entries()].sort(([, left], [, right]) => right - left);
+  for (const [reference] of ranked) {
+    if (await exists(join(target, reference))) return reference;
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
## Description

Two fixes to **Create Link Command**, plus a small tidy-up.

**A `@scope` or `#category` typed into the Package field was taken as part of the brand.** Package drives the generated filename, so `Linear · @work` produced a brand called literally that: the file landed as `linear-work.my-issues.sh` rather than `work.linear.my-issues.sh`, and the list read the scope back as part of the brand instead of as a scope. Typing a sigil there is someone reaching for a control that already exists a few rows away, so it is now moved to that control on blur.

Two deliberate details:

- **A control you have already set is never overridden.** If Environment is set and a conflicting `@scope` is typed into Package, the sigil is removed from the brand and reported as dropped rather than replacing your choice.
- **The move is confirmed in a line beneath the field.** The filename preview shows the *outcome* but never the *edit* — it would name the new filename without ever saying that two tokens were lifted out of the field you were typing in.

Read-side parsing is untouched: `facetsOf` still takes the scope from the title. The new `splitTypedPackage` describes what a person typed, never how a command on disk is interpreted.

**Icons were stored per command rather than per package, and never reused.** The asset directory was keyed on the script's filename, so every new command re-fetched a service's icon into a private folder, accumulating identical copies. It is now keyed on the package, and an icon already present in your script directory is used before the network is asked. That second half matters for private or intranet hosts, which are invisible to any public favicon service — a command for one fell back to a generic link glyph even when the correct mark was already sitting beside it. Commands with no package keep the previous filename-based key.

**Example values in source comments are now neutral placeholders.** Several doc comments illustrated the convention with names taken from one contributor's own command collection, including an internal hostname. They say the same thing with generic examples.

`npm run lint` and `npm run build` both pass. Draft until the distribution build has been click-tested in Raycast.

## Screencast

Not attached — no new UI surface. The only visible addition is one confirmation line under the Package field after a sigil moves, reading e.g. `Moved @work to Environment, moved #dev to Category.`

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
