### PR TITLE
[Browser Bookmarks] Find Firefox and Zen profiles on Windows

### DIFF
--- a/extensions/browser-bookmarks/CHANGELOG.md
+++ b/extensions/browser-bookmarks/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Browser Bookmarks Changelog
 
-## [Find Firefox and Zen profiles on Windows] - {PR_MERGE_DATE}
+## [Find Firefox and Zen profiles on Windows] - 2026-09-06
 
 - Look for Firefox and Zen profiles in the Windows roaming app data folder instead of only the macOS application support folder
 

--- a/extensions/browser-bookmarks/CHANGELOG.md
+++ b/extensions/browser-bookmarks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Browser Bookmarks Changelog
 
+## [Find Firefox and Zen profiles on Windows] - {PR_MERGE_DATE}
+
+- Look for Firefox and Zen profiles in the Windows roaming app data folder instead of only the macOS application support folder
+
 ## [Chrome Account Bookmarks] - 2026-05-20
 
 - Added support for Chrome account-synced bookmarks stored in `AccountBookmarks`

--- a/extensions/browser-bookmarks/src/hooks/useAvailableBrowsers.ts
+++ b/extensions/browser-bookmarks/src/hooks/useAvailableBrowsers.ts
@@ -22,7 +22,26 @@ function getWindowsLocalAppData() {
   return "";
 }
 
+function getWindowsRoamingAppData() {
+  if (process.env.APPDATA) {
+    return process.env.APPDATA;
+  }
+
+  if (process.env.USERPROFILE) {
+    return join(process.env.USERPROFILE, "AppData", "Roaming");
+  }
+
+  const homeDirectory = homedir();
+
+  if (homeDirectory) {
+    return join(homeDirectory, "AppData", "Roaming");
+  }
+
+  return "";
+}
+
 const WINDOWS_LOCAL_APPDATA = process.platform === "win32" ? getWindowsLocalAppData() : "";
+const WINDOWS_ROAMING_APPDATA = process.platform === "win32" ? getWindowsRoamingAppData() : "";
 
 export const BROWSERS_BUNDLE_ID = {
   arc: "company.thebrowser.browser",
@@ -97,7 +116,12 @@ const BROWSER_DEFINITIONS: BrowserDefinition[] = [
   { id: BROWSERS_BUNDLE_ID.comet, name: "Comet", macBundleId: "ai.perplexity.comet" },
   { id: BROWSERS_BUNDLE_ID.dia, name: "Dia", macBundleId: "company.thebrowser.dia" },
   { id: BROWSERS_BUNDLE_ID.chatGPTAtlas, name: "ChatGPT Atlas", macBundleId: "com.openai.atlas" },
-  { id: BROWSERS_BUNDLE_ID.firefox, name: "Firefox", macBundleId: "org.mozilla.firefox" },
+  {
+    id: BROWSERS_BUNDLE_ID.firefox,
+    name: "Firefox",
+    macBundleId: "org.mozilla.firefox",
+    windowsUserDataPath: WINDOWS_ROAMING_APPDATA ? join(WINDOWS_ROAMING_APPDATA, "Mozilla", "Firefox") : undefined,
+  },
   { id: BROWSERS_BUNDLE_ID.firefoxDev, name: "Firefox Dev", macBundleId: "org.mozilla.firefoxdeveloperedition" },
   { id: BROWSERS_BUNDLE_ID.ghostBrowser, name: "Ghost Browser", macBundleId: "com.ghostbrowser.gb1" },
   { id: BROWSERS_BUNDLE_ID.island, name: "Island", macBundleId: "io.island.island" },
@@ -118,7 +142,12 @@ const BROWSER_DEFINITIONS: BrowserDefinition[] = [
   { id: BROWSERS_BUNDLE_ID.prismaAccess, name: "Prisma Access", macBundleId: "com.talon-sec.work" },
   { id: BROWSERS_BUNDLE_ID.vivaldi, name: "Vivaldi", macBundleId: "com.vivaldi.vivaldi" },
   { id: BROWSERS_BUNDLE_ID.vivaldiSnapshot, name: "Vivaldi Snapshot", macBundleId: "com.vivaldi.vivaldi.snapshot" },
-  { id: BROWSERS_BUNDLE_ID.zen, name: "Zen", macBundleId: "app.zen-browser.zen" },
+  {
+    id: BROWSERS_BUNDLE_ID.zen,
+    name: "Zen",
+    macBundleId: "app.zen-browser.zen",
+    windowsUserDataPath: WINDOWS_ROAMING_APPDATA ? join(WINDOWS_ROAMING_APPDATA, "zen") : undefined,
+  },
   { id: BROWSERS_BUNDLE_ID.libreWolf, name: "LibreWolf", macBundleId: "org.mozilla.librewolf" },
   { id: BROWSERS_BUNDLE_ID.whale, name: "Whale", macBundleId: "com.naver.whale" },
   { id: BROWSERS_BUNDLE_ID.helium, name: "Helium", macBundleId: "net.imput.helium" },

--- a/extensions/browser-bookmarks/src/hooks/useFirefoxBookmarks.ts
+++ b/extensions/browser-bookmarks/src/hooks/useFirefoxBookmarks.ts
@@ -9,11 +9,14 @@ import ini from "ini";
 import { useMemo } from "react";
 import initSqlJs, { Database } from "sql.js";
 
-import { BROWSERS_BUNDLE_ID } from "./useAvailableBrowsers";
+import { BROWSERS_BUNDLE_ID, getBrowserDataPath } from "./useAvailableBrowsers";
 
 const read = promisify(readFile);
 
-const FIREFOX_FOLDER = `${homedir()}/Library/Application Support/Firefox`;
+const FIREFOX_FOLDER = getBrowserDataPath(
+  BROWSERS_BUNDLE_ID.firefox,
+  `${homedir()}/Library/Application Support/Firefox`,
+);
 
 const folderNames: Record<string, string> = {
   menu: "Bookmark Menu",

--- a/extensions/browser-bookmarks/src/hooks/useZenBookmarks.ts
+++ b/extensions/browser-bookmarks/src/hooks/useZenBookmarks.ts
@@ -9,11 +9,14 @@ import ini from "ini";
 import { useMemo, useEffect } from "react";
 import initSqlJs, { Database } from "sql.js";
 
-import { BROWSERS_BUNDLE_ID } from "./useAvailableBrowsers";
+import { BROWSERS_BUNDLE_ID, getBrowserDataPath } from "./useAvailableBrowsers";
 
 const read = promisify(readFile);
 
-const ZEN_FOLDER = path.join(process.env.HOME || "", "Library", "Application Support", "zen");
+const ZEN_FOLDER = getBrowserDataPath(
+  BROWSERS_BUNDLE_ID.zen,
+  path.join(process.env.HOME || "", "Library", "Application Support", "zen"),
+);
 
 const folderNames: Record<string, string> = {
   menu: "Bookmark Menu",


### PR DESCRIPTION
Same shape as #30828, but the Firefox side rather than Chromium.

Both hooks look in `~/Library/Application Support`, so neither finds anything on Windows. Zen is the worse of the two:

```js
const ZEN_FOLDER = path.join(process.env.HOME || "", "Library", "Application Support", "zen");
```

Windows doesn't set `HOME`, so that resolves to `\Library\Application Support\zen`, which isn't a real location on any drive.

The Firefox family keeps profiles under Roaming rather than Local, so this adds a roaming helper next to the existing `getWindowsLocalAppData`, then puts both hooks on `getBrowserDataPath`:

- Firefox: `%APPDATA%\Mozilla\Firefox`
- Zen: `%APPDATA%\zen`

macOS is unchanged, since `getBrowserDataPath` returns the macOS path off Windows.

I left LibreWolf alone. It has the same `process.env.HOME` problem, but it isn't installed here and I'd be guessing at its folder name.

Tested on Windows 11 with Raycast 2.2.0.0. Zen was the real test, with three existing profiles; Firefox I installed fresh, so it only had its default bookmarks. Both now appear and their bookmarks are searchable.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast on Windows
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder