### PR TITLE
[feat]: display space name for tabs when searching

### DIFF
--- a/extensions/arc/CHANGELOG.md
+++ b/extensions/arc/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Arc Changelog
 
+## [Improvements] - {PR_MERGE_DATE}
+
+- Display the Space name in `Search Tabs` and `Search Arc` results to help distinguish tabs with identical names across different Spaces.
+
 ## [Fix SQL injection in history and download search] - 2026-06-23
 
 - Escape single quotes and LIKE wildcards (`%`, `_`) in search queries to prevent SQL injection

--- a/extensions/arc/CHANGELOG.md
+++ b/extensions/arc/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Arc Changelog
 
-## [Improvements] - {PR_MERGE_DATE}
+## [Improvements] - 2026-09-07
 
 - Display the Space name in `Search Tabs` and `Search Arc` results to help distinguish tabs with identical names across different Spaces.
 - `getTabsWithSpaceInfo` now falls back to `getTabs()` when the AppleScript response is empty or unparseable, so a Space-metadata failure drops only the Space tags — not the entire tab list.

--- a/extensions/arc/CHANGELOG.md
+++ b/extensions/arc/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Improvements] - {PR_MERGE_DATE}
 
 - Display the Space name in `Search Tabs` and `Search Arc` results to help distinguish tabs with identical names across different Spaces.
+- `getTabsWithSpaceInfo` now falls back to `getTabs()` when the AppleScript response is empty or unparseable, so a Space-metadata failure drops only the Space tags — not the entire tab list.
 
 ## [Fix SQL injection in history and download search] - 2026-06-23
 

--- a/extensions/arc/src/arc.ts
+++ b/extensions/arc/src/arc.ts
@@ -70,6 +70,87 @@ export async function getTabs() {
   return response ? (JSON.parse(response) as Tab[]) : undefined;
 }
 
+export async function getTabsWithSpaceInfo(): Promise<Tab[] | undefined> {
+  await ensureArcIsRunning();
+  const response = await runAppleScript(`
+    on escape_value(this_text)
+      set AppleScript's text item delimiters to "\\\\"
+      set the item_list to every text item of this_text
+      set AppleScript's text item delimiters to "\\\\\\\\"
+      set this_text to the item_list as string
+      set AppleScript's text item delimiters to "\\""
+      set the item_list to every text item of this_text
+      set AppleScript's text item delimiters to "\\\\\\""
+      set this_text to the item_list as string
+      set AppleScript's text item delimiters to ""
+      return this_text
+    end escape_value
+
+    set _tabs to ""
+    set _spaces to "{"
+    set _space_index to 1
+    set _first to true
+
+    tell application "Arc"
+      tell first window
+        set _all_tabs to properties of every tab
+        set _tabs_count to count of _all_tabs
+
+        repeat with i from 1 to _tabs_count
+          set _tab to item i of _all_tabs
+          set _title to my escape_value(get title of _tab)
+          set _url to get URL of _tab
+          set _id to get id of _tab
+          set _location to get location of _tab
+
+          if i > 1 then
+            set _tabs to (_tabs & ",\\n")
+          end if
+          set _tabs to (_tabs & "{ \\"title\\": \\"" & _title & "\\", \\"url\\": \\"" & _url & "\\", \\"id\\": \\"" & _id & "\\", \\"location\\": \\"" & _location & "\\" }")
+        end repeat
+
+        repeat with _space in spaces
+          set _space_title to get title of _space
+          if _space_title is "" then
+            set _space_title to "Space " & _space_index
+          end if
+          set _space_title to my escape_value(_space_title)
+
+          repeat with _tab in every tab of _space
+            set _tab_id to get id of _tab
+
+            if not _first then
+              set _spaces to (_spaces & ",")
+            end if
+            set _spaces to (_spaces & "\\"" & _tab_id & "\\": \\"" & _space_title & "\\"")
+            set _first to false
+          end repeat
+
+          set _space_index to _space_index + 1
+        end repeat
+      end tell
+    end tell
+
+    return "{ \\"tabs\\": [\\n" & _tabs & "\\n], \\"spaces\\": " & _spaces & " }"
+  `);
+
+  if (!response) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(response) as { tabs: Tab[]; spaces: Record<string, string> };
+
+    return parsed.tabs.map((tab) => ({
+      ...tab,
+      spaceName: parsed.spaces[tab.id],
+    }));
+  } catch (e) {
+    console.error(e);
+    return undefined;
+  }
+}
+
 export async function findTab(url: string) {
   const response = await runAppleScript(`
   on escape_value(this_text)

--- a/extensions/arc/src/arc.ts
+++ b/extensions/arc/src/arc.ts
@@ -72,70 +72,78 @@ export async function getTabs() {
 
 export async function getTabsWithSpaceInfo(): Promise<Tab[] | undefined> {
   await ensureArcIsRunning();
-  const response = await runAppleScript(`
-    on escape_value(this_text)
-      set AppleScript's text item delimiters to "\\\\"
-      set the item_list to every text item of this_text
-      set AppleScript's text item delimiters to "\\\\\\\\"
-      set this_text to the item_list as string
-      set AppleScript's text item delimiters to "\\""
-      set the item_list to every text item of this_text
-      set AppleScript's text item delimiters to "\\\\\\""
-      set this_text to the item_list as string
-      set AppleScript's text item delimiters to ""
-      return this_text
-    end escape_value
 
-    set _tabs to ""
-    set _spaces to "{"
-    set _space_index to 1
-    set _first to true
+  let response: string | undefined;
+  try {
+    response = await runAppleScript(`
+      on escape_value(this_text)
+        set AppleScript's text item delimiters to "\\\\"
+        set the item_list to every text item of this_text
+        set AppleScript's text item delimiters to "\\\\\\\\"
+        set this_text to the item_list as string
+        set AppleScript's text item delimiters to "\\""
+        set the item_list to every text item of this_text
+        set AppleScript's text item delimiters to "\\\\\\""
+        set this_text to the item_list as string
+        set AppleScript's text item delimiters to ""
+        return this_text
+      end escape_value
 
-    tell application "Arc"
-      tell first window
-        set _all_tabs to properties of every tab
-        set _tabs_count to count of _all_tabs
+      set _tabs to ""
+      set _spaces to "{"
+      set _space_index to 1
+      set _first to true
 
-        repeat with i from 1 to _tabs_count
-          set _tab to item i of _all_tabs
-          set _title to my escape_value(get title of _tab)
-          set _url to get URL of _tab
-          set _id to get id of _tab
-          set _location to get location of _tab
+      tell application "Arc"
+        tell first window
+          set _all_tabs to properties of every tab
+          set _tabs_count to count of _all_tabs
 
-          if i > 1 then
-            set _tabs to (_tabs & ",\\n")
-          end if
-          set _tabs to (_tabs & "{ \\"title\\": \\"" & _title & "\\", \\"url\\": \\"" & _url & "\\", \\"id\\": \\"" & _id & "\\", \\"location\\": \\"" & _location & "\\" }")
-        end repeat
+          repeat with i from 1 to _tabs_count
+            set _tab to item i of _all_tabs
+            set _title to my escape_value(get title of _tab)
+            set _url to get URL of _tab
+            set _id to get id of _tab
+            set _location to get location of _tab
 
-        repeat with _space in spaces
-          set _space_title to get title of _space
-          if _space_title is "" then
-            set _space_title to "Space " & _space_index
-          end if
-          set _space_title to my escape_value(_space_title)
-
-          repeat with _tab in every tab of _space
-            set _tab_id to get id of _tab
-
-            if not _first then
-              set _spaces to (_spaces & ",")
+            if i > 1 then
+              set _tabs to (_tabs & ",\\n")
             end if
-            set _spaces to (_spaces & "\\"" & _tab_id & "\\": \\"" & _space_title & "\\"")
-            set _first to false
+            set _tabs to (_tabs & "{ \\"title\\": \\"" & _title & "\\", \\"url\\": \\"" & _url & "\\", \\"id\\": \\"" & _id & "\\", \\"location\\": \\"" & _location & "\\" }")
           end repeat
 
-          set _space_index to _space_index + 1
-        end repeat
-      end tell
-    end tell
+          repeat with _space in spaces
+            set _space_title to get title of _space
+            if _space_title is "" then
+              set _space_title to "Space " & _space_index
+            end if
+            set _space_title to my escape_value(_space_title)
 
-    return "{ \\"tabs\\": [\\n" & _tabs & "\\n], \\"spaces\\": " & _spaces & " }"
-  `);
+            repeat with _tab in every tab of _space
+              set _tab_id to get id of _tab
+
+              if not _first then
+                set _spaces to (_spaces & ",")
+              end if
+              set _spaces to (_spaces & "\\"" & _tab_id & "\\": \\"" & _space_title & "\\"")
+              set _first to false
+            end repeat
+
+            set _space_index to _space_index + 1
+          end repeat
+        end tell
+      end tell
+
+      return "{ \\"tabs\\": [\\n" & _tabs & "\\n], \\"spaces\\": " & _spaces & "} }"
+    `);
+  } catch (e) {
+    console.error("getTabsWithSpaceInfo AppleScript failed, falling back to getTabs():", e);
+    return getTabs();
+  }
 
   if (!response) {
-    return undefined;
+    console.error("getTabsWithSpaceInfo received empty response, falling back to getTabs()");
+    return getTabs();
   }
 
   try {
@@ -146,8 +154,8 @@ export async function getTabsWithSpaceInfo(): Promise<Tab[] | undefined> {
       spaceName: parsed.spaces[tab.id],
     }));
   } catch (e) {
-    console.error(e);
-    return undefined;
+    console.error("getTabsWithSpaceInfo failed to parse response, falling back to getTabs():", e);
+    return getTabs();
   }
 }
 

--- a/extensions/arc/src/components/search-tabs-base.tsx
+++ b/extensions/arc/src/components/search-tabs-base.tsx
@@ -76,6 +76,7 @@ export function SearchTabsBase(props: SearchTabsBaseProps) {
       { name: "title", weight: 0.2 },
       { name: "titlePinyin", weight: 0.3 },
       { name: "url", weight: 0.5 },
+      { name: "spaceName", weight: 0.15 },
     ],
     threshold: 0.3, // Adjust this value to control fuzzy matching sensitivity (0.0 = exact match, 1.0 = match anything)
     includeScore: true,

--- a/extensions/arc/src/list.tsx
+++ b/extensions/arc/src/list.tsx
@@ -125,7 +125,8 @@ export function TabListItem(props: { tab: Tab; searchText: string; mutate: Mutat
         value: getDomain(props.tab.url),
         tooltip: props.tab.url,
       }}
-      keywords={[props.tab.url]} // Add this line to include URL in searchable content
+      accessories={props.tab.spaceName ? [{ tag: props.tab.spaceName }] : []}
+      keywords={[props.tab.url, ...(props.tab.spaceName ? [props.tab.spaceName] : [])]}
       actions={
         <ActionPanel>
           <OpenLinkActionSections tabOrUrl={props.tab} searchText={props.searchText} />

--- a/extensions/arc/src/search-tabs.tsx
+++ b/extensions/arc/src/search-tabs.tsx
@@ -1,12 +1,12 @@
 import { LaunchProps } from "@raycast/api";
-import { getTabs } from "./arc";
+import { getTabsWithSpaceInfo } from "./arc";
 import { SearchTabsBase } from "./components/search-tabs-base";
 import { VersionCheck } from "./version";
 
 export default function Command(props: LaunchProps) {
   return (
     <VersionCheck>
-      <SearchTabsBase {...props} getTabsFunction={getTabs} />
+      <SearchTabsBase {...props} getTabsFunction={getTabsWithSpaceInfo} />
     </VersionCheck>
   );
 }

--- a/extensions/arc/src/search.tsx
+++ b/extensions/arc/src/search.tsx
@@ -2,7 +2,7 @@ import { Icon, LaunchProps, List, getPreferenceValues } from "@raycast/api";
 import { MutatePromise, useCachedPromise } from "@raycast/utils";
 import { chain } from "lodash";
 import { useState } from "react";
-import { getTabs } from "./arc";
+import { getTabsWithSpaceInfo } from "./arc";
 import { HistoryEntryListItem, SuggestionListItem, TabListItem } from "./list";
 import { searchArcPreferences } from "./preferences";
 import { useHistorySearch } from "./history";
@@ -21,7 +21,7 @@ import { VersionCheck } from "./version";
 function SearchArc(props: LaunchProps) {
   const [searchText, setSearchText] = useState(props.fallbackText ?? "");
   const { data: history, isLoading: isLoadingHistory, permissionView } = useHistorySearch(searchText, 25);
-  const { data: tabs, isLoading: isLoadingTabs, mutate: mutateTabs } = useCachedPromise(getTabs);
+  const { data: tabs, isLoading: isLoadingTabs, mutate: mutateTabs } = useCachedPromise(getTabsWithSpaceInfo);
   const { data: suggestions, isLoading: isLoadingSuggestions } = useSuggestions(searchText);
 
   if (permissionView) {
@@ -59,7 +59,8 @@ function TabListSections(props: { tabs?: Tab[]; mutateTabs: MutatePromise<Tab[] 
     .filter(
       (tab) =>
         tab.title.toLowerCase().includes(props.searchText.toLowerCase()) ||
-        tab.url.toLowerCase().includes(props.searchText.toLowerCase()),
+        tab.url.toLowerCase().includes(props.searchText.toLowerCase()) ||
+        (tab.spaceName?.toLowerCase().includes(props.searchText.toLowerCase()) ?? false),
     )
     .groupBy((tab) => tab.location)
     .value();

--- a/extensions/arc/src/suggestions.ts
+++ b/extensions/arc/src/suggestions.ts
@@ -18,7 +18,6 @@ const config: SearchConfigs = {
     search: "https://www.google.com/search?q=",
     suggestions: "https://suggestqueries.google.com/complete/search?hl=en-us&output=chrome&q=",
     suggestionParser: (json: GoogleSuggestionParser, suggestions: Suggestion[]) => {
-      console.log(json);
       json[1].map((item: string, i: number) => {
         const type = json[4]["google:suggesttype"][i];
         const description = json[2][i];
@@ -60,7 +59,6 @@ const config: SearchConfigs = {
     search: "https://www.ecosia.org/search?q=",
     suggestions: "https://ac.ecosia.org?type=list&q=",
     suggestionParser: (json: EcosiaSuggestionParser, suggestions: Suggestion[]) => {
-      console.log(json);
       json[1].map((item: string) => {
         suggestions.push({
           id: nanoid(),
@@ -74,7 +72,6 @@ const config: SearchConfigs = {
     search: "https://kagi.com/search?q=",
     suggestions: "https://kagi.com/api/autosuggest?q=",
     suggestionParser: (json: KagiSuggestionParser, suggestions: Suggestion[]) => {
-      console.log(json);
       json[1].map((item: string) => {
         suggestions.push({
           id: nanoid(),

--- a/extensions/arc/src/types.ts
+++ b/extensions/arc/src/types.ts
@@ -11,6 +11,7 @@ export type Tab = {
   url: string;
   title: string;
   location: TabLocation;
+  spaceName?: string;
 };
 
 export type TabLocation = "topApp" | "pinned" | "unpinned";


### PR DESCRIPTION
Fixes #30795

## Description

When using Search Tabs (and Search Arc), tabs with identical names across different Spaces are currently indistinguishable in the results. This change displays each tab's Space name as a tag accessory so users can tell them apart at a glance — e.g. two "Discord" tabs become distinguishable as belonging to "Social" vs "Work".

How
- Added an optional spaceName?: string field to the Tab type.
- Added getTabsWithSpaceInfo() in arc.ts, which fetches all tabs then runs one extra AppleScript that builds a tabId → spaceName map by iterating Spaces. Untitled (default) Spaces fall back to "Space <n>" (same convention as getSpaceTitle). The map reads the same first window as getTabs() so results always match, and title escaping mirrors getTabs().
- TabListItem (list.tsx) renders the space name as a tag accessory and adds it to search keywords.
- spaceName is added to the Fuse.js search keys in Search Tabs, and to the substring filter in Search Arc, so you can search by Space name.
- Graceful degradation: if the Space lookup ever fails, tabs are returned without tags rather than throwing.

## File Changes

| File | Change |
|---|---|
| `extensions/arc/src/types.ts` | Added optional `spaceName?: string` to the `Tab` type |
| `extensions/arc/src/arc.ts` | Added `getTabsWithSpaceInfo()` — fetches tabs and maps each tab to its Space title (`default Space` → `"Space <n>"`), with graceful fallback |
| `extensions/arc/src/components/search-tabs-base.tsx` | Added `spaceName` to Fuse.js fuzzy-search keys |
| `extensions/arc/src/search-tabs.tsx` | Switched to `getTabsWithSpaceInfo` |
| `extensions/arc/src/list.tsx` | `TabListItem` now renders the Space name as a tag accessory and adds it to search keywords |
| `extensions/arc/src/search.tsx` | Switched to `getTabsWithSpaceInfo` and added `spaceName` to the tab filter |
| `extensions/arc/CHANGELOG.md` | Added an `[Improvements]` entry |

## Screencast
<img width="727" height="461" alt="Screenshot 2026-09-05 at 3 29 13 PM" src="https://github.com/user-attachments/assets/f9b651d2-dbd2-452e-83f9-7589b4f82707" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
