### PR TITLE
Plexamp: add track navigation and play album actions

### DIFF
--- a/extensions/plexamp/CHANGELOG.md
+++ b/extensions/plexamp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Plexamp CHANGELOG
 
+## [Go to Album and Artist, Play Album from Track] - {PR_MERGE_DATE}
+
+- Added `Go to Album` (`Cmd+G`) and `Go to Artist` (`Cmd+Shift+G`) actions to every track row in `Browse Library`, `Search Library`, `Recently Played`, playlist track lists, and album track lists.
+- `Go to Album` opens the album's track list with the track pre-selected; `Go to Artist` opens the artist's release list with the album pre-selected in both list and grid view. `Now Playing`'s `Go to Album` and `Go to Artist` pre-select the same way.
+- Added `Play Album from This Track` and `Play Album from Start` to album track lists as the `Enter` and `Cmd+Enter` defaults; `Play in Plexamp`, `Add to Queue`, and `Play Next` (`Cmd+Shift+Enter`) for the single track remain in the action panel.
+- Outside album track lists the navigation actions sit after `Play Next`, so `Enter` still plays the track and `Cmd+Enter` still adds it to the queue.
+
 ## [Play Shortcut] - 2026-05-04
 
 - Added a `Cmd+Enter` shortcut to `Play in Plexamp` on album rows in artist views (list and grid) so an album can be played directly without first drilling into its tracks.

--- a/extensions/plexamp/CHANGELOG.md
+++ b/extensions/plexamp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Plexamp CHANGELOG
 
-## [Go to Album and Artist, Play Album from Track] - {PR_MERGE_DATE}
+## [Go to Album and Artist, Play Album from Track] - 2026-09-07
 
 - Added `Go to Album` (`Cmd+G`) and `Go to Artist` (`Cmd+Shift+G`) actions to every track row in `Browse Library`, `Search Library`, `Recently Played`, playlist track lists, and album track lists.
 - `Go to Album` opens the album's track list with the track pre-selected; `Go to Artist` opens the artist's release list with the album pre-selected in both list and grid view. `Now Playing`'s `Go to Album` and `Go to Artist` pre-select the same way.

--- a/extensions/plexamp/README.md
+++ b/extensions/plexamp/README.md
@@ -26,6 +26,8 @@ Raycast extension for browsing Plex music libraries and controlling a Plexamp pl
 - Toggle between list and grid view for artist albums (`Cmd+Shift+V`), with albums grouped by release type (Albums, EPs, Singles, Compilations, etc.) and sorted by release year in grid view. Grid column count is configurable in extension preferences.
 - Search the library the way Plex does, with grouped results for artists, albums, and songs.
 - Play immediately in Plexamp, add to queue, or insert as play next from browse and search results.
+- Jump from any track to its album (`Cmd+G`), landing on that track, or to its artist (`Cmd+Shift+G`), landing on that album.
+- In album track lists, `Enter` plays the album from the selected track and `Cmd+Enter` plays it from the start; playing, queueing, or inserting just the track stays available in the action panel.
 - Inspect the active Plexamp queue and use transport controls from Raycast in `Now Playing`.
 - Jump to tracks, reorder the queue, and remove queue items from `Now Playing`.
 - Show the active album art and a customizable now playing string in the menu bar, refreshed every 10 seconds.

--- a/extensions/plexamp/package.json
+++ b/extensions/plexamp/package.json
@@ -5,6 +5,9 @@
   "description": "Browse Plex music libraries and control Plexamp playback from Raycast.",
   "icon": "plexamp-icon.png",
   "author": "kendaniels",
+  "contributors": [
+    "sasch"
+  ],
   "categories": [
     "Media"
   ],

--- a/extensions/plexamp/src/browse-media.tsx
+++ b/extensions/plexamp/src/browse-media.tsx
@@ -1,7 +1,7 @@
 import { Action, ActionPanel, getPreferenceValues, Grid, Icon, LaunchProps, List, LocalStorage } from "@raycast/api";
 import { useNavigation } from "@raycast/api";
 import { usePromise } from "@raycast/utils";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 
 import { formatTrackDisplayTitle, getTrackRatingDisplayMode } from "./format";
 import {
@@ -12,7 +12,11 @@ import {
   getTracksForAlbum,
   getTracksForPlaylist,
   getTracksPage,
+  resolveTrackAlbum,
+  resolveTrackArtist,
   searchLibrary,
+  type TrackAlbumTarget,
+  type TrackArtistTarget,
 } from "./plex";
 import {
   NowPlayingAction,
@@ -86,6 +90,29 @@ function useBrowseSearch(sectionKey: string | undefined, query: string): BrowseS
 }
 
 // ---------------------------------------------------------------------------
+// Shared: deferred list selection
+// ---------------------------------------------------------------------------
+
+// Raycast ignores a selectedItemId that arrives in the same update as the item it points at,
+// so the id is handed over one tick after the item is in the list. Once set it stays put: Raycast
+// only re-applies the prop when it changes, so the user's own selection moves are not overridden.
+function useDeferredSelection(items: { ratingKey: string }[], itemId?: string): string | undefined {
+  const [selectedItemId, setSelectedItemId] = useState<string>();
+  const isItemPresent = itemId !== undefined && items.some((item) => item.ratingKey === itemId);
+
+  useEffect(() => {
+    if (!itemId || !isItemPresent) {
+      return;
+    }
+
+    const timer = setTimeout(() => setSelectedItemId(itemId), 0);
+    return () => clearTimeout(timer);
+  }, [itemId, isItemPresent]);
+
+  return selectedItemId;
+}
+
+// ---------------------------------------------------------------------------
 // Shared: launch context
 // ---------------------------------------------------------------------------
 
@@ -93,6 +120,8 @@ interface BrowseLaunchContext {
   target?: "album" | "artist";
   ratingKey?: string;
   sectionKey?: string;
+  // The item to highlight in the target view: a track for "album", an album for "artist".
+  selectedRatingKey?: string;
 }
 
 function getBrowseNavigationTitle(libraryName: string, serverName?: string): string {
@@ -152,6 +181,7 @@ function AlbumRow(props: {
   return (
     <List.Item
       key={props.album.ratingKey}
+      id={props.album.ratingKey}
       icon={artworkSource(props.album.thumb)}
       title={props.album.title}
       subtitle={props.album.parentTitle}
@@ -214,9 +244,10 @@ function PlaylistRow(props: {
   );
 }
 
-function TrackRow(props: {
+export function TrackRow(props: {
   track: MusicTrack;
   coverPath?: string;
+  leadingActions?: ReactNode;
   onPlay: (item: PlayableItem) => Promise<void>;
   onPlayNext: (item: PlayableItem) => Promise<void>;
   onQueue: (item: PlayableItem) => Promise<void>;
@@ -226,6 +257,7 @@ function TrackRow(props: {
   return (
     <List.Item
       key={props.track.ratingKey}
+      id={props.track.ratingKey}
       icon={artworkSource(props.track.thumb ?? props.coverPath)}
       title={formatTrackDisplayTitle(props.track.title, {
         parentIndex: props.track.parentIndex,
@@ -243,7 +275,10 @@ function TrackRow(props: {
             onPlayNext={props.onPlayNext}
             onQueue={props.onQueue}
             nowPlayingShortcut={{ modifiers: ["cmd"], key: "n" }}
-          />
+            leadingActions={props.leadingActions}
+          >
+            <TrackNavigationActions track={props.track} />
+          </PlaybackActionItems>
         </ActionPanel>
       }
     />
@@ -538,6 +573,7 @@ function AlbumGridItem(props: {
   return (
     <Grid.Item
       key={props.album.ratingKey}
+      id={props.album.ratingKey}
       content={artworkSource(props.album.thumb)}
       title={props.album.title}
       subtitle={props.album.year?.toString()}
@@ -563,7 +599,7 @@ function AlbumGridItem(props: {
   );
 }
 
-export function AlbumList(props: { artist: MusicArtist; sectionKey: string }) {
+export function AlbumList(props: { artist: MusicArtist; sectionKey: string; selectedAlbumRatingKey?: string }) {
   const albums = useAsyncValue(
     () => getAlbumsForArtist(props.sectionKey, props.artist),
     `${props.sectionKey}:${props.artist.ratingKey}`,
@@ -573,6 +609,7 @@ export function AlbumList(props: { artist: MusicArtist; sectionKey: string }) {
   const { viewMode, toggleViewMode, isLoaded } = useAlbumViewMode();
 
   const isLoading = !isLoaded || albums.isLoading || playback.isPerforming;
+  const selectedItemId = useDeferredSelection(albums.value, props.selectedAlbumRatingKey);
 
   const errorView = albums.error ? (
     viewMode === "list" ? (
@@ -621,6 +658,7 @@ export function AlbumList(props: { artist: MusicArtist; sectionKey: string }) {
         isLoading={isLoading}
         navigationTitle={props.artist.title}
         searchBarPlaceholder="Filter albums"
+        selectedItemId={selectedItemId}
         actions={defaultActions}
       >
         {errorView}
@@ -649,6 +687,7 @@ export function AlbumList(props: { artist: MusicArtist; sectionKey: string }) {
       isLoading={isLoading}
       navigationTitle={props.artist.title}
       searchBarPlaceholder="Filter albums"
+      selectedItemId={selectedItemId}
       actions={defaultActions}
     >
       {errorView}
@@ -679,7 +718,7 @@ const SCOPED_SEARCH_TRACK_LIMIT = 1000;
 // AlbumTrackList: albums are small — always load all tracks for scoped search
 // ---------------------------------------------------------------------------
 
-export function AlbumTrackList(props: { album: MusicAlbum; sectionKey: string }) {
+export function AlbumTrackList(props: { album: MusicAlbum; sectionKey: string; selectedTrackRatingKey?: string }) {
   const tracks = useAsyncValue(() => getTracksForAlbum(props.album), props.album.ratingKey, [] as MusicTrack[]);
   const playback = usePlaybackActions();
 
@@ -690,6 +729,17 @@ export function AlbumTrackList(props: { album: MusicAlbum; sectionKey: string })
       tracks={tracks.value}
       isLoading={tracks.isLoading || playback.isPerforming}
       error={tracks.error}
+      selectedTrackRatingKey={props.selectedTrackRatingKey}
+      renderLeadingActions={(track) => (
+        <>
+          <Action
+            title="Play Album from This Track"
+            icon={Icon.PlayFilled}
+            onAction={() => playback.playFromTrack(props.album, track)}
+          />
+          <Action title="Play Album from Start" icon={Icon.Rewind} onAction={() => playback.play(props.album)} />
+        </>
+      )}
       onPlay={playback.play}
       onPlayNext={playback.playNext}
       onQueue={playback.queue}
@@ -797,17 +847,20 @@ function TrackList(props: {
   tracks: MusicTrack[];
   isLoading: boolean;
   error?: string;
+  selectedTrackRatingKey?: string;
+  renderLeadingActions?: (track: MusicTrack) => ReactNode;
   onPlay: (item: PlayableItem) => Promise<void>;
   onPlayNext: (item: PlayableItem) => Promise<void>;
   onQueue: (item: PlayableItem) => Promise<void>;
 }) {
-  const ratingDisplayMode = getTrackRatingDisplayMode();
+  const selectedItemId = useDeferredSelection(props.tracks, props.selectedTrackRatingKey);
 
   return (
     <List
       isLoading={props.isLoading}
       navigationTitle={props.title}
       searchBarPlaceholder="Filter tracks"
+      selectedItemId={selectedItemId}
       actions={
         <ActionPanel>
           <NowPlayingAction shortcut={{ modifiers: ["cmd"], key: "n" }} />
@@ -829,28 +882,14 @@ function TrackList(props: {
         />
       ) : null}
       {props.tracks.map((track) => (
-        <List.Item
+        <TrackRow
           key={track.ratingKey}
-          icon={artworkSource(track.thumb ?? props.coverPath)}
-          title={formatTrackDisplayTitle(track.title, {
-            parentIndex: track.parentIndex,
-            index: track.index,
-            userRating: track.userRating,
-            displayMode: ratingDisplayMode,
-          })}
-          subtitle={[track.grandparentTitle, track.parentTitle].filter(Boolean).join(" - ")}
-          accessories={trackAccessories(track)}
-          actions={
-            <ActionPanel>
-              <PlaybackActionItems
-                item={track}
-                onPlay={props.onPlay}
-                onPlayNext={props.onPlayNext}
-                onQueue={props.onQueue}
-                nowPlayingShortcut={{ modifiers: ["cmd"], key: "n" }}
-              />
-            </ActionPanel>
-          }
+          track={track}
+          coverPath={props.coverPath}
+          leadingActions={props.renderLeadingActions?.(track)}
+          onPlay={props.onPlay}
+          onPlayNext={props.onPlayNext}
+          onQueue={props.onQueue}
         />
       ))}
     </List>
@@ -873,8 +912,6 @@ function PaginatedTrackList(props: {
   onPlayNext: (item: PlayableItem) => Promise<void>;
   onQueue: (item: PlayableItem) => Promise<void>;
 }) {
-  const ratingDisplayMode = getTrackRatingDisplayMode();
-
   return (
     <List
       isLoading={props.isLoading}
@@ -892,30 +929,46 @@ function PaginatedTrackList(props: {
       }
     >
       {props.tracks.map((track) => (
-        <List.Item
+        <TrackRow
           key={track.ratingKey}
-          icon={artworkSource(track.thumb ?? props.coverPath)}
-          title={formatTrackDisplayTitle(track.title, {
-            parentIndex: track.parentIndex,
-            index: track.index,
-            userRating: track.userRating,
-            displayMode: ratingDisplayMode,
-          })}
-          subtitle={[track.grandparentTitle, track.parentTitle].filter(Boolean).join(" - ")}
-          accessories={trackAccessories(track)}
-          actions={
-            <ActionPanel>
-              <PlaybackActionItems
-                item={track}
-                onPlay={props.onPlay}
-                onPlayNext={props.onPlayNext}
-                onQueue={props.onQueue}
-                nowPlayingShortcut={{ modifiers: ["cmd"], key: "n" }}
-              />
-            </ActionPanel>
-          }
+          track={track}
+          coverPath={props.coverPath}
+          onPlay={props.onPlay}
+          onPlayNext={props.onPlayNext}
+          onQueue={props.onQueue}
         />
       ))}
+    </List>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shared: loading / error placeholder
+// ---------------------------------------------------------------------------
+
+function PendingView(props: {
+  navigationTitle: string;
+  loadingTitle: string;
+  errorTitle: string;
+  icon: Icon;
+  isLoading: boolean;
+  error?: string;
+}) {
+  const actions = (
+    <ActionPanel>
+      <NowPlayingAction shortcut={{ modifiers: ["cmd"], key: "n" }} />
+      <PreferencesAction />
+    </ActionPanel>
+  );
+
+  return (
+    <List isLoading={props.isLoading} navigationTitle={props.navigationTitle} actions={actions}>
+      <List.EmptyView
+        icon={props.error ? Icon.ExclamationMark : props.icon}
+        title={props.error ? props.errorTitle : props.loadingTitle}
+        description={props.error}
+        actions={actions}
+      />
     </List>
   );
 }
@@ -924,7 +977,7 @@ function PaginatedTrackList(props: {
 // Deep-link launch views
 // ---------------------------------------------------------------------------
 
-function LaunchAlbumView(props: { ratingKey: string; sectionKey: string }) {
+function LaunchAlbumView(props: { ratingKey: string; sectionKey: string; selectedTrackRatingKey?: string }) {
   const album = useAsyncValue(
     async () => {
       const metadata = await getMetadataByRatingKey(props.ratingKey);
@@ -940,36 +993,28 @@ function LaunchAlbumView(props: { ratingKey: string; sectionKey: string }) {
   );
 
   if (album.value) {
-    return <AlbumTrackList album={album.value} sectionKey={props.sectionKey} />;
+    return (
+      <AlbumTrackList
+        album={album.value}
+        sectionKey={props.sectionKey}
+        selectedTrackRatingKey={props.selectedTrackRatingKey}
+      />
+    );
   }
 
   return (
-    <List
-      isLoading={album.isLoading}
+    <PendingView
       navigationTitle="Browse Album"
-      actions={
-        <ActionPanel>
-          <NowPlayingAction shortcut={{ modifiers: ["cmd"], key: "n" }} />
-          <PreferencesAction />
-        </ActionPanel>
-      }
-    >
-      <List.EmptyView
-        icon={album.error ? Icon.ExclamationMark : Icon.Music}
-        title={album.error ? "Unable to load album" : "Loading album"}
-        description={album.error}
-        actions={
-          <ActionPanel>
-            <NowPlayingAction shortcut={{ modifiers: ["cmd"], key: "n" }} />
-            <PreferencesAction />
-          </ActionPanel>
-        }
-      />
-    </List>
+      loadingTitle="Loading album"
+      errorTitle="Unable to load album"
+      icon={Icon.Music}
+      isLoading={album.isLoading}
+      error={album.error}
+    />
   );
 }
 
-function LaunchArtistView(props: { ratingKey: string; sectionKey: string }) {
+function LaunchArtistView(props: { ratingKey: string; sectionKey: string; selectedAlbumRatingKey?: string }) {
   const artist = useAsyncValue(
     async () => {
       const metadata = await getMetadataByRatingKey(props.ratingKey);
@@ -985,32 +1030,107 @@ function LaunchArtistView(props: { ratingKey: string; sectionKey: string }) {
   );
 
   if (artist.value) {
-    return <AlbumList artist={artist.value} sectionKey={props.sectionKey} />;
+    return (
+      <AlbumList
+        artist={artist.value}
+        sectionKey={props.sectionKey}
+        selectedAlbumRatingKey={props.selectedAlbumRatingKey}
+      />
+    );
   }
 
   return (
-    <List
-      isLoading={artist.isLoading}
+    <PendingView
       navigationTitle="Browse Artist"
-      actions={
-        <ActionPanel>
-          <NowPlayingAction shortcut={{ modifiers: ["cmd"], key: "n" }} />
-          <PreferencesAction />
-        </ActionPanel>
-      }
-    >
-      <List.EmptyView
-        icon={artist.error ? Icon.ExclamationMark : Icon.Person}
-        title={artist.error ? "Unable to load artist" : "Loading artist"}
-        description={artist.error}
-        actions={
-          <ActionPanel>
-            <NowPlayingAction shortcut={{ modifiers: ["cmd"], key: "n" }} />
-            <PreferencesAction />
-          </ActionPanel>
-        }
+      loadingTitle="Loading artist"
+      errorTitle="Unable to load artist"
+      icon={Icon.Person}
+      isLoading={artist.isLoading}
+      error={artist.error}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Track navigation: Go to Album / Go to Artist from any track row
+// ---------------------------------------------------------------------------
+
+function TrackAlbumView(props: { track: MusicTrack }) {
+  const target = useAsyncValue(
+    () => resolveTrackAlbum(props.track),
+    props.track.ratingKey,
+    undefined as TrackAlbumTarget | undefined,
+  );
+
+  if (target.value) {
+    return (
+      <AlbumTrackList
+        album={target.value.album}
+        sectionKey={target.value.sectionKey}
+        selectedTrackRatingKey={props.track.ratingKey}
       />
-    </List>
+    );
+  }
+
+  return (
+    <PendingView
+      navigationTitle="Go to Album"
+      loadingTitle="Loading album"
+      errorTitle="Unable to load album"
+      icon={Icon.Music}
+      isLoading={target.isLoading}
+      error={target.error}
+    />
+  );
+}
+
+function TrackArtistView(props: { track: MusicTrack }) {
+  const target = useAsyncValue(
+    () => resolveTrackArtist(props.track),
+    props.track.ratingKey,
+    undefined as TrackArtistTarget | undefined,
+  );
+
+  if (target.value) {
+    return (
+      <AlbumList
+        artist={target.value.artist}
+        sectionKey={target.value.sectionKey}
+        selectedAlbumRatingKey={target.value.albumRatingKey}
+      />
+    );
+  }
+
+  return (
+    <PendingView
+      navigationTitle="Go to Artist"
+      loadingTitle="Loading artist"
+      errorTitle="Unable to load artist"
+      icon={Icon.Person}
+      isLoading={target.isLoading}
+      error={target.error}
+    />
+  );
+}
+
+export function TrackNavigationActions(props: { track: MusicTrack }) {
+  const { push } = useNavigation();
+
+  return (
+    <>
+      <Action
+        title="Go to Album"
+        icon={Icon.Music}
+        shortcut={{ modifiers: ["cmd"], key: "g" }}
+        onAction={() => push(<TrackAlbumView track={props.track} />)}
+      />
+      <Action
+        title="Go to Artist"
+        icon={Icon.Person}
+        shortcut={{ modifiers: ["cmd", "shift"], key: "g" }}
+        onAction={() => push(<TrackArtistView track={props.track} />)}
+      />
+    </>
   );
 }
 
@@ -1022,11 +1142,23 @@ export default function Command(props: LaunchProps<{ launchContext?: BrowseLaunc
   const context = props.launchContext;
 
   if (context?.target === "album" && context.ratingKey && context.sectionKey) {
-    return <LaunchAlbumView ratingKey={context.ratingKey} sectionKey={context.sectionKey} />;
+    return (
+      <LaunchAlbumView
+        ratingKey={context.ratingKey}
+        sectionKey={context.sectionKey}
+        selectedTrackRatingKey={context.selectedRatingKey}
+      />
+    );
   }
 
   if (context?.target === "artist" && context.ratingKey && context.sectionKey) {
-    return <LaunchArtistView ratingKey={context.ratingKey} sectionKey={context.sectionKey} />;
+    return (
+      <LaunchArtistView
+        ratingKey={context.ratingKey}
+        sectionKey={context.sectionKey}
+        selectedAlbumRatingKey={context.selectedRatingKey}
+      />
+    );
   }
 
   return <RootContent />;

--- a/extensions/plexamp/src/browse-media.tsx
+++ b/extensions/plexamp/src/browse-media.tsx
@@ -246,6 +246,7 @@ function PlaylistRow(props: {
 
 export function TrackRow(props: {
   track: MusicTrack;
+  id?: string;
   coverPath?: string;
   leadingActions?: ReactNode;
   onPlay: (item: PlayableItem) => Promise<void>;
@@ -257,7 +258,7 @@ export function TrackRow(props: {
   return (
     <List.Item
       key={props.track.ratingKey}
-      id={props.track.ratingKey}
+      id={props.id ?? props.track.ratingKey}
       icon={artworkSource(props.track.thumb ?? props.coverPath)}
       title={formatTrackDisplayTitle(props.track.title, {
         parentIndex: props.track.parentIndex,
@@ -838,6 +839,23 @@ function LargePlaylistTrackList(props: { playlist: AudioPlaylist; sectionKey: st
 }
 
 // ---------------------------------------------------------------------------
+// Shared: unique item ids for track lists
+// ---------------------------------------------------------------------------
+
+// A playlist can hold the same track more than once, and Raycast needs every item id in a list to be
+// unique. The first occurrence keeps its bare rating key, which album pre-selection targets; repeats get
+// an occurrence suffix.
+function withUniqueItemIds(tracks: MusicTrack[]): { track: MusicTrack; itemId: string }[] {
+  const occurrences = new Map<string, number>();
+
+  return tracks.map((track) => {
+    const occurrence = occurrences.get(track.ratingKey) ?? 0;
+    occurrences.set(track.ratingKey, occurrence + 1);
+    return { track, itemId: occurrence === 0 ? track.ratingKey : `${track.ratingKey}:${occurrence}` };
+  });
+}
+
+// ---------------------------------------------------------------------------
 // TrackList: all tracks loaded — uses Raycast built-in client-side filtering
 // ---------------------------------------------------------------------------
 
@@ -881,9 +899,10 @@ function TrackList(props: {
           }
         />
       ) : null}
-      {props.tracks.map((track) => (
+      {withUniqueItemIds(props.tracks).map(({ track, itemId }) => (
         <TrackRow
-          key={track.ratingKey}
+          key={itemId}
+          id={itemId}
           track={track}
           coverPath={props.coverPath}
           leadingActions={props.renderLeadingActions?.(track)}
@@ -928,9 +947,10 @@ function PaginatedTrackList(props: {
         </ActionPanel>
       }
     >
-      {props.tracks.map((track) => (
+      {withUniqueItemIds(props.tracks).map(({ track, itemId }) => (
         <TrackRow
-          key={track.ratingKey}
+          key={itemId}
+          id={itemId}
           track={track}
           coverPath={props.coverPath}
           onPlay={props.onPlay}

--- a/extensions/plexamp/src/player-controls.tsx
+++ b/extensions/plexamp/src/player-controls.tsx
@@ -4,10 +4,11 @@ import { useCallback, useMemo, useState } from "react";
 import { formatDuration, formatTrackDisplayTitle, getTrackRatingDisplayMode } from "./format";
 import {
   clearPlayQueue,
-  getMetadataByRatingKey,
   movePlayQueueItem,
   playPause,
   removePlayQueueItem,
+  resolveTrackAlbum,
+  resolveTrackArtist,
   setRepeat,
   setShuffle,
   skipNext,
@@ -67,20 +68,6 @@ function getRepeatAccessoryText(repeat?: string): string {
     default:
       return "Loop off";
   }
-}
-
-async function resolveNavigableTrack(track: MusicTrack): Promise<MusicTrack> {
-  if (track.parentRatingKey && track.grandparentRatingKey && track.librarySectionKey) {
-    return track;
-  }
-
-  const metadata = await getMetadataByRatingKey(track.ratingKey);
-
-  if (!metadata || metadata.type !== "track") {
-    throw new Error("Could not load full metadata for this track.");
-  }
-
-  return metadata;
 }
 
 function getPlaybackStateText(state?: string): string {
@@ -175,21 +162,7 @@ export default function Command() {
       ? `${state.timeline.protocol}://${state.timeline.address}:${state.timeline.port}`
       : undefined;
   const navigateToAlbum = useCallback(async (track: MusicTrack) => {
-    const resolvedTrack = await resolveNavigableTrack(track);
-
-    if (!resolvedTrack.parentRatingKey) {
-      throw new Error("This track is missing album metadata.");
-    }
-
-    if (!resolvedTrack.librarySectionKey) {
-      throw new Error("This track is missing library section metadata.");
-    }
-
-    const album = await getMetadataByRatingKey(resolvedTrack.parentRatingKey);
-
-    if (!album || album.type !== "album") {
-      throw new Error("Could not load the album for this track.");
-    }
+    const { album, sectionKey } = await resolveTrackAlbum(track);
 
     await launchCommand({
       name: "browse-media",
@@ -197,27 +170,14 @@ export default function Command() {
       context: {
         target: "album",
         ratingKey: album.ratingKey,
-        sectionKey: resolvedTrack.librarySectionKey,
+        sectionKey,
+        selectedRatingKey: track.ratingKey,
       },
     });
   }, []);
 
   const navigateToArtist = useCallback(async (track: MusicTrack) => {
-    const resolvedTrack = await resolveNavigableTrack(track);
-
-    if (!resolvedTrack.grandparentRatingKey) {
-      throw new Error("This track is missing artist metadata.");
-    }
-
-    if (!resolvedTrack.librarySectionKey) {
-      throw new Error("This track is missing library section metadata.");
-    }
-
-    const artist = await getMetadataByRatingKey(resolvedTrack.grandparentRatingKey);
-
-    if (!artist || artist.type !== "artist") {
-      throw new Error("Could not load the artist for this track.");
-    }
+    const { artist, albumRatingKey, sectionKey } = await resolveTrackArtist(track);
 
     await launchCommand({
       name: "browse-media",
@@ -225,7 +185,8 @@ export default function Command() {
       context: {
         target: "artist",
         ratingKey: artist.ratingKey,
-        sectionKey: resolvedTrack.librarySectionKey,
+        sectionKey,
+        selectedRatingKey: albumRatingKey,
       },
     });
   }, []);

--- a/extensions/plexamp/src/plex-library.ts
+++ b/extensions/plexamp/src/plex-library.ts
@@ -399,3 +399,68 @@ export async function getMetadataByKeyForTimeline(
 export async function getMetadataByRatingKey(ratingKey: string): Promise<MetadataItem | undefined> {
   return getMetadataByKey(buildMetadataKey(ratingKey));
 }
+
+async function resolveNavigableTrack(track: MusicTrack): Promise<MusicTrack> {
+  if (track.parentRatingKey && track.grandparentRatingKey && track.librarySectionKey) {
+    return track;
+  }
+
+  const metadata = await getMetadataByRatingKey(track.ratingKey);
+
+  if (!metadata || metadata.type !== "track") {
+    throw new Error("Could not load full metadata for this track.");
+  }
+
+  return metadata;
+}
+
+export interface TrackAlbumTarget {
+  album: MusicAlbum;
+  sectionKey: string;
+}
+
+export interface TrackArtistTarget {
+  artist: MusicArtist;
+  albumRatingKey?: string;
+  sectionKey: string;
+}
+
+export async function resolveTrackAlbum(track: MusicTrack): Promise<TrackAlbumTarget> {
+  const resolved = await resolveNavigableTrack(track);
+
+  if (!resolved.parentRatingKey) {
+    throw new Error("This track is missing album metadata.");
+  }
+
+  if (!resolved.librarySectionKey) {
+    throw new Error("This track is missing library section metadata.");
+  }
+
+  const album = await getMetadataByRatingKey(resolved.parentRatingKey);
+
+  if (!album || album.type !== "album") {
+    throw new Error("Could not load the album for this track.");
+  }
+
+  return { album, sectionKey: resolved.librarySectionKey };
+}
+
+export async function resolveTrackArtist(track: MusicTrack): Promise<TrackArtistTarget> {
+  const resolved = await resolveNavigableTrack(track);
+
+  if (!resolved.grandparentRatingKey) {
+    throw new Error("This track is missing artist metadata.");
+  }
+
+  if (!resolved.librarySectionKey) {
+    throw new Error("This track is missing library section metadata.");
+  }
+
+  const artist = await getMetadataByRatingKey(resolved.grandparentRatingKey);
+
+  if (!artist || artist.type !== "artist") {
+    throw new Error("Could not load the artist for this track.");
+  }
+
+  return { artist, albumRatingKey: resolved.parentRatingKey, sectionKey: resolved.librarySectionKey };
+}

--- a/extensions/plexamp/src/plex-playback.ts
+++ b/extensions/plexamp/src/plex-playback.ts
@@ -18,7 +18,7 @@ import {
   requestTimelineServer,
 } from "./plex-request";
 import { getMetadataByKeyForTimeline, getMetadataByRatingKey } from "./plex-library";
-import type { MusicTrack, PlayQueueInfo, PlayableItem, TimelineInfo } from "./types";
+import type { MusicAlbum, MusicTrack, PlayQueueInfo, PlayableItem, TimelineInfo } from "./types";
 
 interface ServerIdentity {
   machineIdentifier: string;
@@ -196,7 +196,9 @@ export async function getPlayQueueForTimeline(
   }
 }
 
-async function createPlayQueue(item: PlayableItem): Promise<PlayQueueInfo> {
+// `startKey` picks the item to start from inside a library container. It is ignored for playlists,
+// which are addressed by `playlistID` instead.
+async function createPlayQueue(item: PlayableItem, startKey?: string): Promise<PlayQueueInfo> {
   const identity = await getServerIdentity();
   const params = new URLSearchParams({
     type: "audio",
@@ -209,7 +211,7 @@ async function createPlayQueue(item: PlayableItem): Promise<PlayQueueInfo> {
     params.set("playlistID", item.ratingKey);
   } else {
     params.set("uri", buildPlayableUri(identity.machineIdentifier, item));
-    params.set("key", item.key);
+    params.set("key", startKey ?? item.key);
   }
 
   const container = await requestServer(`/playQueues?${params.toString()}`, {
@@ -350,6 +352,11 @@ async function createExplicitQueueFromTimeline(
 
 export async function playItem(item: PlayableItem): Promise<void> {
   const queue = await createPlayQueue(item);
+  await startPlayQueue(queue);
+}
+
+export async function playAlbumFromTrack(album: MusicAlbum, track: MusicTrack): Promise<void> {
+  const queue = await createPlayQueue(album, track.key);
   await startPlayQueue(queue);
 }
 

--- a/extensions/plexamp/src/plex-playback.ts
+++ b/extensions/plexamp/src/plex-playback.ts
@@ -220,14 +220,17 @@ async function createPlayQueue(item: PlayableItem, startKey?: string): Promise<P
   return parsePlayQueue(container);
 }
 
-async function startPlayQueue(queue: PlayQueueInfo): Promise<void> {
+async function startPlayQueue(queue: PlayQueueInfo, startKey?: string): Promise<void> {
   const config = await requireServerConfig();
   const identity = await getServerIdentity();
-  const selectedKey = queue.selectedKey ?? queue.items[0]?.key;
 
-  if (!selectedKey) {
+  if (queue.items.length === 0) {
     throw new Error("The created play queue did not include a playable track.");
   }
+
+  // The response only carries a window of the queue, and parsePlayQueue falls back to the first item when
+  // the selected one is outside it, so the key the caller asked for takes precedence.
+  const selectedKey = startKey ?? queue.selectedKey ?? queue.items[0].key;
 
   await requestPlayer("/player/playback/playMedia", {
     machineIdentifier: identity.machineIdentifier,
@@ -357,7 +360,7 @@ export async function playItem(item: PlayableItem): Promise<void> {
 
 export async function playAlbumFromTrack(album: MusicAlbum, track: MusicTrack): Promise<void> {
   const queue = await createPlayQueue(album, track.key);
-  await startPlayQueue(queue);
+  await startPlayQueue(queue, track.key);
 }
 
 export async function queueItem(item: PlayableItem): Promise<void> {

--- a/extensions/plexamp/src/plex.ts
+++ b/extensions/plexamp/src/plex.ts
@@ -27,15 +27,18 @@ export {
   getTracksForPlaylist,
   getTracksPage,
   resolveSelectedLibrary,
+  resolveTrackAlbum,
+  resolveTrackArtist,
   searchLibrary,
 } from "./plex-library";
-export type { PageResult } from "./plex-library";
+export type { PageResult, TrackAlbumTarget, TrackArtistTarget } from "./plex-library";
 export {
   clearPlayQueue,
   getPlayQueue,
   getPlayQueueForTimeline,
   getTimeline,
   movePlayQueueItem,
+  playAlbumFromTrack,
   playItem,
   playNextItem,
   playPause,

--- a/extensions/plexamp/src/recently-played.tsx
+++ b/extensions/plexamp/src/recently-played.tsx
@@ -1,5 +1,6 @@
 import { ActionPanel, Icon, List } from "@raycast/api";
 
+import { TrackNavigationActions } from "./browse-media";
 import { formatTrackDisplayTitle, getTrackRatingDisplayMode } from "./format";
 import { getRecentlyPlayed } from "./plex";
 import {
@@ -41,7 +42,9 @@ function RecentTrackRow(props: {
             onPlayNext={props.onPlayNext}
             onQueue={props.onQueue}
             nowPlayingShortcut={{ modifiers: ["cmd"], key: "n" }}
-          />
+          >
+            <TrackNavigationActions track={props.track} />
+          </PlaybackActionItems>
         </ActionPanel>
       }
     />

--- a/extensions/plexamp/src/search-shared.tsx
+++ b/extensions/plexamp/src/search-shared.tsx
@@ -1,8 +1,7 @@
 import { ActionPanel, Icon, List } from "@raycast/api";
 import { useEffect, useState } from "react";
 
-import { AlbumList, AlbumTrackList, PlaylistTrackList } from "./browse-media";
-import { formatTrackDisplayTitle, getTrackRatingDisplayMode } from "./format";
+import { AlbumList, AlbumTrackList, PlaylistTrackList, TrackRow } from "./browse-media";
 import { getAudioPlaylists, searchLibrary } from "./plex";
 import {
   NowPlayingAction,
@@ -11,7 +10,6 @@ import {
   albumAccessories,
   artworkSource,
   librarySetupDescription,
-  trackAccessories,
   usePlaybackActions,
 } from "./shared-ui";
 import { useAsyncValue } from "./use-async-value";
@@ -87,8 +85,6 @@ function SearchResultsList(props: {
   onPlayNext: (item: PlayableItem) => Promise<void>;
   onQueue: (item: PlayableItem) => Promise<void>;
 }) {
-  const ratingDisplayMode = getTrackRatingDisplayMode();
-
   return (
     <>
       {props.artists.length > 0 ? (
@@ -146,35 +142,15 @@ function SearchResultsList(props: {
 
       {props.tracks.length > 0 ? (
         <List.Section title="Songs">
-          {props.tracks.map((track) =>
-            (() => {
-              return (
-                <List.Item
-                  key={`track-${track.ratingKey}`}
-                  icon={artworkSource(track.thumb)}
-                  title={formatTrackDisplayTitle(track.title, {
-                    parentIndex: track.parentIndex,
-                    index: track.index,
-                    userRating: track.userRating,
-                    displayMode: ratingDisplayMode,
-                  })}
-                  subtitle={[track.grandparentTitle, track.parentTitle].filter(Boolean).join(" - ")}
-                  accessories={trackAccessories(track)}
-                  actions={
-                    <ActionPanel>
-                      <PlaybackActionItems
-                        item={track}
-                        onPlay={props.onPlay}
-                        onPlayNext={props.onPlayNext}
-                        onQueue={props.onQueue}
-                        nowPlayingShortcut={{ modifiers: ["cmd"], key: "n" }}
-                      />
-                    </ActionPanel>
-                  }
-                />
-              );
-            })(),
-          )}
+          {props.tracks.map((track) => (
+            <TrackRow
+              key={track.ratingKey}
+              track={track}
+              onPlay={props.onPlay}
+              onPlayNext={props.onPlayNext}
+              onQueue={props.onQueue}
+            />
+          ))}
         </List.Section>
       ) : null}
 

--- a/extensions/plexamp/src/shared-ui.tsx
+++ b/extensions/plexamp/src/shared-ui.tsx
@@ -12,10 +12,10 @@ import {
   showToast,
   useNavigation,
 } from "@raycast/api";
-import { useCallback, useState, type ReactElement } from "react";
+import { useCallback, useState, type ReactElement, type ReactNode } from "react";
 
 import { formatDuration, getTrackAccessoryValues } from "./format";
-import { getImageUrl, playItem, playNextItem, queueItem } from "./plex";
+import { getImageUrl, playAlbumFromTrack, playItem, playNextItem, queueItem } from "./plex";
 import type { MusicAlbum, MusicTrack, PlayableItem } from "./types";
 
 export function artworkSource(
@@ -131,19 +131,19 @@ export function PlaybackActionItems(props: {
   onQueue: (item: PlayableItem) => Promise<void>;
   browseTarget?: ReactElement;
   browseTitle?: string;
-  browseIcon?: Icon;
   nowPlayingShortcut?: Keyboard.Shortcut;
+  leadingActions?: ReactNode;
+  children?: ReactNode;
 }) {
   const { push } = useNavigation();
 
   return (
     <>
+      {/* The first two actions in a panel are the Enter / Cmd+Enter defaults, so leading actions take those
+          over; children land after Play Next. */}
+      {props.leadingActions}
       {props.browseTarget && props.browseTitle ? (
-        <Action
-          title={props.browseTitle}
-          icon={props.browseIcon ?? Icon.ArrowRight}
-          onAction={() => push(props.browseTarget)}
-        />
+        <Action title={props.browseTitle} icon={Icon.ArrowRight} onAction={() => push(props.browseTarget)} />
       ) : null}
       <Action title="Play in Plexamp" icon={Icon.Play} onAction={() => props.onPlay(props.item)} />
       <Action title="Add to Queue" icon={Icon.Plus} onAction={() => props.onQueue(props.item)} />
@@ -153,6 +153,7 @@ export function PlaybackActionItems(props: {
         onAction={() => props.onPlayNext(props.item)}
         shortcut={{ modifiers: ["cmd", "shift"], key: "return" }}
       />
+      {props.children}
       <NowPlayingAction shortcut={props.nowPlayingShortcut} />
       <PreferencesAction />
     </>
@@ -187,5 +188,7 @@ export function usePlaybackActions() {
     play: (item: PlayableItem) => runAction(() => playItem(item), "Playback started in Plexamp"),
     playNext: (item: PlayableItem) => runAction(() => playNextItem(item), "Item added to play next"),
     queue: (item: PlayableItem) => runAction(() => queueItem(item), "Item added to the Plexamp queue"),
+    playFromTrack: (album: MusicAlbum, track: MusicTrack) =>
+      runAction(() => playAlbumFromTrack(album, track), "Playback started in Plexamp"),
   };
 }


### PR DESCRIPTION
## Description

In the Plexamp desktop app, playing a specific track from an album automatically plays the whole album starting from that track, which allows navigating the album using next/previous track shortcuts. Additionally, from any single track, for example from Recently Played or Recently Added sections, the Plexamp desktop app allows users to Go to Album or Go to Artist.

In the Plexamp Raycast extension, from Recently Played, Search Library, and the browse search results, a track row only offered Play, Add to Queue, and Play Next, with no way to reach the album or artist it belongs to. Playing a track from an album this way would queue only that specific track, with no option to queue the rest of the album.

This adds `Go to Album` (`Cmd+G`) and `Go to Artist` (`Cmd+Shift+G`) to every track row. `Go to Album` opens the album's track list with the track selected, and `Go to Artist` opens the artist's release list with the album selected, in both list and grid view. Album track lists also gain `Play Album from This Track` and `Play Album from Start` as the `Enter` and `Cmd+Enter` defaults. Now Playing's existing `Go to Album` and `Go to Artist` deep links pre-select the same way.

### Decisions

- In album track lists, `Enter` and `Cmd+Enter` change meaning: they used to play the single track and add it to the queue. That is deliberate. The single-track actions stay in the panel, and everywhere else the two navigation actions sit after `Play Next`, so `Enter` and `Cmd+Enter` keep their current meaning.
- Playing an album from a track reuses the existing play-queue request. Plex already accepts a `key` next to the container `uri` and starts the queue at that item, so this is one optional parameter on `createPlayQueue` rather than a second playback path. The parameter is ignored for playlists, which is documented at the function.
- The track-to-album and track-to-artist resolution used to exist three times (twice in Now Playing, once in the browse view) and would have gained a fourth copy. It is now two resolvers in `plex-library.ts`, shared by Now Playing and the browse views, with the same error messages as before.
- Navigation requires the track's own library section and shows an error placeholder if it is missing, rather than falling back to the selected library. A playlist can hold a track from another music library, and that is exactly the case where the selected library would query the wrong section. Now Playing already behaved this way.
- The album actions reach the rows through a render prop on `TrackList` and a leading slot in `PlaybackActionItems`. `TrackList` is shared with the playlist views, and the album view owns the playback hook whose in-flight state drives the loading indicator, so the callback cannot live inside `TrackList`. This keeps the track row, search, and Recently Played components unaware of albums.

### Review notes

- `useDeferredSelection` hands `selectedItemId` to Raycast one tick after the target item is in the list, via `setTimeout`. Raycast ignores a `selectedItemId` that arrives in the same update as the item it points at. Once set, the value is never updated again, so the user's own selection moves are not overridden. There is no `onSelectionChange` guard on purpose: Raycast can fire it with the first item before applying the selection, which cancels the pre-selection.
- Track rows now carry `id={ratingKey}`. A playlist holding the same track twice already produced duplicate React keys, and the id inherits that assumption.
- `Go to Album` stays available inside an album's own track list, because a Now Playing deep link lands there with no way up to the artist's other albums.
- One case not ruled out from the code: on a very long album, the play-queue response window may omit the selected item, in which case playback would start at track 1 instead of the selected track. If that shows up, the fix is to pass the track key into `startPlayQueue` explicitly.

## Screencast

https://github.com/user-attachments/assets/6772dc27-26ce-40aa-9177-7d1ad257e5ae

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
