### PR TITLE
[Browser Bookmarks] Find Brave Nightly, Vivaldi, Helium and Dia on Windows

### DIFF
--- a/extensions/browser-bookmarks/CHANGELOG.md
+++ b/extensions/browser-bookmarks/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Detect more Chromium browsers on Windows] - {PR_MERGE_DATE}
 
-- Find Brave Nightly, Vivaldi and Helium on Windows instead of only looking in the macOS application support folder
+- Find Brave Nightly, Vivaldi, Helium and Dia on Windows instead of only looking in the macOS application support folder
 
 ## [Chrome Account Bookmarks] - 2026-05-20
 

--- a/extensions/browser-bookmarks/CHANGELOG.md
+++ b/extensions/browser-bookmarks/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Browser Bookmarks Changelog
 
-## [Detect more Chromium browsers on Windows] - {PR_MERGE_DATE}
+## [Detect more Chromium browsers on Windows] - 2026-09-06
 
 - Find Brave Nightly, Vivaldi, Helium and Dia on Windows instead of only looking in the macOS application support folder
 

--- a/extensions/browser-bookmarks/CHANGELOG.md
+++ b/extensions/browser-bookmarks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Browser Bookmarks Changelog
 
+## [Detect more Chromium browsers on Windows] - {PR_MERGE_DATE}
+
+- Find Brave Nightly, Vivaldi and Helium on Windows instead of only looking in the macOS application support folder
+
 ## [Chrome Account Bookmarks] - 2026-05-20
 
 - Added support for Chrome account-synced bookmarks stored in `AccountBookmarks`

--- a/extensions/browser-bookmarks/src/hooks/useAvailableBrowsers.ts
+++ b/extensions/browser-bookmarks/src/hooks/useAvailableBrowsers.ts
@@ -81,7 +81,14 @@ const BROWSER_DEFINITIONS: BrowserDefinition[] = [
       : undefined,
   },
   { id: BROWSERS_BUNDLE_ID.braveBeta, name: "Brave Beta", macBundleId: "com.brave.browser.beta" },
