### PR TITLE
[Random Data Generator] Fix quicklinks and locale switching

### DIFF
--- a/extensions/random-data-generator/CHANGELOG.md
+++ b/extensions/random-data-generator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Random Data Generator Changelog
 
-## [Fix Quicklinks and Locale Switching] - {PR_MERGE_DATE}
+## [Fix Quicklinks and Locale Switching] - 2026-09-06
 
 - Fixed quicklinks failing with a missing arguments error, by passing the quicklink data as launch context
 - Fixed the locale dropdown reverting to English instead of keeping the selection

--- a/extensions/random-data-generator/CHANGELOG.md
+++ b/extensions/random-data-generator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Random Data Generator Changelog
 
+## [Fix Quicklinks and Locale Switching] - {PR_MERGE_DATE}
+
+- Fixed quicklinks failing with a missing arguments error, by passing the quicklink data as launch context
+- Fixed the locale dropdown reverting to English instead of keeping the selection
+- Regenerated the listed values when the locale changes, so the command no longer needs relaunching
+
+Quicklinks saved before this update need to be recreated.
+
 ## [Fix] - 2026-01-13
 
 - Added shortcuts to the Windows version

--- a/extensions/random-data-generator/src/components/FakerListItem.tsx
+++ b/extensions/random-data-generator/src/components/FakerListItem.tsx
@@ -79,7 +79,7 @@ export default function FakerListItem({ item, pin, unpin }: FakerListItemProps) 
             title="Create Copy Quicklink"
             quicklink={{
               name: `Copy Random ${_.startCase(item.id)}`,
-              link: `${process.env.RAYCAST_SCHEME ?? "raycast"}://extensions/loris/random/open-quicklink?arguments=${encodeURIComponent(
+              link: `${process.env.RAYCAST_SCHEME ?? "raycast"}://extensions/loris/random/open-quicklink?launchContext=${encodeURIComponent(
                 JSON.stringify({ section: item.section, id: item.id, locale: fakerClient.locale, mode: "copy" }),
               )}`,
             }}
@@ -88,7 +88,7 @@ export default function FakerListItem({ item, pin, unpin }: FakerListItemProps) 
             title="Create Paste Quicklink"
             quicklink={{
               name: `Paste Random ${_.startCase(item.id)}`,
-              link: `${process.env.RAYCAST_SCHEME ?? "raycast"}://extensions/loris/random/open-quicklink?arguments=${encodeURIComponent(
+              link: `${process.env.RAYCAST_SCHEME ?? "raycast"}://extensions/loris/random/open-quicklink?launchContext=${encodeURIComponent(
                 JSON.stringify({ section: item.section, id: item.id, locale: fakerClient.locale, mode: "paste" }),
               )}`,
             }}

--- a/extensions/random-data-generator/src/components/Locales.tsx
+++ b/extensions/random-data-generator/src/components/Locales.tsx
@@ -1,22 +1,15 @@
-import { List, LocalStorage } from "@raycast/api";
+import { List } from "@raycast/api";
 
 import fakerClient from "@/faker";
 
 export interface LocalesProps {
-  onChange: () => void;
+  value: string;
+  onChange: (locale: string) => void;
 }
 
