### PR TITLE
[VMware VCenter] Fix Open Console failing with vim.fault.InvalidLocale

### DIFF
--- a/extensions/vmware-vcenter/CHANGELOG.md
+++ b/extensions/vmware-vcenter/CHANGELOG.md
@@ -1,5 +1,9 @@
 # VMware vCenter Changelog
 
+## [Fix] - 2026-09-04
+
+- Fixed "Open Console" failing with `vim.fault.InvalidLocale` by sending an explicit `Accept-Language` header when creating the vCenter session.
+
 ## [Fix] - 2026-05-14
 
 - Fixed the error when trying to configure the first server.

--- a/extensions/vmware-vcenter/CHANGELOG.md
+++ b/extensions/vmware-vcenter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # VMware vCenter Changelog
 
-## [Fix] - 2026-09-04
+## [Fix] - {PR_MERGE_DATE}
 
 - Fixed "Open Console" failing with `vim.fault.InvalidLocale` by sending an explicit `Accept-Language` header when creating the vCenter session.
 

--- a/extensions/vmware-vcenter/CHANGELOG.md
+++ b/extensions/vmware-vcenter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # VMware vCenter Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-09-04
 
 - Fixed "Open Console" failing with `vim.fault.InvalidLocale` by sending an explicit `Accept-Language` header when creating the vCenter session.
 

--- a/extensions/vmware-vcenter/src/api/vCenter.tsx
+++ b/extensions/vmware-vcenter/src/api/vCenter.tsx
@@ -38,6 +38,10 @@ export class vCenter {
       method: "POST",
       headers: {
         Authorization: `Basic ${this._credential}`,
+        // undici (Raycast's Node runtime) sends `Accept-Language: *` by default, which makes
+        // vCenter store `*` as the session locale; VMRC's CloneSession then fails with
+        // vim.fault.InvalidLocale. Pin a valid locale so console tickets stay redeemable.
+        "Accept-Language": "en-US",
       },
       signal: AbortSignal.timeout(this._timeout),
     })


### PR DESCRIPTION
## Root cause

The session-creation call in `getToken()` (`POST /api/session`) sent only the `Authorization` header, so undici — the fetch implementation in Raycast's Node runtime — added its default `Accept-Language: *` (undici's default headers cannot be disabled, only overridden — nodejs/undici#1305).

vCenter derives the REST session locale from that header and stored `*` as the session locale. The console ticket returned by `POST /api/vcenter/vm/{vm}/console/tickets` is a clone ticket for that session, so when VMRC redeemed it via `vim.SessionManager.CloneSession`, vCenter failed to apply the cloned locale and threw `vim.fault.InvalidLocale` (undeclared for CloneSession). VMRC then fell back to an interactive login prompt. Every other extension feature kept working because only CloneSession validates the locale.

## Change

Send an explicit `Accept-Language: en-US` header when creating the session, so the session locale is valid and console tickets stay redeemable. One-line change in `src/api/vCenter.tsx`; all other calls reuse the session token and are unaffected.

## Validation

- Reproduced the header behavior locally: a `fetch` with the old header shape (Authorization only) sends `Accept-Language: *`; with the fix it sends `en-US`.
- The reporter verified end-to-end against vCenter 8.0 U3: default headers → CloneSession fails with `InvalidLocale`; `Accept-Language: en-US` → CloneSession succeeds, and `ray develop` with this change makes Open Console work again (issue #30660).
- Server-side confirmation: vCenter rejects `<locale>*</locale>` in the SOAP Login with `Invalid or unknown locale provided`, and accepts `en-US`.
- `eslint` clean, `tsc --noEmit` clean.

Fixes #30660