### PR TITLE
[Telegram] Fix bot messages showing as Unknown (migrate archived GramJS to teleproto)

### DIFF
--- a/extensions/telegram/CHANGELOG.md
+++ b/extensions/telegram/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Telegram Changelog
 
-## [Support Rich Messages from Bots] - {PR_MERGE_DATE}
+## [Support Rich Messages from Bots] - 2026-09-09
 
 - Show messages from bots that use rich text. Their content is carried in a field added in Telegram API layer 228, which the extension did not read, so these messages appeared as "Unknown" or were dropped from the list entirely
 - Replace the archived `telegram` (GramJS) dependency with its maintained fork `teleproto`. GramJS is pinned to API layer 198 and its authors now direct users to teleproto; Telegram withholds newer message content from clients on the older layer

--- a/extensions/telegram/CHANGELOG.md
+++ b/extensions/telegram/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Telegram Changelog
 
+## [Support Rich Messages from Bots] - {PR_MERGE_DATE}
+
+- Show messages from bots that use rich text. Their content is carried in a field added in Telegram API layer 228, which the extension did not read, so these messages appeared as "Unknown" or were dropped from the list entirely
+- Replace the archived `telegram` (GramJS) dependency with its maintained fork `teleproto`. GramJS is pinned to API layer 198 and its authors now direct users to teleproto; Telegram withholds newer message content from clients on the older layer
+
 ## [Fix Photo Previews and Message Senders] - 2026-09-08
 
 - Show photos in the detail pane. They were embedded as base64 data URIs, which Raycast's markdown renderer drops once they grow large, leaving the pane blank

--- a/extensions/telegram/package-lock.json
+++ b/extensions/telegram/package-lock.json
@@ -12,7 +12,7 @@
         "@raycast/utils": "^1.17.0",
         "ai": "^5.0.118",
         "dedent": "^1.7.1",
-        "telegram": "^2.26.22"
+        "teleproto": "^1.229.0"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.0.4",
@@ -68,12 +68,6 @@
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
-    },
-    "node_modules/@cryptography/aes": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@cryptography/aes/-/aes-0.1.1.tgz",
-      "integrity": "sha512-PcYz4FDGblO6tM2kSC+VzhhK62vml6k6/YAkiWtyPvrgJVfnDRoHGDtKn5UiaRRUrvUTTocBpvc2rRgTCqxjsg==",
-      "license": "GPL-3.0-or-later"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
@@ -1684,39 +1678,10 @@
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
     },
-    "node_modules/async-mutex": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
-      "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
       "license": "MIT"
     },
     "node_modules/big-integer": {
@@ -1735,43 +1700,6 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/bufferutil": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
-      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
       }
     },
     "node_modules/callsites": {
@@ -1911,19 +1839,6 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
-    "node_modules/d": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
-      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
-      "license": "ISC",
-      "dependencies": {
-        "es5-ext": "^0.10.64",
-        "type": "^2.7.2"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1971,61 +1886,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/dom-serializer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
     "node_modules/ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -2046,55 +1906,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
-    },
-    "node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/es5-ext": {
-      "version": "0.10.64",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
-      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
-      "hasInstallScript": true,
-      "license": "ISC",
-      "dependencies": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "esniff": "^2.0.1",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-      "license": "MIT",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "node_modules/es6-symbol": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
-      "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
-      "license": "ISC",
-      "dependencies": {
-        "d": "^1.0.2",
-        "ext": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -2292,21 +2103,6 @@
         "node": "*"
       }
     },
-    "node_modules/esniff": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
-      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
-      "license": "ISC",
-      "dependencies": {
-        "d": "^1.0.1",
-        "es5-ext": "^0.10.62",
-        "event-emitter": "^0.3.5",
-        "type": "^2.7.2"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -2384,16 +2180,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
-      "license": "MIT",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
-      }
-    },
     "node_modules/eventsource-parser": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
