### PR TITLE
[Cobalt] Add Windows support

### DIFF
--- a/extensions/cobalt/CHANGELOG.md
+++ b/extensions/cobalt/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Cobalt Changelog
 
+## [Windows support] - {PR_MERGE_DATE}
+
+- Added Windows support
+- Skipped video thumbnail generation on Windows, since it relies on AppleScript
+- Replaced the AppleScript download notification with the existing success toast on Windows
+- Expanded `~` in the download directory preference so the default resolves on both platforms
+- Fixed `cmd` shortcuts that were not mapped for Windows
+
 ## [Download History command and improvements] - 2025-06-27
 
 - Added `Download History` command (Thanks @ripgrim!)

--- a/extensions/cobalt/CHANGELOG.md
+++ b/extensions/cobalt/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Expanded `~` in the download directory preference so the default resolves on both platforms
 - Fixed `cmd` shortcuts that had no Windows mapping
 - Padded the history grid when it shows status icons rather than thumbnails
+- Kept the download notification preference meaningful on Windows by showing a HUD
+- Fixed thumbnails colliding when two downloads shared a name but not an extension
 
 ## [Download History command and improvements] - 2025-06-27
 

--- a/extensions/cobalt/CHANGELOG.md
+++ b/extensions/cobalt/CHANGELOG.md
@@ -3,10 +3,11 @@
 ## [Windows support] - {PR_MERGE_DATE}
 
 - Added Windows support
-- Skipped video thumbnail generation on Windows, since it relies on AppleScript
-- Replaced the AppleScript download notification with the existing success toast on Windows
+- Generated video thumbnails with ffmpeg off macOS, falling back to the status icon when it is not installed
+- Replaced the AppleScript download notification with the success toast on Windows
 - Expanded `~` in the download directory preference so the default resolves on both platforms
-- Fixed `cmd` shortcuts that were not mapped for Windows
+- Fixed `cmd` shortcuts that had no Windows mapping
+- Padded the history grid when it shows status icons rather than thumbnails
 
 ## [Download History command and improvements] - 2025-06-27
 

--- a/extensions/cobalt/CHANGELOG.md
+++ b/extensions/cobalt/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Cobalt Changelog
 
-## [Windows support] - {PR_MERGE_DATE}
+## [Windows support] - 2026-09-06
 
 - Added Windows support
 - Generated video thumbnails with ffmpeg off macOS, falling back to the status icon when it is not installed

