### PR TITLE
[Telegram] Fix blank photo previews and Unknown message senders

### DIFF
--- a/extensions/telegram/CHANGELOG.md
+++ b/extensions/telegram/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Telegram Changelog
 
-## [Fix Photo Previews and Message Senders] - {PR_MERGE_DATE}
+## [Fix Photo Previews and Message Senders] - 2026-09-08
 
 - Show photos in the detail pane. They were embedded as base64 data URIs, which Raycast's markdown renderer drops once they grow large, leaving the pane blank
 - Resolve message senders from the entity attached to each message rather than `client.getEntity`, which throws in a fresh command process because the session does not persist an entity cache, showing group messages as "Unknown User"

--- a/extensions/telegram/CHANGELOG.md
+++ b/extensions/telegram/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Telegram Changelog
 
+## [Fix Photo Previews and Message Senders] - {PR_MERGE_DATE}
+
+- Show photos in the detail pane. They were embedded as base64 data URIs, which Raycast's markdown renderer drops once they grow large, leaving the pane blank
+- Resolve message senders from the entity attached to each message rather than `client.getEntity`, which throws in a fresh command process because the session does not persist an entity cache, showing group messages as "Unknown User"
+- Attribute messages sent on behalf of a channel, such as channel posts and anonymous group admins
+
 ## [Add 2-Step Verification Login Support] - 2026-03-26
 
 - Handle Telegram 2FA (`SESSION_PASSWORD_NEEDED`) with a password step

--- a/extensions/telegram/src/services/telegram-client.ts
+++ b/extensions/telegram/src/services/telegram-client.ts
@@ -326,6 +326,71 @@ async function downloadProfilePhoto(
   return undefined;
 }
 
+/**
+ * Works out who authored a message, and their id.
+ *
+ * Telegram fills this in three different ways, and only one of them sets `fromId`:
+ * group members set `fromId` to a user, channel posts and anonymous group admins set
+ * it to a channel, and both broadcast posts and private chats may omit it entirely --
+ * in which case the author is whatever the message is attached to.
+ *
+ * Kept free of network calls so the attribution rules can be unit tested.
+ */
+export function resolveMessageAuthor(
+  msg: Api.Message,
+  chatEntity?: Api.User | Api.Chat | Api.Channel,
+): { senderId?: string; entity?: Api.User | Api.Channel } {
+  if (msg.fromId instanceof Api.PeerUser) {
+    // Prefer the entity the library already attached to the message: it comes from the
+    // users map on the same response. client.getEntity() needs a populated entity cache,
+    // and StringSession does not persist one, so in a fresh Raycast command process it
+    // throws "Could not find the input entity" for anyone we have not just fetched.
+    return {
+      senderId: msg.fromId.userId.toString(),
+      entity: msg.sender instanceof Api.User ? msg.sender : undefined,
+    };
+  }
+
+  if (msg.fromId instanceof Api.PeerChannel) {
+    return {
+      senderId: msg.fromId.channelId.toString(),
+      entity: msg.sender instanceof Api.Channel ? msg.sender : undefined,
+    };
+  }
+
+  if (!msg.fromId) {
+    const author = msg.sender ?? chatEntity;
+    if (author instanceof Api.Channel || author instanceof Api.User) {
+      return { senderId: author.id.toString(), entity: author };
+    }
+  }
+
+  return {};
+}
+
+/** Display name and avatar for a user, matching how getChats titles a private chat. */
+async function describeUser(
+  client: TelegramClient,
+  user: Api.User,
+  skipPhotoDownload: boolean,
+): Promise<{ name: string; photo?: string }> {
+  let name = user.firstName || "";
+  if (user.lastName) name += ` ${user.lastName}`;
+
+  if (user.deleted) {
+    name = "Deleted Account";
+  } else if (!name.trim()) {
+    name = "Unknown User";
+  }
+
+  let photo: string | undefined;
+  if (!skipPhotoDownload && user.photo && "photoId" in user.photo) {
+    photo = await downloadProfilePhoto(client, user, user.id.toString(), "profile");
+  }
+
+  return { name, photo };
+}
+
 function parseMessageMedia(msg: Api.Message): MessageMedia | undefined {
   if (!msg.media) return undefined;
 
@@ -455,47 +520,30 @@ async function processChatMessage(
     if (filePath && media) media.filePath = filePath;
   }
 
-  let senderId: string | undefined;
   let senderName: string | undefined;
   let senderPhoto: string | undefined;
 
-  // Try to get sender info from fromId
-  if (msg.fromId && msg.fromId instanceof Api.PeerUser) {
-    senderId = msg.fromId.userId.toString();
+  const { senderId, entity } = resolveMessageAuthor(msg, chatEntity);
+
+  // Fall back to a lookup only when the response did not carry the user with it.
+  let author = entity;
+  if (!author && msg.fromId instanceof Api.PeerUser) {
     try {
       const user = await client.getEntity(msg.fromId.userId);
-      if (user instanceof Api.User) {
-        senderName = user.firstName || "";
-        if (user.lastName) senderName += ` ${user.lastName}`;
-
-        if (user.deleted) {
-          senderName = "Deleted Account";
-        } else if (!senderName.trim()) {
-          senderName = "Unknown User";
-        }
-
-        if (!skipMediaDownload && user.photo && "photoId" in user.photo) {
-          senderPhoto = await downloadProfilePhoto(client, user, user.id.toString(), "profile");
-        }
-      }
+      if (user instanceof Api.User) author = user;
     } catch (error) {
-      console.error("Failed to get sender info:", error);
-      senderName = "Unknown User";
+      console.error(`Failed to resolve sender ${senderId}:`, error);
     }
-  } else if (!msg.fromId && chatEntity instanceof Api.User) {
-    // For private chats, if there's no fromId, assume it's from the chat partner
-    senderId = chatEntity.id.toString();
-    senderName = chatEntity.firstName || "";
-    if (chatEntity.lastName) senderName += ` ${chatEntity.lastName}`;
+  }
 
-    if (chatEntity.deleted) {
-      senderName = "Deleted Account";
-    } else if (!senderName.trim()) {
-      senderName = "Unknown User";
-    }
-
-    if (!skipMediaDownload && chatEntity.photo && "photoId" in chatEntity.photo) {
-      senderPhoto = await downloadProfilePhoto(client, chatEntity, chatEntity.id.toString(), "profile");
+  if (author instanceof Api.User) {
+    const { name, photo } = await describeUser(client, author, skipMediaDownload);
+    senderName = name;
+    senderPhoto = photo;
+  } else if (author instanceof Api.Channel) {
+    senderName = author.title;
+    if (!skipMediaDownload && author.photo && "photoId" in author.photo) {
+      senderPhoto = await downloadProfilePhoto(client, author, author.id.toString(), "channel");
     }
   }
 

--- a/extensions/telegram/src/utils/markdown.ts
+++ b/extensions/telegram/src/utils/markdown.ts
@@ -1,4 +1,5 @@
 import * as fs from "fs";
+import { pathToFileURL } from "url";
 
 interface MediaInfo {
   filePath?: string;
@@ -17,11 +18,14 @@ export function buildMarkdownWithMedia({ prefix = "", text, media }: BuildMarkdo
 
   if (media?.filePath && ["photo", "image"].includes(media.type)) {
     try {
+      // Reference the cached file rather than inlining it. Raycast's markdown
+      // renderer silently drops images embedded as base64 data URIs once they
+      // grow large, and a Telegram photo is comfortably past that point -- the
+      // detail pane rendered blank for every photo. pathToFileURL handles the
+      // percent-encoding the support path needs, and the drive letter and
+      // backslashes on Windows.
       if (fs.existsSync(media.filePath)) {
-        const imageBuffer = fs.readFileSync(media.filePath);
-        const base64Image = imageBuffer.toString("base64");
-        const mimeType = media.mimeType || "image/jpeg";
-        markdown += `![](data:${mimeType};base64,${base64Image})`;
+        markdown += `![](${pathToFileURL(media.filePath).href})`;
       }
     } catch (error) {
       console.error("Failed to read media file:", error);


### PR DESCRIPTION
## Description

Two independent fixes to the Telegram extension. Neither changes dependencies.

**Photos rendered as a blank detail pane.** `buildMarkdownWithMedia` read each cached photo off disk and inlined it into the markdown as a base64 data URI. A Telegram photo is around 400 KB, so the embed ran to roughly 550 KB of text, and Raycast's markdown renderer drops data URIs that large without raising an error — the pane kept its layout and showed no image.

It now references the cached file with a percent-encoded `file://` URL, matching how other extensions in this repo embed local images. That also avoids re-reading and re-encoding the file on every render.

**Senders in group chats showed as "Unknown User".** `processChatMessage` called `client.getEntity()` with a bare user id. That needs a populated entity cache, but `StringSession` persists only the auth key, so every Raycast command starts with an empty cache and the call throws `Could not find the input entity` for any sender not already fetched — the `catch` then wrote "Unknown User".

It now prefers `msg.sender`, which GramJS populates from the users map on the same response: no network call and no cache dependency, with `getEntity` kept as a fallback.

Also in this PR:

- Messages sent on behalf of a channel (channel posts, anonymous group admins) previously produced no sender at all; they are now attributed.
- The user-naming logic is hoisted into a `describeUser` helper shared by both paths, matching the surrounding module-level helpers.

## Screencast

Verified against a live Telegram account: photos that previously rendered a blank detail pane now display, and group senders resolve to real names.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
