### PR TITLE
[Hermes Agent] Add AI tools for Raycast AI integration

### DIFF
--- a/extensions/hermes-agent/CHANGELOG.md
+++ b/extensions/hermes-agent/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [AI Tools] - {PR_MERGE_DATE}
 
 - Add AI Tools for Raycast AI integration:
   - `ask-hermes`: Send questions to Hermes and get answers

--- a/extensions/hermes-agent/CHANGELOG.md
+++ b/extensions/hermes-agent/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+- Add AI Tools for Raycast AI integration:
+  - `ask-hermes`: Send questions to Hermes and get answers
+  - `process-text`: Transform text (summarize, explain, fix grammar, etc.)
+  - `check-status`: Diagnose connection issues with the Hermes API server
+
 ## [0.1.1] - 2026-08-21
 
 - Status uses `GET /v1/models` as the primary liveness check (OpenAI-compatible). `/health` is optional metadata.

--- a/extensions/hermes-agent/CHANGELOG.md
+++ b/extensions/hermes-agent/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [AI Tools] - {PR_MERGE_DATE}
+## [AI Tools] - 2026-09-07
 
 - Add AI Tools for Raycast AI integration:
   - `ask-hermes`: Send questions to Hermes and get answers

--- a/extensions/hermes-agent/package.json
+++ b/extensions/hermes-agent/package.json
@@ -105,5 +105,25 @@
   },
   "platforms": [
     "macOS"
+  ],
+  "tools": [
+    {
+      "name": "ask-hermes",
+      "title": "Ask Hermes",
+      "description": "Ask the local Hermes Agent a question and get its answer. Use for general Q&A, explanations, brainstorming, and advice.",
+      "icon": "icon.png"
+    },
+    {
+      "name": "process-text",
+      "title": "Process Text with Hermes",
+      "description": "Run a text transformation via Hermes: summarize, explain, fix grammar, improve writing, simplify, expand, translate, or review code. Use for private or sensitive text since nothing leaves the user's machine.",
+      "icon": "icon.png"
+    },
+    {
+      "name": "check-status",
+      "title": "Check Hermes Status",
+      "description": "Check whether the Hermes API server is reachable and return the resolved model name. Use to diagnose connection or configuration problems.",
+      "icon": "icon.png"
+    }
   ]
 }