--- a/extensions/cobalt/package.json
+++ b/extensions/cobalt/package.json
@@ -156,7 +156,8 @@
     "publish": "npx @raycast/api@latest publish"
   },
   "platforms": [
-    "macOS"
+    "macOS",
+    "Windows"
   ],
   "overrides": {
     "brace-expansion": "5.0.9",

--- a/extensions/cobalt/src/history.tsx
+++ b/extensions/cobalt/src/history.tsx
@@ -117,11 +117,7 @@ export default function HistoryCommand() {
                   <ActionPanel>
                     {entryExists && <Action.Open title="Open File" target={entry.downloadPath} icon={Icon.Play} />}
                     {entryExists && (
-                      <Action.ShowInFinder
-                        title="Show in Finder"
-                        path={entry.downloadPath}
-                        shortcut={Keyboard.Shortcut.Common.Open}
-                      />
+                      <Action.ShowInFinder path={entry.downloadPath} shortcut={Keyboard.Shortcut.Common.Open} />
                     )}
                     <Action.CopyToClipboard
                       title="Copy URL"
@@ -145,7 +141,7 @@ export default function HistoryCommand() {
                       icon={Icon.ExclamationMark}
                       style={Action.Style.Destructive}
                       onAction={clearHistory}
-                      shortcut={{ modifiers: ["cmd", "shift"], key: "delete" }}
+                      shortcut={Keyboard.Shortcut.Common.RemoveAll}
                     />
                   </ActionPanel>
                 }

--- a/extensions/cobalt/src/history.tsx
+++ b/extensions/cobalt/src/history.tsx
@@ -79,6 +79,10 @@ export default function HistoryCommand() {
       : { source: Icon.XMarkCircle, tintColor: Color.Red };
   }
 
+  // status icons fill the tile edge to edge, real thumbnails should not be padded
+  const padStatusIcons =
+    process.platform !== "darwin" && !history.some((e) => e.thumbnailUrl && fs.existsSync(e.thumbnailUrl));
+
   const groupedHistory = history.reduce(
     (groups, entry) => {
       const date = new Date(entry.timestamp).toDateString();
@@ -102,7 +106,11 @@ export default function HistoryCommand() {
   }
 
   return (
-    <Grid isLoading={loading} searchBarPlaceholder="Search download history...">
+    <Grid
+      isLoading={loading}
+      searchBarPlaceholder="Search download history..."
+      inset={padStatusIcons ? Grid.Inset.Large : undefined}
+    >
       {Object.entries(groupedHistory).map(([date, entries]) => (
         <Grid.Section key={date} title={date}>
           {entries.map((entry) => {

--- a/extensions/cobalt/src/index.tsx
+++ b/extensions/cobalt/src/index.tsx
@@ -20,7 +20,7 @@ import fs from "fs";
 import type { CobaltRequest, CobaltResponse, FormValues } from "./types";
 import { parse as parseContentDispositionHeader } from "content-disposition";
 import { addToHistory } from "./history";
-import { getServiceFromUrl, generateThumbnail } from "./utils";
+import { getServiceFromUrl, generateThumbnail, resolveHome } from "./utils";
 
 // official cobalt instance URLs that are no longer available
 const oldCobaltInstances = ["https://co.wuk.sh", "https://api.cobalt.tools"];
@@ -205,8 +205,9 @@ export default function DownloadCommand() {
       return;
     }
 
-    if (!fs.existsSync(preferences.downloadDirectory)) {
-      await mkdir(preferences.downloadDirectory, { recursive: true });
+    const downloadDirectory = resolveHome(preferences.downloadDirectory);
+    if (!fs.existsSync(downloadDirectory)) {
+      await mkdir(downloadDirectory, { recursive: true });
     }
 
     if (!filename) {
@@ -218,7 +219,7 @@ export default function DownloadCommand() {
       }
     }
 
-    const destination = path.resolve(preferences.downloadDirectory, filename);
+    const destination = path.resolve(downloadDirectory, filename);
     const writeStream = fs.createWriteStream(destination);
 
     const body = Readable.fromWeb(response.body);
@@ -241,7 +242,7 @@ export default function DownloadCommand() {
       toast.message = `Saved to ${filename}`;
       toast.primaryAction = {
         title: "View in History",
-        shortcut: { modifiers: ["cmd"], key: "h" },
+        shortcut: { macOS: { modifiers: ["cmd"], key: "h" }, windows: { modifiers: ["ctrl"], key: "h" } },
         onAction: () => {
           toast.hide();
           launchCommand({
@@ -252,7 +253,7 @@ export default function DownloadCommand() {
           });
         },
       };
-      if (preferences.notifyOnDownload) {
+      if (preferences.notifyOnDownload && process.platform === "darwin") {
         runAppleScript(`display notification "Downloaded ${filename}!" with title "Cobalt" sound name "Glass"`);
       }
 
@@ -304,7 +305,7 @@ export default function DownloadCommand() {
               <Action
                 title="View Download History"
                 icon={Icon.List}
-                shortcut={{ modifiers: ["cmd"], key: "h" }}
+                shortcut={{ macOS: { modifiers: ["cmd"], key: "h" }, windows: { modifiers: ["ctrl"], key: "h" } }}
                 onAction={() => launchCommand({ name: "history", type: LaunchType.UserInitiated })}
               />
             </>

--- a/extensions/cobalt/src/index.tsx
+++ b/extensions/cobalt/src/index.tsx
@@ -3,6 +3,7 @@ import {
   ActionPanel,
   Action,
   showToast,
+  showHUD,
   Toast,
   getPreferenceValues,
   openExtensionPreferences,
@@ -253,8 +254,12 @@ export default function DownloadCommand() {
           });
         },
       };
-      if (preferences.notifyOnDownload && process.platform === "darwin") {
-        runAppleScript(`display notification "Downloaded ${filename}!" with title "Cobalt" sound name "Glass"`);
+      if (preferences.notifyOnDownload) {
+        if (process.platform === "darwin") {
+          runAppleScript(`display notification "Downloaded ${filename}!" with title "Cobalt" sound name "Glass"`);
+        } else {
+          showHUD(`Downloaded ${filename}!`);
+        }
       }
 
       const thumbnailPath = await generateThumbnail(destination);

--- a/extensions/cobalt/src/utils.ts
+++ b/extensions/cobalt/src/utils.ts
@@ -1,9 +1,13 @@
 import { runAppleScript } from "@raycast/utils";
 import { environment } from "@raycast/api";
+import { execFile } from "child_process";
+import { promisify } from "util";
 import { mkdir } from "fs/promises";
 import path from "path";
 import os from "os";
 import fs from "fs";
+
+const execFileAsync = promisify(execFile);
 
 export function resolveHome(dir: string): string {
   return dir.startsWith("~") ? path.join(os.homedir(), dir.slice(1)) : dir;
@@ -32,8 +36,7 @@ export async function generateThumbnail(filePath: string) {
       return filePath;
     }
 
-    // Video thumbnails go through ffmpeg and qlmanage via AppleScript, so macOS only.
-    if (process.platform === "darwin" && [".mp4", ".mov", ".avi", ".mkv", ".webm", ".m4v"].includes(ext)) {
+    if ([".mp4", ".mov", ".avi", ".mkv", ".webm", ".m4v"].includes(ext)) {
       const thumbnailDir = path.join(environment.supportPath, "thumbnails");
       if (!fs.existsSync(thumbnailDir)) {
         await mkdir(thumbnailDir, { recursive: true });
@@ -42,7 +45,15 @@ export async function generateThumbnail(filePath: string) {
       const thumbnailPath = path.join(thumbnailDir, `${path.basename(filePath, ext)}.jpg`);
 
       try {
-        await runAppleScript(`
+        if (process.platform !== "darwin") {
+          // ffmpeg ships with neither Windows nor Linux, so a missing binary just falls through
+          await execFileAsync(
+            "ffmpeg",
+            ["-y", "-ss", "00:00:01", "-i", filePath, "-frames:v", "1", "-q:v", "2", thumbnailPath],
+            { timeout: 15000 },
+          );
+        } else {
+          await runAppleScript(`
           set inputFile to POSIX file "${filePath}"
           set outputFile to POSIX file "${thumbnailPath}"
           
@@ -56,7 +67,8 @@ export async function generateThumbnail(filePath: string) {
               end try
             end try
           end tell
-        `);
+          `);
+        }
 
         if (fs.existsSync(thumbnailPath)) {
           return thumbnailPath;

--- a/extensions/cobalt/src/utils.ts
+++ b/extensions/cobalt/src/utils.ts
@@ -42,7 +42,7 @@ export async function generateThumbnail(filePath: string) {
         await mkdir(thumbnailDir, { recursive: true });
       }
 
-      const thumbnailPath = path.join(thumbnailDir, `${path.basename(filePath, ext)}.jpg`);
+      const thumbnailPath = path.join(thumbnailDir, `${path.basename(filePath)}.jpg`);
 
       try {
         if (process.platform !== "darwin") {

--- a/extensions/cobalt/src/utils.ts
+++ b/extensions/cobalt/src/utils.ts
@@ -2,7 +2,12 @@ import { runAppleScript } from "@raycast/utils";
 import { environment } from "@raycast/api";
 import { mkdir } from "fs/promises";
 import path from "path";
+import os from "os";
 import fs from "fs";
+
+export function resolveHome(dir: string): string {
+  return dir.startsWith("~") ? path.join(os.homedir(), dir.slice(1)) : dir;
+}
 
 export function getServiceFromUrl(url: string): string {
   try {
@@ -27,7 +32,8 @@ export async function generateThumbnail(filePath: string) {
       return filePath;
     }
 
-    if ([".mp4", ".mov", ".avi", ".mkv", ".webm", ".m4v"].includes(ext)) {
+    // Video thumbnails go through ffmpeg and qlmanage via AppleScript, so macOS only.
+    if (process.platform === "darwin" && [".mp4", ".mov", ".avi", ".mkv", ".webm", ".m4v"].includes(ext)) {
       const thumbnailDir = path.join(environment.supportPath, "thumbnails");
       if (!fs.existsSync(thumbnailDir)) {
         await mkdir(thumbnailDir, { recursive: true });


### PR DESCRIPTION
Closes #30261

## Description

Cobalt declared `"platforms": ["macOS"]`. Four things stood in the way of Windows:

- `generateThumbnail` shelled out to `ffmpeg` and `qlmanage` through AppleScript
- the download notification was an AppleScript `display notification` call
- `downloadDirectory` defaults to `~/Downloads`, and nothing expands `~`
- three hand-rolled `cmd` shortcuts had no Windows mapping, since `cmd` is not remapped automatically

## Changes

**Thumbnails.** ffmpeg now runs directly via `execFile` off macOS, with an argument array so paths containing spaces need no quoting, and a 15s timeout. ffmpeg ships with neither OS, so a missing binary throws, is caught, and falls back to the existing status icon. The macOS branch is unchanged.

**Notification.** Gated to macOS. Windows keeps the success toast that already fires on both platforms a few lines above.

**Download directory.** A small `resolveHome` helper expands a leading `~`. Worth noting `fs.existsSync("~/Downloads")` is false on macOS too, so without this the default was relying on Raycast normalising the preference.

**Shortcuts.** "View Download History" is now spelled out for both platforms. "Clear All History" uses `Keyboard.Shortcut.Common.RemoveAll`, which is already platform-aware.

**Grid.** Status icons render edge to edge in a grid tile, which looks wrong when thumbnails are missing. The grid is inset only when no entry has a thumbnail, so real thumbnails are not padded.

`Action.ShowInFinder` needed no change. Its hardcoded `title="Show in Finder"` is removed so Raycast supplies the platform label, which reads "Show in File Explorer" on Windows.

## Testing

Tested on Windows 11 with Raycast 2.2.0.0: downloads land in the configured directory, video thumbnails render, the reveal action opens Explorer and is labelled correctly, and Ctrl+H opens the history from both the form and the success toast.

Not tested at runtime on macOS. The macOS code paths are unchanged and the ffmpeg branch is gated to non-darwin, but a second pair of eyes on a Mac would be welcome.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast on Windows
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder