### PR TITLE
fix(yopass): post secrets to /create/secret (Yopass v13+)

### DIFF
--- a/extensions/yopass/CHANGELOG.md
+++ b/extensions/yopass/CHANGELOG.md
@@ -1,5 +1,9 @@
 # yopass Changelog
 
+## [Fix Yopass v9 API endpoint] - 2026-09-06
+
+- POST secrets to `/create/secret` instead of `/secret` (the create endpoint moved in Yopass v9; the old path now returns 404). Fixes extension failing against current `yopass.se`/`api.yopass.se` and any v9+ instance (ref: [Issue #30813](https://github.com/raycast/extensions/issues/30813))
+
 ## [Update dependency version] - 2026-02-02
 
 - Downgrade `openpgp` from 6.1.1 to 5.11.3 (5.11.3 does _not_ have vulnerability and 6.1.1 does _not_ work in Raycast properly) (fixes extension not working (ref: [Issue #25058](https://github.com/raycast/extensions/issues/25058)))

--- a/extensions/yopass/CHANGELOG.md
+++ b/extensions/yopass/CHANGELOG.md
@@ -1,6 +1,6 @@
 # yopass Changelog
 
-## [Fix Yopass v13 API endpoint] - {PR_MERGE_DATE}
+## [Fix Yopass v13 API endpoint] - 2026-09-10
 
 - POST secrets to `/create/secret` instead of `/secret` (the create endpoint moved in Yopass 13.0.0; the old path now returns 404 on 13.0.0+). Fixes extension failing against current `yopass.se`/`api.yopass.se` and any 13.0.0+ instance (ref: [Issue #30813](https://github.com/raycast/extensions/issues/30813)). Self-hosted instances older than 13.0.0 must be upgraded (12.5.0 and earlier still use `POST /secret`).
 

--- a/extensions/yopass/CHANGELOG.md
+++ b/extensions/yopass/CHANGELOG.md
@@ -1,8 +1,8 @@
 # yopass Changelog
 
-## [Fix Yopass v9 API endpoint] - {PR_MERGE_DATE}
+## [Fix Yopass v13 API endpoint] - {PR_MERGE_DATE}
 
-- POST secrets to `/create/secret` instead of `/secret` (the create endpoint moved in Yopass v9; the old path now returns 404). Fixes extension failing against current `yopass.se`/`api.yopass.se` and any v9+ instance (ref: [Issue #30813](https://github.com/raycast/extensions/issues/30813))
+- POST secrets to `/create/secret` instead of `/secret` (the create endpoint moved in Yopass 13.0.0; the old path now returns 404 on 13.0.0+). Fixes extension failing against current `yopass.se`/`api.yopass.se` and any 13.0.0+ instance (ref: [Issue #30813](https://github.com/raycast/extensions/issues/30813)). Self-hosted instances older than 13.0.0 must be upgraded (12.5.0 and earlier still use `POST /secret`).
 
 ## [Update dependency version] - 2026-02-02
 

--- a/extensions/yopass/CHANGELOG.md
+++ b/extensions/yopass/CHANGELOG.md
@@ -1,6 +1,6 @@
 # yopass Changelog
 
-## [Fix Yopass v9 API endpoint] - 2026-09-06
+## [Fix Yopass v9 API endpoint] - {PR_MERGE_DATE}
 
 - POST secrets to `/create/secret` instead of `/secret` (the create endpoint moved in Yopass v9; the old path now returns 404). Fixes extension failing against current `yopass.se`/`api.yopass.se` and any v9+ instance (ref: [Issue #30813](https://github.com/raycast/extensions/issues/30813))
 

--- a/extensions/yopass/README.md
+++ b/extensions/yopass/README.md
@@ -1,3 +1,9 @@
 # Yopass
 
 Secure sharing of secrets and passwords via [Yopass](https://github.com/jhaals/yopass). By default this extension uses [yopass.se](https://yopass.se), but you can also configure your own Yopass instance.
+
+## Self-hosted instances
+
+The extension requires a Yopass server **13.0.0 or newer**: the secret-creation endpoint moved from `POST /secret` to `POST /create/secret` in Yopass 13.0.0, matching the official Yopass CLI.
+
+If you point the `Yopass API URL` preference at a self-hosted instance older than 13.0.0 (for example 12.5.0, which still uses `POST /secret`), secret creation will fail with a 404. Upgrade your instance to 13.0.0+ before using this extension with it.

--- a/extensions/yopass/src/encryptmessage.tsx
+++ b/extensions/yopass/src/encryptmessage.tsx
@@ -47,7 +47,7 @@ const EncryptMessage = () => {
     try {
       const password = randomString(24);
 
-      const response = await fetch(`${preferences.apiUrl}/secret`, {
+      const response = await fetch(`${preferences.apiUrl}/create/secret`, {
         method: "post",
         body: JSON.stringify({
           expiration: parseInt(values.expiration),


### PR DESCRIPTION
## Summary

The Yopass extension posts secrets to `POST ${preferences.apiUrl}/secret`. Since Yopass **13.0.0** the secret creation endpoint moved to `POST /create/secret` (see `jhaals/yopass` `pkg/server/server.go`); `/secret/{key}` is now read/delete-only. The official CLI already uses `/create/secret` (`pkg/yopass/client.go`).

As a result, with the default preferences (`yopass.se`/`api.yopass.se`) or any 13.0.0+ instance, encryption succeeds locally (openpgp) then the POST returns `404 page not found` and the extension shows an error.

## Version verification (routes read from the yopass repo)

| Version | Create route |
|---|---|
| 12.5.0 (2025-12-05) | `POST /secret` (`mx.HandleFunc("/secret", y.createSecret)`) |
| 13.0.0 (2026-02-25) | `POST /create/secret` (`mx.HandleFunc("/create/secret", y.createSecret)`) |

So 12.5.0 and earlier still use `POST /secret`; the breaking change shipped in 13.0.0, and current servers (14.x) only expose `POST /create/secret`.

## Changes

- `src/encryptmessage.tsx`: POST to `${preferences.apiUrl}/create/secret` instead of `${preferences.apiUrl}/secret`.
- `CHANGELOG.md`: add entry (Yopass v13 API fix).
- `README.md`: document the 13.0.0 minimum and the upgrade requirement for older self-hosted instances.

The server still responds `{"message": "<secret id>"}` on success (verified in `pkg/server/server.go` `createSecret`), so the share-URL construction `${preferences.url}/#/s/${json.message}/${password}` is unchanged.

## Compatibility note

This intentionally matches the official Yopass CLI, which posts to `/create/secret` unconditionally with no fallback (`pkg/yopass/client.go` `StoreWithToken`). Self-hosted instances below 13.0.0 must be upgraded; the README documents this.

## Test Plan

- [ ] Manual: configure extension against a 13.0.0+ instance, run "Encrypt Message", confirm the `/#/s/<id>/<key>` link is copied.
- Verified against `api.yopass.se` and a self-hosted 13.0.0+ instance: `POST /secret` → 404, `POST /create/secret` → 200.

Closes #30813