--- a/extensions/hermes-agent/package.json
+++ b/extensions/hermes-agent/package.json
@@ -116,7 +116,7 @@
     {
       "name": "process-text",
       "title": "Process Text with Hermes",
-      "description": "Run a text transformation via Hermes: summarize, explain, fix grammar, improve writing, simplify, expand, translate, or review code. Use for private or sensitive text since nothing leaves the user's machine.",
+      "description": "Run a text transformation via your own Hermes server: summarize, explain, fix grammar, improve writing, simplify, expand, translate, or review code. Text is sent to the configured Hermes endpoint (local by default).",
       "icon": "icon.png"
     },
     {

--- a/extensions/hermes-agent/src/tools/ask-hermes.ts
+++ b/extensions/hermes-agent/src/tools/ask-hermes.ts
@@ -1,0 +1,30 @@
+import { askQuestion, sendMessage } from "../api";
+
+interface Input {
+  /**
+   * The question or instruction to send to Hermes
+   */
+  question: string;
+  /**
+   * Optional conversation history for multi-turn context, oldest first
+   */
+  history?: { role: "user" | "assistant"; content: string }[];
+}
+
+/**
+ * Ask the local Hermes Agent a question and return its answer.
+ * Use for general Q&A, explanations, brainstorming, and advice.
+ */
+export default async function (input: Input): Promise<string> {
+  const history = input.history ?? [];
+  const messages = [
+    ...history,
+    { role: "user" as const, content: input.question },
+  ];
+
+  if (history.length === 0) {
+    return askQuestion(input.question);
+  }
+
+  return sendMessage(messages);
+}

--- a/extensions/hermes-agent/src/tools/check-status.ts
+++ b/extensions/hermes-agent/src/tools/check-status.ts
@@ -1,4 +1,8 @@
-import { getPreferences, resolveModelName } from "../api";
+import { getPreferences } from "../api";
+
+interface ModelsList {
+  data?: { id?: string }[];
+}
 
 /**
  * Check whether the Hermes API server is reachable and return the resolved
@@ -11,8 +15,31 @@ export default async function (): Promise<{
   message: string;
 }> {
   const prefs = getPreferences();
+  const base = prefs.endpoint.replace(/\/+$/, "");
+
   try {
-    const model = await resolveModelName(prefs);
+    const headers: Record<string, string> = {};
+    if (prefs.token) {
+      headers.Authorization = `Bearer ${prefs.token}`;
+    }
+
+    const response = await fetch(`${base}/v1/models`, {
+      method: "GET",
+      headers,
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    const data = (await response.json()) as ModelsList;
+    const ids = (data.data ?? [])
+      .map((m) => m.id)
+      .filter((id): id is string => typeof id === "string" && id.length > 0);
+    const model = ids.includes("hermes-agent")
+      ? "hermes-agent"
+      : (ids[0] ?? "hermes-agent");
+
     return {
       enabled: true,
       endpoint: prefs.endpoint,

--- a/extensions/hermes-agent/src/tools/check-status.ts
+++ b/extensions/hermes-agent/src/tools/check-status.ts
@@ -36,9 +36,13 @@ export default async function (): Promise<{
     const ids = (data.data ?? [])
       .map((m) => m.id)
       .filter((id): id is string => typeof id === "string" && id.length > 0);
-    const model = ids.includes("hermes-agent")
-      ? "hermes-agent"
-      : (ids[0] ?? "hermes-agent");
+
+    const configured = (prefs.modelName || "").trim();
+    const model =
+      configured ||
+      (ids.includes("hermes-agent")
+        ? "hermes-agent"
+        : (ids[0] ?? "hermes-agent"));
 
     return {
       enabled: true,

--- a/extensions/hermes-agent/src/tools/check-status.ts
+++ b/extensions/hermes-agent/src/tools/check-status.ts
@@ -1,0 +1,30 @@
+import { getPreferences, resolveModelName } from "../api";
+
+/**
+ * Check whether the Hermes API server is reachable and return the resolved
+ * model name. Use this to diagnose connection or configuration problems.
+ */
+export default async function (): Promise<{
+  enabled: boolean;
+  endpoint: string;
+  model: string;
+  message: string;
+}> {
+  const prefs = getPreferences();
+  try {
+    const model = await resolveModelName(prefs);
+    return {
+      enabled: true,
+      endpoint: prefs.endpoint,
+      model,
+      message: `Hermes API server is reachable at ${prefs.endpoint} (model: ${model})`,
+    };
+  } catch (error) {
+    return {
+      enabled: false,
+      endpoint: prefs.endpoint,
+      model: "",
+      message: `Hermes API server is not reachable at ${prefs.endpoint}. Enable it with API_SERVER_ENABLED=true and run \`hermes status\`. Error: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}

--- a/extensions/hermes-agent/src/tools/process-text.ts
+++ b/extensions/hermes-agent/src/tools/process-text.ts
@@ -1,6 +1,6 @@
 import { sendMessage } from "../api";
 
-const OPERATION_PROMPTS: Record<string, string> = {
+const OPERATION_PROMPTS = {
   summarize: "Summarize this concisely:",
   explain: "Explain this in simple terms:",
   "fix-grammar":
@@ -12,7 +12,9 @@ const OPERATION_PROMPTS: Record<string, string> = {
   "explain-code": "Explain what this code does:",
   "review-code": "Review this code and suggest improvements:",
   "bullet-points": "Convert this into clear bullet points:",
-};
+} as const;
+
+type Operation = keyof typeof OPERATION_PROMPTS;
 
 interface Input {
   /**
@@ -23,16 +25,21 @@ interface Input {
    * What to do with the text: summarize, explain, fix-grammar, improve-writing,
    * simplify, expand, translate-to-english, explain-code, review-code, bullet-points
    */
-  operation: string;
+  operation: Operation;
 }
 
 /**
- * Process text with Hermes: summarize, explain, fix grammar, improve writing,
- * simplify, expand, translate, or review code. Useful for private content since
- * nothing leaves the user's machine.
+ * Process text with your own Hermes server: summarize, explain, fix grammar,
+ * improve writing, simplify, expand, translate, or review code. Text is sent
+ * to the configured Hermes endpoint (local by default).
  */
 export default async function (input: Input): Promise<string> {
-  const prompt = OPERATION_PROMPTS[input.operation] ?? `${input.operation}:`;
+  const prompt = OPERATION_PROMPTS[input.operation];
+  if (!prompt) {
+    throw new Error(
+      `Unknown operation "${input.operation}". Valid operations: ${Object.keys(OPERATION_PROMPTS).join(", ")}`,
+    );
+  }
   return sendMessage([
     {
       role: "user",

--- a/extensions/hermes-agent/src/tools/process-text.ts
+++ b/extensions/hermes-agent/src/tools/process-text.ts
@@ -1,0 +1,42 @@
+import { sendMessage } from "../api";
+
+const OPERATION_PROMPTS: Record<string, string> = {
+  summarize: "Summarize this concisely:",
+  explain: "Explain this in simple terms:",
+  "fix-grammar":
+    "Fix the grammar and spelling, return only the corrected text:",
+  "improve-writing": "Improve this writing while keeping the same meaning:",
+  simplify: "Simplify this text to make it easier to understand:",
+  expand: "Expand on this with more detail:",
+  "translate-to-english": "Translate this to English:",
+  "explain-code": "Explain what this code does:",
+  "review-code": "Review this code and suggest improvements:",
+  "bullet-points": "Convert this into clear bullet points:",
+};
+
+interface Input {
+  /**
+   * The text to process
+   */
+  text: string;
+  /**
+   * What to do with the text: summarize, explain, fix-grammar, improve-writing,
+   * simplify, expand, translate-to-english, explain-code, review-code, bullet-points
+   */
+  operation: string;
+}
+
+/**
+ * Process text with Hermes: summarize, explain, fix grammar, improve writing,
+ * simplify, expand, translate, or review code. Useful for private content since
+ * nothing leaves the user's machine.
+ */
+export default async function (input: Input): Promise<string> {
+  const prompt = OPERATION_PROMPTS[input.operation] ?? `${input.operation}:`;
+  return sendMessage([
+    {
+      role: "user",
+      content: `${prompt}\n\n${input.text}`,
+    },
+  ]);
+}


### PR DESCRIPTION
## Description

This PR adds three **AI Tools** to the Hermes Agent extension, enabling Raycast AI to interact with a local Hermes Agent instance.

## New Tools

| Tool | Description |
|------|-------------|
| `ask-hermes` | Send questions to Hermes and get answers. Supports multi-turn conversations via optional history parameter. |
| `process-text` | Transform text via Hermes: summarize, explain, fix grammar, improve writing, simplify, expand, translate, explain code, review code, or create bullet points. |
| `check-status` | Check if the Hermes API server is reachable and return the resolved model name. Useful for diagnosing connection issues. |

## Use Cases

- **Privacy-focused AI**: All processing stays on the user's local machine (or private server)
- **`@hermes-agent` in Raycast AI**: Users can mention the extension in AI chats to leverage their local Hermes instance
- **Sensitive text processing**: Process confidential documents without sending data to cloud APIs

## Testing

- [x] Tools compile successfully with `npm run build`
- [x] Tested against live Hermes API server (v0.21.0)
- [x] `ask-hermes` returns correct responses
- [x] `check-status` correctly reports server status
- [x] `process-text` handles all operation types

## Screenshots

_Tools appear in Raycast AI when typing `@hermes-agent`_

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder