### PR TITLE
Update how long to beat extension

### DIFF
--- a/extensions/how-long-to-beat/CHANGELOG.md
+++ b/extensions/how-long-to-beat/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Howlongtobeat Changelog
 
+## [Fixes] - {PR_MERGE_DATE}
+
+- Fix: update to new API endpoint
+
 ## [Fixes] - 2026-05-04
 
 - Fix: update to new API endpoint

--- a/extensions/how-long-to-beat/CHANGELOG.md
+++ b/extensions/how-long-to-beat/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Howlongtobeat Changelog
 
-## [Fixes] - {PR_MERGE_DATE}
+## [Fixes] - 2026-09-06
 
 - Fix: update to new API endpoint
 

--- a/extensions/how-long-to-beat/src/constants.ts
+++ b/extensions/how-long-to-beat/src/constants.ts
@@ -1,7 +1,7 @@
 export const HLTB_BASE_URL = "https://howlongtobeat.com/";
 export const HLTB_DETAIL_URL = `${HLTB_BASE_URL}game/`;
 export const HLTB_IMAGE_URL = `${HLTB_BASE_URL}games/`;
-export const HLTB_API_SEARCH_ENDPOINT = "/api/bleed/";
-export const HLTB_API_SEARCH_INIT_ENDPOINT = "/api/bleed/init";
+export const HLTB_API_SEARCH_ENDPOINT = "/api/search/site/";
+export const HLTB_API_SEARCH_INIT_ENDPOINT = "/api/search/site/init";
 
 export const TOKEN_CACHE_DURATION_MS = 5 * 60 * 1000;


### PR DESCRIPTION
Fixes #30815

## Description

HowLongToBeat renamed its search API again, from `/api/bleed` to `/api/search/site`. The extension still calls `/api/bleed/init`, which now returns 404, so every search fails before it starts:

```
Error: Failed to get auth token: Not Found
    at Ou.getAuthToken (index.js:158:4167)
```

This updates the two endpoint constants. The request payload, headers and token handling are unchanged, and the game detail page is unaffected since it scrapes HTML rather than using the API.

Verified against the live site: `/api/search/site/init` returns a token, and posting the extension's existing search payload to `/api/search/site/` returns 200 with 78 results for "zelda". `ray lint` and `ray build` both pass.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` (I verified the endpoints directly against the live API rather than in the Raycast client)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder