### PR TITLE
Update OneCal Unified Calendar - open Google Meet links with the calendar's account

### DIFF
--- a/extensions/onecal-unified-calendar/CHANGELOG.md
+++ b/extensions/onecal-unified-calendar/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OneCal Unified Calendar Changelog
 
+## [Account-aware meeting links] - {PR_MERGE_DATE}
+
+- Open Google Meet links with the calendar's own Google account (via the `authuser` parameter), so meetings from a work calendar open with the work account even when the browser is signed in to multiple Google accounts. Copied URLs are left untouched
+
 ## [Initial Version] - 2026-09-01
 
 - Unified calendar view: list events from all synced OneCal calendars, grouped by day

--- a/extensions/onecal-unified-calendar/CHANGELOG.md
+++ b/extensions/onecal-unified-calendar/CHANGELOG.md
@@ -1,6 +1,6 @@
 # OneCal Unified Calendar Changelog
 
-## [Account-aware meeting links] - {PR_MERGE_DATE}
+## [Account-aware meeting links] - 2026-09-04
 
 - Open Google Meet links with the calendar's own Google account (via the `authuser` parameter), so meetings from a work calendar open with the work account even when the browser is signed in to multiple Google accounts. Copied URLs are left untouched
 

--- a/extensions/onecal-unified-calendar/package.json
+++ b/extensions/onecal-unified-calendar/package.json
@@ -97,6 +97,7 @@
     "build": "ray build -e dist",
     "dev": "ray develop",
     "lint": "ray lint",
-    "fix-lint": "ray lint --fix"
+    "fix-lint": "ray lint --fix",
+    "test": "node --experimental-strip-types --test src/api/meeting-url.test.ts"
   }
 }

--- a/extensions/onecal-unified-calendar/src/api/meeting-url.test.ts
+++ b/extensions/onecal-unified-calendar/src/api/meeting-url.test.ts
@@ -1,0 +1,73 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { withAuthUser } from "./meeting-url.ts";
+
+describe("withAuthUser", () => {
+  it("appends authuser with proper encoding for meet.google.com", () => {
+    assert.equal(
+      withAuthUser(
+        "https://meet.google.com/abc-defg-hij",
+        "k.sato@example.co.jp",
+      ),
+      "https://meet.google.com/abc-defg-hij?authuser=k.sato%40example.co.jp",
+    );
+  });
+
+  it("preserves existing query parameters", () => {
+    assert.equal(
+      withAuthUser("https://meet.google.com/abc?hs=122", "a@b.jp"),
+      "https://meet.google.com/abc?hs=122&authuser=a%40b.jp",
+    );
+  });
+
+  it("preserves URL fragments", () => {
+    assert.equal(
+      withAuthUser("https://meet.google.com/abc#section", "a@b.jp"),
+      "https://meet.google.com/abc?authuser=a%40b.jp#section",
+    );
+  });
+
+  it("replaces an existing authuser instead of duplicating it", () => {
+    assert.equal(
+      withAuthUser(
+        "https://meet.google.com/abc?authuser=old%40b.jp",
+        "new@b.jp",
+      ),
+      "https://meet.google.com/abc?authuser=new%40b.jp",
+    );
+  });
+
+  it("leaves non-Google conferencing hosts unchanged", () => {
+    for (const url of [
+      "https://zoom.us/j/123456789",
+      "https://company.zoom.us/j/123",
+      "https://teams.microsoft.com/l/meetup-join/x",
+      "https://teams.live.com/meet/x",
+      "https://example.webex.com/meet/x",
+    ]) {
+      assert.equal(withAuthUser(url, "a@b.jp"), url);
+    }
+  });
+
+  it("does not treat lookalike hosts as Google Meet", () => {
+    assert.equal(
+      withAuthUser("https://evilmeet.google.com.attacker.example/x", "a@b.jp"),
+      "https://evilmeet.google.com.attacker.example/x",
+    );
+  });
+
+  it("returns the URL unchanged when the account email is missing or empty", () => {
+    assert.equal(
+      withAuthUser("https://meet.google.com/abc", undefined),
+      "https://meet.google.com/abc",
+    );
+    assert.equal(
+      withAuthUser("https://meet.google.com/abc", ""),
+      "https://meet.google.com/abc",
+    );
+  });
+
+  it("returns unparsable URLs unchanged", () => {
+    assert.equal(withAuthUser("not a url", "a@b.jp"), "not a url");
+  });
+});

--- a/extensions/onecal-unified-calendar/src/api/meeting-url.ts
+++ b/extensions/onecal-unified-calendar/src/api/meeting-url.ts
@@ -1,0 +1,26 @@
+/**
+ * Google Meetの会議URLに、イベント所属カレンダーのアカウントを authuser クエリで付与する。
+ * ブラウザが複数Googleアカウントにログインしていても、その予定のアカウントで開けるようにするため。
+ * Google以外のホスト（Zoom/Teams等）は認証機構が異なるためそのまま返す。
+ * コピー用途には使わない（他人に共有するURLへ自分のメールを混ぜないため、開く直前のみ適用する）。
+ *
+ * 依存ゼロの独立モジュールにしてある（meeting-url.test.ts が node:test で直接importするため）。
+ */
+export function withAuthUser(
+  meetingUrl: string,
+  accountEmail?: string,
+): string {
+  if (!accountEmail) {
+    return meetingUrl;
+  }
+  try {
+    const url = new URL(meetingUrl);
+    if (url.hostname.toLowerCase() === "meet.google.com") {
+      url.searchParams.set("authuser", accountEmail);
+      return url.toString();
+    }
+  } catch {
+    // 不正URLはそのまま返す（呼び出し側は検証済みのはずだが防御的に）
+  }
+  return meetingUrl;
+}

--- a/extensions/onecal-unified-calendar/src/api/mock.ts
+++ b/extensions/onecal-unified-calendar/src/api/mock.ts
@@ -40,6 +40,7 @@ export function buildMockData(): UnifiedCalendarData {
     {
       id: "demo-1",
       calendarId: "work",
+      accountEmail: "work@example.com",
       calendarName: "Work",
       title: "Product Sync",
       start: at(-20),
@@ -51,6 +52,7 @@ export function buildMockData(): UnifiedCalendarData {
     {
       id: "demo-2",
       calendarId: "team",
+      accountEmail: "team@example.com",
       calendarName: "Team",
       title: "1on1 Meeting",
       start: at(4),
@@ -62,6 +64,7 @@ export function buildMockData(): UnifiedCalendarData {
     {
       id: "demo-3",
       calendarId: "work",
+      accountEmail: "work@example.com",
       calendarName: "Work",
       title: "Design Review",
       start: at(120),
@@ -73,6 +76,7 @@ export function buildMockData(): UnifiedCalendarData {
     {
       id: "demo-4",
       calendarId: "work",
+      accountEmail: "work@example.com",
       calendarName: "Work",
       title: "Focus Block",
       start: at(240),
@@ -83,6 +87,7 @@ export function buildMockData(): UnifiedCalendarData {
     {
       id: "demo-5",
       calendarId: "personal",
+      accountEmail: "personal@example.com",
       calendarName: "Personal",
       title: "Gym",
       start: at(600),
@@ -93,6 +98,7 @@ export function buildMockData(): UnifiedCalendarData {
     {
       id: "demo-6",
       calendarId: "team",
+      accountEmail: "team@example.com",
       calendarName: "Team",
       title: "Quarterly Planning Review",
       start: `${dayStr(1)}T10:00:00+09:00`,
@@ -104,6 +110,7 @@ export function buildMockData(): UnifiedCalendarData {
     {
       id: "demo-7",
       calendarId: "personal",
+      accountEmail: "personal@example.com",
       calendarName: "Personal",
       title: "Dentist Appointment",
       start: `${dayStr(1)}T15:00:00+09:00`,
@@ -115,6 +122,7 @@ export function buildMockData(): UnifiedCalendarData {
     {
       id: "demo-8",
       calendarId: "work",
+      accountEmail: "work@example.com",
       calendarName: "Work",
       title: "Team Offsite",
       start: dayStr(2),
@@ -125,6 +133,7 @@ export function buildMockData(): UnifiedCalendarData {
     {
       id: "demo-1-clone",
       calendarId: "personal",
+      accountEmail: "personal@example.com",
       calendarName: "Personal",
       title: "Product Sync",
       start: at(-20),
@@ -135,6 +144,7 @@ export function buildMockData(): UnifiedCalendarData {
     {
       id: "demo-3-clone",
       calendarId: "personal",
+      accountEmail: "personal@example.com",
       calendarName: "Personal",
       title: "Design Review",
       start: at(120),

--- a/extensions/onecal-unified-calendar/src/api/onecal.ts
+++ b/extensions/onecal-unified-calendar/src/api/onecal.ts
@@ -1,6 +1,8 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { callToolJson, listTools, resolveTool } from "./mcp";
 
+export { withAuthUser } from "./meeting-url";
+
 // 注意: この2つの型はuseCachedPromiseでJSONシリアライズしてキャッシュされるため、
 // 生イベント（nativeEvent等）は含めず、表示に必要なフィールドだけに絞って軽量に保つ。
 export interface OneCalCalendar {
@@ -255,31 +257,6 @@ const MEETING_HOST_SUFFIXES = [
   "gotomeeting.com",
   "chime.aws",
 ];
-
-/**
- * Google Meetの会議URLに、イベント所属カレンダーのアカウントを authuser クエリで付与する。
- * ブラウザが複数Googleアカウントにログインしていても、その予定のアカウントで開けるようにするため。
- * Google以外のホスト（Zoom/Teams等）は認証機構が異なるためそのまま返す。
- * コピー用途には使わない（他人に共有するURLへ自分のメールを混ぜないため、開く直前のみ適用する）。
- */
-export function withAuthUser(
-  meetingUrl: string,
-  accountEmail?: string,
-): string {
-  if (!accountEmail) {
-    return meetingUrl;
-  }
-  try {
-    const url = new URL(meetingUrl);
-    if (url.hostname.toLowerCase() === "meet.google.com") {
-      url.searchParams.set("authuser", accountEmail);
-      return url.toString();
-    }
-  } catch {
-    // 不正URLはそのまま返す（呼び出し側は検証済みのはずだが防御的に）
-  }
-  return meetingUrl;
-}
 
 /** httpsのみ・hostnameの完全一致または「.suffix」境界つきサブドメインのみ許可する */
 function isMeetingUrl(candidate: string): boolean {

--- a/extensions/onecal-unified-calendar/src/api/onecal.ts
+++ b/extensions/onecal-unified-calendar/src/api/onecal.ts
@@ -15,6 +15,8 @@ export interface OneCalEvent {
   id: string;
   calendarId?: string;
   calendarName?: string;
+  /** 所属カレンダーのアカウントメール。Google系会議URLのauthuser付与に使う */
+  accountEmail?: string;
   title: string;
   start: string; // ISO日時 or YYYY-MM-DD（終日）
   end?: string;
@@ -227,6 +229,7 @@ function normalizeEvent(
       `${start}-${str(raw, ["title", "summary"]) ?? ""}`,
     calendarId,
     calendarName: calendar?.name ?? str(raw, ["calendarName", "calendar"]),
+    accountEmail: calendar?.accountEmail,
     title: str(raw, ["title", "summary", "subject", "name"]) ?? "(untitled)",
     start: start ?? "",
     end,
@@ -252,6 +255,31 @@ const MEETING_HOST_SUFFIXES = [
   "gotomeeting.com",
   "chime.aws",
 ];
+
+/**
+ * Google Meetの会議URLに、イベント所属カレンダーのアカウントを authuser クエリで付与する。
+ * ブラウザが複数Googleアカウントにログインしていても、その予定のアカウントで開けるようにするため。
+ * Google以外のホスト（Zoom/Teams等）は認証機構が異なるためそのまま返す。
+ * コピー用途には使わない（他人に共有するURLへ自分のメールを混ぜないため、開く直前のみ適用する）。
+ */
+export function withAuthUser(
+  meetingUrl: string,
+  accountEmail?: string,
+): string {
+  if (!accountEmail) {
+    return meetingUrl;
+  }
+  try {
+    const url = new URL(meetingUrl);
+    if (url.hostname.toLowerCase() === "meet.google.com") {
+      url.searchParams.set("authuser", accountEmail);
+      return url.toString();
+    }
+  } catch {
+    // 不正URLはそのまま返す（呼び出し側は検証済みのはずだが防御的に）
+  }
+  return meetingUrl;
+}
 
 /** httpsのみ・hostnameの完全一致または「.suffix」境界つきサブドメインのみ許可する */
 function isMeetingUrl(candidate: string): boolean {

--- a/extensions/onecal-unified-calendar/src/unified-calendar.tsx
+++ b/extensions/onecal-unified-calendar/src/unified-calendar.tsx
@@ -13,10 +13,15 @@ import { useCachedPromise } from "@raycast/utils";
 import { useState } from "react";
 import { authorize, logout } from "./api/oauth";
 import { connectMcp } from "./api/mcp";
-import { fetchUnifiedCalendar, filterClones, OneCalEvent } from "./api/onecal";
+import {
+  fetchUnifiedCalendar,
+  filterClones,
+  OneCalEvent,
+  withAuthUser,
+} from "./api/onecal";
 import { buildMockData } from "./api/mock";
 
-const CACHE_VERSION = "v2";
+const CACHE_VERSION = "v3";
 
 export default function UnifiedCalendar(
   props: LaunchProps<{ arguments: Arguments.UnifiedCalendar }>,
@@ -241,7 +246,7 @@ function FeaturedMeetingItem(props: {
             <Action.OpenInBrowser
               title="Join Meeting"
               icon={Icon.Video}
-              url={event.meetingUrl}
+              url={withAuthUser(event.meetingUrl, event.accountEmail)}
             />
           )}
           <Action.OpenInBrowser
@@ -303,7 +308,7 @@ function EventItem(props: {
             <Action.OpenInBrowser
               title="Join Meeting"
               icon={Icon.Video}
-              url={event.meetingUrl}
+              url={withAuthUser(event.meetingUrl, event.accountEmail)}
             />
           )}
           <Action.CopyToClipboard title="Copy Title" content={event.title} />

--- a/extensions/onecal-unified-calendar/tsconfig.json
+++ b/extensions/onecal-unified-calendar/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "compilerOptions": {
-    "lib": ["ES2023"],
+    "lib": [
+      "ES2023"
+    ],
     "module": "commonjs",
     "target": "ES2022",
     "strict": true,
@@ -9,7 +11,11 @@
     "skipLibCheck": true,
     "jsx": "react-jsx",
     "resolveJsonModule": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "allowImportingTsExtensions": true
   },
-  "include": ["raycast-env.d.ts", "src/**/*"]
+  "include": [
+    "raycast-env.d.ts",
+    "src/**/*"
+  ]
 }

--- a/extensions/onecal-unified-calendar/tsconfig.json
+++ b/extensions/onecal-unified-calendar/tsconfig.json
@@ -12,7 +12,8 @@
     "jsx": "react-jsx",
     "resolveJsonModule": true,
     "moduleResolution": "node",
-    "allowImportingTsExtensions": true
+    "allowImportingTsExtensions": true,
+    "noEmit": true
   },
   "include": [
     "raycast-env.d.ts",


### PR DESCRIPTION
## Description

When the browser is signed in to multiple Google accounts, joining a meeting from the extension could open Google Meet with the wrong (default) account.

This update appends the event's calendar account email as the `authuser` query parameter to `meet.google.com` URLs opened via the **Join Meeting** action, so a meeting on a work calendar opens with the work account and a personal event opens with the personal account.

- Applies only to `meet.google.com` (other conferencing providers such as Zoom / Teams / Webex use their own auth and are left unchanged)
- **Copy Meeting URL** still copies the original URL (no personal email is leaked into shared links)
- `withAuthUser()` is defensive: no account email or an unparsable URL returns the URL unchanged. Verified with bundled unit checks (parameter added with proper encoding, existing query preserved, non-Google hosts and missing email pass through)

## Screencast

No visual changes — only the URL opened by the existing Join Meeting action gains the `authuser` parameter.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)