### PR TITLE
fix(runpool): exclude paused pools from menu bar fill fraction

### DIFF
--- a/extensions/runpool/CHANGELOG.md
+++ b/extensions/runpool/CHANGELOG.md
@@ -1,6 +1,6 @@
 # RunPool Changelog
 
-## [Stop a paused pool's slots counting toward the busy fraction] - {PR_MERGE_DATE}
+## [Stop a paused pool's slots counting toward the busy fraction] - 2026-09-04
 
 - Exclude paused pools from the menu bar icon, its tooltip, and the root subtitle's busy/slot totals, so a fully busy pool no longer reads as partial because a sibling pool is paused
 

--- a/extensions/runpool/CHANGELOG.md
+++ b/extensions/runpool/CHANGELOG.md
@@ -1,5 +1,9 @@
 # RunPool Changelog
 
+## [Stop a paused pool's slots counting toward the busy fraction] - {PR_MERGE_DATE}
+
+- Exclude paused pools from the menu bar icon, its tooltip, and the root subtitle's busy/slot totals, so a fully busy pool no longer reads as partial because a sibling pool is paused
+
 ## [Fix a resize that could act on the wrong count] - 2026-09-02
 
 - Record every size a resize confirmation was shown, so two questions open at once cannot swap starting counts and turn approved growth into a shrink

--- a/extensions/runpool/src/lib/runpool.ts
+++ b/extensions/runpool/src/lib/runpool.ts
@@ -376,9 +376,12 @@ export function githubUnchecked(status: Status): boolean {
 export function summarise(status: Status): string {
   if (status.paused) return "Paused";
   if (status.pools.length > 0 && status.pools.every((pool) => pool.paused)) return "Pools Paused";
-  const running = status.pools.reduce((n, p) => n + p.running, 0);
-  const busy = status.pools.reduce((n, p) => n + p.busy, 0);
-  const slots = status.pools.reduce((n, p) => n + p.count, 0);
+  // Same reasoning as the menu bar mark: a paused pool's slots are not
+  // enabled capacity, so they are excluded rather than counted as idle.
+  const activePools = status.pools.filter((pool) => !pool.paused);
+  const running = activePools.reduce((n, p) => n + p.running, 0);
+  const busy = activePools.reduce((n, p) => n + p.busy, 0);
+  const slots = activePools.reduce((n, p) => n + p.count, 0);
   if (busy > 0) return `Active ${busy}/${slots}`;
   if (running === 0) return "Offline";
   return "Idle";

--- a/extensions/runpool/src/menubar.tsx
+++ b/extensions/runpool/src/menubar.tsx
@@ -48,8 +48,14 @@ export default function Command() {
     );
   }
 
-  const busy = status?.pools.reduce((n, p) => n + p.busy, 0) ?? 0;
-  const slots = status?.pools.reduce((n, p) => n + p.count, 0) ?? 0;
+  // A paused pool's slots are not enabled capacity. Counting them anyway
+  // dilutes the fraction: a pool that is fully busy reads as half-full the
+  // moment a sibling pool is paused, because its idle slots are still in the
+  // denominator. The mark should answer "how full is what's enabled", which
+  // means paused pools are excluded rather than counted as empty.
+  const activePools = status?.pools.filter((pool) => !pool.paused) ?? [];
+  const busy = activePools.reduce((n, p) => n + p.busy, 0);
+  const slots = activePools.reduce((n, p) => n + p.count, 0);
 
   // Monochrome by default, and deliberately untinted: a built-in icon left
   // alone is redrawn per display in that menu bar's own ink, which is the only


### PR DESCRIPTION
## Summary
- The menu bar icon and root-command subtitle summed `busy`/`count` across every pool, paused ones included, so a paused pool's idle slots diluted the fraction. A fully busy pool could read as half-full simply because a sibling pool was paused.
- Both aggregates now exclude paused pools, matching how each per-pool row already treats a paused pool's fraction as not meaningful.

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] Verified against live `runpool status --json` output with one paused pool and one active pool