@@ -2401,15 +2187,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/ext": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
-      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
-      "license": "ISC",
-      "dependencies": {
-        "type": "^2.7.2"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2583,25 +2360,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/htmlparser2": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.5.2",
-        "entities": "^2.0.0"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -2617,26 +2375,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -2684,9 +2422,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -2738,12 +2476,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "license": "MIT"
     },
     "node_modules/is-wsl": {
       "version": "2.2.0",
@@ -2929,12 +2661,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
-      "license": "ISC"
-    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -2953,17 +2679,6 @@
         "encoding": {
           "optional": true
         }
-      }
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "license": "MIT",
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-localstorage": {
@@ -3044,12 +2759,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/pako": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
-      "license": "(MIT AND Zlib)"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3062,12 +2771,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/path-browserify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -3152,12 +2855,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/real-cancellable-promise": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/real-cancellable-promise/-/real-cancellable-promise-1.2.3.tgz",
-      "integrity": "sha512-hBI5Gy/55VEeeMtImMgEirD7eq5UmqJf1J8dFZtbJZA/3rB0pYFZ7PayMGueb6v4UtUtpKpP+05L0VwyE1hI9Q==",
-      "license": "MIT"
-    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3241,12 +2938,12 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.10.tgz",
+      "integrity": "sha512-e0VyvkVTwVYViNovRkZ9aodhxVlyoMn7eJhVUPxZ+eK9P/7CBkxvvsBOHqFPEH416726W8tLXXXjKwqgTErrCQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -3329,30 +3026,24 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/telegram": {
-      "version": "2.26.22",
-      "resolved": "https://registry.npmjs.org/telegram/-/telegram-2.26.22.tgz",
-      "integrity": "sha512-EIj7Yrjiu0Yosa3FZ/7EyPg9s6UiTi/zDQrFmR/2Mg7pIUU+XjAit1n1u9OU9h2oRnRM5M+67/fxzQluZpaJJg==",
+    "node_modules/teleproto": {
+      "version": "1.229.0",
+      "resolved": "https://registry.npmjs.org/teleproto/-/teleproto-1.229.0.tgz",
+      "integrity": "sha512-aEKx22ZS76SYy26eWR+2oV5XM4+orbq/2ZINvSKoV2SZERn6yqq9mw5lNK22nCax7lTnC0gcz8uqP26gaUxEqA==",
       "license": "MIT",
       "dependencies": {
-        "@cryptography/aes": "^0.1.1",
-        "async-mutex": "^0.3.0",
         "big-integer": "^1.6.48",
-        "buffer": "^6.0.3",
-        "htmlparser2": "^6.1.0",
         "mime": "^3.0.0",
         "node-localstorage": "^2.2.1",
-        "pako": "^2.0.3",
-        "path-browserify": "^1.0.1",
-        "real-cancellable-promise": "^1.1.1",
         "socks": "^2.6.2",
-        "store2": "^2.13.0",
-        "ts-custom-error": "^3.2.0",
-        "websocket": "^1.0.34"
+        "store2": "^2.13.0"
       },
-      "optionalDependencies": {
-        "bufferutil": "^4.0.3",
-        "utf-8-validate": "^5.0.5"
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/sanyok12345"
       }
     },
     "node_modules/tinyglobby": {
@@ -3390,27 +3081,6 @@
         "typescript": ">=4.8.4"
       }
     },
-    "node_modules/ts-custom-error": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
-      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
-    "node_modules/type": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
-      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
-      "license": "ISC"
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3434,15 +3104,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "license": "MIT",
-      "dependencies": {
-        "is-typedarray": "^1.0.0"
       }
     },
     "node_modules/typescript": {
@@ -3499,56 +3160,11 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
-    },
-    "node_modules/websocket": {
-      "version": "1.0.35",
-      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.35.tgz",
-      "integrity": "sha512-/REy6amwPZl44DDzvRCkaI1q1bIiQB0mEFQLUrhz3z2EK91cp3n72rAjUlrTP0zV22HJIUOVHQGPxhFRjxjt+Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bufferutil": "^4.0.1",
-        "debug": "^2.2.0",
-        "es5-ext": "^0.10.63",
-        "typedarray-to-buffer": "^3.1.5",
-        "utf-8-validate": "^5.0.2",
-        "yaeti": "^0.0.6"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/websocket/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/websocket/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -3630,16 +3246,6 @@
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
         "slide": "^1.1.5"
-      }
-    },
-    "node_modules/yaeti": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-      "integrity": "sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.32"
       }
     },
     "node_modules/yocto-queue": {

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -172,7 +172,7 @@
     "@raycast/utils": "^1.17.0",
     "ai": "^5.0.118",
     "dedent": "^1.7.1",
-    "telegram": "^2.26.22"
+    "teleproto": "^1.229.0"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.0.4",

--- a/extensions/telegram/src/components/chat-message-list-item-detail.tsx
+++ b/extensions/telegram/src/components/chat-message-list-item-detail.tsx
@@ -10,7 +10,7 @@ interface ChatMessageListItemDetailProps {
 export function ChatMessageListItemDetail({ message }: ChatMessageListItemDetailProps) {
   const markdown = buildMarkdownWithMedia({
     prefix: message.senderName ? `**${message.senderName}**\n\n` : undefined,
-    text: message.text,
+    text: message.markdown ?? message.text,
     media: message.media,
   });
 

--- a/extensions/telegram/src/components/saved-message-detail.tsx
+++ b/extensions/telegram/src/components/saved-message-detail.tsx
@@ -8,7 +8,7 @@ interface SavedMessageDetailProps {
 
 export function SavedMessageDetail({ message }: SavedMessageDetailProps) {
   const markdown = buildMarkdownWithMedia({
-    text: message.text,
+    text: message.markdown ?? message.text,
     media: message.media,
   });
 

--- a/extensions/telegram/src/components/saved-message-list-item-detail.tsx
+++ b/extensions/telegram/src/components/saved-message-list-item-detail.tsx
@@ -8,7 +8,7 @@ interface SavedMessageListItemDetailProps {
 
 export function SavedMessageListItemDetail({ message }: SavedMessageListItemDetailProps) {
   const markdown = buildMarkdownWithMedia({
-    text: message.text,
+    text: message.markdown ?? message.text,
     media: message.media,
   });
 

--- a/extensions/telegram/src/services/telegram-client.ts
+++ b/extensions/telegram/src/services/telegram-client.ts
@@ -1,8 +1,8 @@
-import { TelegramClient } from "telegram";
-import { StringSession } from "telegram/sessions";
+import { TelegramClient, Rich } from "teleproto";
+import { StringSession } from "teleproto/sessions";
 import { LocalStorage, environment } from "@raycast/api";
-import { Api } from "telegram/tl";
-import { computeCheck } from "telegram/Password";
+import { Api } from "teleproto/tl";
+import { computeCheck } from "teleproto/Password";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -43,6 +43,8 @@ export interface MessageMedia {
 export interface SavedMessage {
   id: number;
   text: string;
+  /** Rendered Markdown, set only for rich messages (layer 228+). */
+  markdown?: string;
   date: Date;
   media?: MessageMedia;
 }
@@ -50,6 +52,8 @@ export interface SavedMessage {
 export interface ChatMessage {
   id: number;
   text: string;
+  /** Rendered Markdown, set only for rich messages (layer 228+). */
+  markdown?: string;
   date: Date;
   media?: MessageMedia;
   senderId?: string;
@@ -368,6 +372,36 @@ export function resolveMessageAuthor(
   return {};
 }
 
+/**
+ * Reads a message's text.
+ *
+ * Bots can send rich messages (layer 228), whose content lives in `richMessage`
+ * as a block tree rather than in the flat `message` string. Older clients are not
+ * shown these at all -- the server substitutes messageMediaUnsupported -- so any
+ * code that only reads `msg.message` silently loses every rich message.
+ */
+function renderMessageContent(msg: Api.Message): { text: string; markdown?: string } {
+  if (msg.message) {
+    return { text: msg.message };
+  }
+
+  if (msg.richMessage) {
+    const plain = Rich.toPlainText(msg.richMessage);
+    return {
+      // List titles are single-line, so collapse the block structure for display.
+      text: plain.replace(/\s+/g, " ").trim(),
+      markdown: Rich.toMarkdown(msg.richMessage),
+    };
+  }
+
+  return { text: "" };
+}
+
+/** True when a message carries anything worth rendering. */
+function hasRenderableContent(msg: Api.Message): boolean {
+  return Boolean(msg.message || msg.media || msg.richMessage);
+}
+
 /** Display name and avatar for a user, matching how getChats titles a private chat. */
 async function describeUser(
   client: TelegramClient,
@@ -499,9 +533,12 @@ async function processSavedMessage(
     }
   }
 
+  const { text, markdown } = renderMessageContent(msg);
+
   return {
     id: msg.id,
-    text: msg.message || "",
+    text,
+    markdown,
     date: new Date(msg.date * 1000),
     media,
   };
@@ -547,9 +584,12 @@ async function processChatMessage(
     }
   }
 
+  const { text, markdown } = renderMessageContent(msg);
+
   return {
     id: msg.id,
-    text: msg.message || "",
+    text,
+    markdown,
     date: new Date(msg.date * 1000),
     media,
     senderId,
@@ -577,7 +617,7 @@ export async function getSavedMessages(options: GetSavedMessagesOptions): Promis
     search: searchQuery || undefined,
   });
 
-  const filteredMessages = messages.filter((msg) => msg.message || msg.media);
+  const filteredMessages = messages.filter(hasRenderableContent);
 
   const processedMessages = await Promise.all(
     filteredMessages.map((msg) => processSavedMessage(client, msg, skipMediaDownload)),
@@ -600,7 +640,7 @@ export async function getChatMessages(options: GetMessagesOptions): Promise<Chat
     search: searchQuery || undefined,
   });
 
-  const filteredMessages = messages.filter((msg) => msg.message || msg.media);
+  const filteredMessages = messages.filter(hasRenderableContent);
 
   // Get the chat entity to know who the chat partner is
   const entity = await client.getEntity(chatId);


### PR DESCRIPTION
## Description

Closes #30817.

Messages from bots appeared as **"Unknown"** in the list, or vanished from it entirely. There are two causes, one on the wire and one in this extension.

### Telegram is not sending the content

Telegram added rich messages for bots in **API layer 228**. The `telegram` package (GramJS) is pinned to **layer 198**, and rather than downgrading newer content the server withholds it, substituting `messageMediaUnsupported` with the text stripped.

Captured from a live bot chat, every affected message arrives as:

```
out: false, hasText: false, textLength: 0,
mediaClass: "MessageMediaUnsupported"
```

`parseMessageMedia` maps that to type `"unknown"`, and the list item falls back to the media label — rendering the title as literally "Unknown". No parser change can recover this, because the bytes are never delivered. The client logs `Using LAYER 198 for initial connect` on every connection.

**GramJS has been archived by its authors.** Its npm deprecation notice reads:

> This package is archived and no longer maintained. Development continues in teleproto, a largely compatible, actively maintained fork.

This PR follows that instruction. teleproto is on layer 229. The swap is five import lines — `TelegramClient`, `StringSession`, `Api` and `computeCheck` are unchanged, and existing `StringSession` strings are read as-is, so **users stay logged in**. It typechecks with no other changes; `sendReadAcknowledge`, the one renamed method, is not used here.

For reviewer confidence: **this extension is the only consumer of GramJS in the repository** — nothing else is affected.

### The extension cannot read the content

With delivery restored, the text still needs reading. Rich message content lives in `message.richMessage` as a block tree, not in the flat `message.message` string, so both filters that decide whether a message is worth showing —

```ts
messages.filter((msg) => msg.message || msg.media)
```

— discarded every one of them. On the test chat that was **50 fetched, 30 kept**: the missing 20 were the bot's messages.

They are now read through teleproto's `Rich` helpers: whitespace-collapsed plain text for list titles, and Markdown for the detail pane so the bot's formatting survives.

## Screencast

Verified against a live bot chat: messages that rendered as "Unknown" — and then disappeared once delivery was restored — now show their real text, with formatting preserved in the detail pane.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

