### PR TITLE
Format Quran ayah ranges as one passage

### DIFF
--- a/extensions/quran-quick-insert/CHANGELOG.md
+++ b/extensions/quran-quick-insert/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Quran Quick Insert Changelog
 
+## [Improved Ayah Range Formatting] - {PR_MERGE_DATE}
+
+- Format copied ayah ranges as one passage with Arabic verse numbers.
+
 ## [Initial Version] - 2026-07-27
 
 - Add local Quran search.

--- a/extensions/quran-quick-insert/CHANGELOG.md
+++ b/extensions/quran-quick-insert/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Quran Quick Insert Changelog
 
-## [Improved Ayah Range Formatting] - {PR_MERGE_DATE}
+## [Improved Ayah Range Formatting] - 2026-09-05
 
 - Format copied ayah ranges as one passage with Arabic verse numbers.
 

--- a/extensions/quran-quick-insert/package-lock.json
+++ b/extensions/quran-quick-insert/package-lock.json
@@ -1153,7 +1153,6 @@
       "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -1220,7 +1219,6 @@
       "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.65.0",
         "@typescript-eslint/types": "8.65.0",
@@ -1425,7 +1423,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1524,9 +1521,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -1720,7 +1717,6 @@
       "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -2394,7 +2390,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2602,7 +2597,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/quran-quick-insert/src/quran-check.ts
+++ b/extensions/quran-quick-insert/src/quran-check.ts
@@ -38,6 +38,18 @@ assert.match(
   /^﴿[\s\S]+﴾\n\n\[البقرة: 255\]$/,
 );
 
+const asr_ayahs = [1, 2, 3].map((ayah_number) =>
+  ayah_at({ surah_number: 103, ayah_number }),
+);
+assert.equal(
+  format_ayahs(
+    asr_ayahs,
+    { text_style: "uthmani", reference_style: "arabic", prefix: "none" },
+    "plain",
+  ),
+  `﴿${asr_ayahs[0].text} (١) ${asr_ayahs[1].text} (٢) ${asr_ayahs[2].text} (٣)﴾ [العصر: 1-3]`,
+);
+
 const sample_ayahs = [ayah_at({ surah_number: 1, ayah_number: 2 })];
 const sample_options = {
   text_style: "imlai",

--- a/extensions/quran-quick-insert/src/quran-check.ts
+++ b/extensions/quran-quick-insert/src/quran-check.ts
@@ -41,13 +41,23 @@ assert.match(
 const asr_ayahs = [1, 2, 3].map((ayah_number) =>
   ayah_at({ surah_number: 103, ayah_number }),
 );
+const asr_options = {
+  text_style: "uthmani",
+  reference_style: "arabic",
+  prefix: "none",
+} as const;
+const asr_text = `﴿${asr_ayahs[0].text} (١) ${asr_ayahs[1].text} (٢) ${asr_ayahs[2].text} (٣)﴾`;
 assert.equal(
-  format_ayahs(
-    asr_ayahs,
-    { text_style: "uthmani", reference_style: "arabic", prefix: "none" },
-    "plain",
-  ),
-  `﴿${asr_ayahs[0].text} (١) ${asr_ayahs[1].text} (٢) ${asr_ayahs[2].text} (٣)﴾ [العصر: 1-3]`,
+  format_ayahs(asr_ayahs, asr_options, "plain"),
+  `${asr_text} [العصر: 1-3]`,
+);
+assert.equal(
+  format_ayahs(asr_ayahs, asr_options, "markdown"),
+  `> ${asr_text}\n\n**[العصر: 1-3]**`,
+);
+assert.equal(
+  format_ayahs(asr_ayahs, asr_options, "html"),
+  `<div dir="rtl"><p>${asr_text}</p><p>[العصر: 1-3]</p></div>`,
 );
 
 const sample_ayahs = [ayah_at({ surah_number: 1, ayah_number: 2 })];

--- a/extensions/quran-quick-insert/src/quran.ts
+++ b/extensions/quran-quick-insert/src/quran.ts
@@ -261,8 +261,14 @@ export function format_ayahs(
   options: OutputOptions,
   format: OutputFormat,
 ) {
-  const text_lines = ayahs.map((ayah) =>
-    wrap_ayah(ayah_text(ayah, options.text_style)),
+  const is_range = ayahs.length > 1;
+  const text = wrap_ayah(
+    ayahs
+      .map(
+        (ayah) =>
+          `${ayah_text(ayah, options.text_style)}${is_range ? ` (${ayah.ayah_number.toLocaleString("ar-u-nu-arab")})` : ""}`,
+      )
+      .join(" "),
   );
   const range = normalize_range(ayahs[0], ayahs[ayahs.length - 1]);
   const reference = format_reference(
@@ -271,19 +277,19 @@ export function format_ayahs(
     options.reference_style,
   );
   const prefix = prefix_text(options.prefix);
-  const plain = [prefix, text_lines.join("\n"), reference]
+  const plain = [
+    prefix,
+    [text, reference].filter(Boolean).join(is_range ? " " : "\n\n"),
+  ]
     .filter(Boolean)
     .join("\n\n");
   if (format === "plain") return plain;
   if (format === "markdown") {
-    const quote = text_lines.map((line) => `> ${line}`).join("\n>\n");
-    return [prefix, quote, reference && `**${reference}**`]
+    return [prefix, `> ${text}`, reference && `**${reference}**`]
       .filter(Boolean)
       .join("\n\n");
   }
-  return `<div dir="rtl">${prefix ? `<p>${escape_html(prefix)}</p>` : ""}${text_lines
-    .map((line) => `<p>${escape_html(line)}</p>`)
-    .join("")}${reference ? `<p>${escape_html(reference)}</p>` : ""}</div>`;
+  return `<div dir="rtl">${prefix ? `<p>${escape_html(prefix)}</p>` : ""}<p>${escape_html(text)}</p>${reference ? `<p>${escape_html(reference)}</p>` : ""}</div>`;
 }
 
 export function ayah_title(ayah: Ayah, style: OutputOptions["text_style"]) {


### PR DESCRIPTION
## Description

- Format multi-ayah ranges as one continuous Quran passage.
- Add Arabic-Indic ayah numbers using the explicit `arab` numbering system.
- Keep the range reference inline in plain-text output.
- Preserve the grouped passage in Markdown and HTML output.

## Validation

- `npm run check`
- `npm run lint`
- `npm run build`

## Screencast

Not applicable; this is an output-formatting fix covered by a regression check.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used by the `README` are placed outside of the `metadata` folder