### PR TITLE
[Obsidian] Name the core plugin each command actually requires

### DIFF
--- a/extensions/obsidian/CHANGELOG.md
+++ b/extensions/obsidian/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Obsidian Changelog
 
+## [Fix Misleading Required Plugin Message] - {PR_MERGE_DATE}
+
+- Name the core plugin a command actually needs instead of always naming Daily Notes, so Open Workspace now asks for Workspaces
+- Drop the core plugin sentence from the Append Task message, which only needs Advanced URI
+- Retitle the screen to "Required plugins missing", since Advanced URI is often already installed
+
 ## [Fix Open Note on Creation] - 2026-08-27
 
 - Open the created note in Obsidian before the command window closes, so the "Open on creation" preference works reliably

--- a/extensions/obsidian/CHANGELOG.md
+++ b/extensions/obsidian/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Obsidian Changelog
 
-## [Fix Misleading Required Plugin Message] - {PR_MERGE_DATE}
+## [Fix Misleading Required Plugin Message] - 2026-09-06
 
 - Name the core plugin a command actually needs instead of always naming Daily Notes, so Open Workspace now asks for Workspaces
 - Drop the core plugin sentence from the Append Task message, which only needs Advanced URI

--- a/extensions/obsidian/src/components/Notifications/AdvancedURIPluginNotInstalled.tsx
+++ b/extensions/obsidian/src/components/Notifications/AdvancedURIPluginNotInstalled.tsx
@@ -1,8 +1,24 @@
 import { Detail } from "@raycast/api";
 
-export default function AdvancedURIPluginNotInstalled({ vaultName }: { vaultName?: string }) {
-  const vaultText = vaultName ? `vault "${vaultName}"` : "any vault";
-  const text = `# Required plugins not installed or enabled in ${vaultText}.\nThis command requires the [Advanced URI plugin](https://obsidian.md/plugins?id=obsidian-advanced-uri) for Obsidian to be installed and the core Daily Notes plugin in Obsidian to be enabled.  \n  \n Install it through the community plugins list.`;
+const CORE_PLUGIN_NAMES: Record<string, string> = {
+  "daily-notes": "Daily Notes",
+  workspaces: "Workspaces",
+};
 
-  return <Detail navigationTitle="Advanced URI plugin not installed" markdown={text} />;
+export default function AdvancedURIPluginNotInstalled({
+  vaultName,
+  corePlugins = [],
+}: {
+  vaultName?: string;
+  corePlugins?: string[];
+}) {
+  const vaultText = vaultName ? `vault "${vaultName}"` : "any vault";
+  const names = corePlugins.map((plugin) => CORE_PLUGIN_NAMES[plugin] ?? plugin);
+  const coreText =
+    names.length > 0
+      ? ` and the core ${names.join(" and ")} plugin${names.length > 1 ? "s" : ""} in Obsidian to be enabled`
+      : "";
+  const text = `# Required plugins not installed or enabled in ${vaultText}.\nThis command requires the [Advanced URI plugin](https://obsidian.md/plugins?id=obsidian-advanced-uri) for Obsidian to be installed${coreText}.  \n  \n Install it through the community plugins list.`;
+
+  return <Detail navigationTitle="Required plugins missing" markdown={text} />;
 }

--- a/extensions/obsidian/src/dailyNoteAppendCommand.tsx
+++ b/extensions/obsidian/src/dailyNoteAppendCommand.tsx
@@ -71,10 +71,10 @@ export default function DailyNoteAppend(props: { arguments: DailyNoteAppendArgs 
   }
 
   if (vaultsWithPlugin.length === 0) {
-    return <AdvancedURIPluginNotInstalled />;
+    return <AdvancedURIPluginNotInstalled corePlugins={["daily-notes"]} />;
   }
   if (vaultName && !vaultsWithPlugin.some((v) => v.name === vaultName)) {
-    return <AdvancedURIPluginNotInstalled vaultName={vaultName} />;
+    return <AdvancedURIPluginNotInstalled vaultName={vaultName} corePlugins={["daily-notes"]} />;
   }
 
   // Only show the vault selection list if we have multiple vaults and no specific vault configured

--- a/extensions/obsidian/src/dailyNoteCommand.tsx
+++ b/extensions/obsidian/src/dailyNoteCommand.tsx
@@ -24,7 +24,7 @@ export default function Command() {
   }
 
   if (vaultsWithPlugin.length == 0) {
-    return <AdvancedURIPluginNotInstalled />;
+    return <AdvancedURIPluginNotInstalled corePlugins={["daily-notes"]} />;
   }
 
   if (preselectedVault || vaultsWithPlugin.length == 1) {

--- a/extensions/obsidian/src/openWorkspaceCommand.tsx
+++ b/extensions/obsidian/src/openWorkspaceCommand.tsx
@@ -24,7 +24,7 @@ export default function Command() {
   }
 
   if (vaultsWithPlugin.length === 0) {
-    return <AdvancedURIPluginNotInstalled />;
+    return <AdvancedURIPluginNotInstalled corePlugins={["workspaces"]} />;
   }
 
   if (vaultsWithPlugin.length > 1) {


### PR DESCRIPTION
Closes #29917

## Description

`openWorkspaceCommand` requires the **Workspaces** core plugin:

```js
communityPlugins: ["obsidian-advanced-uri"],
corePlugins: ["workspaces"],
```

When that check fails it renders the shared `AdvancedURIPluginNotInstalled` component, whose text was hardcoded to say:

> This command requires the Advanced URI plugin for Obsidian to be installed and the core **Daily Notes** plugin in Obsidian to be enabled.

So Open Workspace failed because Workspaces was disabled, then told people to enable Daily Notes, which it never uses, and never mentioned the plugin it actually needed. The screenshots in #29917 show exactly that: the reporter had Advanced URI installed and Daily Notes enabled, did what the message asked, and it still failed.

The same component is shared by four commands with three different requirements, so Append Task also claimed a Daily Notes dependency it does not have.

## Changes

The component now takes the required core plugins as a prop and builds the sentence from them, with a small id-to-name map so `workspaces` reads as "Workspaces". Each render site passes what its own `useVaultPluginCheck` call already asks for, and Append Task passes none, which drops the core plugin clause entirely.

The title is now "Required plugins missing" rather than "Advanced URI plugin not installed", since Advanced URI is usually installed already and naming it as the cause is the same mistake as the body text.

## Not Windows specific

The issue carries the `platform: Windows` label, but nothing here is platform dependent. The same misleading message appears on macOS whenever the Workspaces plugin is disabled. I reproduced it on Windows because that is the machine I have.

## Testing

Windows 11, Raycast 2.2.0.0, Obsidian 1.13.7, on a fresh vault with the Advanced URI plugin installed:

- Workspaces disabled, before: Open Workspace asked for the core Daily Notes plugin, which was already enabled.
- Workspaces enabled: the command works and lists workspaces.
- Workspaces disabled, after this change: the message asks for the core Workspaces plugin.
- Append Task no longer mentions any core plugin.

`ray lint` is clean. `npm test` reports 352 passing and 3 failing in `bookmarks.spec.ts` and `vault.spec.ts`; those 3 fail identically on an unmodified checkout, so they are pre-existing and unrelated to this change.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast on Windows
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder