### PR TITLE
[LastPass Credentials Search] Keep the master password out of the shell and the logs

### DIFF
--- a/extensions/lastpass/CHANGELOG.md
+++ b/extensions/lastpass/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Fix] - {PR_MERGE_DATE}
 
 - Stop passing the master password on the command line, so it no longer shows up in the process list
-- Stop writing the master password and the decrypted vault contents to the extension log
+- Stop writing the master password and the decrypted vault contents to the extension's console output
 - Pass `lpass` arguments as positional parameters instead of interpolating them into a shell string, fixing failures for passwords containing `` ` ``, `$`, `\`, or both quote characters
 - Drop the fixed `maxBuffer` limit, so arbitrarily large vaults are handled
 

--- a/extensions/lastpass/CHANGELOG.md
+++ b/extensions/lastpass/CHANGELOG.md
@@ -1,5 +1,12 @@
 # LastPass Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Stop passing the master password on the command line, so it no longer shows up in the process list
+- Stop writing the master password and the decrypted vault contents to the extension log
+- Pass `lpass` arguments as positional parameters instead of interpolating them into a shell string, fixing failures for passwords containing `` ` ``, `$`, `\`, or both quote characters
+- Drop the fixed `maxBuffer` limit, so arbitrarily large vaults are handled
+
 ## [Fix] - 2024-08-01
 
 - Increase `maxBuffer` to be able to handle larger output

--- a/extensions/lastpass/CHANGELOG.md
+++ b/extensions/lastpass/CHANGELOG.md
@@ -1,6 +1,6 @@
 # LastPass Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-09-05
 
 - Stop passing the master password on the command line, so it no longer shows up in the process list
 - Stop writing the master password and the decrypted vault contents to the extension's console output

--- a/extensions/lastpass/package.json
+++ b/extensions/lastpass/package.json
@@ -86,5 +86,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/lastpass/src/cli.ts
+++ b/extensions/lastpass/src/cli.ts
@@ -1,4 +1,4 @@
-import { exec, ExecException } from "child_process";
+import { spawn } from "child_process";
 
 export type Account = {
   name: string;
@@ -26,74 +26,86 @@ const serializeFromJson = (jsonArray: string): Account[] => {
   return res;
 };
 
-const execute = async (command: string) => {
-  const PATH = "/usr/gnu/bin:/usr/local/bin:/bin:/usr/bin:.:/opt/homebrew/bin";
-  const wrappedCommand = `zsh -l -c 'export PATH="$PATH:${PATH}" && ${command}'`;
+// Directories `lpass` is commonly installed into, appended to whatever PATH the
+// user's login shell already provides.
+const EXTRA_PATH = "/usr/gnu/bin:/usr/local/bin:/bin:/usr/bin:.:/opt/homebrew/bin";
 
-  console.log(`Executing: ${wrappedCommand}`);
+// `lpass` still runs through a login shell so the user's own PATH applies, but its
+// arguments are handed over as positional parameters instead of being interpolated
+// into the script, so the shell never re-parses them. The master password goes to
+// stdin rather than into the command line, which keeps it out of the process list.
+const execute = async (args: string[], password: string) => {
+  const script = `export PATH="$PATH:${EXTRA_PATH}" && exec lpass "$@"`;
+  const subcommand = args[0];
+
+  console.log(`Executing: lpass ${subcommand}`);
   const startTimestamp = Date.now();
 
-  return new Promise<string>((res, rej) =>
-    exec(
-      wrappedCommand,
-      { maxBuffer: 4 * 1024 * 1024 }, // 4 times bigger stdout buffer size for large sets of credentials
-      (error: ExecException | null, stdout: string, stderr: string) => {
-        const tookSeconds = (Date.now() - startTimestamp) / 1000;
-        if (error) {
-          console.error(`[${tookSeconds}s] Failed:\n${stderr}`);
-          rej({
-            ...error,
-            message: error.message,
-          });
-        }
-        console.log(`[${tookSeconds}s] Success:\n${stdout}`);
-        res(stdout.trim());
-      }
-    )
-  );
-};
+  return new Promise<string>((res, rej) => {
+    const child = spawn("zsh", ["-l", "-c", script, "lpass", ...args], {
+      env: { ...process.env, LPASS_DISABLE_PINENTRY: "1" },
+    });
 
-const authorize = (subcommand: string, opts: { password: string }) => {
-  const { password } = opts;
-  const quote = password?.includes('"') ? "'" : '"';
-  const maskedCommand = `echo ${quote}${password}${quote} | LPASS_DISABLE_PINENTRY=1 lpass ${subcommand}`;
-  return maskedCommand;
+    // Collected by hand rather than through `exec`, so there is no output size cap
+    // to outgrow on large vaults.
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+
+    // `lpass` only reads stdin when it actually has to unlock the vault; otherwise
+    // the pipe is closed underneath us and writing to it raises EPIPE.
+    child.stdin.on("error", () => undefined);
+    child.stdin.end(`${password}\n`);
+
+    const elapsedSeconds = () => (Date.now() - startTimestamp) / 1000;
+
+    child.on("error", (error) => {
+      console.error(`[${elapsedSeconds()}s] Failed to spawn: lpass ${subcommand}`);
+      rej(error);
+    });
+
+    child.on("close", (code) => {
+      if (code !== 0) {
+        console.error(`[${elapsedSeconds()}s] Failed: lpass ${subcommand}\n${stderr}`);
+        rej(new Error(stderr.trim() || `lpass ${subcommand} exited with code ${code}`));
+        return;
+      }
+      // Deliberately logs no output — for most subcommands it is the vault itself.
+      console.log(`[${elapsedSeconds()}s] Success: lpass ${subcommand}`);
+      res(stdout.trim());
+    });
+  });
 };
 
 export const lastPass = (email: string, password: string) => {
   return {
     isLogged: () =>
-      execute(authorize("status", { password }))
+      execute(["status"], password)
         .then((stdout) => stdout.includes(email))
         .catch(() => false),
 
-    login: () => execute(authorize(`login ${email}`, { password })),
+    login: () => execute(["login", email], password),
 
     show: (id: string, opts: { sync: "auto" | "now" | "no" } = { sync: "auto" }): Promise<Account> =>
-      execute(authorize(`show --sync=${opts.sync} --json ${id}`, { password })).then(
-        (stdout) => serializeFromJson(stdout)[0]
-      ),
+      execute(["show", `--sync=${opts.sync}`, "--json", id], password).then((stdout) => serializeFromJson(stdout)[0]),
 
     list: (opts: { sync: "auto" | "now" | "no" } = { sync: "auto" }) =>
-      execute(authorize(`ls --sync=${opts.sync} --format="%ai<=>%an<=>%au<=>%ap<=>%al"`, { password })).then(
-        (stdout) => {
-          const items: { id: string; name: string; username: string; password: string; url: string }[] = stdout
-            .split("\n")
-            .map((line) => {
-              const [id, name, username, password, url] = line.split("<=>");
-              return { id, name, username, password, url };
-            })
-            .filter(({ name }) => name);
-          return items;
-        }
-      ),
+      execute(["ls", `--sync=${opts.sync}`, "--format=%ai<=>%an<=>%au<=>%ap<=>%al"], password).then((stdout) => {
+        const items: { id: string; name: string; username: string; password: string; url: string }[] = stdout
+          .split("\n")
+          .map((line) => {
+            const [id, name, username, password, url] = line.split("<=>");
+            return { id, name, username, password, url };
+          })
+          .filter(({ name }) => name);
+        return items;
+      }),
 
     export: (opts: { sync: "auto" | "now" | "no" } = { sync: "auto" }) =>
-      execute(
-        authorize(`export --sync=${opts.sync} --fields=id,name,username,password,url`, {
-          password,
-        })
-      ).then((stdout) => {
+      execute(["export", `--sync=${opts.sync}`, "--fields=id,name,username,password,url"], password).then((stdout) => {
         const items: { id: string; name: string; username: string; password: string; url: string }[] = stdout
           .split("\n")
           .filter((line) => line.trim() !== "")


### PR DESCRIPTION
## Description

The LastPass extension built every `lpass` invocation as one shell string with the user's **master password interpolated into it**, then handed that string to `child_process.exec`:

```ts
const quote = password?.includes('"') ? "'" : '"';
const maskedCommand = `echo ${quote}${password}${quote} | LPASS_DISABLE_PINENTRY=1 lpass ${subcommand}`;
// ...
const wrappedCommand = `zsh -l -c 'export PATH="$PATH:${PATH}" && ${command}'`;
console.log(`Executing: ${wrappedCommand}`);
```

Three separate problems fall out of that one line. Each is described below with the mechanism and a worked example.

---

### 1. The master password was visible in the process list

`exec` runs the string through a shell, so the fully-expanded command — password and all — becomes the **argv of a real process**. Process arguments are world-readable on macOS, so any other process running as the user (or any user, via `ps -A`) could read the LastPass master password for as long as the command ran. Every keystroke in the extension's search field can trigger a `show`, so that window is hit constantly.

Observed with a fake `lpass` on `PATH` and the password `sw0rdfishZZ-MARKER`, snapshotting `ps -Awwo args=` from inside the CLI:

```
PS=zsh -l -c export PATH="$PATH:/usr/gnu/bin:..." && echo "sw0rdfishZZ-MARKER" | LPASS_DISABLE_PINENTRY=1 lpass ls --sync=auto --format=...
```

After the change, the same snapshot contains no match: the password is written to the child's stdin, never to its argv.

### 2. The master password and the decrypted vault were written to the extension's console output

`console.log("Executing: " + wrappedCommand)` logged the password in cleartext, and `console.log("Success:\n" + stdout)` logged the **entire command output** — which for `ls`, `export` and `show` is the decrypted vault, passwords included.

Run against a real 585-entry vault, the current code emits **574 of the account's actual passwords** to `console`; the new code emits none.

> Scope, stated precisely: I verified that these strings are written to the extension's stdout. I could **not** establish where Raycast routes that output — it did not reach the `ray develop` stdout on my machine (Raycast 1.x, macOS 15), even under a PTY, and I found no file on disk containing it. So please read this as "the master password and the full decrypted vault are written to console output", not as a claim that they are persisted to a log file. Removing them is worth doing either way, and costs nothing.

The existing `mask()` helper in `errorDetails.tsx` only covers the error toast, so it never touched either of these. Harness run, checking what reached `console`:

```
Executing: zsh -l -c 'export PATH="..." && echo "sw0rdfishZZ-MARKER" | LPASS_DISABLE_PINENTRY=1 lpass ls ...'
[0.657s] Success:
id1<=>Example<=>user@example.com<=>hunter2<=>https://example.com
```

Logging now records the subcommand and its duration only. `stderr` is still logged on failure, because it carries no vault data and is what makes the CLI-missing case diagnosable.

### 3. Quoting broke, and let the password execute as code

The quote character was chosen by a single check: use `'` if the password contains `"`, otherwise use `"`. Under double quotes the shell still expands `$`, backticks and `\`, and neither branch handles a password containing *both* quote characters.

Worked examples, all with the current code:

| Master password contains | What happened |
| --- | --- |
| `sw0rdfish` | worked |
| `` a`whoami`b `` | backticks expanded; the wrong string was sent to `lpass`, so login failed with "wrong password" |
| `a$(touch /tmp/PWNED)b` | **the subshell ran** — `/tmp/PWNED` was created |
| `p\`whoami\`$(id)"'\ZZ` | command was unparseable: ``/bin/sh: -c: line 0: unexpected EOF while looking for matching `"' `` |

The injected value is the user's own password, so this is a self-inflicted breakage rather than a path for a third party — but it means a user with a shell metacharacter in their master password gets a permanently broken extension and a misleading "wrong password" error, and in the `$(...)` case gets arbitrary code run on every keystroke.

> [!NOTE]
> **Reviewer callout — behaviour that changes for existing users:** anyone whose master password contains `` ` ``, `$`, `\`, or both `"` and `'` currently sees the extension fail (or silently misbehave). After this change those passwords work. Nothing changes for passwords made of ordinary characters. The `2023-09-06` changelog entry ("Add guard for cases when user password includes special characters") was aimed at this; the guard was incomplete.

---

## The fix

`spawn` instead of `exec`, with the `lpass` arguments passed as **positional parameters** rather than interpolated into the script:

```ts
const script = `export PATH="$PATH:${EXTRA_PATH}" && exec lpass "$@"`;
const child = spawn("zsh", ["-l", "-c", script, "lpass", ...args], {
  env: { ...process.env, LPASS_DISABLE_PINENTRY: "1" },
});
child.stdin.end(`${password}\n`);
```

- The login shell still supplies the user's own `PATH`, so `lpass` is still found the same way — but `"$@"` is not re-parsed, so no argument can be interpreted as shell syntax.
- The password goes over stdin, which is where `LPASS_DISABLE_PINENTRY=1` already made `lpass` look for it. It is the same input the old `echo … |` produced, just without a shell in between.
- `LPASS_DISABLE_PINENTRY` moves from the command string to the child's environment.
- `child.stdin` has an `error` handler because `lpass` only reads stdin when it actually needs to unlock the vault; otherwise the pipe closes underneath us and the write raises `EPIPE`.

Collecting `stdout` by hand also **removes the fixed 4 MB `maxBuffer`** added in #13817, so large vaults are no longer capped at all rather than at a larger number.

| | Before | After |
| --- | --- | --- |
| Password in process argv | yes | no |
| Password in extension log | yes | no |
| Vault contents in extension log | yes | no |
| Password with `` ` `` / `$` / `\` | corrupted or executed | works |
| Password with both `"` and `'` | command unparseable | works |
| Output size limit | 4 MB | none |

## Verification

`npm run lint` and `npm run build` both pass.

Behaviour was checked by putting a fake `lpass` on `PATH` that records its argv, its stdin, and a snapshot of the process table, then driving the compiled `cli.ts` through it — the **unmodified** file first, to confirm the harness actually catches each problem, then the new one:

| Check | old `cli.ts` | new `cli.ts` |
| --- | --- | --- |
| password visible in process table | LEAKED (1 process) | no |
| password arrives intact on stdin | yes | yes |
| password written to console log | LEAKED | no |
| vault contents written to console log | LEAKED | no |
| `$(touch …)` in password executes | **file created** | file not created |
| parsed account list | correct | identical |

`lpass` receives exactly the same arguments as before (`ls`, `--sync=auto`, `--format=%ai<=>%an<=>%au<=>%ap<=>%al`), and with `lpass` absent the rejection message is still `zsh:1: command not found: lpass`, so `ErrorDetails` continues to show the "LastPass CLI is missing!" screen.

### Against a real vault

Also run end-to-end against a real LastPass account with **585 entries**, driving both the old and the new `cli.ts` through the live CLI and comparing the parsed results:

| | old `cli.ts` | new `cli.ts` |
| --- | --- | --- |
| accounts parsed | 585 | 585 |
| entries with a username / password | 568 / 576 | 568 / 576 |
| malformed rows (stray `<=>`) | 0 | 0 |
| real vault passwords reaching `console` | **574** | 0 |
| parsed output | — | **byte-identical to old** |

`show()` on a real entry returns every expected field with valid `lastModified` / `lastTouch` dates. The extension was then loaded into Raycast with `ray develop` and driven through the UI against the same vault — search, detail pane, show/hide password, and the copy actions all behave as before.

Two limits on that, stated plainly:

- The **shell-quoting fix could not be exercised against the live account**, because that account's master password does not contain `` ` ``, `$`, `\`, or both quote characters. That fix rests on the harness evidence above, on synthetic input.
- The 585-entry run exercises the removed `maxBuffer` in the right direction but does not prove an upper bound; there is simply no cap in the new code.

## Screencast

Not included — this is an internal change with no UI surface; the list, detail view and all actions are untouched.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast (against a real 585-entry vault)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