-  { id: BROWSERS_BUNDLE_ID.braveNightly, name: "Brave Nightly", macBundleId: "com.brave.browser.nightly" },
+  {
+    id: BROWSERS_BUNDLE_ID.braveNightly,
+    name: "Brave Nightly",
+    macBundleId: "com.brave.browser.nightly",
+    windowsUserDataPath: WINDOWS_LOCAL_APPDATA
+      ? join(WINDOWS_LOCAL_APPDATA, "BraveSoftware", "Brave-Browser-Nightly", "User Data")
+      : undefined,
+  },
   {
     id: BROWSERS_BUNDLE_ID.chrome,
     name: "Chrome",
@@ -116,12 +123,24 @@ const BROWSER_DEFINITIONS: BrowserDefinition[] = [
   { id: BROWSERS_BUNDLE_ID.edgeDev, name: "Edge Dev", macBundleId: "com.microsoft.edgemac.dev" },
   { id: BROWSERS_BUNDLE_ID.edgeCanary, name: "Edge Canary", macBundleId: "com.microsoft.edgemac.canary" },
   { id: BROWSERS_BUNDLE_ID.prismaAccess, name: "Prisma Access", macBundleId: "com.talon-sec.work" },
-  { id: BROWSERS_BUNDLE_ID.vivaldi, name: "Vivaldi", macBundleId: "com.vivaldi.vivaldi" },
+  {
+    id: BROWSERS_BUNDLE_ID.vivaldi,
+    name: "Vivaldi",
+    macBundleId: "com.vivaldi.vivaldi",
+    windowsUserDataPath: WINDOWS_LOCAL_APPDATA ? join(WINDOWS_LOCAL_APPDATA, "Vivaldi", "User Data") : undefined,
+  },
   { id: BROWSERS_BUNDLE_ID.vivaldiSnapshot, name: "Vivaldi Snapshot", macBundleId: "com.vivaldi.vivaldi.snapshot" },
   { id: BROWSERS_BUNDLE_ID.zen, name: "Zen", macBundleId: "app.zen-browser.zen" },
   { id: BROWSERS_BUNDLE_ID.libreWolf, name: "LibreWolf", macBundleId: "org.mozilla.librewolf" },
   { id: BROWSERS_BUNDLE_ID.whale, name: "Whale", macBundleId: "com.naver.whale" },
-  { id: BROWSERS_BUNDLE_ID.helium, name: "Helium", macBundleId: "net.imput.helium" },
+  {
+    id: BROWSERS_BUNDLE_ID.helium,
+    name: "Helium",
+    macBundleId: "net.imput.helium",
+    windowsUserDataPath: WINDOWS_LOCAL_APPDATA
+      ? join(WINDOWS_LOCAL_APPDATA, "imput", "Helium", "User Data")
+      : undefined,
+  },
 ];
 
 const BROWSER_DEFINITION_BY_ID = new Map(BROWSER_DEFINITIONS.map((definition) => [definition.id, definition]));

--- a/extensions/browser-bookmarks/src/hooks/useAvailableBrowsers.ts
+++ b/extensions/browser-bookmarks/src/hooks/useAvailableBrowsers.ts
@@ -102,7 +102,22 @@ const BROWSER_DEFINITIONS: BrowserDefinition[] = [
   { id: BROWSERS_BUNDLE_ID.chromeBeta, name: "Chrome Beta", macBundleId: "com.google.chrome.beta" },
   { id: BROWSERS_BUNDLE_ID.chromeDev, name: "Chrome Dev", macBundleId: "com.google.chrome.dev" },
   { id: BROWSERS_BUNDLE_ID.comet, name: "Comet", macBundleId: "ai.perplexity.comet" },
-  { id: BROWSERS_BUNDLE_ID.dia, name: "Dia", macBundleId: "company.thebrowser.dia" },
+  {
+    id: BROWSERS_BUNDLE_ID.dia,
+    name: "Dia",
+    macBundleId: "company.thebrowser.dia",
+    windowsUserDataPath: WINDOWS_LOCAL_APPDATA
+      ? join(
+          WINDOWS_LOCAL_APPDATA,
+          "Packages",
+          "TheBrowserCompany.Dia_ttt1ap7aakyb4",
+          "LocalCache",
+          "Local",
+          "Dia",
+          "User Data",
+        )
+      : undefined,
+  },
   { id: BROWSERS_BUNDLE_ID.chatGPTAtlas, name: "ChatGPT Atlas", macBundleId: "com.openai.atlas" },
   { id: BROWSERS_BUNDLE_ID.firefox, name: "Firefox", macBundleId: "org.mozilla.firefox" },
   { id: BROWSERS_BUNDLE_ID.firefoxDev, name: "Firefox Dev", macBundleId: "org.mozilla.firefoxdeveloperedition" },

--- a/extensions/browser-bookmarks/src/hooks/useBraveNightlyBookmarks.ts
+++ b/extensions/browser-bookmarks/src/hooks/useBraveNightlyBookmarks.ts
@@ -1,9 +1,12 @@
 import { homedir } from "os";
 
-import { BROWSERS_BUNDLE_ID } from "./useAvailableBrowsers";
+import { BROWSERS_BUNDLE_ID, getBrowserDataPath } from "./useAvailableBrowsers";
 import useChromiumBookmarks from "./useChromiumBookmarks";
 
-const BRAVE_NIGHTLY_BOOKMARKS_PATH = `${homedir()}/Library/Application Support/BraveSoftware/Brave-Browser-Nightly`;
+const BRAVE_NIGHTLY_BOOKMARKS_PATH = getBrowserDataPath(
+  BROWSERS_BUNDLE_ID.braveNightly,
+  `${homedir()}/Library/Application Support/BraveSoftware/Brave-Browser-Nightly`,
+);
 
 export default function useBraveBookmarks(enabled: boolean) {
   return useChromiumBookmarks(enabled, {

--- a/extensions/browser-bookmarks/src/hooks/useDiaBookmarks.ts
+++ b/extensions/browser-bookmarks/src/hooks/useDiaBookmarks.ts
@@ -1,9 +1,9 @@
 import { homedir } from "os";
 
-import { BROWSERS_BUNDLE_ID } from "./useAvailableBrowsers";
+import { BROWSERS_BUNDLE_ID, getBrowserDataPath } from "./useAvailableBrowsers";
 import useChromiumBookmarks from "./useChromiumBookmarks";
 
-const DIA_PATH = `${homedir()}/Library/Application Support/Dia/User Data`;
+const DIA_PATH = getBrowserDataPath(BROWSERS_BUNDLE_ID.dia, `${homedir()}/Library/Application Support/Dia/User Data`);
 
 export default function useDiaBookmarks(enabled: boolean) {
   return useChromiumBookmarks(enabled, {

--- a/extensions/browser-bookmarks/src/hooks/useHeliumBookmarks.ts
+++ b/extensions/browser-bookmarks/src/hooks/useHeliumBookmarks.ts
@@ -1,9 +1,12 @@
 import { homedir } from "os";
 
-import { BROWSERS_BUNDLE_ID } from "./useAvailableBrowsers";
+import { BROWSERS_BUNDLE_ID, getBrowserDataPath } from "./useAvailableBrowsers";
 import useChromiumBookmarks from "./useChromiumBookmarks";
 
-const HELIUM_PATH = `${homedir()}/Library/Application Support/net.imput.helium`;
+const HELIUM_PATH = getBrowserDataPath(
+  BROWSERS_BUNDLE_ID.helium,
+  `${homedir()}/Library/Application Support/net.imput.helium`,
+);
 
 export default function useHeliumBookmarks(enabled: boolean) {
   return useChromiumBookmarks(enabled, {

--- a/extensions/browser-bookmarks/src/hooks/useVivaldiBrowser.ts
+++ b/extensions/browser-bookmarks/src/hooks/useVivaldiBrowser.ts
@@ -1,9 +1,12 @@
 import { homedir } from "os";
 
-import { BROWSERS_BUNDLE_ID } from "./useAvailableBrowsers";
+import { BROWSERS_BUNDLE_ID, getBrowserDataPath } from "./useAvailableBrowsers";
 import useChromiumBookmarks from "./useChromiumBookmarks";
 
-const VIVALDI_BOOKMARKS_PATH = `${homedir()}/Library/Application Support/Vivaldi`;
+const VIVALDI_BOOKMARKS_PATH = getBrowserDataPath(
+  BROWSERS_BUNDLE_ID.vivaldi,
+  `${homedir()}/Library/Application Support/Vivaldi`,
+);
 
 export default function useVivaldiBookmarks(enabled: boolean) {
   return useChromiumBookmarks(enabled, {


### PR DESCRIPTION
On Windows this extension only ever showed me Edge, even though I had 1,403 bookmarks sitting in Brave Nightly.

When Windows support landed, Chrome, Brave and Edge were moved onto `getBrowserDataPath`. The other Chromium hooks still point at `~/Library/Application Support/...`, and `listAvailableBrowsers` drops any browser whose Windows path is missing, so they never get as far as reading a bookmark file.

This adds Windows paths for the four I could check against a real install, and puts their hooks on the same helper:

- Brave Nightly: `%LOCALAPPDATA%\BraveSoftware\Brave-Browser-Nightly\User Data`
- Vivaldi: `%LOCALAPPDATA%\Vivaldi\User Data`
- Helium: `%LOCALAPPDATA%\imput\Helium\User Data`
- Dia: `%LOCALAPPDATA%\Packages\TheBrowserCompany.Dia_ttt1ap7aakyb4\LocalCache\Local\Dia\User Data`

Dia is the odd one because it ships as an MSIX package on Windows, so its data sits inside the package container. The suffix on that folder is the publisher hash, which is the same for everyone installing the signed package, not something per machine.

`getBrowserDataPath` hands back the macOS path on anything that isn't Windows, so macOS behaviour doesn't move.

Two things I left alone on purpose. The remaining browsers (Comet, Sidekick, Whale, the channel variants and so on) aren't installed here and I'd only be guessing at their paths. And I didn't add executable matching: Helium ships its binary as `chrome.exe`, so matching on that would have it claim Chrome's entry. The path fallback lists these browsers without an application path, which means their bookmarks open in the default browser rather than in that specific browser. Happy to add proper matching for the ones where it's unambiguous if you'd rather.

Tested on Windows 11 with Raycast 2.2.0.0. All five browsers now appear in the dropdown and their bookmarks are searchable, including Dia's 1,616.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast on Windows
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder