### PR TITLE
Fix Visual Studio Code terminal shortcut conflict

### DIFF
--- a/extensions/visual-studio-code-recent-projects/CHANGELOG.md
+++ b/extensions/visual-studio-code-recent-projects/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Visual Studio Code Changelog
 
+## [Fix: Terminal shortcut conflict] - {PR_MERGE_DATE}
+
+- Changed the terminal action shortcut to `Cmd` + `Shift` + `T` on macOS and `Ctrl` + `Shift` + `T` on Windows to avoid conflicting with `Open With…`. Fixes [#28408](https://github.com/raycast/extensions/issues/28408).
+
 ## [Fix: Opening workspaces on Windows] - 2026-08-19
 
 - Fixed `.code-workspace` entries on Windows opening as a new empty file instead of the workspace. The `file://` URI was passed to the editor as a positional argument, which the VS Code CLI interprets as a file path. Windows now opens all local entries by path, completing the revert in [#28913](https://github.com/raycast/extensions/pull/28913).

--- a/extensions/visual-studio-code-recent-projects/CHANGELOG.md
+++ b/extensions/visual-studio-code-recent-projects/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Visual Studio Code Changelog
 
-## [Fix: Terminal shortcut conflict] - {PR_MERGE_DATE}
+## [Fix: Terminal shortcut conflict] - 2026-09-03
 
 - Changed the terminal action shortcut to `Cmd` + `Shift` + `T` on macOS and `Ctrl` + `Shift` + `T` on Windows to avoid conflicting with `Open With…`. Fixes [#28408](https://github.com/raycast/extensions/issues/28408).
 

--- a/extensions/visual-studio-code-recent-projects/package.json
+++ b/extensions/visual-studio-code-recent-projects/package.json
@@ -35,7 +35,8 @@
     "jkker",
     "sillashead",
     "KamilDev",
-    "muhammadrizo"
+    "muhammadrizo",
+    "Tambouil"
   ],
   "keywords": [
     "vscode",

--- a/extensions/visual-studio-code-recent-projects/src/lib/shortcuts.ts
+++ b/extensions/visual-studio-code-recent-projects/src/lib/shortcuts.ts
@@ -37,7 +37,7 @@ export const Shortcut = {
   CopyTertiary: platformShortcut(",", ["cmd", "shift"]),
   CreateQuickLink: platformShortcut("s", ["cmd", "shift"]),
   OpenInBrowser: platformShortcut("b", ["cmd"]),
-  OpenInTerminal: platformShortcut("o", ["cmd", "shift"]),
+  OpenInTerminal: platformShortcut("t", ["cmd", "shift"]),
   RevealInFileManager: platformShortcut("f", ["cmd", "shift"]),
   Pin: platformShortcut("p", ["cmd", "shift"]),
   UnpinAll: sharedShortcut("x", ["ctrl", "shift"]),


### PR DESCRIPTION
## Summary

- Change terminal action from Cmd/Ctrl + Shift + O to Cmd/Ctrl + Shift + T
- Avoid conflict with Open With
- Keep fix isolated from unrelated changes in #29644

Fixes #28408.
Supersedes the shortcut portion of #29644, currently draft with conflicts.

## Validation

- npm run lint
- npm run build

Manual UI test not run.