-export default function Locales({ onChange }: LocalesProps) {
+export default function Locales({ value, onChange }: LocalesProps) {
   return (
-    <List.Dropdown
-      tooltip="Change Language"
-      value={fakerClient.locale}
-      onChange={(newLocale) => {
-        fakerClient.setLocale(newLocale);
-        LocalStorage.setItem("locale", newLocale);
-        onChange();
-      }}
-    >
+    <List.Dropdown tooltip="Change Language" value={value} onChange={onChange}>
       {Object.entries(fakerClient.locales).map(([localeKey, locale]) => {
         if (!locale) return null;
 

--- a/extensions/random-data-generator/src/index.tsx
+++ b/extensions/random-data-generator/src/index.tsx
@@ -12,21 +12,24 @@ import { buildItems } from "@/utils";
 type LocalStorageValues = { pinnedItemIds: string };
 
 export default function FakerList() {
+  const [locale, setLocale] = useState(fakerClient.locale);
   const [items, setItems] = useState<Item[]>([]);
   const [groupedItems, setGroupedItems] = useState<Record<string, Item[]>>({});
   const [pinnedItems, setPinnedItems] = useState<Item[]>([]);
 
-  // Simple locale change - no regeneration, no loops
-  const handleLocaleChange = useCallback(() => {
-    // Just update locale, user needs to manually refresh
+  const handleLocaleChange = useCallback((nextLocale: string) => {
+    fakerClient.setLocale(nextLocale);
+    LocalStorage.setItem("locale", nextLocale);
+    setLocale(nextLocale);
+    setItems(buildItems("", fakerClient.faker));
   }, []);
 
   useEffect(() => {
     const init = async () => {
-      const locale = ((await LocalStorage.getItem("locale")) as string) || "en";
-      fakerClient.setLocale(locale);
-      const newItems = buildItems("", fakerClient.faker);
-      setItems(newItems);
+      const storedLocale = ((await LocalStorage.getItem("locale")) as string) || "en";
+      fakerClient.setLocale(storedLocale);
+      setLocale(storedLocale);
+      setItems(buildItems("", fakerClient.faker));
     };
     init();
   }, []);
@@ -62,18 +65,18 @@ export default function FakerList() {
   };
 
   return (
-    <List isShowingDetail searchBarAccessory={<Locales onChange={handleLocaleChange} />}>
+    <List isShowingDetail searchBarAccessory={<Locales value={locale} onChange={handleLocaleChange} />}>
       {pinnedItems.length > 0 && (
         <List.Section key="pinned" title="Pinned">
           {_.map(pinnedItems, (item) => (
-            <FakerListItem key={item.id} item={item} unpin={unpin} />
+            <FakerListItem key={`${locale}:${item.id}`} item={item} unpin={unpin} />
           ))}
         </List.Section>
       )}
       {_.map(groupedItems, (items, section) => (
         <List.Section key={section} title={_.startCase(section)}>
           {_.map(items, (item) => (
-            <FakerListItem key={item.id} item={item} pin={pin} />
+            <FakerListItem key={`${locale}:${item.id}`} item={item} pin={pin} />
           ))}
         </List.Section>
       ))}

--- a/extensions/random-data-generator/src/open-quicklink.ts
+++ b/extensions/random-data-generator/src/open-quicklink.ts
@@ -4,15 +4,16 @@ import { Clipboard, Toast, showHUD, showToast } from "@raycast/api";
 
 import fakerClient from "@/faker";
 
-export default async function openQuicklink(options: {
-  arguments: { id?: string; section?: string; mode?: "copy" | "paste"; locale?: string };
-}) {
-  const { id, section, mode, locale } = options.arguments;
+type QuicklinkContext = { id?: string; section?: string; mode?: "copy" | "paste"; locale?: string };
+
+export default async function openQuicklink(options: { launchContext?: QuicklinkContext }) {
+  const { id, section, mode, locale } = options.launchContext ?? {};
 
   if (!id || !section || !mode || !locale) {
     showToast({
-      title: "Missing Arguments",
-      message: "This command is not meant to be run directly. Instead, create a quicklink from the generate command.",
+      title: "Missing Quicklink Data",
+      message:
+        "This command is not meant to be run directly. Create a quicklink from the generate command, and recreate any quicklink saved before this update.",
       style: Toast.Style.Failure,
     });
     return;


### PR DESCRIPTION
Closes #29991

## Description

Quicklinks created by this extension always fail with a missing arguments error.

The link is built as `?arguments=<json>` and the command reads `options.arguments`, but Raycast only populates `LaunchProps.arguments` for arguments the command declares in its manifest, and `open-quicklink` declares none. So nothing arrives and the guard fires every time.

Declaring them is not an option either: a Raycast command is capped at 3 arguments and the quicklink carries 4 (`section`, `id`, `locale`, `mode`). Both sides now use `launchContext`, which is the mechanism intended for this and has no such limit.

## A second bug found while testing

Verifying the locale survived the round trip surfaced a separate problem. `Locales` was a controlled `List.Dropdown` whose `value` came from a plain property on the faker singleton rather than React state, and its change handler in `index.tsx` was an empty callback:

```js
const handleLocaleChange = useCallback(() => {
  // Just update locale, user needs to manually refresh
}, []);
```

Picking a locale updated the singleton and `LocalStorage`, but nothing re-rendered, so the dropdown redrew from the stale `value` and snapped back to English. Every quicklink therefore encoded `locale: "en"` no matter what was selected.

Locale is now React state, and the list items are keyed by it so their values regenerate on change. That also removes the manual relaunch the 2025-10-23 changelog entry had to warn about.

## Compatibility

Quicklinks saved in the old `?arguments=` format cannot be recovered, since nothing ever populated those arguments. The failure toast now says to recreate them, and the changelog notes it.

## Testing

Tested on Windows 11 with Raycast 2.2.0.0:

- Created a copy quicklink for `iban` and ran it. Copies a value instead of erroring.
- Set the locale to Swiss German. The dropdown holds the selection and the listed values regenerate immediately.
- Created a quicklink for `city` under that locale and ran it, which returned `Oftringen`, so the locale survives the round trip.
- Ran `Open Quicklink` directly from the root search and got the guard toast telling me to create a quicklink from the generate command.

Not tested at runtime on macOS. Nothing in the change is platform specific.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast on Windows
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder