### PR TITLE
Update brew extension

### DIFF
--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed: a pinned cask was included in Upgrade All and reported as a **failed** upgrade. Pinned packages are now skipped, matching how pinned formulae are handled
 - Fixed: pinning or unpinning a cask did not refresh the installed list — cask pins live in a separate directory that the cache was not watching
 - Fixed: the "D" dependency badge never appeared. Homebrew removed the field it read in 5.1.9; it now reads the field brew actually reports
+- The upgrade progress toast now reports the download phase as a batch rather than naming one package: brew announces every package up front, then downloads them concurrently, so a per-package label there was not true
 - Removed the unused two-phase loading path (`brew list --versions`, added in 5.0 support). It had no caller and its cache read duplicated the main loader; installed packages already paint from cache
 - Search's "Sort by Popularity" moved from ⇧⌘P to ⇧⌘S: ⇧⌘P is Raycast's standard Pin shortcut, which now collides with the Pin action on installed packages
 - **This extension now requires Homebrew 6.0 or later.** The "Use internal API" preference is gone — Homebrew 6 uses that API by default and deprecates the setting, which made brew abort outright under `HOMEBREW_DEVELOPER`

--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed: the "D" dependency badge never appeared. Homebrew removed the field it read in 5.1.9; it now reads the field brew actually reports
 - The upgrade progress toast now reports the download phase as a batch rather than naming one package: brew announces every package up front, then downloads them concurrently, so a per-package label there was not true
 - A pinned cask now shows "Pinned: Yes" in the metadata panel, as pinned formulae already did — the list's tack accessory is hidden while that panel is open, so it was the only place the state could be seen. Formula metadata also gained the Tap row casks already had
+- Cask details now list the formulae and casks a cask depends on, and the architectures it requires — formula details have always shown dependencies, so casks were missing information brew reports (`gcloud-cli` needs `python@3.14`, for one)
 - Removed the unused two-phase loading path (`brew list --versions`, added in 5.0 support). It had no caller and its cache read duplicated the main loader; installed packages already paint from cache
 - Search's "Sort by Popularity" moved from ⇧⌘P to ⇧⌘S: ⇧⌘P is Raycast's standard Pin shortcut, which now collides with the Pin action on installed packages
 - **This extension now requires Homebrew 6.0 or later.** The "Use internal API" preference is gone — Homebrew 6 uses that API by default and deprecates the setting, which made brew abort outright under `HOMEBREW_DEVELOPER`

--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -11,6 +11,8 @@
 - The upgrade progress toast now reports the download phase as a batch rather than naming one package: brew announces every package up front, then downloads them concurrently, so a per-package label there was not true
 - A pinned cask now shows "Pinned: Yes" in the metadata panel, as pinned formulae already did — the list's tack accessory is hidden while that panel is open, so it was the only place the state could be seen. Formula metadata also gained the Tap row casks already had
 - A package Homebrew declines to upgrade is no longer reported as upgraded. Brew warns and skips a disabled, unavailable, already-current or un-upgradable package while still exiting 0, and each reason is now shown as its own outcome rather than one generic skip
+- Upgrading a single package that Homebrew declines now shows it as skipped, with the reason, rather than a red failure — and the "N of M" progress counter no longer stalls a step behind when a package is skipped mid-run
+- A cask that belongs to no tap no longer offers a "Copy Tap Name" action that would copy nothing
 - Pin state is now read from Homebrew's own pin directory immediately before an upgrade or uninstall, so a package pinned in another command — or outside Raycast — is respected rather than trusted from a cached snapshot. One directory read per run, ~20µs
 - If Homebrew refuses an upgrade or uninstall because the package is pinned, the toast now offers to unpin, instead of showing the raw error
 - Cask details now list the formulae and casks a cask depends on, and the architectures it requires — formula details have always shown dependencies, so casks were missing information brew reports (`gcloud-cli` needs `python@3.14`, for one)

--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -1,12 +1,24 @@
 # Brew Changelog
 
+## [Cask pinning, Homebrew 6] - {PR_MERGE_DATE}
+
+- **Casks can now be pinned**, just like formulae — pin a cask and it is locked out of upgrades, gets its own section in Show Installed, and shows the same pin icon everywhere. Homebrew has supported this since 5.1.12
+- Pinning a cask that updates itself now says so: the pin holds for brew, but the app can still self-update, so the toast says "Pinning may be overridden by auto-updates" instead of implying the version is frozen
+- Uninstalling a pinned package used to surface a raw brew error — brew refuses this for pinned formulae as well as casks. It now says the package is pinned and offers "Unpin and Force Uninstall" as an explicit choice
+- Fixed: a pinned cask was included in Upgrade All and reported as a **failed** upgrade. Pinned packages are now skipped, matching how pinned formulae are handled
+- Fixed: pinning or unpinning a cask did not refresh the installed list — cask pins live in a separate directory that the cache was not watching
+- Fixed: the "D" dependency badge never appeared. Homebrew removed the field it read in 5.1.9; it now reads the field brew actually reports
+- Removed the unused two-phase loading path (`brew list --versions`, added in 5.0 support). It had no caller and its cache read duplicated the main loader; installed packages already paint from cache
+- Search's "Sort by Popularity" moved from ⇧⌘P to ⇧⌘S: ⇧⌘P is Raycast's standard Pin shortcut, which now collides with the Pin action on installed packages
+- **This extension now requires Homebrew 6.0 or later.** The "Use internal API" preference is gone — Homebrew 6 uses that API by default and deprecates the setting, which made brew abort outright under `HOMEBREW_DEVELOPER`
+
 ## [Show Upgrades: reviewed, selective upgrading] - 2026-09-01
 
 - **Show Outdated is now Show Upgrades**: the outdated list has grown into a review surface — ↩ toggles a package (formula or cask) in or out of the upgrade, **⌘↩ runs it from any row** ("Upgrade All" with the default full selection, "Upgrade N Selected" once narrowed) and ⌘⇧A selects or deselects everything upgradable. The default selection is everything not pinned — exactly what a plain `brew upgrade` would do. Every per-package action the view offered (single upgrade, pin, copy/terminal commands, uninstall) remains on each row, and the command still answers to "outdated" in search
 - A reviewed run upgrades exactly the selected packages: each is upgraded individually by name, so deselected packages are simply left out — nothing is pinned, held or otherwise touched on their behalf. Packages that become outdated during the run's own `brew update` are not upgraded unreviewed; they remain visible — and selectable for a follow-up run — in the list afterwards
 - A pin is a lock, matching brew's own behaviour: pinned formulae cannot be selected, and upgrading one means unpinning it — ↩ on a pinned row unpins and selects it in one step. Pinning from the review (⌘.) deselects
 - Refreshing mid-review (⌘R) keeps the selections you have already made; a formula pinned outside the extension is deselected on refresh — the lock always wins
-- Casks are selectable exactly like formulae. Cask *pinning* (the lock semantics) waits on Homebrew 6's `brew pin --cask` and ships in a follow-up
+- Casks are selectable exactly like formulae. Cask *pinning* (the lock semantics) ships in a follow-up
 - Running the upgrade cancels the review's in-flight background `brew update` (and waits for it to release Homebrew's update lock) instead of asking the user to try again in a moment
 - Reopening either upgrade command after a run no longer flashes the pre-run list: a snapshot the run made stale is withheld until fresh data lands
 - A failed check-for-upgrades now shows a failure screen with a Retry action instead of a blank list (Show Upgrades) or a stuck checking placeholder (Upgrade); with cached packages still on screen the failure arrives as a toast instead, and with nothing outdated the empty screen offers a route to Show Installed

--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Fixed: the "D" dependency badge never appeared. Homebrew removed the field it read in 5.1.9; it now reads the field brew actually reports
 - The upgrade progress toast now reports the download phase as a batch rather than naming one package: brew announces every package up front, then downloads them concurrently, so a per-package label there was not true
 - A pinned cask now shows "Pinned: Yes" in the metadata panel, as pinned formulae already did — the list's tack accessory is hidden while that panel is open, so it was the only place the state could be seen. Formula metadata also gained the Tap row casks already had
+- A package Homebrew declines to upgrade is no longer reported as upgraded. Brew warns and skips a disabled, unavailable, already-current or un-upgradable package while still exiting 0, and each reason is now shown as its own outcome rather than one generic skip
+- Pin state is now read from Homebrew's own pin directory immediately before an upgrade or uninstall, so a package pinned in another command — or outside Raycast — is respected rather than trusted from a cached snapshot. One directory read per run, ~20µs
+- If Homebrew refuses an upgrade or uninstall because the package is pinned, the toast now offers to unpin, instead of showing the raw error
 - Cask details now list the formulae and casks a cask depends on, and the architectures it requires — formula details have always shown dependencies, so casks were missing information brew reports (`gcloud-cli` needs `python@3.14`, for one)
 - Removed the unused two-phase loading path (`brew list --versions`, added in 5.0 support). It had no caller and its cache read duplicated the main loader; installed packages already paint from cache
 - Search's "Sort by Popularity" moved from ⇧⌘P to ⇧⌘S: ⇧⌘P is Raycast's standard Pin shortcut, which now collides with the Pin action on installed packages

--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Brew Changelog
 
-## [Cask pinning, Homebrew 6] - {PR_MERGE_DATE}
+## [Cask pinning, Homebrew 6] - 2026-09-08
 
 - **Casks can now be pinned**, just like formulae — pin a cask and it is locked out of upgrades, gets its own section in Show Installed, and shows the same pin icon everywhere. Homebrew has supported this since 5.1.12
 - Pinning a cask that updates itself now says so: the pin holds for brew, but the app can still self-update, so the toast says "Pinning may be overridden by auto-updates" instead of implying the version is frozen

--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed: pinning or unpinning a cask did not refresh the installed list — cask pins live in a separate directory that the cache was not watching
 - Fixed: the "D" dependency badge never appeared. Homebrew removed the field it read in 5.1.9; it now reads the field brew actually reports
 - The upgrade progress toast now reports the download phase as a batch rather than naming one package: brew announces every package up front, then downloads them concurrently, so a per-package label there was not true
+- A pinned cask now shows "Pinned: Yes" in the metadata panel, as pinned formulae already did — the list's tack accessory is hidden while that panel is open, so it was the only place the state could be seen. Formula metadata also gained the Tap row casks already had
 - Removed the unused two-phase loading path (`brew list --versions`, added in 5.0 support). It had no caller and its cache read duplicated the main loader; installed packages already paint from cache
 - Search's "Sort by Popularity" moved from ⇧⌘P to ⇧⌘S: ⇧⌘P is Raycast's standard Pin shortcut, which now collides with the Pin action on installed packages
 - **This extension now requires Homebrew 6.0 or later.** The "Use internal API" preference is gone — Homebrew 6 uses that API by default and deprecates the setting, which made brew abort outright under `HOMEBREW_DEVELOPER`

--- a/extensions/brew/CHANGELOG.md
+++ b/extensions/brew/CHANGELOG.md
@@ -17,7 +17,6 @@
 - If Homebrew refuses an upgrade or uninstall because the package is pinned, the toast now offers to unpin, instead of showing the raw error
 - Cask details now list the formulae and casks a cask depends on, and the architectures it requires — formula details have always shown dependencies, so casks were missing information brew reports (`gcloud-cli` needs `python@3.14`, for one)
 - Removed the unused two-phase loading path (`brew list --versions`, added in 5.0 support). It had no caller and its cache read duplicated the main loader; installed packages already paint from cache
-- Search's "Sort by Popularity" moved from ⇧⌘P to ⇧⌘S: ⇧⌘P is Raycast's standard Pin shortcut, which now collides with the Pin action on installed packages
 - **This extension now requires Homebrew 6.0 or later.** The "Use internal API" preference is gone — Homebrew 6 uses that API by default and deprecates the setting, which made brew abort outright under `HOMEBREW_DEVELOPER`
 
 ## [Show Upgrades: reviewed, selective upgrading] - 2026-09-01

--- a/extensions/brew/CONTRIBUTING.md
+++ b/extensions/brew/CONTRIBUTING.md
@@ -1,0 +1,125 @@
+# Contributing to Brew
+
+Thanks for contributing. This guide covers what this extension expects beyond the
+[Raycast contribution guide](https://github.com/raycast/extensions/blob/main/CONTRIBUTING.md) —
+mostly the things review keeps catching here.
+
+## Requirements
+
+- **Homebrew 6.0 or later.** The extension targets 6.x exclusively; see the compatibility
+  section in [README.md](README.md).
+- Node.js — `@raycast/api` declares `>=22.22.2`.
+- Raycast.
+
+## Getting started
+
+```bash
+npm install
+npm run dev      # reloads in Raycast as you edit
+```
+
+## Before you open a PR
+
+All four must be green. `ray build` and `ray lint` do **not** typecheck, so `tsc` is separate
+and non-negotiable:
+
+```bash
+npx tsc --noEmit    # exit 0
+npm run lint
+npm run build
+npm test            # vitest
+```
+
+Also run `npm run check:analytics` if you touched analytics parsing. It hits
+formulae.brew.sh live, by design — it verifies the API contract that fixtures cannot.
+It fails offline; that is not a reason to remove the network calls.
+
+## Tests
+
+Pure logic lives under `src/utils/` and is tested with vitest. `@raycast/api` has no
+resolvable entry outside the Raycast runtime, so `vitest.config.ts` aliases it to
+`src/utils/__mocks__/raycast-api.ts`. That stub returns the **declared preference defaults**
+from `package.json` — if you add a preference with a default, tests see it.
+
+Anything that renders is not covered. State that plainly in the PR rather than implying
+a test proves a visual change.
+
+## Formulae vs casks: the trap
+
+The most common bug in this extension, by a wide margin, is code that loses track of whether
+a package is a formula or a cask and builds a brew command without `--cask`. It has been found
+in review repeatedly, in different guises, and it is worth assuming your change has a version
+of it.
+
+The rules:
+
+- **`isCask()` keys off `token`.** `brew outdated --json=v2` reports casks with a `name` and
+  **no token**, so an outdated cask is indistinguishable from a formula until
+  `normalizeOutdatedResults()` synthesizes one. Every parser of that payload, and every read
+  of a cached one, must call it. Skipping one silently reintroduces the bug.
+- **Don't write a value guard.** Both kinds now report `pinned`, so `"pinned" in x` no longer
+  identifies a formula. Two previous guards broke this way.
+- **Pass the kind explicitly** where you have it (`PinKind`, the `isCask` prop on the outdated
+  action panels) rather than re-deriving it downstream.
+- A wrong kind is not a type error. `tsc` passes; brew then operates on the wrong package.
+
+## Pinning
+
+A pin is a lock, and Homebrew enforces it:
+
+- `brew upgrade <name>` on a pinned package **fails** (exit 1) when named explicitly, and only
+  warns on a bare `brew upgrade`. The extension names every package, so pinned ones must be
+  filtered out before the run — otherwise a deliberate skip is reported as a failure.
+- `brew uninstall` refuses a pinned package of **either** kind without `--force`.
+- Therefore: never offer a pinned row an upgrade action, or a copy/terminal command it cannot
+  run. Formulae and casks are both pinnable and behave identically here.
+
+## What reviewers have asked for
+
+- **Don't reorder existing action panels.** Adding an action at the top pushes Upgrade, Pin and
+  the copy actions down and changes muscle memory. Add to the end of the relevant section, or
+  say why the new order is better.
+- **A failure must not read as success.** A failed `brew outdated` that shows a success toast,
+  or an empty list that reads as "nothing to upgrade", is the single most repeated finding on
+  this extension. If a fetch fails, say so on screen.
+- **Long operations need an indicator before the work starts**, not after.
+- **Every `Toast.Style.Failure` needs a Copy Error / Copy Logs action** so a user can report
+  what actually happened.
+- **Match the icon vocabulary** in `src/components/packageIcons.ts` — green up to date, blue in
+  progress, red failed, yellow update available. Check that table before introducing a colour.
+
+## Homebrew is the source of truth
+
+Do not describe Homebrew behaviour from memory — read its source (`$(brew --repo)`) or
+[docs.brew.sh](https://docs.brew.sh). Comments in this codebase have been confidently wrong
+about brew for months at a time, including claims about features that already shipped. Cite the
+Ruby file when a non-obvious behaviour drives your change.
+
+## CHANGELOG
+
+Add a **new** top entry using the `{PR_MERGE_DATE}` placeholder — Raycast CI stamps it on merge:
+
+```markdown
+## [Short Title] - {PR_MERGE_DATE}
+
+- What a user notices, not how the code works
+```
+
+Never edit an entry that already carries a real date, and never leave more than one
+placeholder. Describe the observable effect: a bullet about internals goes stale the moment
+they are refactored, and nothing compiles a changelog.
+
+## Pull requests
+
+- Title: `Update Brew extension`, or `[Brew] <fix>` when one change dominates. No Conventional
+  Commits.
+- Describe the change for someone who has never seen the code, and double-check the description
+  names *this* extension.
+- Say what you tested by hand. Anything visual is eyes-only.
+
+## Useful links
+
+- [Contribute to an extension](https://developers.raycast.com/basics/contribute-to-an-extension)
+- [Prepare an extension for the Store](https://developers.raycast.com/basics/prepare-an-extension-for-store)
+- [Extension guidelines](https://manual.raycast.com/extensions)
+- [Homebrew documentation](https://docs.brew.sh)

--- a/extensions/brew/README.md
+++ b/extensions/brew/README.md
@@ -5,32 +5,34 @@ Search and manage your brew casks and formulae from [Raycast](https://raycast.co
 ## Commands
 
 - **Search** — search brew formulae & casks and install them
-- **Show Installed** — list installed formulae & casks, with pinned formulae in their own section
-- **Show Upgrades** (previously Show Outdated) — review outdated packages, choose which upgrade, and run it. The review opens with everything not pinned selected (exactly what a plain `brew upgrade` would do), so running immediately upgrades everything. A pin is a lock, matching brew's own behaviour: pinned formulae cannot be selected, and including one means unpinning it first — the primary action on a pinned row does both in one step. Casks are selectable exactly like formulae; cask pinning waits on Homebrew 6's `brew pin --cask` and ships in a follow-up.
-- **Upgrade** — upgrade everything outdated in one shot, no review step, with progress reported per package via the toast
+- **Show Installed** — list installed formulae & casks, with pinned formulae and pinned casks each in their own section
+- **Show Upgrades** (previously Show Outdated) — review outdated packages, choose which upgrade, and run it. The review opens with everything not pinned selected (exactly what a plain `brew upgrade` would do), so running immediately upgrades everything. A pin is a lock, matching brew's own behaviour: a pinned package cannot be selected, and including one means unpinning it first — the primary action on a pinned row does both in one step. Formulae and casks behave identically.
+- **Upgrade All** — upgrade everything outdated in one shot, no review step, with progress reported per package via the toast
 - **Manage Services** — start, stop & restart Homebrew services
 - **Services Menu Bar** — control Homebrew services from the menu bar
 - **Clean up** — clean files and packages from the cache that are older than 120 days
 - **Clear Cache** — clear the cached formulae, casks, and installed packages files
 
-## Homebrew 5.0 Compatibility
+## Homebrew Compatibility
 
-This extension is compatible with Homebrew 5.0 and later. Key changes in Homebrew 5.0:
+**This extension requires Homebrew 6.0 or later.**
 
-- **Concurrent Downloads**: Homebrew 5.0 enables parallel downloads by default. If you experience issues, you can disable this in the extension preferences.
-- **Internal API**: Homebrew 5.0 introduces a more efficient internal JSON API. You can opt-in to this experimental feature in preferences.
-- **Deprecated Flags**: The `--no-quarantine` and `--quarantine` flags are deprecated in Homebrew 5.0.
-- **macOS Support**: Homebrew 5.0 no longer supports macOS Mojave (10.14) and older.
+- **Internal API**: the faster internal JSON API is the default. The extension's "Use internal API"
+  preference is gone — Homebrew 6 deprecates `HOMEBREW_USE_INTERNAL_API`, and setting it makes brew
+  abort outright for anyone running with `HOMEBREW_DEVELOPER`.
+- **Concurrent Downloads**: parallel downloads are on by default. If you hit trouble, turn them off
+  in the extension preferences.
+- **Removed Flags**: `--no-quarantine` and `--quarantine`, deprecated in 5.x, are gone in 6.
+- **Pinning**: formulae and casks can both be pinned. A pin is a lock — brew refuses to upgrade or
+  uninstall a pinned package until you unpin it.
 
-For more details, see the [Homebrew 5.0 release notes](https://brew.sh/2025/11/12/homebrew-5.0.0/).
+For more details, see the [Homebrew 6.0 release notes](https://brew.sh/2026/06/11/homebrew-6.0.0/).
 
 ## Performance
 
 This extension uses several optimizations to provide a fast experience:
 
-- **Two-Phase Loading**: Installed packages load quickly with basic info, then fetch full metadata in the background.
 - **Lazy Loading**: Package details are fetched on-demand when viewing, not upfront.
-- **Internal API Option**: When enabled, downloads are 96% smaller (~1 MB vs ~30 MB for formulae).
 
 ## Install Statistics
 
@@ -38,7 +40,7 @@ Selecting a package shows its install counts (30 / 90 / 365 days) and build erro
 [formulae.brew.sh](https://formulae.brew.sh) analytics API. Only the selected package is fetched —
 about 5 KB per row you land on, and nothing at all for the rest of the list.
 
-**Sort by Popularity** (⇧⌘P in Search) is different: ranking every result requires Homebrew's bulk
+**Sort by Popularity** (⇧⌘S in Search) is different: ranking every result requires Homebrew's bulk
 30-day rankings, about 2.6 MB for formulae and casks combined. That download happens the first time
 you enable the sort, is cached on disk, and is never fetched if you don't use the sort. While it is
 on, each row also shows its 30-day install count.

--- a/extensions/brew/README.md
+++ b/extensions/brew/README.md
@@ -40,7 +40,7 @@ Selecting a package shows its install counts (30 / 90 / 365 days) and build erro
 [formulae.brew.sh](https://formulae.brew.sh) analytics API. Only the selected package is fetched —
 about 5 KB per row you land on, and nothing at all for the rest of the list.
 
-**Sort by Popularity** (⇧⌘S in Search) is different: ranking every result requires Homebrew's bulk
+**Sort by Popularity** (⇧⌘P in Search) is different: ranking every result requires Homebrew's bulk
 30-day rankings, about 2.6 MB for formulae and casks combined. That download happens the first time
 you enable the sort, is cached on disk, and is never fetched if you don't use the sort. While it is
 on, each row also shows its 30-day install count.

--- a/extensions/brew/TODO.md
+++ b/extensions/brew/TODO.md
@@ -273,6 +273,6 @@ Focus: Implement AI-powered features, improve user experience, and add advanced 
 - [x] Add formula/cask analytics
   - [x] Show install counts from Homebrew analytics (30/90/365 days)
   - [x] Show popularity ranking (Sort by Popularity, ⇧⌘S in Search)
-- [x] Add batch operations
-  - [x] Select multiple packages for install/uninstall — selection review in Show Upgrades
-  - [x] Bulk upgrade selected packages
+- [ ] Add batch operations
+  - [ ] Select multiple packages for install/uninstall — only upgrade selection exists today
+  - [x] Bulk upgrade selected packages (selection review in Show Upgrades)

--- a/extensions/brew/TODO.md
+++ b/extensions/brew/TODO.md
@@ -262,14 +262,72 @@ Focus: Implement AI-powered features, improve user experience, and add advanced 
 - [x] Homebrew 6.0+ only; removed the deprecated internal-API preference
 - [x] vitest coverage for selection and formula/cask discriminator logic
 
+## ⚠️ Exit-0 no-ops brew does not report as failures
+
+Homebrew warns and skips more often than it fails. `brew upgrade` skips are handled
+(`upgradeSkipReason`), but these remain — each one currently reports success for work brew
+declined to do:
+
+- [ ] **Pinned uninstall exits 0.** `onoe "<name> is pinned. You must unpin it to uninstall."`
+      does NOT set `Homebrew.failed` (uninstall.rb, cask/uninstall.rb, utils/output.rb), so brew
+      exits 0, no catch runs, and the extension reports "Uninstalled <name>". The pre-check from
+      the pin directories prevents the common case, but a pin landing between check and command
+      slips through. Needs the same read-the-output treatment as upgrade
+- [ ] **Install of an already-installed package exits 0.** A formula warns "is already installed
+      and up-to-date" (install/check.rb); an up-to-date cask is partitioned out with `quiet: true`
+      and can be a completely SILENT exit-0 no-op (cmd/install.rb). Output parsing alone cannot
+      cover the cask case — this needs a before/after installed-state check, not a matcher
+- [ ] **`brewUpgradeAll` (bare `brew upgrade`) claims "All packages upgraded".** Bare upgrade warns
+      and skips pinned and disabled packages and may upgrade nothing at all, and its output carries
+      no complete per-package result. Currently unreachable — every UI route supplies the
+      per-package engine instead — so the honest fix may be to delete the fallback rather than
+      teach it to parse
+
 ## 🔮 Future Enhancements
 
 - [ ] Add "brew doctor" command integration
   - [ ] Show health check results in a dedicated view
   - [ ] Add quick-fix actions for common issues
-- [ ] Add tap management
-  - [ ] List installed taps
-  - [ ] Add/remove taps
+### Custom tap support
+
+The search index is `formulae.brew.sh/api/formula.json` and `.../cask.json`, which publish
+**homebrew/core and homebrew/cask only**. Anything from a third-party tap is therefore invisible
+to Search today, even when it is installed and shows correctly in Show Installed — its `tap`
+field just reads e.g. `cameroncooke/axe`. Supporting taps is mostly about closing that gap.
+
+- [ ] **Manage Taps** command (its own view command, alongside Manage Services)
+  - [ ] List installed taps (`brew tap`), with the packages each provides
+  - [ ] Add and remove taps (`brew tap <user/repo>`, `brew untap`), with a confirmation on untap
+        since it can orphan installed packages
+  - [ ] Surface a tap's status: pinned, official vs third-party, whether it needs `--force-auto-update`
+  - [ ] **Trust preamble before adding a tap.** Adding a tap means running code from an arbitrary
+        third party, which is a different kind of decision from installing a reviewed core package.
+        Follow whatever model Raycast already uses for adding an MCP server — study that flow
+        first rather than inventing our own consent screen, so this reads as the platform's
+        existing pattern. Name the tap's GitHub owner and repo, and make accepting a deliberate
+        act rather than a default
+- [ ] Make tapped packages searchable
+  - [ ] Decide the source: `brew search` shells out and covers taps but is slow and returns names
+        only, whereas the JSON index is fast and complete but core/cask only. Likely both — index
+        first, tap results merged in behind them
+  - [ ] Read tap formulae locally from `$(brew --repo)/Library/Taps/**/Formula/*.rb` for offline
+        name matching, accepting that descriptions need `brew info`
+  - [ ] Decide what a tapped package's detail panel shows: no analytics exist for it
+        (formulae.brew.sh has install counts only for core/cask), so the Statistics rows need an
+        honest empty state rather than zeros
+- [ ] Attribute packages to their tap in the UI
+  - [ ] Show the tap on rows for anything outside core/cask, so a third-party package is
+        identifiable at a glance
+  - [ ] Filter or group by tap in Search and Show Installed
+- [ ] Install from a tap
+  - [ ] Fully-qualified install (`brew install user/repo/name`), including the case where the tap
+        is not yet added — brew will add it implicitly, which the confirmation should say
+  - [ ] Handle a name that exists in both core and a tap: brew resolves core first, so an
+        unqualified install can silently install the wrong package
+
+**Open question before any of this ships:** third-party taps are arbitrary code from arbitrary
+people. Adding a tap is a trust decision, and the extension should make that explicit rather than
+treating it as an ordinary install.
 - [x] Add formula/cask analytics
   - [x] Show install counts from Homebrew analytics (30/90/365 days)
   - [x] Show popularity ranking (Sort by Popularity, ⇧⌘S in Search)

--- a/extensions/brew/TODO.md
+++ b/extensions/brew/TODO.md
@@ -288,6 +288,13 @@ Homebrew warns and skips more often than it fails. `brew upgrade` skips are hand
 (`upgradeSkipReason`), but these remain — each one currently reports success for work brew
 declined to do:
 
+- [ ] **A stale `effectivePinned: false` bypasses the disk check on uninstall.** The Show Upgrades
+      panel derives that boolean from its snapshot and passes it in, and `uninstall()` only reads the
+      pin directories when it is `undefined` — so a package pinned elsewhere since the fetch skips
+      the authoritative check. Combined with the exit-0 refusal below, the extension then reports
+      "Uninstalled". Predates the pin-directory work: the read happened before, but `effectivePinned`
+      overrode it either way. Fix by treating the override as a live pin CHANGE rather than a
+      complete answer, and by reading the command's outcome
 - [ ] **Pinned uninstall exits 0.** `onoe "<name> is pinned. You must unpin it to uninstall."`
       does NOT set `Homebrew.failed` (uninstall.rb, cask/uninstall.rb, utils/output.rb), so brew
       exits 0, no catch runs, and the extension reports "Uninstalled <name>". The pre-check from

--- a/extensions/brew/TODO.md
+++ b/extensions/brew/TODO.md
@@ -262,6 +262,26 @@ Focus: Implement AI-powered features, improve user experience, and add advanced 
 - [x] Homebrew 6.0+ only; removed the deprecated internal-API preference
 - [x] vitest coverage for selection and formula/cask discriminator logic
 
+## 🔒 Dependencies
+
+- [ ] **Migrate `stream-json` 1.9.1 → 3.6.0** (moderate advisory
+      [GHSA-528h-pc64-c93x](https://github.com/advisories/GHSA-528h-pc64-c93x), CVSS 6.2, affects
+      `<=3.4.0`). The `pick`/`ignore`/`filter`/`replace` filters are O(depth²) on nested input, so
+      small crafted JSON can block the event loop for seconds to minutes.
+  - [ ] **We use the affected API.** `src/utils/cache.ts` builds
+        `chain([… parser(), filter({ filter: keysRe }), streamArray()])` to stream the ~2.6 MB
+        `formula.json` / `cask.json` indexes, so this is not a dormant transitive dependency
+  - [ ] Exposure is low but not nil: the input is Homebrew's own API over HTTPS, and its JSON is
+        shallow — the advisory needs deep nesting we would never receive from formulae.brew.sh.
+        This is worth doing on its own schedule, not as an emergency
+  - [ ] It is a **two-major** jump and `npm audit fix --force` territory, which is why it was left
+        out of the Homebrew 6 PR. `stream-json@3.6.0` also requires `stream-chain@^4.2.5`, against
+        the 3.4.0 we pin — both move together
+  - [ ] Verify after upgrading: the chunked cache still builds, `filter`'s options shape is
+        unchanged across the majors, and the abort path still destroys the pipeline
+        (`src/utils/cache.ts` around the `onAbort` handler)
+  - [ ] Re-run `npm audit` afterwards and confirm the advisory clears rather than assuming it did
+
 ## ⚠️ Exit-0 no-ops brew does not report as failures
 
 Homebrew warns and skips more often than it fails. `brew upgrade` skips are handled

--- a/extensions/brew/TODO.md
+++ b/extensions/brew/TODO.md
@@ -104,16 +104,20 @@ Focus: Refactor codebase structure, integrate logging, fix critical bugs, and im
 
 ## Add Support for Homebrew 5.0
 
+> **Superseded.** The extension now requires **Homebrew 6.0+**, so the remaining 5.0
+> verification items below no longer apply. The `HOMEBREW_USE_INTERNAL_API` preference was
+> removed: 6 uses that API by default and deprecates the variable.
+
 - [x] See https://brew.sh/2025/11/12/homebrew-5.0.0/ and https://github.com/Homebrew/brew/pull/20951
 - [x] Update brew command execution to handle new Homebrew 5.0 changes, including concurrency
   - [x] Added `HOMEBREW_DOWNLOAD_CONCURRENCY` environment variable support
   - [x] Added `HOMEBREW_USE_INTERNAL_API` environment variable support
   - [x] Added preferences to control these features
-- [ ] Test compatibility with Homebrew 5.0 features
+- [~] Test compatibility with Homebrew 5.0 features — superseded, targets 6.0+
 - [x] Update documentation for Homebrew 5.0
   - [x] Updated README.md with Homebrew 5.0 compatibility section
   - [x] Added code comments documenting Homebrew 5.0 changes
-- [ ] Verify all existing functionality works with Homebrew 5.0
+- [~] Verify all existing functionality works with Homebrew 5.0 — superseded, targets 6.0+
 
 ---
 
@@ -182,7 +186,7 @@ Focus: Implement AI-powered features, improve user experience, and add advanced 
 
 - [ ] Implement proper caching for brew data
   - [ ] Add cache TTL configuration option
-  - [ ] Add manual cache invalidation action
+  - [x] Add manual cache invalidation action (`Clear Cache` command)
   - [ ] Consider using SQLite for faster queries (noted in `utils.ts` comments)
   - [ ] Add cache size monitoring/cleanup
   - [ ] Simplify cache invalidation logic
@@ -201,31 +205,31 @@ Focus: Implement AI-powered features, improve user experience, and add advanced 
   - [ ] Consider a shared `PackageInfoDetail` wrapper component
 - [ ] Add more detailed cask information panels
   - [ ] Show download URL and size (from `url` field)
-  - [ ] Show installation date/time (from `installed_time` field)
+  - [x] Show installation date/time (from `installed_time` field)
   - [ ] Show SHA256 checksum (from `sha256` field)
   - [ ] Show bundle version info (`bundle_version`, `bundle_short_version`)
   - [ ] Show app artifacts (what gets installed: `.app`, binaries, etc.)
   - [ ] Show zap paths (files removed on full uninstall)
-  - [ ] Show deprecation/disabled status with reason and replacement
+  - [x] Show deprecation/disabled status with reason and replacement
   - [ ] Show old tokens/aliases (from `old_tokens` field)
   - [ ] Show supported languages (from `languages` field)
   - [ ] Add app icon from installed `.app` bundle
 - [ ] Add more detailed formula information panels
-  - [ ] Show installation date/time (from `installed[].time` - Unix timestamp)
+  - [x] Show installation date/time (from `installed[].time` - Unix timestamp)
   - [ ] Show bottle info (pre-built binary availability per architecture)
   - [ ] Show if poured from bottle vs built from source
   - [ ] Show runtime dependencies with versions (richer than just names)
   - [ ] Show test dependencies
   - [ ] Show `uses_from_macos` system dependencies
-  - [ ] Show deprecation/disabled status with reason and replacement
+  - [x] Show deprecation/disabled status with reason and replacement
   - [ ] Show if formula has post-install script (`post_install_defined`)
   - [ ] Show service info if formula provides a service
   - [ ] Show link overwrite paths
   - [ ] Show conflicts with reasons (not just names)
-- [ ] Improve icons for outdated packages
-  - [ ] Use distinct icons for outdated vs up-to-date (currently both use `CheckCircle`)
-  - [ ] Add visual indicator for pinned packages in list view
-  - [ ] Consider using `Icon.ArrowUp` or `Icon.ExclamationMark` for outdated items
+- [x] Improve icons for outdated packages
+  - [x] Use distinct icons for outdated vs up-to-date (`src/components/packageIcons.ts`)
+  - [x] Add visual indicator for pinned packages in list view (tack accessory)
+  - [x] Yellow `Icon.ArrowUpCircle` for outdated; red is reserved for a failed upgrade
 - [ ] Implement search filtering by category/type
   - [ ] Add filter for taps
   - [ ] Add filter by license type
@@ -234,9 +238,9 @@ Focus: Implement AI-powered features, improve user experience, and add advanced 
   - [ ] Track package update dates
   - [ ] Add "Recently Added" section
   - [ ] Add "Recently Updated" section
-- [ ] To Show Installed, show available updates
-  - [ ] Add action to update individual package
-  - [ ] Add action to update all packages at once
+- [x] To Show Installed, show available updates
+  - [x] Add action to update individual package
+  - [x] Add action to update all packages at once
 - [ ] Add download progress HUD to show download % complete
 - [ ] Improve keyboard shortcuts for Actions
 - [ ] Improve loading states with more informative messages
@@ -249,8 +253,14 @@ Focus: Implement AI-powered features, improve user experience, and add advanced 
   - [ ] Add screenshots of all commands
   - [ ] Document all preferences
   - [ ] Add troubleshooting section
-  - [ ] Add contribution guidelines
+  - [x] Add contribution guidelines (`CONTRIBUTING.md`)
   - [ ] Document keyboard shortcuts
+
+## ✅ Shipped since this list was written
+
+- [x] Cask pinning (`brew pin --cask`), matching formula pinning across all views
+- [x] Homebrew 6.0+ only; removed the deprecated internal-API preference
+- [x] vitest coverage for selection and formula/cask discriminator logic
 
 ## 🔮 Future Enhancements
 
@@ -260,9 +270,9 @@ Focus: Implement AI-powered features, improve user experience, and add advanced 
 - [ ] Add tap management
   - [ ] List installed taps
   - [ ] Add/remove taps
-- [ ] Add formula/cask analytics
-  - [ ] Show install counts from Homebrew analytics
-  - [ ] Show popularity ranking
-- [ ] Add batch operations
-  - [ ] Select multiple packages for install/uninstall
-  - [ ] Bulk upgrade selected packages
+- [x] Add formula/cask analytics
+  - [x] Show install counts from Homebrew analytics (30/90/365 days)
+  - [x] Show popularity ranking (Sort by Popularity, ⇧⌘S in Search)
+- [x] Add batch operations
+  - [x] Select multiple packages for install/uninstall — selection review in Show Upgrades
+  - [x] Bulk upgrade selected packages

--- a/extensions/brew/package-lock.json
+++ b/extensions/brew/package-lock.json
@@ -8,7 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "@chrismessina/raycast-logger": "^1.4.0",
-        "@raycast/api": "^2.1.0",
+        "@raycast/api": "^2.2.0",
         "@raycast/utils": "^2.3.0",
         "@types/stream-json": "^1.7.8",
         "stream-chain": "^3.4.0",
@@ -574,25 +574,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -988,9 +1002,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1102,9 +1113,9 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-2.1.0.tgz",
-      "integrity": "sha512-KFE7cG071YJp9DdqpTdBao3AjomIConCVuLLjhbB7GQyS0E9s5NKVi8jIezY8MQwro1lnsRR3cSZBsY8EGdCqA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-2.2.0.tgz",
+      "integrity": "sha512-AGzeNi1oj3UTDh7GlejU7+sGupPJ3aCN20yvMhkcsMnk7r/RjppcSkHEXqb+I4uv4Pr8vqB8OLLbTbJmfSoFHg==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.11.4",
@@ -1314,9 +1325,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1331,9 +1339,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1348,9 +1353,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1365,9 +1367,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1382,9 +1381,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1399,9 +1395,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1416,9 +1409,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1433,9 +1423,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1450,9 +1437,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1467,9 +1451,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1484,9 +1465,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1501,9 +1479,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1518,9 +1493,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/extensions/brew/package.json
+++ b/extensions/brew/package.json
@@ -2,7 +2,11 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "brew",
   "title": "Brew",
-  "description": "Search and install Homebrew formulae",
+  "description": "Search, install and manage Homebrew formulae and casks",
+  "categories": [
+    "Developer Tools",
+    "System"
+  ],
   "author": "nhojb",
   "contributors": [
     "Aayush9029",
@@ -69,7 +73,7 @@
     },
     {
       "name": "upgrade",
-      "title": "Upgrade",
+      "title": "Upgrade All",
       "subtitle": "Brew",
       "description": "Upgrade brew formulae & casks",
       "mode": "view"
@@ -185,18 +189,19 @@
     },
     {
       "default": false,
-      "description": "Homebrew 5.0 enables parallel downloads by default. Enable this option to disable concurrent downloads if you experience issues.",
+      "description": "Homebrew enables parallel downloads by default. Enable this option to disable concurrent downloads if you experience issues.",
       "label": "Disable concurrent downloads",
       "name": "disableDownloadConcurrency",
       "required": false,
-      "title": "Homebrew 5.0 Options",
+      "title": "Homebrew Options",
       "type": "checkbox"
     },
     {
-      "default": false,
-      "description": "Use Homebrew's internal JSON API.",
-      "label": "Use internal API (experimental)",
-      "name": "useInternalApi",
+      "default": true,
+      "description": "Show pinned formulae and casks at the top of Show Installed and Show Upgrades, rather than at the bottom. Pinned packages are excluded from upgrades until you unpin them.",
+      "label": "Show pinned items at the top of lists",
+      "title": "Lists",
+      "name": "pinnedFirst",
       "required": false,
       "type": "checkbox"
     },
@@ -221,7 +226,7 @@
   ],
   "dependencies": {
     "@chrismessina/raycast-logger": "^1.4.0",
-    "@raycast/api": "^2.1.0",
+    "@raycast/api": "^2.2.0",
     "@raycast/utils": "^2.3.0",
     "@types/stream-json": "^1.7.8",
     "stream-chain": "^3.4.0",

--- a/extensions/brew/src/clean-up.tsx
+++ b/extensions/brew/src/clean-up.tsx
@@ -10,7 +10,7 @@ export default async (): Promise<void> => {
       cancelable: true,
     });
     await brewCleanup(preferences.withoutThreshold, handle.abort?.signal);
-    showToast(Toast.Style.Success, "Cleaning completed");
+    await showToast({ style: Toast.Style.Success, title: "Cleaning completed" });
   } catch (err) {
     await showBrewFailureToast("Cleaning failed", ensureError(err));
     await wait(3000);

--- a/extensions/brew/src/components/actionPanels.tsx
+++ b/extensions/brew/src/components/actionPanels.tsx
@@ -36,8 +36,9 @@ const SortByPopularityAction = (props: { sortByPopularity: boolean; onToggleSort
   <Action
     title={props.sortByPopularity ? "Sort by Relevance" : "Sort by Popularity"}
     icon={props.sortByPopularity ? Icon.Text : Icon.LineChart}
-    // ⌘⇧P is free: Keyboard.Shortcut.Common.Pin is ⌘. on macOS (verified in the
-    // Raycast runtime), so the Pin action in this same panel does not collide.
+    // ⌘⇧P is free: Keyboard.Shortcut.Common.Pin is ⌘. on macOS (read from the
+    // Raycast 2.2.0.0 runtime), so the Pin action in this panel does not collide.
+    // The API docs say ⌘⇧P and are wrong — see raycast/extensions#30879.
     shortcut={{ modifiers: ["cmd", "shift"], key: "p" }}
     onAction={props.onToggleSort}
   />

--- a/extensions/brew/src/components/actionPanels.tsx
+++ b/extensions/brew/src/components/actionPanels.tsx
@@ -219,7 +219,7 @@ export function CaskActionPanel(props: {
 
         <ActionPanel.Section>
           <Action.CopyToClipboard title="Copy Cask ID" content={cask.token} shortcut={Keyboard.Shortcut.Common.Copy} />
-          <Action.CopyToClipboard title="Copy Tap Name" content={cask.tap} />
+          {cask.tap && <Action.CopyToClipboard title="Copy Tap Name" content={cask.tap} />}
         </ActionPanel.Section>
 
         <ViewSection
@@ -250,7 +250,7 @@ export function CaskActionPanel(props: {
         </ActionPanel.Section>
         <ActionPanel.Section>
           <Action.CopyToClipboard title="Copy Cask ID" content={cask.token} shortcut={Keyboard.Shortcut.Common.Copy} />
-          <Action.CopyToClipboard title="Copy Tap Name" content={cask.tap} />
+          {cask.tap && <Action.CopyToClipboard title="Copy Tap Name" content={cask.tap} />}
           <Action.CopyToClipboard
             title="Copy Install Command"
             content={brewInstallCommand(cask)}

--- a/extensions/brew/src/components/actionPanels.tsx
+++ b/extensions/brew/src/components/actionPanels.tsx
@@ -36,6 +36,8 @@ const SortByPopularityAction = (props: { sortByPopularity: boolean; onToggleSort
   <Action
     title={props.sortByPopularity ? "Sort by Relevance" : "Sort by Popularity"}
     icon={props.sortByPopularity ? Icon.Text : Icon.LineChart}
+    // ⌘⇧P is free: Keyboard.Shortcut.Common.Pin is ⌘. on macOS (verified in the
+    // Raycast runtime), so the Pin action in this same panel does not collide.
     shortcut={{ modifiers: ["cmd", "shift"], key: "p" }}
     onAction={props.onToggleSort}
   />

--- a/extensions/brew/src/components/actionPanels.tsx
+++ b/extensions/brew/src/components/actionPanels.tsx
@@ -36,7 +36,9 @@ const SortByPopularityAction = (props: { sortByPopularity: boolean; onToggleSort
   <Action
     title={props.sortByPopularity ? "Sort by Relevance" : "Sort by Popularity"}
     icon={props.sortByPopularity ? Icon.Text : Icon.LineChart}
-    shortcut={{ modifiers: ["cmd", "shift"], key: "p" }}
+    // Not ⌘⇧P: that is Keyboard.Shortcut.Common.Pin, and the Pin action shares
+    // this panel for an installed package.
+    shortcut={{ modifiers: ["cmd", "shift"], key: "s" }}
     onAction={props.onToggleSort}
   />
 );
@@ -167,6 +169,7 @@ export function CaskActionPanel(props: {
             />
           )}
           <Action.ShowInFinder path={brewInstallPath(cask)} />
+          <Actions.PinAction item={cask} kind="cask" onAction={props.onAction} />
         </ActionPanel.Section>
         <ActionPanel.Section>
           <Action.OpenInBrowser
@@ -194,18 +197,24 @@ export function CaskActionPanel(props: {
         </ActionPanel.Section>
         <ActionPanel.Section>
           <Actions.FormulaUninstallAction formula={cask} onAction={props.onAction} />
-          <Action.CopyToClipboard
-            title="Copy Uninstall Command"
-            content={brewUninstallCommand(cask)}
-            shortcut={{ modifiers: ["cmd", "opt"], key: "c" }}
-          />
-          <Action
-            title={`Run Uninstall in ${terminalName}`}
-            icon={terminalIcon}
-            style={Action.Style.Destructive}
-            shortcut={{ modifiers: ["cmd", "shift"], key: "return" }}
-            onAction={() => runCommandInTerminal(brewUninstallCommand(cask))}
-          />
+          {/* A pinned package cannot be uninstalled without --force, which the
+              command builder does not add — so no command is offered to paste. */}
+          {!cask.pinned && (
+            <>
+              <Action.CopyToClipboard
+                title="Copy Uninstall Command"
+                content={brewUninstallCommand(cask)}
+                shortcut={{ modifiers: ["cmd", "opt"], key: "c" }}
+              />
+              <Action
+                title={`Run Uninstall in ${terminalName}`}
+                icon={terminalIcon}
+                style={Action.Style.Destructive}
+                shortcut={{ modifiers: ["cmd", "shift"], key: "return" }}
+                onAction={() => runCommandInTerminal(brewUninstallCommand(cask))}
+              />
+            </>
+          )}
         </ActionPanel.Section>
 
         <ActionPanel.Section>
@@ -354,7 +363,7 @@ export function FormulaActionPanel(props: {
             />
           )}
           <Action.ShowInFinder path={brewInstallPath(formula)} />
-          <Actions.FormulaPinAction formula={formula} onAction={props.onAction} />
+          <Actions.PinAction item={formula} kind="formula" onAction={props.onAction} />
         </ActionPanel.Section>
         <ActionPanel.Section>
           <Action.OpenInBrowser
@@ -382,18 +391,24 @@ export function FormulaActionPanel(props: {
         </ActionPanel.Section>
         <ActionPanel.Section>
           <Actions.FormulaUninstallAction formula={formula} onAction={props.onAction} />
-          <Action.CopyToClipboard
-            title="Copy Uninstall Command"
-            content={brewUninstallCommand(formula)}
-            shortcut={{ modifiers: ["cmd", "opt"], key: "c" }}
-          />
-          <Action
-            title={`Run Uninstall in ${terminalName}`}
-            style={Action.Style.Destructive}
-            icon={terminalIcon}
-            shortcut={{ modifiers: ["cmd", "shift"], key: "return" }}
-            onAction={() => runCommandInTerminal(brewUninstallCommand(formula))}
-          />
+          {/* A pinned package cannot be uninstalled without --force, which the
+              command builder does not add — so no command is offered to paste. */}
+          {!formula.pinned && (
+            <>
+              <Action.CopyToClipboard
+                title="Copy Uninstall Command"
+                content={brewUninstallCommand(formula)}
+                shortcut={{ modifiers: ["cmd", "opt"], key: "c" }}
+              />
+              <Action
+                title={`Run Uninstall in ${terminalName}`}
+                style={Action.Style.Destructive}
+                icon={terminalIcon}
+                shortcut={{ modifiers: ["cmd", "shift"], key: "return" }}
+                onAction={() => runCommandInTerminal(brewUninstallCommand(formula))}
+              />
+            </>
+          )}
         </ActionPanel.Section>
 
         <ViewSection
@@ -501,13 +516,21 @@ export function FormulaActionPanel(props: {
 
 interface OutdatedActionProps {
   outdated: OutdatedCask | OutdatedFormula;
+  /**
+   * Which kind this is, stated rather than sniffed. Both kinds report `pinned`,
+   * so a value guard cannot separate them, and `isCask()` depends on the
+   * synthetic `token` from `normalizeOutdatedResults` having been applied.
+   */
+  isCask: boolean;
+  /**
+   * Effective pin state. The payload's own `pinned` can be a stale snapshot
+   * from an in-flight fetch, and the review view tracks the live value in its
+   * pin overrides — so every guard here reads this, not the payload.
+   */
+  pinned?: boolean;
   /** Called when the upgrade starts or finishes, e.g. to show its status in a list */
   onUpgrade?: (status: UpgradePackageStatus) => void;
   onAction: (result: boolean) => void;
-}
-
-function isPinable(o: OutdatedCask | OutdatedFormula): o is OutdatedFormula {
-  return (o as OutdatedFormula).pinned != undefined;
 }
 
 /**
@@ -527,6 +550,7 @@ export function OutdatedUpgradeAction(props: OutdatedActionProps) {
   return (
     <Actions.FormulaUpgradeAction
       formula={props.outdated}
+      pinned={props.pinned ?? props.outdated.pinned === true}
       onStart={() => props.onUpgrade?.("upgrading")}
       onSkip={() => props.onUpgrade?.("skipped")}
       onAction={onUpgradeAction}
@@ -553,19 +577,34 @@ export function OutdatedActionSections(
      * otherwise share the panel.
      */
     omitPin?: boolean;
+    /**
+     * Omit the upgrade COMMAND actions (copy / run in terminal). For a pinned
+     * package: brew refuses an explicitly named pinned package outright
+     * (cmd/upgrade.rb, cask/upgrade.rb), so handing the user
+     * `brew upgrade --cask docker` to paste is handing them a command that
+     * cannot succeed until they unpin.
+     */
+    omitUpgradeCommand?: boolean;
   },
 ) {
   const { outdated } = props;
   const { terminalName, terminalIcon, runCommandInTerminal } = useTerminalApp();
+  const pinned = props.pinned ?? outdated.pinned === true;
 
   return (
     <>
       <ActionPanel.Section>
         {!props.omitUpgrade && (
-          <OutdatedUpgradeAction outdated={outdated} onUpgrade={props.onUpgrade} onAction={props.onAction} />
+          <OutdatedUpgradeAction
+            outdated={outdated}
+            isCask={props.isCask}
+            pinned={pinned}
+            onUpgrade={props.onUpgrade}
+            onAction={props.onAction}
+          />
         )}
-        {!props.omitPin && isPinable(outdated) && (
-          <Actions.FormulaPinAction formula={outdated} onAction={props.onAction} />
+        {!props.omitPin && (
+          <Actions.PinAction item={outdated} kind={props.isCask ? "cask" : "formula"} onAction={props.onAction} />
         )}
         <Action
           title="Refresh"
@@ -574,33 +613,43 @@ export function OutdatedActionSections(
           onAction={() => props.onAction(true)}
         />
       </ActionPanel.Section>
+      {!(props.omitUpgradeCommand ?? pinned) && (
+        <ActionPanel.Section>
+          <Action.CopyToClipboard
+            title="Copy Upgrade Command"
+            content={brewUpgradeCommand(outdated)}
+            shortcut={{ modifiers: ["cmd", "opt"], key: "c" }}
+          />
+          <Action
+            title={`Run Upgrade in ${terminalName}`}
+            icon={terminalIcon}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "t" }}
+            onAction={() => runCommandInTerminal(brewUpgradeCommand(outdated))}
+          />
+        </ActionPanel.Section>
+      )}
       <ActionPanel.Section>
-        <Action.CopyToClipboard
-          title="Copy Upgrade Command"
-          content={brewUpgradeCommand(outdated)}
-          shortcut={{ modifiers: ["cmd", "opt"], key: "c" }}
-        />
-        <Action
-          title={`Run Upgrade in ${terminalName}`}
-          icon={terminalIcon}
-          shortcut={{ modifiers: ["cmd", "shift"], key: "t" }}
-          onAction={() => runCommandInTerminal(brewUpgradeCommand(outdated))}
-        />
-      </ActionPanel.Section>
-      <ActionPanel.Section>
-        <Actions.FormulaUninstallAction formula={outdated} onAction={props.onAction} />
-        <Action.CopyToClipboard
-          title="Copy Uninstall Command"
-          content={brewUninstallCommand(outdated)}
-          shortcut={{ modifiers: ["cmd", "shift", "opt"], key: "c" }}
-        />
-        <Action
-          title={`Run Uninstall in ${terminalName}`}
-          icon={terminalIcon}
-          style={Action.Style.Destructive}
-          shortcut={{ modifiers: ["cmd", "shift"], key: "return" }}
-          onAction={() => runCommandInTerminal(brewUninstallCommand(outdated))}
-        />
+        <Actions.FormulaUninstallAction formula={outdated} pinned={pinned} onAction={props.onAction} />
+        {/* brew refuses to uninstall a pinned package without --force, and the
+            command builder does not add it — so a pinned row is offered no
+            uninstall command it could paste. The action above handles it, with
+            an explicit unpin confirmation. */}
+        {!pinned && (
+          <>
+            <Action.CopyToClipboard
+              title="Copy Uninstall Command"
+              content={brewUninstallCommand(outdated)}
+              shortcut={{ modifiers: ["cmd", "shift", "opt"], key: "c" }}
+            />
+            <Action
+              title={`Run Uninstall in ${terminalName}`}
+              icon={terminalIcon}
+              style={Action.Style.Destructive}
+              shortcut={{ modifiers: ["cmd", "shift"], key: "return" }}
+              onAction={() => runCommandInTerminal(brewUninstallCommand(outdated))}
+            />
+          </>
+        )}
       </ActionPanel.Section>
     </>
   );
@@ -615,13 +664,21 @@ export function OutdatedActionPanel(
   return (
     <ActionPanel>
       <ActionPanel.Section>
-        <OutdatedUpgradeAction outdated={props.outdated} onUpgrade={props.onUpgrade} onAction={props.onAction} />
+        <OutdatedUpgradeAction
+          outdated={props.outdated}
+          isCask={props.isCask}
+          pinned={props.pinned}
+          onUpgrade={props.onUpgrade}
+          onAction={props.onAction}
+        />
         <Actions.FormulaUpgradeAllAction onUpgradeAll={props.onUpgradeAll} onAction={props.onAction} />
       </ActionPanel.Section>
       <OutdatedActionSections
         outdated={props.outdated}
+        isCask={props.isCask}
         onUpgrade={props.onUpgrade}
         onAction={props.onAction}
+        pinned={props.pinned}
         omitUpgrade
       />
     </ActionPanel>
@@ -633,7 +690,15 @@ export function OutdatedActionPanel(
  *
  * Other brew actions are omitted, since Homebrew does not support concurrent processes.
  */
-export function UpgradingActionPanel(props: { outdated: OutdatedCask | OutdatedFormula; onCancel: () => void }) {
+export function UpgradingActionPanel(props: {
+  outdated: OutdatedCask | OutdatedFormula;
+  /** Effective pin state; the payload's own value may be a stale snapshot. */
+  pinned?: boolean;
+  onCancel: () => void;
+}) {
+  // A pinned row is skipped by the run, and brew refuses a named pinned
+  // package — so it gets no upgrade command to copy.
+  const pinned = props.pinned ?? props.outdated.pinned === true;
   return (
     <ActionPanel>
       <Action
@@ -642,11 +707,13 @@ export function UpgradingActionPanel(props: { outdated: OutdatedCask | OutdatedF
         style={Action.Style.Destructive}
         onAction={props.onCancel}
       />
-      <Action.CopyToClipboard
-        title="Copy Upgrade Command"
-        content={brewUpgradeCommand(props.outdated)}
-        shortcut={{ modifiers: ["cmd", "opt"], key: "c" }}
-      />
+      {!pinned && (
+        <Action.CopyToClipboard
+          title="Copy Upgrade Command"
+          content={brewUpgradeCommand(props.outdated)}
+          shortcut={{ modifiers: ["cmd", "opt"], key: "c" }}
+        />
+      )}
     </ActionPanel>
   );
 }

--- a/extensions/brew/src/components/actionPanels.tsx
+++ b/extensions/brew/src/components/actionPanels.tsx
@@ -36,9 +36,7 @@ const SortByPopularityAction = (props: { sortByPopularity: boolean; onToggleSort
   <Action
     title={props.sortByPopularity ? "Sort by Relevance" : "Sort by Popularity"}
     icon={props.sortByPopularity ? Icon.Text : Icon.LineChart}
-    // Not ⌘⇧P: that is Keyboard.Shortcut.Common.Pin, and the Pin action shares
-    // this panel for an installed package.
-    shortcut={{ modifiers: ["cmd", "shift"], key: "s" }}
+    shortcut={{ modifiers: ["cmd", "shift"], key: "p" }}
     onAction={props.onToggleSort}
   />
 );

--- a/extensions/brew/src/components/actions.tsx
+++ b/extensions/brew/src/components/actions.tsx
@@ -6,6 +6,7 @@ import {
   brewName,
   brewIdentifier,
   brewPinnedIdentifiers,
+  pinLookupKey,
   isCask,
   brewPin,
   brewUninstall,
@@ -24,6 +25,26 @@ import {
   showActionToast,
   showBrewFailureToast,
 } from "../utils";
+
+/**
+ * Read Homebrew's pin state, reporting a read failure rather than throwing past
+ * the caller's error handling.
+ *
+ * `brewPinnedIdentifiers` deliberately throws on anything but a missing
+ * directory: an unreadable pin directory is not evidence that nothing is
+ * pinned. But these reads happen BEFORE the try/catch that owns an action's
+ * failure toast, so an escaping error rejected the action callback with no HUD
+ * and no diagnostic. Fail closed and say so — running the command anyway could
+ * hand a pinned package to a brew that refuses it.
+ */
+async function readPins(operation: string): Promise<{ formulae: Set<string>; casks: Set<string> } | undefined> {
+  try {
+    return await brewPinnedIdentifiers();
+  } catch (err) {
+    showBrewFailureToast(`${operation} failed`, ensureError(err));
+    return undefined;
+  }
+}
 
 export function FormulaInstallAction(props: { formula: Cask | Formula; onAction: (result: boolean) => void }) {
   // TD: Support installing other versions?
@@ -106,8 +127,14 @@ export function FormulaUpgradeAction(props: {
         // The DECISION reads Homebrew's own pin directory: a package pinned in
         // another command or outside Raycast is pinned whatever this snapshot
         // says, and brew errors rather than warns when we name it. ~20µs.
-        const pins = await brewPinnedIdentifiers();
-        const reallyPinned = cask ? pins.casks.has(brewIdentifier(props.formula)) : pins.formulae.has(name);
+        const pins = await readPins("Upgrade");
+        if (!pins) {
+          return;
+        }
+        // Identity, not display name: `brewName` gives a cask its title. And
+        // pins are keyed by the SHORT name — see pinLookupKey.
+        const pinKey = pinLookupKey(brewIdentifier(props.formula));
+        const reallyPinned = cask ? pins.casks.has(pinKey) : pins.formulae.has(pinKey);
 
         if (reallyPinned) {
           if (!unpinAndUpgrade) {
@@ -272,8 +299,16 @@ async function uninstall(
   const cask = isCask(formula);
   // Ask Homebrew, not the cached payload — see FormulaUpgradeAction. The caller's
   // effective value still wins when it has one (a live pin change in the review).
-  const pins = await brewPinnedIdentifiers();
-  const pinned = effectivePinned ?? (cask ? pins.casks.has(brewIdentifier(formula)) : pins.formulae.has(name));
+  // Only ask about pins when the caller has not already decided.
+  let pinned = effectivePinned;
+  if (pinned === undefined) {
+    const pins = await readPins("Uninstall");
+    if (!pins) {
+      return false;
+    }
+    const pinKey = pinLookupKey(brewIdentifier(formula));
+    pinned = cask ? pins.casks.has(pinKey) : pins.formulae.has(pinKey);
+  }
 
   // Homebrew refuses to uninstall a pinned package — casks in
   // cask/uninstall.rb (`unpin_for_removal?`) and formulae in uninstall.rb

--- a/extensions/brew/src/components/actions.tsx
+++ b/extensions/brew/src/components/actions.tsx
@@ -6,7 +6,7 @@ import {
   brewName,
   brewIdentifier,
   brewPinnedIdentifiers,
-  pinLookupKey,
+  isPinnedPackage,
   isCask,
   brewPin,
   brewUninstall,
@@ -131,10 +131,8 @@ export function FormulaUpgradeAction(props: {
         if (!pins) {
           return;
         }
-        // Identity, not display name: `brewName` gives a cask its title. And
-        // pins are keyed by the SHORT name — see pinLookupKey.
-        const pinKey = pinLookupKey(brewIdentifier(props.formula));
-        const reallyPinned = cask ? pins.casks.has(pinKey) : pins.formulae.has(pinKey);
+        // Identity, not display name: `brewName` gives a cask its title.
+        const reallyPinned = isPinnedPackage(pins, brewIdentifier(props.formula), cask);
 
         if (reallyPinned) {
           if (!unpinAndUpgrade) {
@@ -306,8 +304,7 @@ async function uninstall(
     if (!pins) {
       return false;
     }
-    const pinKey = pinLookupKey(brewIdentifier(formula));
-    pinned = cask ? pins.casks.has(pinKey) : pins.formulae.has(pinKey);
+    pinned = isPinnedPackage(pins, brewIdentifier(formula), cask);
   }
 
   // Homebrew refuses to uninstall a pinned package — casks in
@@ -331,8 +328,8 @@ async function uninstall(
     return true;
   } catch (err) {
     const error = ensureError(err);
-    // A pin that landed between the check above and this command. Offer the same
-    // remedy the pre-check does, rather than leaving brew's raw refusal.
+    // Only reached when brew actually FAILS. An ordinary pinned uninstall uses
+    // `onoe` and exits 0, so it never lands here — see TODO.md.
     if (!force && isPinnedRefusal(error)) {
       await handle.hide();
       await offerForcedUninstall(formula, name, cask, effectivePinned, onComplete);
@@ -364,9 +361,8 @@ async function upgrade(formula: Cask | Nameable): Promise<boolean | typeof DECLI
       handle.abort?.signal,
     );
 
-    // Exit 0 is not proof of an upgrade — brew warns and skips a deprecated,
-    // unavailable or already-current package. Saying "Upgraded" there would be
-    // a success message for work it declined to do.
+    // Exit 0 is not proof of an upgrade — brew warns and skips a disabled,
+    // unavailable or already-current package.
     const declined = upgradeSkipReason(`${result.stderr ?? ""}\n${result.stdout ?? ""}`, brewIdentifier(formula));
     if (declined) {
       await handle.hide();

--- a/extensions/brew/src/components/actions.tsx
+++ b/extensions/brew/src/components/actions.tsx
@@ -4,6 +4,8 @@ import {
   type BrewProgress,
   brewInstallWithProgress,
   brewName,
+  brewIdentifier,
+  brewPinnedIdentifiers,
   isCask,
   brewPin,
   brewUninstall,
@@ -12,6 +14,8 @@ import {
   brewUpgradeSingleWithProgress,
   type Cask,
   ensureError,
+  isPinnedRefusal,
+  upgradeSkipReason,
   type Formula,
   type Nameable,
   type PinKind,
@@ -98,7 +102,14 @@ export function FormulaUpgradeAction(props: {
       icon={unpinAndUpgrade ? Icon.TackDisabled : Icon.ArrowUpCircle}
       shortcut={{ modifiers: ["cmd", "shift"], key: "u" }}
       onAction={async () => {
-        if (pinned) {
+        // The title above is drawn from the payload, which is fine for display.
+        // The DECISION reads Homebrew's own pin directory: a package pinned in
+        // another command or outside Raycast is pinned whatever this snapshot
+        // says, and brew errors rather than warns when we name it. ~20µs.
+        const pins = await brewPinnedIdentifiers();
+        const reallyPinned = cask ? pins.casks.has(brewIdentifier(props.formula)) : pins.formulae.has(name);
+
+        if (reallyPinned) {
           if (!unpinAndUpgrade) {
             props.onSkip?.();
             await showToast({
@@ -117,6 +128,13 @@ export function FormulaUpgradeAction(props: {
 
         props.onStart?.();
         const result = await upgrade(props.formula);
+        if (result === DECLINED) {
+          // Brew declined rather than failed. Report it the way the batch run
+          // does — and the way the pinned branch above does — instead of
+          // painting the row red for something that is not an error.
+          props.onSkip?.();
+          return;
+        }
         props.onAction(result);
       }}
     />
@@ -216,6 +234,34 @@ async function install(formula: Cask | Formula): Promise<boolean> {
   }
 }
 
+/**
+ * Homebrew refuses to uninstall a pinned package of either kind. Say so, and
+ * offer the one thing that gets past it — which unpins, so it needs an explicit
+ * confirmation rather than a silent `--force`.
+ */
+async function offerForcedUninstall(
+  formula: Cask | Nameable,
+  name: string,
+  cask: boolean,
+  effectivePinned: boolean | undefined,
+  onComplete?: (result: boolean) => void,
+): Promise<void> {
+  await showToast({
+    style: Toast.Style.Failure,
+    title: `Can't uninstall pinned ${cask ? "cask" : "formula"} ${name}`,
+    message: "It is pinned. Unpin it first, or force the uninstall.",
+    primaryAction: {
+      title: `Unpin ${cask ? "Cask" : "Formula"} and Force Uninstall`,
+      onAction: async (toast) => {
+        await toast.hide();
+        // Tell the caller the row changed: without this the view revalidates
+        // only after the refused attempt, leaving the removed package on screen.
+        onComplete?.(await uninstall(formula, true, effectivePinned));
+      },
+    },
+  });
+}
+
 async function uninstall(
   formula: Cask | Nameable,
   force = false,
@@ -224,7 +270,10 @@ async function uninstall(
 ): Promise<boolean> {
   const name = brewName(formula);
   const cask = isCask(formula);
-  const pinned = effectivePinned ?? isPinned(formula);
+  // Ask Homebrew, not the cached payload — see FormulaUpgradeAction. The caller's
+  // effective value still wins when it has one (a live pin change in the review).
+  const pins = await brewPinnedIdentifiers();
+  const pinned = effectivePinned ?? (cask ? pins.casks.has(brewIdentifier(formula)) : pins.formulae.has(name));
 
   // Homebrew refuses to uninstall a pinned package — casks in
   // cask/uninstall.rb (`unpin_for_removal?`) and formulae in uninstall.rb
@@ -232,20 +281,7 @@ async function uninstall(
   // surface as a raw brew error, say what happened and offer the remedy, which
   // unpins as part of the removal and so needs explicit confirmation.
   if (!force && pinned) {
-    await showToast({
-      style: Toast.Style.Failure,
-      title: `Can't uninstall pinned ${cask ? "cask" : "formula"} ${name}`,
-      message: "It is pinned. Unpin it first, or force the uninstall.",
-      primaryAction: {
-        title: `Unpin ${cask ? "Cask" : "Formula"} and Force Uninstall`,
-        onAction: async (toast) => {
-          await toast.hide();
-          // Tell the caller the row changed: without this the view revalidates
-          // only after the refused attempt, leaving the removed package on screen.
-          onComplete?.(await uninstall(formula, true, effectivePinned));
-        },
-      },
-    });
+    await offerForcedUninstall(formula, name, cask, effectivePinned, onComplete);
     return false;
   }
 
@@ -260,13 +296,23 @@ async function uninstall(
     return true;
   } catch (err) {
     const error = ensureError(err);
+    // A pin that landed between the check above and this command. Offer the same
+    // remedy the pre-check does, rather than leaving brew's raw refusal.
+    if (!force && isPinnedRefusal(error)) {
+      await handle.hide();
+      await offerForcedUninstall(formula, name, cask, effectivePinned, onComplete);
+      return false;
+    }
     await handle.showFailureHUD(`Failed to uninstall ${name}`);
     showBrewFailureToast("Uninstall failed", error);
     return false;
   }
 }
 
-async function upgrade(formula: Cask | Nameable): Promise<boolean> {
+/** Homebrew ran, exited 0, and chose not to upgrade — neither success nor failure. */
+const DECLINED = "declined" as const;
+
+async function upgrade(formula: Cask | Nameable): Promise<boolean | typeof DECLINED> {
   const name = brewName(formula);
   const handle = showActionToast({
     title: `Upgrading ${name}`,
@@ -275,13 +321,24 @@ async function upgrade(formula: Cask | Nameable): Promise<boolean> {
   });
   try {
     // Use progress-enabled upgrade to show download progress
-    await brewUpgradeSingleWithProgress(
+    const result = await brewUpgradeSingleWithProgress(
       formula,
       (progress: BrewProgress) => {
         handle.updateMessage(progress.message);
       },
       handle.abort?.signal,
     );
+
+    // Exit 0 is not proof of an upgrade — brew warns and skips a deprecated,
+    // unavailable or already-current package. Saying "Upgraded" there would be
+    // a success message for work it declined to do.
+    const declined = upgradeSkipReason(`${result.stderr ?? ""}\n${result.stdout ?? ""}`, brewIdentifier(formula));
+    if (declined) {
+      await handle.hide();
+      await showToast({ style: Toast.Style.Failure, title: `Did not upgrade ${name}`, message: declined });
+      return DECLINED;
+    }
+
     await handle.showSuccessHUD(`Upgraded ${name}`);
     return true;
   } catch (err) {

--- a/extensions/brew/src/components/actions.tsx
+++ b/extensions/brew/src/components/actions.tsx
@@ -5,16 +5,17 @@ import {
   brewInstallWithProgress,
   brewName,
   isCask,
-  brewPinFormula,
+  brewPin,
   brewUninstall,
-  brewUnpinFormula,
+  brewUnpin,
   brewUpgradeAll,
   brewUpgradeSingleWithProgress,
   type Cask,
   ensureError,
   type Formula,
   type Nameable,
-  type OutdatedFormula,
+  type PinKind,
+  type Pinnable,
   preferences,
   showActionToast,
   showBrewFailureToast,
@@ -34,7 +35,16 @@ export function FormulaInstallAction(props: { formula: Cask | Formula; onAction:
   );
 }
 
-export function FormulaUninstallAction(props: { formula: Cask | Nameable; onAction: (result: boolean) => void }) {
+export function FormulaUninstallAction(props: {
+  formula: Cask | Nameable;
+  /**
+   * Effective pin state, when the caller tracks it live. The payload's own
+   * `pinned` can be a stale snapshot from an in-flight fetch, so a view that
+   * knows better says so rather than letting a guard read the stale value.
+   */
+  pinned?: boolean;
+  onAction: (result: boolean) => void;
+}) {
   return (
     <Action
       title="Uninstall"
@@ -42,7 +52,7 @@ export function FormulaUninstallAction(props: { formula: Cask | Nameable; onActi
       shortcut={Keyboard.Shortcut.Common.Remove}
       style={Action.Style.Destructive}
       onAction={async () => {
-        const result = await uninstall(props.formula);
+        const result = await uninstall(props.formula, false, props.pinned, props.onAction);
         props.onAction(result);
       }}
     />
@@ -52,11 +62,14 @@ export function FormulaUninstallAction(props: { formula: Cask | Nameable; onActi
 /**
  * Upgrade a single package.
  *
- * A PINNED formula is skipped rather than attempted. `brew upgrade` refuses it
- * outright — "Error: Not upgrading 1 pinned package" — so running it would
- * surface a failure toast for a package the user deliberately froze. Upgrade
- * All already skips pinned formulae and reports them as skipped; this makes the
- * single-package action say the same thing, in every view that offers it.
+ * `brew upgrade` refuses a PINNED package outright — "Error: Not upgrading 1
+ * pinned package" — so the action never simply attempts one.
+ *
+ * Where the caller tracks per-package status (the upgrade run), it stays a
+ * skip: a row that reports "skipped" should not quietly unpin itself. Elsewhere
+ * (Search, Show Installed) the only sensible reading of pressing Upgrade on a
+ * pinned row is "do the thing" — so the action says "Unpin and Upgrade" and
+ * does both, rather than refusing and naming a shortcut to press instead.
  */
 export function FormulaUpgradeAction(props: {
   formula: Cask | Nameable;
@@ -68,22 +81,38 @@ export function FormulaUpgradeAction(props: {
    * no status (Search, Show Installed) leave it undefined and rely on the toast.
    */
   onSkip?: () => void;
+  /** Effective pin state, when the caller tracks it live. See FormulaUninstallAction. */
+  pinned?: boolean;
   onAction: (result: boolean) => void;
 }) {
+  const pinned = props.pinned ?? isPinned(props.formula);
+  const cask = isCask(props.formula);
+  const unpinAndUpgrade = pinned && !props.onSkip;
+  // Name the package: this action sits beside "Upgrade All" in the same panel,
+  // so "Upgrade" alone leaves the scope of what is about to run ambiguous.
+  const name = brewName(props.formula);
+
   return (
     <Action
-      title="Upgrade"
-      icon={Icon.ArrowUpCircle}
+      title={unpinAndUpgrade ? `Unpin ${cask ? "Cask" : "Formula"} and Upgrade ${name}` : `Upgrade ${name}`}
+      icon={unpinAndUpgrade ? Icon.TackDisabled : Icon.ArrowUpCircle}
       shortcut={{ modifiers: ["cmd", "shift"], key: "u" }}
       onAction={async () => {
-        if (isPinned(props.formula)) {
-          props.onSkip?.();
-          await showToast({
-            style: Toast.Style.Success,
-            title: "Skipping Pinned Formulae Upgrades",
-            message: `${brewName(props.formula)} is pinned. Unpin it (⌘ .) to upgrade.`,
-          });
-          return;
+        if (pinned) {
+          if (!unpinAndUpgrade) {
+            props.onSkip?.();
+            await showToast({
+              style: Toast.Style.Success,
+              title: "Skipping Pinned Upgrades",
+              message: `${brewName(props.formula)} is pinned. Unpin it (⌘ .) to upgrade.`,
+            });
+            return;
+          }
+          // The pin is the only thing standing in the way, and the user just
+          // asked for the upgrade — so lift it, then proceed.
+          if (!(await unpin(props.formula as Pinnable, cask ? "cask" : "formula"))) {
+            return;
+          }
         }
 
         props.onStart?.();
@@ -94,13 +123,9 @@ export function FormulaUpgradeAction(props: {
   );
 }
 
-/**
- * Pinning is formula-only. A cask is never treated as pinned even if the API
- * hands one a `pinned` field — there is no Unpin action in the cask panel, so
- * the toast would name a remedy the user cannot reach.
- */
+/** Formulae and casks are both pinnable (casks since Homebrew 5.1.12). */
 function isPinned(item: Cask | Nameable): boolean {
-  return !isCask(item) && (item as Formula).pinned === true;
+  return (item as Formula | Cask).pinned === true;
 }
 
 export function FormulaUpgradeAllAction(props: {
@@ -125,18 +150,19 @@ export function FormulaUpgradeAllAction(props: {
   );
 }
 
-export function FormulaPinAction(props: { formula: Formula | OutdatedFormula; onAction: (result: boolean) => void }) {
-  const isPinned = props.formula.pinned;
+export function PinAction(props: { item: Pinnable; kind: PinKind; onAction: (result: boolean) => void }) {
+  const pinned = props.item.pinned;
+  const noun = props.kind === "cask" ? "Cask" : "Formula";
   return (
     <Action
-      title={isPinned ? "Unpin" : "Pin"}
-      icon={isPinned ? Icon.TackDisabled : Icon.Tack}
+      title={`${pinned ? "Unpin" : "Pin"} ${noun}`}
+      icon={pinned ? Icon.TackDisabled : Icon.Tack}
       shortcut={Keyboard.Shortcut.Common.Pin}
       onAction={async () => {
-        if (isPinned) {
-          props.onAction(await unpin(props.formula));
+        if (pinned) {
+          props.onAction(await unpin(props.item, props.kind));
         } else {
-          props.onAction(await pin(props.formula));
+          props.onAction(await pin(props.item, props.kind));
         }
       }}
     />
@@ -190,15 +216,46 @@ async function install(formula: Cask | Formula): Promise<boolean> {
   }
 }
 
-async function uninstall(formula: Cask | Nameable): Promise<boolean> {
+async function uninstall(
+  formula: Cask | Nameable,
+  force = false,
+  effectivePinned?: boolean,
+  onComplete?: (result: boolean) => void,
+): Promise<boolean> {
   const name = brewName(formula);
+  const cask = isCask(formula);
+  const pinned = effectivePinned ?? isPinned(formula);
+
+  // Homebrew refuses to uninstall a pinned package — casks in
+  // cask/uninstall.rb (`unpin_for_removal?`) and formulae in uninstall.rb
+  // ("is pinned. You must unpin it to uninstall."). Rather than let that
+  // surface as a raw brew error, say what happened and offer the remedy, which
+  // unpins as part of the removal and so needs explicit confirmation.
+  if (!force && pinned) {
+    await showToast({
+      style: Toast.Style.Failure,
+      title: `Can't uninstall pinned ${cask ? "cask" : "formula"} ${name}`,
+      message: "It is pinned. Unpin it first, or force the uninstall.",
+      primaryAction: {
+        title: `Unpin ${cask ? "Cask" : "Formula"} and Force Uninstall`,
+        onAction: async (toast) => {
+          await toast.hide();
+          // Tell the caller the row changed: without this the view revalidates
+          // only after the refused attempt, leaving the removed package on screen.
+          onComplete?.(await uninstall(formula, true, effectivePinned));
+        },
+      },
+    });
+    return false;
+  }
+
   const handle = showActionToast({
     title: `Uninstalling ${name}`,
     message: "",
     cancelable: true,
   });
   try {
-    await brewUninstall(formula, handle.abort?.signal);
+    await brewUninstall(formula, handle.abort?.signal, force);
     await handle.showSuccessHUD(`Uninstalled ${name}`);
     return true;
   } catch (err) {
@@ -253,28 +310,40 @@ async function upgradeAll(): Promise<boolean> {
   }
 }
 
-export async function pin(formula: Formula | OutdatedFormula): Promise<boolean> {
-  showToast(Toast.Style.Animated, `Pinning ${brewName(formula)}`);
+export async function pin(item: Pinnable, kind: PinKind): Promise<boolean> {
+  const name = brewName(item as Cask | Nameable);
+  showToast(Toast.Style.Animated, `Pinning ${name}`);
   try {
-    await brewPinFormula(formula);
-    formula.pinned = true;
-    showToast(Toast.Style.Success, `Pinned ${brewName(formula)}`);
+    const mayAutoUpdate = await brewPin(item, kind);
+    item.pinned = true;
+    // A cask that updates itself ignores the pin: Homebrew pins it anyway and
+    // warns (cmd/pin.rb). Say so rather than implying the version is frozen.
+    if (mayAutoUpdate) {
+      await showToast({
+        style: Toast.Style.Success,
+        title: `Pinned ${name}`,
+        message: "Pinning may be overridden by auto-updates",
+      });
+    } else {
+      showToast(Toast.Style.Success, `Pinned ${name}`);
+    }
     return true;
   } catch (err) {
-    showBrewFailureToast("Pin formula failed", ensureError(err));
+    showBrewFailureToast(`Pin ${kind} failed`, ensureError(err));
     return false;
   }
 }
 
-export async function unpin(formula: Formula | OutdatedFormula): Promise<boolean> {
-  showToast(Toast.Style.Animated, `Unpinning ${brewName(formula)}`);
+export async function unpin(item: Pinnable, kind: PinKind): Promise<boolean> {
+  const name = brewName(item as Cask | Nameable);
+  showToast(Toast.Style.Animated, `Unpinning ${name}`);
   try {
-    await brewUnpinFormula(formula);
-    formula.pinned = false;
-    showToast(Toast.Style.Success, `Unpinned ${brewName(formula)}`);
+    await brewUnpin(item, kind);
+    item.pinned = false;
+    showToast(Toast.Style.Success, `Unpinned ${name}`);
     return true;
   } catch (err) {
-    showBrewFailureToast("Unpin formula failed", ensureError(err));
+    showBrewFailureToast(`Unpin ${kind} failed`, ensureError(err));
     return false;
   }
 }

--- a/extensions/brew/src/components/caskInfo.tsx
+++ b/extensions/brew/src/components/caskInfo.tsx
@@ -5,10 +5,7 @@ import { Cask, brewName, brewFetchCaskInfo, uiLogger, ensureError } from "../uti
 import { DetailMetadata, caskMetadataRows } from "./packageMetadata";
 import { usePackageDetail } from "../hooks/usePackageDetail";
 
-/**
- * Whether this cask carries only summary fields — from the search index or a
- * list row — rather than full `brew info` metadata.
- */
+/** Whether this cask looks like a summary record and should be refetched. */
 function hasMinimalData(cask: Cask): boolean {
   // A summary record has missing or empty homepage, tap, or desc
   return !cask.homepage || !cask.tap || !cask.desc;

--- a/extensions/brew/src/components/caskInfo.tsx
+++ b/extensions/brew/src/components/caskInfo.tsx
@@ -6,10 +6,11 @@ import { DetailMetadata, caskMetadataRows } from "./packageMetadata";
 import { usePackageDetail } from "../hooks/usePackageDetail";
 
 /**
- * Check if a cask has minimal data (from fast list) vs full data.
+ * Whether this cask carries only summary fields — from the search index or a
+ * list row — rather than full `brew info` metadata.
  */
 function hasMinimalData(cask: Cask): boolean {
-  // Minimal casks have missing or empty homepage, tap, or desc
+  // A summary record has missing or empty homepage, tap, or desc
   return !cask.homepage || !cask.tap || !cask.desc;
 }
 

--- a/extensions/brew/src/components/formulaInfo.tsx
+++ b/extensions/brew/src/components/formulaInfo.tsx
@@ -6,10 +6,11 @@ import { DetailMetadata, formulaMetadataRows } from "./packageMetadata";
 import { usePackageDetail } from "../hooks/usePackageDetail";
 
 /**
- * Check if a formula has minimal data (from fast list) vs full data.
+ * Whether this formula carries only summary fields — from the search index or a
+ * list row — rather than full `brew info` metadata.
  */
 function hasMinimalData(formula: Formula): boolean {
-  // Minimal formulae have missing or empty homepage, tap, or desc
+  // A summary record has missing or empty homepage, tap, or desc
   return !formula.homepage || !formula.tap || !formula.desc;
 }
 

--- a/extensions/brew/src/components/formulaInfo.tsx
+++ b/extensions/brew/src/components/formulaInfo.tsx
@@ -5,10 +5,7 @@ import { Formula, brewPrefix, brewFetchFormulaInfo, uiLogger, ensureError } from
 import { DetailMetadata, formulaMetadataRows } from "./packageMetadata";
 import { usePackageDetail } from "../hooks/usePackageDetail";
 
-/**
- * Whether this formula carries only summary fields — from the search index or a
- * list row — rather than full `brew info` metadata.
- */
+/** Whether this formula looks like a summary record and should be refetched. */
 function hasMinimalData(formula: Formula): boolean {
   // A summary record has missing or empty homepage, tap, or desc
   return !formula.homepage || !formula.tap || !formula.desc;

--- a/extensions/brew/src/components/list.tsx
+++ b/extensions/brew/src/components/list.tsx
@@ -58,8 +58,7 @@ export function FormulaList(props: FormulaListProps) {
   // know which one is actually on screen before it fetches anything for it.
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
-  // A pin is an explicit user decision, so surfacing it first is the default;
-  // the preference exists because the sections used to sit at the bottom.
+  // A pin is an explicit user decision, so surfacing it first is the default.
   const pinnedFirst = preferences.pinnedFirst;
 
   const formulaeSection = formulae.length > 0 && (

--- a/extensions/brew/src/components/list.tsx
+++ b/extensions/brew/src/components/list.tsx
@@ -9,6 +9,7 @@ import {
   brewName,
   Cask,
   Formula,
+  preferences,
 } from "../utils";
 import { CaskActionPanel, FormulaActionPanel } from "./actionPanels";
 import { installStateIcon, UPDATE_AVAILABLE_COLOR } from "./packageIcons";
@@ -19,6 +20,7 @@ export interface FormulaListProps {
   formulae: Formula[];
   casks: Cask[];
   pinnedFormulae?: Formula[];
+  pinnedCasks?: Cask[];
   searchBarPlaceholder: string;
   searchBarAccessory?: React.ComponentProps<typeof List>["searchBarAccessory"];
   searchText?: string;
@@ -48,12 +50,104 @@ export function FormulaList(props: FormulaListProps) {
   const formulae = props.formulae;
   const casks = props.casks;
   const pinnedFormulae = props.pinnedFormulae ?? [];
-  const hasResults = formulae.length > 0 || casks.length > 0 || pinnedFormulae.length > 0;
+  const pinnedCasks = props.pinnedCasks ?? [];
+  const hasResults = formulae.length > 0 || casks.length > 0 || pinnedFormulae.length > 0 || pinnedCasks.length > 0;
   const showMetadataPanel = props.showMetadataPanel ?? false;
 
   // Raycast constructs the detail element for every row, so the panel needs to
   // know which one is actually on screen before it fetches anything for it.
   const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  // A pin is an explicit user decision, so surfacing it first is the default;
+  // the preference exists because the sections used to sit at the bottom.
+  const pinnedFirst = preferences.pinnedFirst;
+
+  const formulaeSection = formulae.length > 0 && (
+    <List.Section title="Formulae">
+      {formulae.map((formula) => (
+        <FormulaListItem
+          key={`formula-${formula.name}`}
+          id={`formula-${formula.name}`}
+          selectedId={selectedId}
+          formula={formula}
+          isInstalled={props.isInstalled}
+          onAction={props.onAction}
+          showMetadataPanel={showMetadataPanel}
+          onToggleSidebar={props.onToggleSidebar}
+          sortByPopularity={props.sortByPopularity}
+          onToggleSort={props.onToggleSort}
+          showDescription={props.showDescription}
+          onToggleDescription={props.onToggleDescription}
+          showInstalledDate={props.showInstalledDate}
+          showDependenciesFilter={props.showDependenciesFilter}
+        />
+      ))}
+      {formulae.isTruncated() && <MoreListItem />}
+    </List.Section>
+  );
+  const casksSection = casks.length > 0 && (
+    <List.Section title="Casks">
+      {casks.map((cask) => (
+        <CaskListItem
+          key={`cask-${cask.token}`}
+          id={`cask-${cask.token}`}
+          selectedId={selectedId}
+          cask={cask}
+          isInstalled={props.isInstalled}
+          onAction={props.onAction}
+          showMetadataPanel={showMetadataPanel}
+          onToggleSidebar={props.onToggleSidebar}
+          sortByPopularity={props.sortByPopularity}
+          onToggleSort={props.onToggleSort}
+          showDescription={props.showDescription}
+          onToggleDescription={props.onToggleDescription}
+          showInstalledDate={props.showInstalledDate}
+        />
+      ))}
+      {casks.isTruncated() && <MoreListItem />}
+    </List.Section>
+  );
+  const pinnedFormulaeSection = pinnedFormulae.length > 0 && (
+    <List.Section title="Pinned Formulae" subtitle={`${pinnedFormulae.length}`}>
+      {pinnedFormulae.map((formula) => (
+        <FormulaListItem
+          key={`pinned-formula-${formula.name}`}
+          id={`pinned-formula-${formula.name}`}
+          selectedId={selectedId}
+          formula={formula}
+          isInstalled={props.isInstalled}
+          onAction={props.onAction}
+          showMetadataPanel={showMetadataPanel}
+          onToggleSidebar={props.onToggleSidebar}
+          showDescription={props.showDescription}
+          onToggleDescription={props.onToggleDescription}
+          showInstalledDate={props.showInstalledDate}
+          showDependenciesFilter={props.showDependenciesFilter}
+        />
+      ))}
+    </List.Section>
+  );
+  const pinnedCasksSection = pinnedCasks.length > 0 && (
+    <List.Section title="Pinned Casks" subtitle={`${pinnedCasks.length}`}>
+      {pinnedCasks.map((cask) => (
+        <CaskListItem
+          key={`pinned-cask-${cask.token}`}
+          id={`pinned-cask-${cask.token}`}
+          selectedId={selectedId}
+          cask={cask}
+          isInstalled={props.isInstalled}
+          onAction={props.onAction}
+          showMetadataPanel={showMetadataPanel}
+          onToggleSidebar={props.onToggleSidebar}
+          sortByPopularity={props.sortByPopularity}
+          onToggleSort={props.onToggleSort}
+          showDescription={props.showDescription}
+          onToggleDescription={props.onToggleDescription}
+          showInstalledDate={props.showInstalledDate}
+        />
+      ))}
+    </List.Section>
+  );
 
   return (
     <List
@@ -77,70 +171,20 @@ export function FormulaList(props: FormulaListProps) {
       {!hasResults && !props.isLoading && props.dataFetched && (
         <List.EmptyView icon={Icon.MagnifyingGlass} title="No Results" description="No packages found" />
       )}
-      {formulae.length > 0 && (
-        <List.Section title="Formulae">
-          {formulae.map((formula) => (
-            <FormulaListItem
-              key={`formula-${formula.name}`}
-              id={`formula-${formula.name}`}
-              selectedId={selectedId}
-              formula={formula}
-              isInstalled={props.isInstalled}
-              onAction={props.onAction}
-              showMetadataPanel={showMetadataPanel}
-              onToggleSidebar={props.onToggleSidebar}
-              sortByPopularity={props.sortByPopularity}
-              onToggleSort={props.onToggleSort}
-              showDescription={props.showDescription}
-              onToggleDescription={props.onToggleDescription}
-              showInstalledDate={props.showInstalledDate}
-              showDependenciesFilter={props.showDependenciesFilter}
-            />
-          ))}
-          {formulae.isTruncated() && <MoreListItem />}
-        </List.Section>
-      )}
-      {casks.length > 0 && (
-        <List.Section title="Casks">
-          {casks.map((cask) => (
-            <CaskListItem
-              key={`cask-${cask.token}`}
-              id={`cask-${cask.token}`}
-              selectedId={selectedId}
-              cask={cask}
-              isInstalled={props.isInstalled}
-              onAction={props.onAction}
-              showMetadataPanel={showMetadataPanel}
-              onToggleSidebar={props.onToggleSidebar}
-              sortByPopularity={props.sortByPopularity}
-              onToggleSort={props.onToggleSort}
-              showDescription={props.showDescription}
-              onToggleDescription={props.onToggleDescription}
-              showInstalledDate={props.showInstalledDate}
-            />
-          ))}
-          {casks.isTruncated() && <MoreListItem />}
-        </List.Section>
-      )}
-      {pinnedFormulae.length > 0 && (
-        <List.Section title="Pinned Formulae" subtitle={`${pinnedFormulae.length}`}>
-          {pinnedFormulae.map((formula) => (
-            <FormulaListItem
-              key={`pinned-formula-${formula.name}`}
-              id={`pinned-formula-${formula.name}`}
-              selectedId={selectedId}
-              formula={formula}
-              isInstalled={props.isInstalled}
-              onAction={props.onAction}
-              showMetadataPanel={showMetadataPanel}
-              onToggleSidebar={props.onToggleSidebar}
-              showDescription={props.showDescription}
-              onToggleDescription={props.onToggleDescription}
-              showInstalledDate={props.showInstalledDate}
-              showDependenciesFilter={props.showDependenciesFilter}
-            />
-          ))}
-        </List.Section>
+      {pinnedFirst ? (
+        <>
+          {pinnedFormulaeSection}
+          {pinnedCasksSection}
+          {formulaeSection}
+          {casksSection}
+        </>
+      ) : (
+        <>
+          {formulaeSection}
+          {casksSection}
+          {pinnedFormulaeSection}
+          {pinnedCasksSection}
+        </>
       )}
     </List>
   );
@@ -249,7 +293,12 @@ export function CaskListItem(props: {
     accessories.push({ tag: { value: "Outdated", color: UPDATE_AVAILABLE_COLOR } });
   }
   accessories.push({ text: version });
-  pushAccessories(accessories, props.showInstalledDate ? brewInstalledDate(cask) : undefined, cask.installs, false);
+  pushAccessories(
+    accessories,
+    props.showInstalledDate ? brewInstalledDate(cask) : undefined,
+    cask.installs,
+    cask.pinned,
+  );
 
   return (
     <List.Item
@@ -301,7 +350,8 @@ const compactNumber = new Intl.NumberFormat("en", { notation: "compact", maximum
  *   in that case alone. Showing it unconditionally would mean every user paid
  *   for that download on first search, so the count rides along with the sort
  *   rather than being always-on.
- * - **Pin** — formulae only; casks cannot be pinned.
+ * - **Pin** — shown for any pinned package. Casks have been pinnable since
+ *   Homebrew 5.1.12.
  */
 function pushAccessories(
   accessories: List.Item.Accessory[],

--- a/extensions/brew/src/components/outdatedList.tsx
+++ b/extensions/brew/src/components/outdatedList.tsx
@@ -7,7 +7,7 @@
 import React from "react";
 import { Color, Icon, List } from "@raycast/api";
 import { getProgressIcon } from "@raycast/utils";
-import { OutdatedCask, OutdatedFormula, OutdatedResults, type UpgradePackageStatus } from "../utils";
+import { OutdatedCask, OutdatedFormula, OutdatedResults, preferences, type UpgradePackageStatus } from "../utils";
 import type { PackageState } from "../hooks/useBrewUpgrade";
 import { OutdatedActionPanel } from "./actionPanels";
 import { OutdatedErrorView } from "./outdatedErrorView";
@@ -70,15 +70,17 @@ export function statusIcon(state?: PackageState): React.ComponentProps<typeof Li
   if (!state) return { value: PENDING_ICON, tooltip: "Pending" };
 
   switch (state.status) {
+    case "downloading":
+      return { value: { source: Icon.ArrowDownCircle, tintColor: Color.Blue }, tooltip: "Downloading…" };
     case "upgrading":
-      return { value: { source: Icon.ArrowDownCircle, tintColor: Color.Blue }, tooltip: "Upgrading…" };
+      return { value: { source: getProgressIcon(0.5, Color.Blue), tintColor: Color.Blue }, tooltip: "Upgrading…" };
     case "upgraded":
       return { value: { source: Icon.CheckCircle, tintColor: Color.Green }, tooltip: "Upgraded" };
     case "failed":
       return { value: { source: Icon.XMarkCircle, tintColor: Color.Red }, tooltip: state.message ?? "Upgrade failed" };
     case "skipped":
       return {
-        value: { source: Icon.MinusCircle, tintColor: Color.SecondaryText },
+        value: { source: Icon.MinusCircleFilled, tintColor: Color.SecondaryText },
         tooltip: state.message ?? "Skipped",
       };
   }
@@ -86,7 +88,7 @@ export function statusIcon(state?: PackageState): React.ComponentProps<typeof Li
 
 export function OutdatedList(props: OutdatedListProps) {
   const allFormulae = props.filterType != InstallableFilterType.casks ? (props.outdated?.formulae ?? []) : [];
-  const casks = props.filterType != InstallableFilterType.formulae ? (props.outdated?.casks ?? []) : [];
+  const allCasks = props.filterType != InstallableFilterType.formulae ? (props.outdated?.casks ?? []) : [];
 
   // Pinned formulae are separated out the way Show Installed separates them.
   // Here it also carries meaning: a pinned formula is one `brew upgrade` will
@@ -94,11 +96,48 @@ export function OutdatedList(props: OutdatedListProps) {
   // that without needing the row to explain itself.
   const formulae = allFormulae.filter((formula) => !formula.pinned);
   const pinnedFormulae = allFormulae.filter((formula) => formula.pinned);
-  const hasResults = allFormulae.length > 0 || casks.length > 0;
+  const unpinnedCasks = allCasks.filter((cask) => !cask.pinned);
+  const pinnedCasks = allCasks.filter((cask) => cask.pinned);
+  const hasResults = allFormulae.length > 0 || allCasks.length > 0;
 
   // Determine search bar placeholder based on loading state
   const searchBarPlaceholder =
     props.searchBarPlaceholder ?? (props.isLoading ? "Checking for outdated packages…" : placeholder(props.filterType));
+
+  const pinnedSections = (
+    <>
+      {pinnedFormulae.length > 0 && (
+        <List.Section title="Pinned Formulae" subtitle={`${pinnedFormulae.length}`}>
+          {pinnedFormulae.map((formula) => (
+            <OutdatedFormulaeListItem
+              key={formula.name}
+              outdated={formula}
+              icon={props.icon}
+              actions={props.actions}
+              onUpgrade={props.onUpgrade}
+              onUpgradeAll={props.onUpgradeAll}
+              onAction={props.onAction}
+            />
+          ))}
+        </List.Section>
+      )}
+      {pinnedCasks.length > 0 && (
+        <List.Section title="Pinned Casks" subtitle={`${pinnedCasks.length}`}>
+          {pinnedCasks.map((cask) => (
+            <OutdatedCaskListItem
+              key={cask.name}
+              outdated={cask}
+              icon={props.icon}
+              actions={props.actions}
+              onUpgrade={props.onUpgrade}
+              onUpgradeAll={props.onUpgradeAll}
+              onAction={props.onAction}
+            />
+          ))}
+        </List.Section>
+      )}
+    </>
+  );
 
   return (
     <List
@@ -133,35 +172,10 @@ export function OutdatedList(props: OutdatedListProps) {
       {/* Results */}
       {hasResults && (
         <>
-          <List.Section title="Formulae">
-            {formulae.map((formula) => (
-              <OutdatedFormulaeListItem
-                key={formula.name}
-                outdated={formula}
-                icon={props.icon}
-                actions={props.actions}
-                onUpgrade={props.onUpgrade}
-                onUpgradeAll={props.onUpgradeAll}
-                onAction={props.onAction}
-              />
-            ))}
-          </List.Section>
-          <List.Section title="Casks">
-            {casks.map((cask) => (
-              <OutdatedCaskListItem
-                key={cask.name}
-                outdated={cask}
-                icon={props.icon}
-                actions={props.actions}
-                onUpgrade={props.onUpgrade}
-                onUpgradeAll={props.onUpgradeAll}
-                onAction={props.onAction}
-              />
-            ))}
-          </List.Section>
-          {pinnedFormulae.length > 0 && (
-            <List.Section title="Pinned Formulae" subtitle={`${pinnedFormulae.length}`}>
-              {pinnedFormulae.map((formula) => (
+          {preferences.pinnedFirst && pinnedSections}
+          {formulae.length > 0 && (
+            <List.Section title="Formulae">
+              {formulae.map((formula) => (
                 <OutdatedFormulaeListItem
                   key={formula.name}
                   outdated={formula}
@@ -174,6 +188,22 @@ export function OutdatedList(props: OutdatedListProps) {
               ))}
             </List.Section>
           )}
+          {unpinnedCasks.length > 0 && (
+            <List.Section title="Casks">
+              {unpinnedCasks.map((cask) => (
+                <OutdatedCaskListItem
+                  key={cask.name}
+                  outdated={cask}
+                  icon={props.icon}
+                  actions={props.actions}
+                  onUpgrade={props.onUpgrade}
+                  onUpgradeAll={props.onUpgradeAll}
+                  onAction={props.onAction}
+                />
+              ))}
+            </List.Section>
+          )}
+          {!preferences.pinnedFirst && pinnedSections}
         </>
       )}
     </List>
@@ -199,12 +229,13 @@ function OutdatedCaskListItem(props: OutdatedListItemProps & { outdated: Outdate
     <List.Item
       id={outdated.name}
       title={outdated.name}
-      accessories={[{ text: version }]}
+      accessories={[...(outdated.pinned ? [{ icon: Icon.Tack, tooltip: "Pinned" }] : []), { text: version }]}
       icon={props.icon?.(outdated, true) ?? PENDING_ICON}
       actions={
         props.actions?.(outdated, true) ?? (
           <OutdatedActionPanel
             outdated={outdated}
+            isCask
             onUpgrade={(status) => props.onUpgrade?.(outdated, true, status)}
             onUpgradeAll={props.onUpgradeAll}
             onAction={props.onAction}
@@ -237,6 +268,7 @@ function OutdatedFormulaeListItem(props: OutdatedListItemProps & { outdated: Out
         props.actions?.(outdated, false) ?? (
           <OutdatedActionPanel
             outdated={outdated}
+            isCask={false}
             onUpgrade={(status) => props.onUpgrade?.(outdated, false, status)}
             onUpgradeAll={props.onUpgradeAll}
             onAction={props.onAction}

--- a/extensions/brew/src/components/outdatedList.tsx
+++ b/extensions/brew/src/components/outdatedList.tsx
@@ -70,8 +70,6 @@ export function statusIcon(state?: PackageState): React.ComponentProps<typeof Li
   if (!state) return { value: PENDING_ICON, tooltip: "Pending" };
 
   switch (state.status) {
-    case "downloading":
-      return { value: { source: Icon.ArrowDownCircle, tintColor: Color.Blue }, tooltip: "Downloading…" };
     case "upgrading":
       return { value: { source: getProgressIcon(0.5, Color.Blue), tintColor: Color.Blue }, tooltip: "Upgrading…" };
     case "upgraded":

--- a/extensions/brew/src/components/packageMetadata.tsx
+++ b/extensions/brew/src/components/packageMetadata.tsx
@@ -95,6 +95,20 @@ function dependencyTags(names: string[] | undefined, isInstalled: (name: string)
   );
 }
 
+/** Append a tag row and its separator, or nothing when there is nothing to show. */
+function pushTagRow(
+  rows: MetadataRow[],
+  key: string,
+  title: string,
+  tags: { text: string; color?: Color.ColorLike }[] | undefined,
+): void {
+  if (!tags || tags.length === 0) {
+    return;
+  }
+  rows.push({ kind: "separator", key: `${key}-sep` });
+  rows.push({ kind: "tags", key, title, tags });
+}
+
 /** Leading rows shared by both kinds: the lifecycle warning, then the prose. */
 function leadingRows(item: Cask | Formula, options: MetadataOptions, caveats: string | undefined): MetadataRow[] {
   const rows: MetadataRow[] = [];
@@ -194,10 +208,7 @@ export function formulaMetadataRows(formula: Formula, options: MetadataOptions):
     ["build-dependencies", "Build Dependencies", formula.build_dependencies],
     ["conflicts", "Conflicts With", formula.conflicts_with],
   ] as const) {
-    if (names && names.length > 0) {
-      rows.push({ kind: "separator", key: `${key}-sep` });
-      rows.push({ kind: "tags", key, title, tags: dependencyTags(names, options.isInstalled) });
-    }
+    pushTagRow(rows, key, title, names && dependencyTags(names, options.isInstalled));
   }
 
   if (formula.pinned) {
@@ -225,57 +236,33 @@ export function caskMetadataRows(cask: Cask, options: MetadataOptions): Metadata
   ];
 
   // Casks depend on formulae and other casks, not only an OS version
-  // (cask/dsl/depends_on.rb) — formula metadata has always shown its
-  // dependencies, so omitting these was drift rather than a kind difference.
+  // (cask/dsl/depends_on.rb).
   const packageDeps = [...(cask.depends_on?.formula ?? []), ...(cask.depends_on?.cask ?? [])];
-  if (packageDeps.length > 0) {
-    rows.push({ kind: "separator", key: "dependencies-sep" });
-    rows.push({
-      kind: "tags",
-      key: "dependencies",
-      title: "Dependencies",
-      tags: dependencyTags(packageDeps, options.isInstalled),
-    });
-  }
+  pushTagRow(rows, "dependencies", "Dependencies", dependencyTags(packageDeps, options.isInstalled));
 
-  const arch = cask.depends_on?.arch;
-  if (arch && arch.length > 0) {
-    rows.push({ kind: "separator", key: "arch-sep" });
-    rows.push({
-      kind: "tags",
-      key: "arch",
-      title: "Architecture",
-      tags: arch.map(({ type, bits }) => ({ text: bits ? `${type}${bits}` : type })),
-    });
-  }
+  pushTagRow(
+    rows,
+    "arch",
+    "Architecture",
+    cask.depends_on?.arch?.map(({ type, bits }) => ({ text: bits ? `${type}${bits}` : type })),
+  );
 
   const macos = cask.depends_on?.macos;
-  if (macos) {
-    rows.push({ kind: "separator", key: "macos-sep" });
-    rows.push({
-      kind: "tags",
-      key: "macos",
-      title: "macOS Version",
-      tags: Object.entries(macos)
+  pushTagRow(
+    rows,
+    "macos",
+    "macOS Version",
+    macos &&
+      Object.entries(macos)
         .filter(([, values]) => values)
         .map(([key, values]) => ({ text: `${key} ${values.join(", ")}` })),
-    });
-  }
+  );
 
   const conflicts = cask.conflicts_with?.cask;
-  if (conflicts && conflicts.length > 0) {
-    rows.push({ kind: "separator", key: "conflicts-sep" });
-    rows.push({
-      kind: "tags",
-      key: "conflicts",
-      title: "Conflicts With",
-      tags: dependencyTags(conflicts, options.isInstalled),
-    });
-  }
+  pushTagRow(rows, "conflicts", "Conflicts With", conflicts && dependencyTags(conflicts, options.isInstalled));
 
-  // Same row formulae get. The list's tack accessory is hidden while the metadata
-  // panel is open (list.tsx), so without this a pinned cask has no visible pin
-  // state at all in the one view that is showing its metadata.
+  // The list's tack accessory is hidden while the metadata panel is open
+  // (list.tsx), so this is the only pin indicator a cask has in that view.
   if (cask.pinned) {
     rows.push({ kind: "separator", key: "pinned-sep" });
     rows.push({ kind: "label", key: "pinned", title: "Pinned", text: "Yes" });

--- a/extensions/brew/src/components/packageMetadata.tsx
+++ b/extensions/brew/src/components/packageMetadata.tsx
@@ -224,6 +224,31 @@ export function caskMetadataRows(cask: Cask, options: MetadataOptions): Metadata
     { kind: "label", key: "version", title: "Version", text: formatPackageVersion(cask) },
   ];
 
+  // Casks depend on formulae and other casks, not only an OS version
+  // (cask/dsl/depends_on.rb) — formula metadata has always shown its
+  // dependencies, so omitting these was drift rather than a kind difference.
+  const packageDeps = [...(cask.depends_on?.formula ?? []), ...(cask.depends_on?.cask ?? [])];
+  if (packageDeps.length > 0) {
+    rows.push({ kind: "separator", key: "dependencies-sep" });
+    rows.push({
+      kind: "tags",
+      key: "dependencies",
+      title: "Dependencies",
+      tags: dependencyTags(packageDeps, options.isInstalled),
+    });
+  }
+
+  const arch = cask.depends_on?.arch;
+  if (arch && arch.length > 0) {
+    rows.push({ kind: "separator", key: "arch-sep" });
+    rows.push({
+      kind: "tags",
+      key: "arch",
+      title: "Architecture",
+      tags: arch.map(({ type, bits }) => ({ text: bits ? `${type}${bits}` : type })),
+    });
+  }
+
   const macos = cask.depends_on?.macos;
   if (macos) {
     rows.push({ kind: "separator", key: "macos-sep" });

--- a/extensions/brew/src/components/packageMetadata.tsx
+++ b/extensions/brew/src/components/packageMetadata.tsx
@@ -70,7 +70,7 @@ export function formatPackageVersion(item: Cask | Formula): string {
   if (brewIsInstalled(item)) {
     status.push("installed");
   }
-  if (!cask && item.installed?.first()?.installed_as_dependency) {
+  if (!cask && item.installed?.first()?.installed_on_request === false) {
     status.push("dependency");
   }
 
@@ -80,8 +80,19 @@ export function formatPackageVersion(item: Cask | Formula): string {
   return status.length > 0 ? `${version} (${status.join(", ")})` : version;
 }
 
+/**
+ * A checkmark prefix, so an installed dependency reads as such without relying
+ * on colour alone. U+2713 rather than an SF Symbols codepoint: this has to
+ * render on Windows too.
+ */
+const INSTALLED_TAG_PREFIX = "✓ ";
+
 function dependencyTags(names: string[] | undefined, isInstalled: (name: string) => boolean) {
-  return (names ?? []).map((name) => ({ text: name, color: isInstalled(name) ? Color.Green : Color.SecondaryText }));
+  return (names ?? []).map((name) =>
+    isInstalled(name)
+      ? { text: `${INSTALLED_TAG_PREFIX}${name}`, color: Color.Green }
+      : { text: name, color: Color.SecondaryText },
+  );
 }
 
 /** Leading rows shared by both kinds: the lifecycle warning, then the prose. */

--- a/extensions/brew/src/components/packageMetadata.tsx
+++ b/extensions/brew/src/components/packageMetadata.tsx
@@ -173,6 +173,8 @@ export function formulaMetadataRows(formula: Formula, options: MetadataOptions):
     ...leadingRows(formula, options, formulaCaveatsText(formula)),
     homepageRow(formula.homepage, options),
     { kind: "separator", key: "homepage-sep" },
+    { kind: "label", key: "tap", title: "Tap", text: formula.tap || missing(options) },
+    { kind: "separator", key: "tap-sep" },
   ];
 
   if (formula.license) {
@@ -244,6 +246,14 @@ export function caskMetadataRows(cask: Cask, options: MetadataOptions): Metadata
       title: "Conflicts With",
       tags: dependencyTags(conflicts, options.isInstalled),
     });
+  }
+
+  // Same row formulae get. The list's tack accessory is hidden while the metadata
+  // panel is open (list.tsx), so without this a pinned cask has no visible pin
+  // state at all in the one view that is showing its metadata.
+  if (cask.pinned) {
+    rows.push({ kind: "separator", key: "pinned-sep" });
+    rows.push({ kind: "label", key: "pinned", title: "Pinned", text: "Yes" });
   }
 
   rows.push({ kind: "separator", key: "auto-sep" });

--- a/extensions/brew/src/hooks/useBrewOutdated.ts
+++ b/extensions/brew/src/hooks/useBrewOutdated.ts
@@ -5,7 +5,14 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { showToast, Toast } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
-import { brewFetchOutdated, brewUpdate, OutdatedResults, isBrewLockError, brewLogger } from "../utils";
+import {
+  brewFetchOutdated,
+  brewUpdate,
+  normalizeOutdatedResults,
+  OutdatedResults,
+  isBrewLockError,
+  brewLogger,
+} from "../utils";
 import { preferences, isOutdatedSnapshotDirty, clearOutdatedSnapshotDirty, outdatedFetchFailureCopy } from "../utils";
 
 /**
@@ -180,7 +187,11 @@ export function useBrewOutdated(options?: { backgroundRefresh?: boolean }) {
   const withholding = wasDirtyAtMount && !hasFreshFetchRef.current;
   return {
     ...result,
-    data: withholding ? undefined : result.data,
+    // `useCachedPromise` persists between command runs, so `data` can be a
+    // snapshot written before outdated casks carried a `token` — without which
+    // every brew argv built from these rows loses its `--cask`. Normalizing on
+    // read migrates those in place; it is idempotent for fresh data.
+    data: withholding ? undefined : result.data && normalizeOutdatedResults(result.data),
     // While withholding with no failure yet, the commands must read as
     // loading — data alone being undefined would render neither rows, nor an
     // empty state, nor an error.

--- a/extensions/brew/src/hooks/useBrewSearch.ts
+++ b/extensions/brew/src/hooks/useBrewSearch.ts
@@ -451,9 +451,11 @@ function applyInstalledStatus(results: InstallableResults, installed?: Installed
     if (info && isCask(info)) {
       cask.installed = info.installed;
       cask.outdated = info.outdated;
+      cask.pinned = info.pinned;
     } else {
       cask.installed = undefined;
       cask.outdated = false;
+      cask.pinned = false;
     }
   }
 }
@@ -465,7 +467,9 @@ function isCask(installable: Installable): installable is Cask {
 }
 
 function isFormula(installable: Installable): installable is Formula {
-  return (installable as Formula).pinned != undefined;
+  // Not `pinned`: casks report that too since cask pinning landed. `token` is
+  // the discriminator (see isCask), so its ABSENCE identifies a formula.
+  return (installable as Cask).token === undefined;
 }
 
 /**

--- a/extensions/brew/src/hooks/useBrewUpgrade.ts
+++ b/extensions/brew/src/hooks/useBrewUpgrade.ts
@@ -122,7 +122,10 @@ export function useBrewUpgrade(): BrewUpgrade {
                   if (event.status === "upgrading") {
                     toast.updateTitle(`Upgrading ${event.package.name} (${finished + 1}/${total})`);
                     toast.updateMessage("");
-                  } else if (event.status !== "skipped") {
+                  } else {
+                    // Every terminal status advances the counter. A package brew
+                    // declined at runtime is still one of `total` — only pinned
+                    // packages are outside it, having been filtered before the run.
                     finished += 1;
                   }
                   setState(upgradeKey(event.package), { status: event.status, message: event.message });

--- a/extensions/brew/src/hooks/useBrewUpgrade.ts
+++ b/extensions/brew/src/hooks/useBrewUpgrade.ts
@@ -90,6 +90,7 @@ export function useBrewUpgrade(): BrewUpgrade {
       // Progress is reported via the toast: only the package status is reflected in the list
       let total = 0;
       let finished = 0;
+      let inRun = new Set<string>();
 
       try {
         const summary = await brewUpgradeOutdated({
@@ -107,6 +108,10 @@ export function useBrewUpgrade(): BrewUpgrade {
                 break;
               case "start":
                 total = event.packages.length;
+                // The counter denominator. Pinned packages are reported as
+                // skipped but were filtered out before the run, so they are not
+                // in here — count only what the run actually attempts.
+                inRun = new Set(event.packages.map(upgradeKey));
                 setOutdated(event.outdated);
                 break;
               case "prefetch":
@@ -122,10 +127,10 @@ export function useBrewUpgrade(): BrewUpgrade {
                   if (event.status === "upgrading") {
                     toast.updateTitle(`Upgrading ${event.package.name} (${finished + 1}/${total})`);
                     toast.updateMessage("");
-                  } else {
-                    // Every terminal status advances the counter. A package brew
-                    // declined at runtime is still one of `total` — only pinned
-                    // packages are outside it, having been filtered before the run.
+                  } else if (inRun.has(upgradeKey(event.package))) {
+                    // Terminal status for a package this run attempted. A runtime
+                    // decline counts; a pinned skip does not, because it was never
+                    // in the denominator.
                     finished += 1;
                   }
                   setState(upgradeKey(event.package), { status: event.status, message: event.message });

--- a/extensions/brew/src/hooks/useBrewUpgrade.ts
+++ b/extensions/brew/src/hooks/useBrewUpgrade.ts
@@ -122,9 +122,7 @@ export function useBrewUpgrade(): BrewUpgrade {
                   if (event.status === "upgrading") {
                     toast.updateTitle(`Upgrading ${event.package.name} (${finished + 1}/${total})`);
                     toast.updateMessage("");
-                  } else if (event.status !== "skipped" && event.status !== "downloading") {
-                    // "downloading" is a pre-pass over every package; only a
-                    // terminal status advances the N-of-M counter.
+                  } else if (event.status !== "skipped") {
                     finished += 1;
                   }
                   setState(upgradeKey(event.package), { status: event.status, message: event.message });

--- a/extensions/brew/src/hooks/useBrewUpgrade.ts
+++ b/extensions/brew/src/hooks/useBrewUpgrade.ts
@@ -122,7 +122,9 @@ export function useBrewUpgrade(): BrewUpgrade {
                   if (event.status === "upgrading") {
                     toast.updateTitle(`Upgrading ${event.package.name} (${finished + 1}/${total})`);
                     toast.updateMessage("");
-                  } else if (event.status !== "skipped") {
+                  } else if (event.status !== "skipped" && event.status !== "downloading") {
+                    // "downloading" is a pre-pass over every package; only a
+                    // terminal status advances the N-of-M counter.
                     finished += 1;
                   }
                   setState(upgradeKey(event.package), { status: event.status, message: event.message });

--- a/extensions/brew/src/installed.tsx
+++ b/extensions/brew/src/installed.tsx
@@ -19,7 +19,11 @@ function InstalledContent() {
   const [showDescription, setShowDescription] = useCachedState("show-description", true);
   const { isLoading, data: installed, revalidate } = useBrewInstalled();
   const [excludeDependencies] = useBrewDependencies();
-  const { formulae, pinnedFormulae, casks } = showInstalledPackages(installed, filter, excludeDependencies);
+  const { formulae, pinnedFormulae, casks, pinnedCasks } = showInstalledPackages(
+    installed,
+    filter,
+    excludeDependencies,
+  );
 
   // Log rendering statistics
   if (installed && !isLoading) {
@@ -28,7 +32,8 @@ function InstalledContent() {
       formulaeDisplayed: formulae.length,
       pinnedFormulaeDisplayed: pinnedFormulae.length,
       casksDisplayed: casks.length,
-      totalDisplayed: formulae.length + pinnedFormulae.length + casks.length,
+      pinnedCasksDisplayed: pinnedCasks.length,
+      totalDisplayed: formulae.length + pinnedFormulae.length + casks.length + pinnedCasks.length,
       totalAvailable: (installed.formulae?.size ?? 0) + (installed.casks?.size ?? 0),
     });
   }
@@ -41,6 +46,7 @@ function InstalledContent() {
       formulae={formulae}
       pinnedFormulae={pinnedFormulae}
       casks={casks}
+      pinnedCasks={pinnedCasks}
       searchBarPlaceholder={searchBarPlaceholder}
       searchBarAccessory={<InstallableFilterDropdown onSelect={setFilter} />}
       isLoading={isLoading}

--- a/extensions/brew/src/outdated.tsx
+++ b/extensions/brew/src/outdated.tsx
@@ -4,10 +4,9 @@
  *
  * The list opens with everything not pinned selected — exactly what a plain
  * `brew upgrade` would do — so running immediately is equivalent to Upgrade
- * All. A pin is a lock, matching brew's own behaviour: pinned formulae cannot
+ * All. A pin is a lock, matching brew's own behaviour: a pinned package cannot
  * be selected, and upgrading one means unpinning it first, which selects it.
- * Casks carry no pin state before Homebrew 6, so every cask is simply
- * selectable.
+ * Formulae and casks behave identically here.
  * Upgrades are reported via the toast/HUD, with the icon of each item
  * reflecting its selection and upgrade status.
  */
@@ -18,6 +17,8 @@ import {
   upgradeKey,
   type OutdatedCask,
   type OutdatedFormula,
+  type OutdatedResults,
+  type PinKind,
   type UpgradePackage,
   type UpgradePackageStatus,
 } from "./utils";
@@ -46,9 +47,15 @@ import { OutdatedList, statusIcon } from "./components/outdatedList";
 // and a selection that shares it makes the post-run list (kept open unless
 // the closeAfterAction preference is set) unreadable — "chosen for the next
 // run" and "done in the last run" must not look identical.
-const INCLUDED_ICON = { source: Icon.CheckCircle, tintColor: Color.Blue };
-const EXCLUDED_ICON = { source: Icon.Circle, tintColor: Color.SecondaryText };
-const PINNED_ICON = { source: Icon.Tack, tintColor: Color.SecondaryText };
+// Included and excluded are two states of one control, so they share a tint and
+// differ only in glyph — two different greys read as two unrelated things.
+// Blue means "in progress" in the icon vocabulary (see packageIcons.ts), so the
+// neutral primary tint is what is left for a selection.
+const SELECTION_TINT = Color.PrimaryText;
+const INCLUDED_ICON = { source: Icon.CheckCircle, tintColor: SELECTION_TINT };
+const EXCLUDED_ICON = { source: Icon.CircleDisabled, tintColor: SELECTION_TINT };
+// A pinned row is excluded too — the pin accessory is what says why.
+const PINNED_ICON = EXCLUDED_ICON;
 
 function ShowUpgradesContent() {
   const [filter, setFilter] = useState(InstallableFilterType.all);
@@ -90,8 +97,7 @@ function ShowUpgradesContent() {
   const reviewPackages = useMemo<SelectablePackage[]>(() => {
     const fetched: SelectablePackage[] = [
       ...(reviewSource?.formulae ?? []).map((f) => ({ kind: "formula" as const, name: f.name, pinned: f.pinned })),
-      // Casks carry no pin state before Homebrew 6 — plainly selectable
-      ...(reviewSource?.casks ?? []).map((c) => ({ kind: "cask" as const, name: c.name })),
+      ...(reviewSource?.casks ?? []).map((c) => ({ kind: "cask" as const, name: c.name, pinned: c.pinned })),
     ];
     return applyPinOverrides(fetched, pinOverrides);
   }, [reviewSource, pinOverrides]);
@@ -101,7 +107,14 @@ function ShowUpgradesContent() {
     if (!data) return;
     setPinOverrides((previous) => {
       if (previous.size === 0) return previous;
-      const fetched = data.formulae.map((f) => ({ kind: "formula" as const, name: f.name, pinned: f.pinned }));
+      // Both kinds, or confirmedPinOverrides reads every cask as "no longer
+      // outdated" and retires its override on the next fetch — handing authority
+      // back to a possibly stale `pinned` and undoing the race protection the
+      // overrides exist to provide.
+      const fetched = [
+        ...data.formulae.map((f) => ({ kind: "formula" as const, name: f.name, pinned: f.pinned })),
+        ...data.casks.map((c) => ({ kind: "cask" as const, name: c.name, pinned: c.pinned })),
+      ];
       const retired = confirmedPinOverrides(fetched, previous);
       if (retired.length === 0) return previous;
       const next = new Map(previous);
@@ -159,10 +172,10 @@ function ShowUpgradesContent() {
   );
 
   const handlePinChange = useCallback(
-    async (formula: OutdatedFormula, pinned: boolean) => {
-      const ok = pinned ? await pin(formula) : await unpin(formula);
+    async (item: OutdatedCask | OutdatedFormula, kind: PinKind, pinned: boolean) => {
+      const ok = pinned ? await pin(item, kind) : await unpin(item, kind);
       if (!ok) return;
-      const key = selectionKey("formula", formula.name);
+      const key = selectionKey(kind, item.name);
       setPinOverrides((previous) => new Map(previous).set(key, pinned));
       setSelection(applyPinChange(reviewSelection, key, pinned));
       revalidate();
@@ -175,10 +188,8 @@ function ShowUpgradesContent() {
       const state = upgrade.states.get(upgradeKey({ name: item.name, isCask }));
       if (state) return statusIcon(state);
       const key = selectionKey(isCask ? "cask" : "formula", item.name);
-      if (!isCask) {
-        const pinned = pinOverrides.get(key) ?? (item as OutdatedFormula).pinned;
-        if (pinned) return { value: PINNED_ICON, tooltip: "Pinned — unpin to include" };
-      }
+      const pinned = pinOverrides.get(key) ?? item.pinned;
+      if (pinned) return { value: PINNED_ICON, tooltip: "Pinned — unpin to include" };
       if (reviewSelection.get(key) !== true) {
         return { value: EXCLUDED_ICON, tooltip: upgrade.isUpgrading ? "Not in this upgrade" : "Excluded from upgrade" };
       }
@@ -190,21 +201,27 @@ function ShowUpgradesContent() {
   const actions = useCallback(
     (item: OutdatedCask | OutdatedFormula, isCask: boolean) => {
       if (upgrade.isUpgrading) {
-        return <UpgradingActionPanel outdated={item} onCancel={upgrade.cancel} />;
+        return (
+          <UpgradingActionPanel
+            outdated={item}
+            pinned={(pinOverrides.get(selectionKey(isCask ? "cask" : "formula", item.name)) ?? item.pinned) === true}
+            onCancel={upgrade.cancel}
+          />
+        );
       }
       const key = selectionKey(isCask ? "cask" : "formula", item.name);
       return (
         <ReviewActionPanel
           outdated={item}
           isCask={isCask}
-          pinned={!isCask && (pinOverrides.get(key) ?? (item as OutdatedFormula).pinned) === true}
+          pinned={(pinOverrides.get(key) ?? item.pinned) === true}
           included={reviewSelection.get(key) === true}
           runTitle={selectedCount > 0 ? runTitle : undefined}
           allSelected={allSelected}
           onToggle={() => toggle(key)}
           onToggleAll={toggleAll}
           onStart={startUpgrade}
-          onPinChange={(pinned) => handlePinChange(item as OutdatedFormula, pinned)}
+          onPinChange={(pinned) => handlePinChange(item, isCask ? "cask" : "formula", pinned)}
           onUpgrade={(status) => upgrade.setPackageState({ name: item.name, isCask }, { status })}
           onAction={handleAction}
         />
@@ -225,9 +242,18 @@ function ShowUpgradesContent() {
     ],
   );
 
+  // The list partitions rows into Pinned sections and draws the tack from each
+  // item's own `pinned`, so it needs the same effective state the icons and
+  // actions use — otherwise a just-pinned package sits in the wrong section,
+  // with the wrong accessory, until a refetch lands (or forever, if it fails).
+  const listSource = applyPinOverridesToResults(
+    upgrade.isUpgrading ? (upgrade.outdated ?? data) : (data ?? upgrade.outdated),
+    pinOverrides,
+  );
+
   return (
     <OutdatedList
-      outdated={upgrade.isUpgrading ? (upgrade.outdated ?? data) : (data ?? upgrade.outdated)}
+      outdated={listSource}
       isLoading={isLoading || isRefreshing || upgrade.isUpgrading}
       filterType={filter}
       searchBarPlaceholder={upgrade.isUpgrading ? "Upgrading…" : undefined}
@@ -258,6 +284,34 @@ async function showInstalled() {
   } catch {
     await showToast({ style: Toast.Style.Failure, title: "Could Not Open Show Installed" });
   }
+}
+
+/**
+ * A copy of the outdated results with locally made pin changes applied, so the
+ * list renders the same pin state the icons and action guards already use.
+ *
+ * Returns the input untouched when there is nothing to override, keeping the
+ * object identity React memoization depends on, and never mutates it: the same
+ * payload is held by the fetch cache and the upgrade engine's snapshot.
+ */
+function applyPinOverridesToResults(
+  results: OutdatedResults | undefined,
+  overrides: ReadonlyMap<string, boolean>,
+): OutdatedResults | undefined {
+  if (!results || overrides.size === 0) {
+    return results;
+  }
+  const withOverride = <T extends { name: string; pinned: boolean }>(kind: PinKind, items: T[]): T[] =>
+    items.map((item) => {
+      const pinned = overrides.get(selectionKey(kind, item.name));
+      return pinned === undefined || pinned === item.pinned ? item : { ...item, pinned };
+    });
+
+  return {
+    ...results,
+    formulae: withOverride("formula", results.formulae),
+    casks: withOverride("cask", results.casks),
+  };
 }
 
 function ReviewActionPanel(props: {
@@ -291,7 +345,7 @@ function ReviewActionPanel(props: {
   const toggleAllAction = (
     <Action
       title={props.allSelected ? "Deselect All" : "Select All"}
-      icon={props.allSelected ? Icon.Circle : Icon.CheckCircle}
+      icon={props.allSelected ? Icon.CircleDisabled : Icon.CheckCircle}
       shortcut={{ modifiers: ["cmd", "shift"], key: "a" }}
       onAction={props.onToggleAll}
     />
@@ -304,7 +358,7 @@ function ReviewActionPanel(props: {
       <ActionPanel>
         <ActionPanel.Section>
           <Action
-            title="Unpin and Select"
+            title={props.isCask ? "Unpin Cask and Include" : "Unpin Formula and Include"}
             icon={Icon.TackDisabled}
             shortcut={Keyboard.Shortcut.Common.Pin}
             onAction={() => props.onPinChange(false)}
@@ -312,11 +366,17 @@ function ReviewActionPanel(props: {
           {runAction}
           {toggleAllAction}
         </ActionPanel.Section>
+        {/* Pinned: no single-package upgrade and no upgrade command — brew
+            refuses an explicitly named pinned package outright. */}
         <OutdatedActionSections
           outdated={props.outdated}
+          isCask={props.isCask}
+          pinned
           onUpgrade={props.onUpgrade}
           onAction={props.onAction}
           omitPin
+          omitUpgrade
+          omitUpgradeCommand
         />
       </ActionPanel>
     );
@@ -327,23 +387,27 @@ function ReviewActionPanel(props: {
       <ActionPanel.Section>
         <Action
           title={props.included ? "Exclude from Upgrade" : "Include in Upgrade"}
-          icon={props.included ? Icon.Circle : Icon.CheckCircle}
+          icon={props.included ? Icon.CircleDisabled : Icon.CheckCircle}
           onAction={props.onToggle}
         />
         {runAction}
         {toggleAllAction}
-        {/* Selection-aware pin: pinning locks the formula out of the run.
-            Formulae only — casks cannot be pinned before Homebrew 6. */}
-        {!props.isCask && (
-          <Action
-            title="Pin"
-            icon={Icon.Tack}
-            shortcut={Keyboard.Shortcut.Common.Pin}
-            onAction={() => props.onPinChange(true)}
-          />
-        )}
+        {/* Selection-aware pin: pinning locks the package out of the run. */}
+        <Action
+          title={props.isCask ? "Pin Cask" : "Pin Formula"}
+          icon={Icon.Tack}
+          shortcut={Keyboard.Shortcut.Common.Pin}
+          onAction={() => props.onPinChange(true)}
+        />
       </ActionPanel.Section>
-      <OutdatedActionSections outdated={props.outdated} onUpgrade={props.onUpgrade} onAction={props.onAction} omitPin />
+      <OutdatedActionSections
+        outdated={props.outdated}
+        isCask={props.isCask}
+        pinned={props.pinned}
+        onUpgrade={props.onUpgrade}
+        onAction={props.onAction}
+        omitPin
+      />
     </ActionPanel>
   );
 }

--- a/extensions/brew/src/upgrade.tsx
+++ b/extensions/brew/src/upgrade.tsx
@@ -48,7 +48,6 @@ function UpgradeContent() {
       outdated={upgrade.outdated ?? data}
       isLoading={isLoading || upgrade.isUpgrading}
       filterType={filter}
-      navigationTitle="Upgrade"
       searchBarPlaceholder={upgrade.isUpgrading ? "Upgrading…" : undefined}
       searchBarAccessory={<InstallableFilterDropdown onSelect={setFilter} />}
       icon={(item, isCask) => statusIcon(upgrade.states.get(upgradeKey({ name: item.name, isCask })))}

--- a/extensions/brew/src/utils/__mocks__/raycast-api.ts
+++ b/extensions/brew/src/utils/__mocks__/raycast-api.ts
@@ -4,10 +4,8 @@
  * helpers, is otherwise untestable.
  *
  * `getPreferenceValues` returns the DECLARED DEFAULTS from package.json rather
- * than an empty object. An empty object silently reads every preference as
- * `undefined`, which means a test can pass by exercising only the falsy branch
- * of something like `zapCask` while the real default is true — the test looks
- * green and covers behaviour no user ever gets.
+ * than an empty object, which would read every preference as `undefined` and let
+ * a test pass by exercising a branch the declared default never reaches.
  */
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";

--- a/extensions/brew/src/utils/__mocks__/raycast-api.ts
+++ b/extensions/brew/src/utils/__mocks__/raycast-api.ts
@@ -1,0 +1,105 @@
+/**
+ * Test stand-in for `@raycast/api`, which has no resolvable entry outside the
+ * Raycast runtime — so any module that transitively imports it, including pure
+ * helpers, is otherwise untestable.
+ *
+ * `getPreferenceValues` returns the DECLARED DEFAULTS from package.json rather
+ * than an empty object. An empty object silently reads every preference as
+ * `undefined`, which means a test can pass by exercising only the falsy branch
+ * of something like `zapCask` while the real default is true — the test looks
+ * green and covers behaviour no user ever gets.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const EXTENSION_NAME = "brew";
+
+/**
+ * The extension root, supplied by vitest.config.ts. Falls back to walking up
+ * from the working directory so a direct vitest invocation still works.
+ */
+function findManifest(): string {
+  const supplied = process.env.RAYCAST_EXTENSION_ROOT;
+  if (supplied) {
+    return join(supplied, "package.json");
+  }
+  let dir = process.cwd();
+  for (;;) {
+    const candidate = join(dir, "package.json");
+    if (existsSync(candidate)) {
+      const parsed = JSON.parse(readFileSync(candidate, "utf8")) as { name?: string };
+      if (parsed.name === EXTENSION_NAME) {
+        return candidate;
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      throw new Error(`@raycast/api stub could not find the ${EXTENSION_NAME} manifest above ${process.cwd()}`);
+    }
+    dir = parent;
+  }
+}
+
+interface DeclaredPreference {
+  name: string;
+  default?: unknown;
+  type?: string;
+}
+
+function declaredDefaults(): Record<string, unknown> {
+  // `import.meta` is unavailable under the extension's tsconfig module target,
+  // so walk up from the working directory for THIS extension's manifest. Reading
+  // whatever package.json happens to sit at cwd would hand every test another
+  // project's defaults when vitest is invoked from a monorepo root.
+  const manifestPath = findManifest();
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+    preferences?: DeclaredPreference[];
+    commands?: { preferences?: DeclaredPreference[] }[];
+  };
+
+  const defaults: Record<string, unknown> = {};
+  // Extension preferences first, then command ones: a command inherits the
+  // extension's preferences and may override a same-named entry.
+  for (const preference of manifest.preferences ?? []) {
+    defaults[preference.name] = preferenceDefault(preference);
+  }
+  // No active command in a unit test, so every command's preferences are
+  // merged. Fine while no two commands declare the same name with different
+  // defaults; if that changes, this stub has to learn which command is running.
+  for (const command of manifest.commands ?? []) {
+    for (const preference of command.preferences ?? []) {
+      defaults[preference.name] = preferenceDefault(preference);
+    }
+  }
+  return defaults;
+}
+
+function preferenceDefault(preference: DeclaredPreference): unknown {
+  if (preference.default !== undefined) {
+    return preference.default;
+  }
+  // Raycast gives an unset checkbox `false` and an unset text field "".
+  return preference.type === "checkbox" ? false : "";
+}
+
+const defaults = declaredDefaults();
+
+export function getPreferenceValues<T = Record<string, unknown>>(): T {
+  return { ...defaults } as T;
+}
+
+export const environment = { assetsPath: "/tmp/assets", supportPath: "/tmp/support" };
+
+export const Color = {
+  Green: "green",
+  Yellow: "yellow",
+  Red: "red",
+  Blue: "blue",
+  Orange: "orange",
+  Magenta: "magenta",
+  Purple: "purple",
+  PrimaryText: "primaryText",
+  SecondaryText: "secondaryText",
+};
+
+export const Icon = new Proxy({}, { get: (_target, key) => String(key) });

--- a/extensions/brew/src/utils/brew/actions.ts
+++ b/extensions/brew/src/utils/brew/actions.ts
@@ -10,7 +10,7 @@ import { preferences } from "../preferences";
 import { execBrew } from "./commands";
 import { execBrewWithProgress, ProgressCallback } from "./progress";
 import { brewIdentifier, brewCaskOption, isCask } from "./helpers";
-import { ExecError } from "../types";
+import { ExecError, ExecResult } from "../types";
 
 /**
  * Install a package.
@@ -96,14 +96,18 @@ export async function brewUpgradeSingleWithProgress(
   upgradable: Cask | Nameable,
   onProgress?: ProgressCallback,
   cancel?: AbortSignal,
-): Promise<void> {
+): Promise<ExecResult> {
   const identifier = brewIdentifier(upgradable);
   actionsLogger.log("Upgrading package with progress", {
     identifier,
     type: isCask(upgradable) ? "cask" : "formula",
   });
-  await execBrewWithProgress(`upgrade ${brewCaskOption(upgradable)} ${identifier}`, onProgress, cancel);
-  actionsLogger.log("Package upgraded successfully", { identifier });
+  // The result is returned, not discarded: brew exits 0 after declining to
+  // upgrade a deprecated or already-current package, and only its warning says
+  // so. See upgradeSkipReason.
+  const result = await execBrewWithProgress(`upgrade ${brewCaskOption(upgradable)} ${identifier}`, onProgress, cancel);
+  actionsLogger.log("Package upgrade finished", { identifier });
+  return result;
 }
 
 /**

--- a/extensions/brew/src/utils/brew/actions.ts
+++ b/extensions/brew/src/utils/brew/actions.ts
@@ -65,9 +65,9 @@ export async function brewUninstall(installable: Cask | Nameable, cancel?: Abort
     zap: preferences.zapCask,
     force,
   });
-  // `--force` is what lets a pinned package be removed: Homebrew unpins it
-  // first — casks in cask/uninstall.rb (`unpin_for_removal?`), formulae in
-  // uninstall.rb. Only ever set from an explicit user confirmation.
+  // `--force` is what lets a pinned package be removed; it also drops the pin
+  // (cask/uninstall.rb unpins first, uninstall.rb rm_pins after). Only ever set
+  // from an explicit user confirmation.
   const forceOption = force ? " --force" : "";
   await execBrew(
     `rm ${brewCaskOption(installable, true)}${forceOption} ${identifier}`,
@@ -102,9 +102,8 @@ export async function brewUpgradeSingleWithProgress(
     identifier,
     type: isCask(upgradable) ? "cask" : "formula",
   });
-  // The result is returned, not discarded: brew exits 0 after declining to
-  // upgrade a deprecated or already-current package, and only its warning says
-  // so. See upgradeSkipReason.
+  // Returned, not discarded: brew exits 0 after declining to upgrade, and only
+  // its warning says so. See upgradeSkipReason.
   const result = await execBrewWithProgress(`upgrade ${brewCaskOption(upgradable)} ${identifier}`, onProgress, cancel);
   actionsLogger.log("Package upgrade finished", { identifier });
   return result;

--- a/extensions/brew/src/utils/brew/actions.ts
+++ b/extensions/brew/src/utils/brew/actions.ts
@@ -4,7 +4,7 @@
  * Provides functions for installing, uninstalling, and upgrading packages.
  */
 
-import { Cask, Formula, Nameable, OutdatedFormula } from "../types";
+import { Cask, Formula, Nameable, PinKind, Pinnable } from "../types";
 import { actionsLogger } from "../logger";
 import { preferences } from "../preferences";
 import { execBrew } from "./commands";
@@ -26,9 +26,7 @@ export async function brewInstall(installable: Cask | Formula, cancel?: AbortSig
   if (isCaskType) {
     (installable as Cask).installed = (installable as Cask).version;
   } else {
-    installable.installed = [
-      { version: installable.versions.stable, installed_as_dependency: false, installed_on_request: true },
-    ];
+    installable.installed = [{ version: installable.versions.stable, installed_on_request: true }];
   }
   actionsLogger.log("Package installed successfully", { identifier });
 }
@@ -51,9 +49,7 @@ export async function brewInstallWithProgress(
   if (isCaskType) {
     (installable as Cask).installed = (installable as Cask).version;
   } else {
-    installable.installed = [
-      { version: installable.versions.stable, installed_as_dependency: false, installed_on_request: true },
-    ];
+    installable.installed = [{ version: installable.versions.stable, installed_on_request: true }];
   }
   actionsLogger.log("Package installed successfully", { identifier });
 }
@@ -61,14 +57,22 @@ export async function brewInstallWithProgress(
 /**
  * Uninstall a package.
  */
-export async function brewUninstall(installable: Cask | Nameable, cancel?: AbortSignal): Promise<void> {
+export async function brewUninstall(installable: Cask | Nameable, cancel?: AbortSignal, force = false): Promise<void> {
   const identifier = brewIdentifier(installable);
   actionsLogger.log("Uninstalling package", {
     identifier,
     type: isCask(installable) ? "cask" : "formula",
     zap: preferences.zapCask,
+    force,
   });
-  await execBrew(`rm ${brewCaskOption(installable, true)} ${identifier}`, cancel ? { signal: cancel } : undefined);
+  // `--force` is what lets a pinned package be removed: Homebrew unpins it
+  // first — casks in cask/uninstall.rb (`unpin_for_removal?`), formulae in
+  // uninstall.rb. Only ever set from an explicit user confirmation.
+  const forceOption = force ? " --force" : "";
+  await execBrew(
+    `rm ${brewCaskOption(installable, true)}${forceOption} ${identifier}`,
+    cancel ? { signal: cancel } : undefined,
+  );
   actionsLogger.log("Package uninstalled successfully", { identifier });
 }
 
@@ -129,23 +133,36 @@ export async function brewCleanup(withoutThreshold: boolean, cancel?: AbortSigna
 }
 
 /**
- * Pin a formula to prevent upgrades.
+ * `brew pin`/`unpin` resolve a bare name against both formulae and casks
+ * (`cmd/pin.rb`: `named_args [:installed_formula, :installed_cask]`), so a token
+ * installed as both is ambiguous. Always state which one we mean.
+ *
+ * The kind is passed in rather than sniffed. `isCask()` keys off `token`, which
+ * brew omits from outdated casks; `normalizeOutdatedResults` synthesises one,
+ * but an explicit kind does not depend on that having happened.
  */
-export async function brewPinFormula(formula: Formula | OutdatedFormula): Promise<void> {
-  actionsLogger.log("Pinning formula", { name: formula.name });
-  await execBrew(`pin ${formula.name}`);
-  formula.pinned = true;
-  actionsLogger.log("Formula pinned successfully", { name: formula.name });
+export async function brewPin(item: Pinnable, kind: PinKind): Promise<boolean> {
+  const identifier = brewIdentifier(item);
+  actionsLogger.log("Pinning package", { identifier, type: kind });
+  const output = await execBrew(`pin --${kind} ${identifier}`);
+  item.pinned = true;
+  actionsLogger.log("Package pinned successfully", { identifier });
+  // A cask with `auto_updates true` is pinned, but Homebrew warns that the app
+  // may still update itself (cmd/pin.rb). Read brew's own warning rather than
+  // the payload's `auto_updates`: the outdated shapes do not carry that field,
+  // so checking it would silently drop the warning in Show Upgrades.
+  return /may update itself outside Homebrew/i.test(output.stderr ?? "");
 }
 
 /**
- * Unpin a formula to allow upgrades.
+ * Unpin a package to allow upgrades.
  */
-export async function brewUnpinFormula(formula: Formula | OutdatedFormula): Promise<void> {
-  actionsLogger.log("Unpinning formula", { name: formula.name });
-  await execBrew(`unpin ${formula.name}`);
-  formula.pinned = false;
-  actionsLogger.log("Formula unpinned successfully", { name: formula.name });
+export async function brewUnpin(item: Pinnable, kind: PinKind): Promise<void> {
+  const identifier = brewIdentifier(item);
+  actionsLogger.log("Unpinning package", { identifier, type: kind });
+  await execBrew(`unpin --${kind} ${identifier}`);
+  item.pinned = false;
+  actionsLogger.log("Package unpinned successfully", { identifier });
 }
 
 /**

--- a/extensions/brew/src/utils/brew/analytics.ts
+++ b/extensions/brew/src/utils/brew/analytics.ts
@@ -86,7 +86,7 @@ export function invalidatePopularityRanks(): void {
  * Fetch (and disk-cache) the bulk install rankings for formulae and casks.
  *
  * `usePromise` re-runs its callback on mount, on every `execute` transition
- * (⇧⌘P toggling), and on revalidate — so without the in-process cache, each
+ * (⇧⌘S toggling), and on revalidate — so without the in-process cache, each
  * toggle re-reads and re-parses ~2.6MB of JSON. The download itself is already
  * avoided by downloadRemoteToCache's freshness check; this avoids the parse.
  */

--- a/extensions/brew/src/utils/brew/analytics.ts
+++ b/extensions/brew/src/utils/brew/analytics.ts
@@ -86,7 +86,7 @@ export function invalidatePopularityRanks(): void {
  * Fetch (and disk-cache) the bulk install rankings for formulae and casks.
  *
  * `usePromise` re-runs its callback on mount, on every `execute` transition
- * (⇧⌘S toggling), and on revalidate — so without the in-process cache, each
+ * (⇧⌘P toggling), and on revalidate — so without the in-process cache, each
  * toggle re-reads and re-parses ~2.6MB of JSON. The download itself is already
  * avoided by downloadRemoteToCache's freshness check; this avoids the parse.
  */

--- a/extensions/brew/src/utils/brew/commands.ts
+++ b/extensions/brew/src/utils/brew/commands.ts
@@ -3,11 +3,10 @@
  *
  * Provides functions for executing brew commands with proper error handling.
  *
- * Homebrew 5.0 Compatibility Notes:
- * - Download concurrency is now enabled by default (HOMEBREW_DOWNLOAD_CONCURRENCY=auto)
- * - The extension supports controlling this via preferences
- * - --no-quarantine and --quarantine flags are deprecated
- * - HOMEBREW_USE_INTERNAL_API can be enabled for the new smaller JSON API
+ * Targets Homebrew 6.0 and later.
+ *
+ * Download concurrency is enabled by default (HOMEBREW_DOWNLOAD_CONCURRENCY=auto);
+ * the extension exposes a preference to turn it off.
  */
 
 import { exec } from "child_process";
@@ -25,7 +24,7 @@ import { bundleIdentifier } from "../cache";
 
 const execp = promisify(exec);
 
-// Track if we've logged the Homebrew 5.0 environment configuration
+// Track if we've logged the Homebrew environment configuration
 let homebrewEnvLogged = false;
 
 /**
@@ -68,7 +67,7 @@ export async function execBrew(cmd: string, options?: { signal?: AbortSignal }):
 /**
  * Get the environment variables for brew execution.
  *
- * Homebrew 5.0 environment variables:
+ * Homebrew environment variables:
  * - HOMEBREW_DOWNLOAD_CONCURRENCY: Controls parallel downloads (default: "auto")
  *   Set to "1" to disable concurrent downloads
  */
@@ -82,31 +81,23 @@ export async function execBrewEnv(): Promise<NodeJS.ProcessEnv> {
   const env = { ...process.env };
   env["SUDO_ASKPASS"] = askpassPath;
   // Use HOMEBREW_BROWSER to pass through the app's bundle identifier.
-  // Brew will ignore custom environment variables.
+  // Only commands that open a URL read this (brew execs it directly), and the
+  // extension never invokes one — which is the reason this is safe.
   env["HOMEBREW_BROWSER"] = bundleIdentifier;
 
-  // Homebrew 5.0: Control download concurrency
-  // By default, Homebrew 5.0 enables concurrent downloads (auto)
-  // Users can disable this via preferences if they experience issues
+  // Control download concurrency. Homebrew enables concurrent downloads by
+  // default (auto); users can disable this via preferences if it causes trouble.
   const downloadConcurrencyDisabled = preferences.disableDownloadConcurrency;
   if (downloadConcurrencyDisabled) {
     env["HOMEBREW_DOWNLOAD_CONCURRENCY"] = "1";
   }
 
-  // Homebrew 5.0: Opt-in to the new internal API (smaller JSON)
-  // This will become default in a future version
-  const useInternalApi = preferences.useInternalApi;
-  if (useInternalApi) {
-    env["HOMEBREW_USE_INTERNAL_API"] = "1";
-  }
-
-  // Log Homebrew 5.0 configuration once per session
+  // Log the Homebrew configuration once per session
   if (!homebrewEnvLogged) {
     homebrewEnvLogged = true;
-    brewLogger.log("Homebrew 5.0 Configuration", {
+    brewLogger.log("Homebrew Configuration", {
       downloadConcurrencyEnabled: !downloadConcurrencyDisabled,
       downloadConcurrencyMode: downloadConcurrencyDisabled ? "sequential (1)" : "parallel (auto)",
-      internalApiEnabled: useInternalApi,
       verboseLogging: preferences.verboseLogging,
     });
   }

--- a/extensions/brew/src/utils/brew/fetch.ts
+++ b/extensions/brew/src/utils/brew/fetch.ts
@@ -3,9 +3,8 @@
  *
  * Provides functions for fetching installed and outdated packages.
  *
- * Performance optimization: Uses a two-phase loading strategy:
- * 1. Fast initial load with `brew list --versions` (returns minimal data quickly)
- * 2. Background fetch with `brew info --json=v2 --installed` for full metadata
+ * Installed packages come from `brew info --json=v2 --installed`, served from a
+ * cache invalidated by watching brew's own state (see `readCache`).
  */
 
 import * as fs from "fs/promises";
@@ -34,6 +33,7 @@ import {
   CHUNKED_CACHE_VERSION,
 } from "../cache";
 import { brewPath, brewCachePrefix } from "./paths";
+import { normalizeOutdatedResults } from "./helpers";
 import { execBrew } from "./commands";
 import { brewLogger, cacheLogger } from "../logger";
 
@@ -96,154 +96,6 @@ export async function hasSearchCache(): Promise<boolean> {
   } catch {
     return false;
   }
-}
-
-/**
- * Minimal installed package info parsed from `brew list --versions`.
- * This is much faster than `brew info --json=v2 --installed`.
- */
-interface InstalledListItem {
-  name: string;
-  version: string;
-  installed_on_request: boolean;
-}
-
-/**
- * Parse `brew list --versions` output into InstalledListItem array.
- * Format: "package_name version1 version2 ..." (one per line)
- */
-function parseListVersionsOutput(output: string): InstalledListItem[] {
-  const items: InstalledListItem[] = [];
-  const lines = output
-    .trim()
-    .split("\n")
-    .filter((line) => line.length > 0);
-
-  for (const line of lines) {
-    const parts = line.split(/\s+/);
-    if (parts.length >= 2) {
-      const name = parts[0];
-      // Use the first (most recent) version
-      const version = parts[1];
-      items.push({
-        name,
-        version,
-        // We don't know this from list output, default to true
-        installed_on_request: true,
-      });
-    }
-  }
-
-  return items;
-}
-
-/**
- * Fetch a fast list of installed packages (names and versions only).
- * Uses `brew list --versions` which is significantly faster than `brew info --json=v2 --installed`.
- *
- * @returns Minimal installed package data for quick initial display
- */
-export async function brewFetchInstalledFast(cancel?: AbortSignal): Promise<InstalledMap | undefined> {
-  const startTime = Date.now();
-
-  try {
-    // Try to read from cache first
-    const cacheBuffer = await fs.readFile(installedCachePath);
-    const cached = JSON.parse(cacheBuffer.toString()) as InstallableResults;
-    const mapped = brewMapInstalled(cached);
-    const duration = Date.now() - startTime;
-
-    cacheLogger.log("Fast load from cache", {
-      formulaeCount: mapped?.formulae.size ?? 0,
-      casksCount: mapped?.casks.size ?? 0,
-      durationMs: duration,
-    });
-
-    return mapped;
-  } catch {
-    // Cache miss - fall back to fast list command
-    const listStartTime = Date.now();
-
-    try {
-      // brew list --versions is fast and gives us name + version
-      // Note: --versions output is "name version1 version2 ..." per line
-      const [formulaeOutput, casksOutput] = await Promise.all([
-        execBrew(`list --formula --versions`, cancel ? { signal: cancel } : undefined),
-        execBrew(`list --cask --versions`, cancel ? { signal: cancel } : undefined),
-      ]);
-
-      const formulaeList = parseListVersionsOutput(formulaeOutput.stdout);
-      const casksList = parseListVersionsOutput(casksOutput.stdout);
-
-      // Create minimal Formula/Cask objects for display
-      const formulae = new Map<string, Formula>();
-      for (const item of formulaeList) {
-        formulae.set(item.name, createMinimalFormula(item));
-      }
-
-      const casks = new Map<string, Cask>();
-      for (const item of casksList) {
-        casks.set(item.name, createMinimalCask(item));
-      }
-
-      const duration = Date.now() - listStartTime;
-      brewLogger.log("Fast list fetched", {
-        formulaeCount: formulae.size,
-        casksCount: casks.size,
-        durationMs: duration,
-      });
-
-      return { formulae, casks };
-    } catch (err) {
-      brewLogger.error("Fast list fetch failed", { error: err });
-      return undefined;
-    }
-  }
-}
-
-/**
- * Create a minimal Formula object from list data.
- */
-function createMinimalFormula(item: InstalledListItem): Formula {
-  return {
-    name: item.name,
-    tap: "",
-    homepage: "",
-    versions: { stable: item.version, bottle: false },
-    outdated: false,
-    license: null,
-    aliases: [],
-    dependencies: [],
-    build_dependencies: [],
-    installed: [
-      {
-        version: item.version,
-        installed_as_dependency: !item.installed_on_request,
-        installed_on_request: item.installed_on_request,
-      },
-    ],
-    keg_only: false,
-    linked_key: "",
-    pinned: false,
-  };
-}
-
-/**
- * Create a minimal Cask object from list data.
- */
-function createMinimalCask(item: InstalledListItem): Cask {
-  return {
-    token: item.name,
-    name: [item.name],
-    tap: "",
-    homepage: "",
-    version: item.version,
-    versions: { stable: item.version, bottle: false },
-    outdated: false,
-    installed: item.version,
-    auto_updates: false,
-    depends_on: {},
-  };
 }
 
 /**
@@ -340,12 +192,11 @@ export async function brewFetchInstallableResults(
     const caskroomTime = await mtimeMs(brewPath("Caskroom"));
 
     // 'var/homebrew/pinned' is updated after pin/unpin actions (but does not exist if there are no pinned formula).
-    let pinnedTime;
-    try {
-      pinnedTime = await mtimeMs(brewPath("var/homebrew/pinned"));
-    } catch {
-      pinnedTime = 0;
-    }
+    const pinnedTime = await mtimeMsOrZero(brewPath("var/homebrew/pinned"));
+    // Cask pins live in a SEPARATE directory (startup/config.rb: HOMEBREW_PINNED_CASKS),
+    // which unpin removes when it empties. The parent check below only catches the
+    // first cask pin — creating the directory bumps var/homebrew — so probe it too.
+    const pinnedCasksTime = await mtimeMsOrZero(brewPath("var/homebrew/pinned_casks"));
     // Because '/var/homebrew/pinned can be removed, we need to also check the parent directory'
     const homebrewTime = await mtimeMs(brewPath("var/homebrew"));
 
@@ -363,6 +214,7 @@ export async function brewFetchInstallableResults(
       caskroomTime < cacheTime &&
       locksTime < cacheTime &&
       pinnedTime < cacheTime &&
+      pinnedCasksTime < cacheTime &&
       apiIndexTime < cacheTime &&
       fetchHeadTime < cacheTime
     ) {
@@ -383,6 +235,7 @@ export async function brewFetchInstallableResults(
         caskroomTime,
         locksTime,
         pinnedTime,
+        pinnedCasksTime,
         cacheTime,
       });
       return await updateCache();
@@ -458,7 +311,7 @@ export async function brewFetchOutdated(
     await brewUpdate(cancel);
   }
   const output = await execBrew(cmd, cancel ? { signal: cancel } : undefined);
-  const results = JSON.parse(output.stdout) as OutdatedResults;
+  const results = normalizeOutdatedResults(JSON.parse(output.stdout) as OutdatedResults);
   brewLogger.log("Outdated packages fetched", {
     formulaeCount: results.formulae.length,
     casksCount: results.casks.length,
@@ -844,7 +697,9 @@ export async function brewFetchCaskInfo(token: string, cancel?: AbortSignal): Pr
   brewLogger.log("Fetching cask info", { token });
 
   try {
-    const output = await execBrew(`info --json=v2 ${token}`, cancel ? { signal: cancel } : undefined);
+    // `--cask` is required, not decorative: without it brew's resolver prefers a
+    // same-named FORMULA (cli/named_args.rb), returning an empty `casks` array.
+    const output = await execBrew(`info --json=v2 --cask ${token}`, cancel ? { signal: cancel } : undefined);
     const results = JSON.parse(output.stdout) as InstallableResults;
     const duration = Date.now() - startTime;
 

--- a/extensions/brew/src/utils/brew/helpers.ts
+++ b/extensions/brew/src/utils/brew/helpers.ts
@@ -135,8 +135,10 @@ export function normalizeOutdatedResults(results: OutdatedResults): OutdatedResu
  *
  * A pin is a symlink under `var/homebrew/pinned` (formulae) or
  * `var/homebrew/pinned_casks` (casks), created by `brew pin` and removed by
- * `brew unpin` — so the directory listing IS the source of truth, and a package
- * pinned in another command or outside Raycast appears here immediately.
+ * `brew unpin`, so a package pinned in another command or outside Raycast
+ * appears here immediately. This is a directory snapshot, not brew's own
+ * predicate — it checks the symlink (formula_pin.rb) and, for a cask, that its
+ * target still exists (cask.rb).
  *
  * Cached payloads carry a `pinned` flag that is only as fresh as the last
  * fetch, which is fine for rendering but not for deciding whether to run a
@@ -154,9 +156,8 @@ export function normalizeOutdatedResults(results: OutdatedResults): OutdatedResu
  *
  * Homebrew pins a formula at `HOMEBREW_PINNED_KEGS/<formula.name>` — the short
  * name (formula_pin.rb) — while `brew outdated --json=v2` reports a tapped
- * formula by its qualified `full_name`, e.g. `steipete/tap/birdclaw`. Looking a
- * pin up by the qualified name therefore misses every tapped formula, and the
- * package is handed to a named `brew upgrade` that Homebrew refuses.
+ * formula by its qualified `full_name`. Looking a pin up by the qualified name
+ * therefore misses every tapped formula.
  *
  * Cask tokens are already unqualified in the outdated payload, so the last
  * segment is correct for both kinds. Use this for pin lookups only — argv keeps
@@ -164,6 +165,21 @@ export function normalizeOutdatedResults(results: OutdatedResults): OutdatedResu
  */
 export function pinLookupKey(identifier: string): string {
   return identifier.split("/").pop() || identifier;
+}
+
+/**
+ * Whether Homebrew has this package pinned, given a set read from disk.
+ *
+ * Keys by the short name (see pinLookupKey) and picks the right directory —
+ * the two rules every caller needs, in one place.
+ */
+export function isPinnedPackage(
+  pins: { formulae: Set<string>; casks: Set<string> },
+  identifier: string,
+  isCask: boolean,
+): boolean {
+  const key = pinLookupKey(identifier);
+  return isCask ? pins.casks.has(key) : pins.formulae.has(key);
 }
 
 export async function brewPinnedIdentifiers(): Promise<{ formulae: Set<string>; casks: Set<string> }> {

--- a/extensions/brew/src/utils/brew/helpers.ts
+++ b/extensions/brew/src/utils/brew/helpers.ts
@@ -5,7 +5,7 @@
  */
 
 import { join as path_join } from "path";
-import { Cask, Formula, Nameable } from "../types";
+import { Cask, Formula, Nameable, OutdatedResults } from "../types";
 import { preferences } from "../preferences";
 import { brewPath, brewExecutable } from "./paths";
 import { isOutdatedVersion, stripRevision } from "./version";
@@ -24,8 +24,8 @@ export function isCask(maybeCask: Cask | Nameable): maybeCask is Cask {
  *
  * Homebrew reports this per installed version (`installed[].time`) for formulae
  * and as `installed_time` for casks, both in unix *seconds*. Undefined for a
- * package that isn't installed, and while the fast `brew list --versions` path
- * is still the source — it doesn't carry timestamps.
+ * package that isn't installed, and for a search result not yet joined with
+ * local installed state.
  */
 export function brewInstalledDate(item: Cask | Formula): Date | undefined {
   const seconds = isCask(item) ? item.installed_time : item.installed?.first()?.time;
@@ -97,10 +97,36 @@ export function brewIdentifier(item: Cask | Nameable): string {
  */
 export function brewName(item: Cask | Nameable): string {
   if (isCask(item)) {
-    return item.name && item.name[0] ? item.name[0] : "Unknown";
+    // A Cask's `name` is an array of display names, but an OutdatedCask's is a
+    // plain string — and both are casks as far as `isCask` is concerned. Indexing
+    // blindly would return the first CHARACTER of an outdated cask's name.
+    const name = item.name as string | string[];
+    if (typeof name === "string") {
+      return name || "Unknown";
+    }
+    return name?.[0] ?? "Unknown";
   } else {
     return item.name;
   }
+}
+
+/**
+ * `brew outdated --json=v2` reports casks by `name` with no `token`, but
+ * `isCask()` — and so `brewCaskOption`, `brewIdentifier` and every argv built
+ * from them — keys off `token`. An un-normalized outdated cask is therefore
+ * indistinguishable from a formula and gets formula-shaped brew commands.
+ *
+ * Every path that parses that payload, and every path that reads a cached one,
+ * must pass it through here first. Idempotent, and safe on data cached before
+ * the field existed.
+ */
+export function normalizeOutdatedResults(results: OutdatedResults): OutdatedResults {
+  for (const cask of results.casks ?? []) {
+    if (!cask.token) {
+      cask.token = cask.name;
+    }
+  }
+  return results;
 }
 
 /// Options
@@ -189,8 +215,15 @@ function caskFormatVersion(cask: Cask): string {
   }
 
   let version = cask.installed;
+  let status = "";
+  if (cask.pinned) {
+    status += "P";
+  }
   if (cask.outdated) {
-    version += " (O)";
+    status += "O";
+  }
+  if (status) {
+    version += ` (${status})`;
   }
   return version;
 }
@@ -203,7 +236,7 @@ function formulaFormatVersion(formula: Formula): string {
 
   let version = installed_version.version;
   let status = "";
-  if (installed_version.installed_as_dependency) {
+  if (!installed_version.installed_on_request) {
     status += "D";
   }
   if (formula.pinned) {

--- a/extensions/brew/src/utils/brew/helpers.ts
+++ b/extensions/brew/src/utils/brew/helpers.ts
@@ -4,6 +4,7 @@
  * Provides utility functions for working with brew packages.
  */
 
+import { readdir } from "fs/promises";
 import { join as path_join } from "path";
 import { Cask, Formula, Nameable, OutdatedResults } from "../types";
 import { preferences } from "../preferences";
@@ -127,6 +128,43 @@ export function normalizeOutdatedResults(results: OutdatedResults): OutdatedResu
     }
   }
   return results;
+}
+
+/**
+ * The pin state Homebrew itself holds, read from disk.
+ *
+ * A pin is a symlink under `var/homebrew/pinned` (formulae) or
+ * `var/homebrew/pinned_casks` (casks), created by `brew pin` and removed by
+ * `brew unpin` — so the directory listing IS the source of truth, and a package
+ * pinned in another command or outside Raycast appears here immediately.
+ *
+ * Cached payloads carry a `pinned` flag that is only as fresh as the last
+ * fetch, which is fine for rendering but not for deciding whether to run a
+ * command Homebrew will refuse. Reading both directories measures ~20µs, about
+ * 30,000x cheaper than `brew list --pinned` (~650ms), so the authoritative
+ * check is affordable immediately before an operation — and once per batch,
+ * not once per package.
+ *
+ * Absent directories mean nothing is pinned: `unpin` removes the directory
+ * when it empties.
+ */
+export async function brewPinnedIdentifiers(): Promise<{ formulae: Set<string>; casks: Set<string> }> {
+  const read = async (dir: string): Promise<Set<string>> => {
+    try {
+      return new Set(await readdir(brewPath(path_join("var/homebrew", dir))));
+    } catch (err) {
+      // An absent directory means nothing of that kind is pinned: `unpin`
+      // removes it when it empties. Anything else — a permission problem, a
+      // broken prefix — is NOT evidence of that, and treating it as such would
+      // hand a pinned package to a command brew refuses. Fail loudly instead.
+      if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+        return new Set();
+      }
+      throw err;
+    }
+  };
+  const [formulae, casks] = await Promise.all([read("pinned"), read("pinned_casks")]);
+  return { formulae, casks };
 }
 
 /// Options

--- a/extensions/brew/src/utils/brew/helpers.ts
+++ b/extensions/brew/src/utils/brew/helpers.ts
@@ -148,6 +148,24 @@ export function normalizeOutdatedResults(results: OutdatedResults): OutdatedResu
  * Absent directories mean nothing is pinned: `unpin` removes the directory
  * when it empties.
  */
+/**
+ * The key a pin is stored under, which is NOT always the identifier brew wants
+ * on the command line.
+ *
+ * Homebrew pins a formula at `HOMEBREW_PINNED_KEGS/<formula.name>` — the short
+ * name (formula_pin.rb) — while `brew outdated --json=v2` reports a tapped
+ * formula by its qualified `full_name`, e.g. `steipete/tap/birdclaw`. Looking a
+ * pin up by the qualified name therefore misses every tapped formula, and the
+ * package is handed to a named `brew upgrade` that Homebrew refuses.
+ *
+ * Cask tokens are already unqualified in the outdated payload, so the last
+ * segment is correct for both kinds. Use this for pin lookups only — argv keeps
+ * the full identifier.
+ */
+export function pinLookupKey(identifier: string): string {
+  return identifier.split("/").pop() || identifier;
+}
+
 export async function brewPinnedIdentifiers(): Promise<{ formulae: Set<string>; casks: Set<string> }> {
   const read = async (dir: string): Promise<Set<string>> => {
     try {

--- a/extensions/brew/src/utils/brew/index.ts
+++ b/extensions/brew/src/utils/brew/index.ts
@@ -35,7 +35,6 @@ export type { BrewPhase, BrewProgress, ProgressCallback } from "./progress";
 export {
   brewFetchInstalled,
   brewFetchInstallableResults,
-  brewFetchInstalledFast,
   brewMapInstalled,
   asInstallableResults,
   brewFetchOutdated,
@@ -80,8 +79,8 @@ export {
   brewUpgradeSingleWithProgress,
   brewUpgradeAll,
   brewCleanup,
-  brewPinFormula,
-  brewUnpinFormula,
+  brewPin,
+  brewUnpin,
   brewDoctor,
 } from "./actions";
 
@@ -123,6 +122,7 @@ export {
   brewInstalledDate,
   brewIdentifier,
   brewCaskOption,
+  normalizeOutdatedResults,
   isCask,
   brewCompare,
   brewInstallCommand,

--- a/extensions/brew/src/utils/brew/index.ts
+++ b/extensions/brew/src/utils/brew/index.ts
@@ -123,6 +123,7 @@ export {
   brewIdentifier,
   brewCaskOption,
   normalizeOutdatedResults,
+  brewPinnedIdentifiers,
   isCask,
   brewCompare,
   brewInstallCommand,

--- a/extensions/brew/src/utils/brew/index.ts
+++ b/extensions/brew/src/utils/brew/index.ts
@@ -124,6 +124,7 @@ export {
   brewCaskOption,
   normalizeOutdatedResults,
   brewPinnedIdentifiers,
+  pinLookupKey,
   isCask,
   brewCompare,
   brewInstallCommand,

--- a/extensions/brew/src/utils/brew/index.ts
+++ b/extensions/brew/src/utils/brew/index.ts
@@ -125,6 +125,7 @@ export {
   normalizeOutdatedResults,
   brewPinnedIdentifiers,
   pinLookupKey,
+  isPinnedPackage,
   isCask,
   brewCompare,
   brewInstallCommand,

--- a/extensions/brew/src/utils/brew/upgrade.ts
+++ b/extensions/brew/src/utils/brew/upgrade.ts
@@ -21,13 +21,6 @@ import { getErrorMessage, ensureError, StaleProcessError, BrewLockError } from "
 import { preferences } from "../preferences";
 import { normalizeOutdatedResults } from "./helpers";
 
-/**
- * brew's per-package fetch announcement: `Fetching <name> from <tap>`
- * (cmd/fetch.rb). Deliberately does NOT match the `Fetching: a, b, c` batch
- * header, which names every package at once.
- */
-const FETCHING_PACKAGE = /Fetching (\S+) from\s/;
-
 /// Upgrade Types
 
 /**
@@ -41,7 +34,7 @@ export interface UpgradePackage {
 /**
  * Status of a single package during an upgrade run.
  */
-export type UpgradePackageStatus = "downloading" | "upgrading" | "upgraded" | "failed" | "skipped";
+export type UpgradePackageStatus = "upgrading" | "upgraded" | "failed" | "skipped";
 
 /**
  * Events emitted while upgrading outdated packages.
@@ -201,46 +194,24 @@ export async function brewUpgradeOutdated(options?: UpgradeOptions): Promise<Upg
   // This leverages HOMEBREW_DOWNLOAD_CONCURRENCY for parallel downloads
   if (prefetch && packages.length > 1) {
     onEvent?.({ type: "prefetch" });
-    // brew fetches every package in one invocation, so its progress lines are the
-    // only clue as to which one is in flight. Match against the names we already
-    // hold rather than parsing brew's format: a miss simply leaves rows untouched.
-    // Longest first, so "warp@preview" wins over "warp".
-    // Scoped to the batch actually running: formulae and casks are fetched in
-    // separate invocations, and a name can belong to both kinds.
-    let fetchCandidates: UpgradePackage[] = [];
-    let fetching: UpgradePackage | undefined;
-    const onFetchProgress = (progress: BrewProgress) => {
-      onEvent?.({ type: "prefetch", progress });
-      // Attribute a row ONLY from brew's own per-package announcement,
-      // `Fetching <name> from <tap>` (cmd/fetch.rb). A substring scan of
-      // arbitrary progress text mis-fires: download lines carry full URLs, so a
-      // package named "git" matches an unrelated package's GitHub URL, and the
-      // batch header ("Fetching: a, b, c" — note the colon, which this pattern
-      // does not match) names every package at once.
-      const announced = FETCHING_PACKAGE.exec(progress.message)?.[1];
-      if (!announced) return;
-      const match = fetchCandidates.find((pkg) => pkg.name === announced);
-      if (match && (match.name !== fetching?.name || match.isCask !== fetching?.isCask)) {
-        fetching = match;
-        onEvent?.({ type: "package", package: match, status: "downloading" });
-      }
-    };
+    // Batch progress only — deliberately NOT attributed to a row. brew prints
+    // every `Fetching <name> from <tap>` line while ENQUEUEING (cmd/fetch.rb),
+    // then downloads the queue concurrently, so those lines say what is about to
+    // be fetched, not what is downloading now. Marking rows from them would race
+    // through the whole list and then park on whichever was announced last.
+    // The toast reports the batch; per-row status resumes at the sequential
+    // upgrade loop below, where it is real.
+    const onFetchProgress = (progress: BrewProgress) => onEvent?.({ type: "prefetch", progress });
 
     // Fetch formulae and casks separately (brew fetch syntax)
     const formulaNames = packages.filter((pkg) => !pkg.isCask).map((pkg) => pkg.name);
     const caskNames = packages.filter((pkg) => pkg.isCask).map((pkg) => pkg.name);
 
     try {
-      const ofKind = (kind: boolean) => packages.filter((pkg) => pkg.isCask === kind);
-
       if (formulaNames.length > 0) {
-        fetchCandidates = ofKind(false);
-        fetching = undefined;
         await execBrewWithProgress(`fetch ${formulaNames.join(" ")}`, onFetchProgress, cancel, execOptions);
       }
       if (caskNames.length > 0) {
-        fetchCandidates = ofKind(true);
-        fetching = undefined;
         await execBrewWithProgress(`fetch --cask ${caskNames.join(" ")}`, onFetchProgress, cancel, execOptions);
       }
       actionsLogger.log("Pre-fetch completed", { packages: packages.length });

--- a/extensions/brew/src/utils/brew/upgrade.ts
+++ b/extensions/brew/src/utils/brew/upgrade.ts
@@ -17,9 +17,9 @@ import { OutdatedResults } from "../types";
 import { restrictToSelection } from "../upgrade-selection";
 import { actionsLogger } from "../logger";
 import { execBrewWithProgress, BrewProgress, DEFAULT_STALE_TIMEOUT_MS } from "./progress";
-import { getErrorMessage, ensureError, StaleProcessError, BrewLockError } from "../errors";
+import { getErrorMessage, ensureError, StaleProcessError, BrewLockError, upgradeSkipReason } from "../errors";
 import { preferences } from "../preferences";
-import { normalizeOutdatedResults } from "./helpers";
+import { brewPinnedIdentifiers, normalizeOutdatedResults } from "./helpers";
 
 /// Upgrade Types
 
@@ -154,14 +154,19 @@ export async function brewUpgradeOutdated(options?: UpgradeOptions): Promise<Upg
   // This matters because we name every package explicitly: Homebrew only warns
   // about a pinned package on a bare `brew upgrade`, but errors (exit 1) when it
   // is named. Leaving one in would report a deliberate skip as a failure.
-  let packages: UpgradePackage[] = [
-    ...outdated.formulae.filter((formula) => !formula.pinned).map((formula) => ({ name: formula.name, isCask: false })),
-    ...outdated.casks.filter((cask) => !cask.pinned).map((cask) => ({ name: cask.name, isCask: true })),
+  //
+  // Read the pin state from disk rather than trusting the payload: a package
+  // pinned in another command, or outside Raycast, is pinned in Homebrew's eyes
+  // whatever this snapshot says. One directory read for the whole run.
+  const pins = await brewPinnedIdentifiers();
+  const isPinned = (name: string, isCask: boolean) => (isCask ? pins.casks.has(name) : pins.formulae.has(name));
+
+  const all: UpgradePackage[] = [
+    ...outdated.formulae.map((formula) => ({ name: formula.name, isCask: false })),
+    ...outdated.casks.map((cask) => ({ name: cask.name, isCask: true })),
   ];
-  const pinned: UpgradePackage[] = [
-    ...outdated.formulae.filter((formula) => formula.pinned).map((formula) => ({ name: formula.name, isCask: false })),
-    ...outdated.casks.filter((cask) => cask.pinned).map((cask) => ({ name: cask.name, isCask: true })),
-  ];
+  let packages: UpgradePackage[] = all.filter((pkg) => !isPinned(pkg.name, pkg.isCask));
+  const pinned: UpgradePackage[] = all.filter((pkg) => isPinned(pkg.name, pkg.isCask));
 
   // Honour the selection: upgrade only the reviewed packages that are still
   // outdated. Everything else stays untouched.
@@ -247,12 +252,22 @@ export async function brewUpgradeOutdated(options?: UpgradeOptions): Promise<Upg
 
     try {
       const cmd = `upgrade ${pkg.isCask ? "--cask " : ""}${pkg.name}`;
-      await execBrewWithProgress(
+      const result = await execBrewWithProgress(
         cmd,
         (progress) => onEvent?.({ type: "package", package: pkg, status: "upgrading", progress }),
         cancel,
         { ...execOptions, packageName: pkg.name },
       );
+
+      // Exit 0 does not mean it was upgraded. Homebrew warns and skips a
+      // deprecated, unavailable or already-current package, so without reading
+      // that warning the run claims an upgrade that never happened.
+      const declined = upgradeSkipReason(`${result.stderr ?? ""}\n${result.stdout ?? ""}`, pkg.name);
+      if (declined) {
+        summary.skipped.push(pkg);
+        onEvent?.({ type: "package", package: pkg, status: "skipped", message: declined });
+        continue;
+      }
 
       summary.upgraded.push(pkg);
       onEvent?.({ type: "package", package: pkg, status: "upgraded" });

--- a/extensions/brew/src/utils/brew/upgrade.ts
+++ b/extensions/brew/src/utils/brew/upgrade.ts
@@ -5,7 +5,7 @@
  *
  * Note: Homebrew does NOT support concurrent `brew upgrade` commands.
  * Running multiple upgrade processes simultaneously causes lock errors.
- * However, Homebrew 5.0 supports concurrent downloads via HOMEBREW_DOWNLOAD_CONCURRENCY.
+ * However, Homebrew supports concurrent downloads via HOMEBREW_DOWNLOAD_CONCURRENCY.
  *
  * Strategy for faster upgrades:
  * 1. Pre-fetch all packages concurrently using `brew fetch`
@@ -19,6 +19,14 @@ import { actionsLogger } from "../logger";
 import { execBrewWithProgress, BrewProgress, DEFAULT_STALE_TIMEOUT_MS } from "./progress";
 import { getErrorMessage, ensureError, StaleProcessError, BrewLockError } from "../errors";
 import { preferences } from "../preferences";
+import { normalizeOutdatedResults } from "./helpers";
+
+/**
+ * brew's per-package fetch announcement: `Fetching <name> from <tap>`
+ * (cmd/fetch.rb). Deliberately does NOT match the `Fetching: a, b, c` batch
+ * header, which names every package at once.
+ */
+const FETCHING_PACKAGE = /Fetching (\S+) from\s/;
 
 /// Upgrade Types
 
@@ -33,7 +41,7 @@ export interface UpgradePackage {
 /**
  * Status of a single package during an upgrade run.
  */
-export type UpgradePackageStatus = "upgrading" | "upgraded" | "failed" | "skipped";
+export type UpgradePackageStatus = "downloading" | "upgrading" | "upgraded" | "failed" | "skipped";
 
 /**
  * Events emitted while upgrading outdated packages.
@@ -82,7 +90,7 @@ export interface UpgradeSummary {
 export interface UpgradeOptions {
   /** Include auto-updating casks */
   greedy?: boolean;
-  /** Pre-fetch all packages before upgrading (uses Homebrew 5.0 concurrent downloads) */
+  /** Pre-fetch all packages before upgrading (uses Homebrew's concurrent downloads) */
   prefetch?: boolean;
   /** Continue upgrading remaining packages if one fails */
   continueOnError?: boolean;
@@ -116,7 +124,7 @@ export function upgradeKey(pkg: UpgradePackage): string {
  * Upgrade all outdated packages, reporting progress via events.
  *
  * Features:
- * - Optional pre-fetching with Homebrew 5.0 concurrent downloads
+ * - Optional pre-fetching with Homebrew's concurrent downloads
  * - Pinned formulae are skipped
  * - Continue upgrading remaining packages when one fails
  * - Cancellation via AbortSignal
@@ -147,16 +155,20 @@ export async function brewUpgradeOutdated(options?: UpgradeOptions): Promise<Upg
     cmd += " --greedy";
   }
   const result = await execBrewWithProgress(cmd, undefined, cancel, execOptions);
-  const outdated = JSON.parse(result.stdout) as OutdatedResults;
+  const outdated = normalizeOutdatedResults(JSON.parse(result.stdout) as OutdatedResults);
 
-  // Pinned formulae cannot be upgraded, so exclude them from the run
+  // Pinned packages cannot be upgraded, so exclude them from the run.
+  // This matters because we name every package explicitly: Homebrew only warns
+  // about a pinned package on a bare `brew upgrade`, but errors (exit 1) when it
+  // is named. Leaving one in would report a deliberate skip as a failure.
   let packages: UpgradePackage[] = [
     ...outdated.formulae.filter((formula) => !formula.pinned).map((formula) => ({ name: formula.name, isCask: false })),
-    ...outdated.casks.map((cask) => ({ name: cask.name, isCask: true })),
+    ...outdated.casks.filter((cask) => !cask.pinned).map((cask) => ({ name: cask.name, isCask: true })),
   ];
-  const pinned: UpgradePackage[] = outdated.formulae
-    .filter((formula) => formula.pinned)
-    .map((formula) => ({ name: formula.name, isCask: false }));
+  const pinned: UpgradePackage[] = [
+    ...outdated.formulae.filter((formula) => formula.pinned).map((formula) => ({ name: formula.name, isCask: false })),
+    ...outdated.casks.filter((cask) => cask.pinned).map((cask) => ({ name: cask.name, isCask: true })),
+  ];
 
   // Honour the selection: upgrade only the reviewed packages that are still
   // outdated. Everything else stays untouched.
@@ -186,20 +198,49 @@ export async function brewUpgradeOutdated(options?: UpgradeOptions): Promise<Upg
   });
 
   // Step 3 (optional): Pre-fetch all packages concurrently
-  // This leverages Homebrew 5.0's HOMEBREW_DOWNLOAD_CONCURRENCY for parallel downloads
+  // This leverages HOMEBREW_DOWNLOAD_CONCURRENCY for parallel downloads
   if (prefetch && packages.length > 1) {
     onEvent?.({ type: "prefetch" });
-    const onFetchProgress = (progress: BrewProgress) => onEvent?.({ type: "prefetch", progress });
+    // brew fetches every package in one invocation, so its progress lines are the
+    // only clue as to which one is in flight. Match against the names we already
+    // hold rather than parsing brew's format: a miss simply leaves rows untouched.
+    // Longest first, so "warp@preview" wins over "warp".
+    // Scoped to the batch actually running: formulae and casks are fetched in
+    // separate invocations, and a name can belong to both kinds.
+    let fetchCandidates: UpgradePackage[] = [];
+    let fetching: UpgradePackage | undefined;
+    const onFetchProgress = (progress: BrewProgress) => {
+      onEvent?.({ type: "prefetch", progress });
+      // Attribute a row ONLY from brew's own per-package announcement,
+      // `Fetching <name> from <tap>` (cmd/fetch.rb). A substring scan of
+      // arbitrary progress text mis-fires: download lines carry full URLs, so a
+      // package named "git" matches an unrelated package's GitHub URL, and the
+      // batch header ("Fetching: a, b, c" — note the colon, which this pattern
+      // does not match) names every package at once.
+      const announced = FETCHING_PACKAGE.exec(progress.message)?.[1];
+      if (!announced) return;
+      const match = fetchCandidates.find((pkg) => pkg.name === announced);
+      if (match && (match.name !== fetching?.name || match.isCask !== fetching?.isCask)) {
+        fetching = match;
+        onEvent?.({ type: "package", package: match, status: "downloading" });
+      }
+    };
 
     // Fetch formulae and casks separately (brew fetch syntax)
     const formulaNames = packages.filter((pkg) => !pkg.isCask).map((pkg) => pkg.name);
     const caskNames = packages.filter((pkg) => pkg.isCask).map((pkg) => pkg.name);
 
     try {
+      const ofKind = (kind: boolean) => packages.filter((pkg) => pkg.isCask === kind);
+
       if (formulaNames.length > 0) {
+        fetchCandidates = ofKind(false);
+        fetching = undefined;
         await execBrewWithProgress(`fetch ${formulaNames.join(" ")}`, onFetchProgress, cancel, execOptions);
       }
       if (caskNames.length > 0) {
+        fetchCandidates = ofKind(true);
+        fetching = undefined;
         await execBrewWithProgress(`fetch --cask ${caskNames.join(" ")}`, onFetchProgress, cancel, execOptions);
       }
       actionsLogger.log("Pre-fetch completed", { packages: packages.length });

--- a/extensions/brew/src/utils/brew/upgrade.ts
+++ b/extensions/brew/src/utils/brew/upgrade.ts
@@ -19,7 +19,7 @@ import { actionsLogger } from "../logger";
 import { execBrewWithProgress, BrewProgress, DEFAULT_STALE_TIMEOUT_MS } from "./progress";
 import { getErrorMessage, ensureError, StaleProcessError, BrewLockError, upgradeSkipReason } from "../errors";
 import { preferences } from "../preferences";
-import { brewPinnedIdentifiers, normalizeOutdatedResults, pinLookupKey } from "./helpers";
+import { brewPinnedIdentifiers, isPinnedPackage, normalizeOutdatedResults } from "./helpers";
 
 /// Upgrade Types
 
@@ -157,12 +157,9 @@ export async function brewUpgradeOutdated(options?: UpgradeOptions): Promise<Upg
   //
   // Read the pin state from disk rather than trusting the payload: a package
   // pinned in another command, or outside Raycast, is pinned in Homebrew's eyes
-  // whatever this snapshot says. One directory read for the whole run.
+  // whatever this snapshot says. One snapshot of both pin directories per run.
   const pins = await brewPinnedIdentifiers();
-  // Pins are keyed by the short name; the outdated payload names a tapped
-  // formula in full. See pinLookupKey.
-  const isPinned = (name: string, isCask: boolean) =>
-    isCask ? pins.casks.has(pinLookupKey(name)) : pins.formulae.has(pinLookupKey(name));
+  const isPinned = (name: string, isCask: boolean) => isPinnedPackage(pins, name, isCask);
 
   const all: UpgradePackage[] = [
     ...outdated.formulae.map((formula) => ({ name: formula.name, isCask: false })),
@@ -262,9 +259,8 @@ export async function brewUpgradeOutdated(options?: UpgradeOptions): Promise<Upg
         { ...execOptions, packageName: pkg.name },
       );
 
-      // Exit 0 does not mean it was upgraded. Homebrew warns and skips a
-      // deprecated, unavailable or already-current package, so without reading
-      // that warning the run claims an upgrade that never happened.
+      // Exit 0 does not mean it was upgraded: Homebrew warns and skips a
+      // disabled, unavailable or already-current package.
       const declined = upgradeSkipReason(`${result.stderr ?? ""}\n${result.stdout ?? ""}`, pkg.name);
       if (declined) {
         summary.skipped.push(pkg);

--- a/extensions/brew/src/utils/brew/upgrade.ts
+++ b/extensions/brew/src/utils/brew/upgrade.ts
@@ -19,7 +19,7 @@ import { actionsLogger } from "../logger";
 import { execBrewWithProgress, BrewProgress, DEFAULT_STALE_TIMEOUT_MS } from "./progress";
 import { getErrorMessage, ensureError, StaleProcessError, BrewLockError, upgradeSkipReason } from "../errors";
 import { preferences } from "../preferences";
-import { brewPinnedIdentifiers, normalizeOutdatedResults } from "./helpers";
+import { brewPinnedIdentifiers, normalizeOutdatedResults, pinLookupKey } from "./helpers";
 
 /// Upgrade Types
 
@@ -159,7 +159,10 @@ export async function brewUpgradeOutdated(options?: UpgradeOptions): Promise<Upg
   // pinned in another command, or outside Raycast, is pinned in Homebrew's eyes
   // whatever this snapshot says. One directory read for the whole run.
   const pins = await brewPinnedIdentifiers();
-  const isPinned = (name: string, isCask: boolean) => (isCask ? pins.casks.has(name) : pins.formulae.has(name));
+  // Pins are keyed by the short name; the outdated payload names a tapped
+  // formula in full. See pinLookupKey.
+  const isPinned = (name: string, isCask: boolean) =>
+    isCask ? pins.casks.has(pinLookupKey(name)) : pins.formulae.has(pinLookupKey(name));
 
   const all: UpgradePackage[] = [
     ...outdated.formulae.map((formula) => ({ name: formula.name, isCask: false })),

--- a/extensions/brew/src/utils/cache.ts
+++ b/extensions/brew/src/utils/cache.ts
@@ -163,7 +163,7 @@ const valid_keys = [
   "build_dependencies",
   "installed",
   "keg_only",
-  "linked_key",
+  "linked_keg",
   "pinned",
 ];
 

--- a/extensions/brew/src/utils/errors.ts
+++ b/extensions/brew/src/utils/errors.ts
@@ -356,10 +356,23 @@ const BREW_LOCK_PATTERNS = [
  * Each reason stays distinct because each asks something different of the user.
  */
 export function upgradeSkipReason(output: string, name: string): string | undefined {
-  // Anchored to the package we named. No optional @version suffix: `foo` must
-  // not absorb a warning about the distinct formula `foo@2`.
+  // Anchored to the package we named, with two properties that must both hold:
+  //
+  //  - A TAP PREFIX is optional. Homebrew names a package in these warnings with
+  //    `full_specified_name`, which is `<tap>/<name>` outside homebrew/core
+  //    (formula.rb `full_name_with_optional_tap`). `brew outdated --json=v2`
+  //    already returns the qualified form, but `brew info --json=v2 --installed`
+  //    returns the short name with the tap in a separate field — so the same
+  //    package arrives here spelled either way depending on the caller.
+  //  - A VERSION SUFFIX is not. `python` must not absorb `python@3.14`'s
+  //    warning: those are different formulae.
   const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const named = new RegExp(`^.*\\bNot upgrading ${escaped}, ([^\n]+)`, "im").exec(output);
+  // Homebrew rejects extra slashes in a tap name, not punctuation
+  // (tap_constants.rb) — so the segments are "anything but a slash or space".
+  const tap = "(?:[^\\s/]+/[^\\s/]+/)?";
+  const before = "(?:^|[\\s'\"])";
+
+  const named = new RegExp(`Not upgrading ${tap}${escaped}, ([^\n]+)`, "i").exec(output);
   if (named) {
     const reason = named[1];
     if (/it is disabled/i.test(reason)) return "Disabled by Homebrew";
@@ -371,14 +384,14 @@ export function upgradeSkipReason(output: string, name: string): string | undefi
     return reason.replace(/\.$/, "");
   }
 
-  // "<name> <version> already installed" — a formula that was brought up to date
-  // as a dependency of an earlier package in the same run is the common case.
-  if (new RegExp(`^.*\\b${escaped} \\S+ already installed\\b`, "im").test(output)) {
+  // "<name> <version> already installed" — a formula brought up to date as a
+  // dependency of an earlier package in the same run is the common case.
+  if (new RegExp(`${before}${tap}${escaped} \\S+ already installed\\b`, "im").test(output)) {
     return "Already up to date";
   }
 
   // "The cask '<token>' cannot be upgraded as-is."
-  if (new RegExp(`The cask '${escaped}' cannot be upgraded as-is`, "i").test(output)) {
+  if (new RegExp(`The cask '${tap}${escaped}' cannot be upgraded as-is`, "i").test(output)) {
     return "Cannot be upgraded as-is — reinstall it";
   }
 

--- a/extensions/brew/src/utils/errors.ts
+++ b/extensions/brew/src/utils/errors.ts
@@ -321,7 +321,7 @@ const BREW_LOCK_PATTERNS = [
   /Error: Another.*brew.*process/i,
   /waiting for lock/i,
   /lock file/i,
-  /has already locked/i, // Homebrew 5.0: "A `brew upgrade` process has already locked ..."
+  /has already locked/i, // "A `brew upgrade` process has already locked ..."
   /brew upgrade.*process has already/i,
 ];
 

--- a/extensions/brew/src/utils/errors.ts
+++ b/extensions/brew/src/utils/errors.ts
@@ -326,6 +326,91 @@ const BREW_LOCK_PATTERNS = [
 ];
 
 /**
+ * Why Homebrew declined to upgrade a package it was explicitly named.
+ *
+ * These are `opoo` warnings, NOT failures: brew prints one, skips the package
+ * and exits 0. Without reading them the run reports the package as upgraded
+ * when nothing happened — a success message for work that was declined.
+ *
+ * The shapes differ per kind and are quoted from the installed source; they do
+ * NOT all share the `Not upgrading <name>` prefix, which an earlier version of
+ * this function assumed:
+ *
+ *   cask/upgrade.rb   "Not upgrading <token>, it is disabled because …"
+ *                     "Not upgrading <token>, no version is available for the current platform"
+ *                     "Not upgrading <token>, the downloaded artifact has not changed"
+ *                     "Not upgrading <token>, the latest version is already installed"
+ *                     "Not upgrading <token>, the installed version is not below the minimum version …"
+ *                     "The cask '<token>' cannot be upgraded as-is. To fix this, run: …"
+ *   cmd/upgrade.rb    "<name> <version> already installed"
+ *                     "Not upgrading <name>, the installed version is not below the minimum version …"
+ *
+ * Deprecation is deliberately absent: brew warns about a deprecated package and
+ * upgrades it anyway (formula_installer.rb, cask/installer.rb), so treating it
+ * as a skip would report a real upgrade as declined. A DISABLED formula raises
+ * and fails; only a disabled cask is an exit-0 skip.
+ *
+ * The pinned case is absent too — that one is `ofail` when the package is
+ * named, and `isPinnedRefusal` handles it.
+ *
+ * Each reason stays distinct because each asks something different of the user.
+ */
+export function upgradeSkipReason(output: string, name: string): string | undefined {
+  // Anchored to the package we named. No optional @version suffix: `foo` must
+  // not absorb a warning about the distinct formula `foo@2`.
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const named = new RegExp(`^.*\\bNot upgrading ${escaped}, ([^\n]+)`, "im").exec(output);
+  if (named) {
+    const reason = named[1];
+    if (/it is disabled/i.test(reason)) return "Disabled by Homebrew";
+    if (/no version is available for the current platform/i.test(reason)) return "No version for this platform";
+    if (/the installed version is not below the minimum version/i.test(reason)) return "Installed version is not older";
+    if (/artifact has not changed|latest version is already installed/i.test(reason)) return "Already up to date";
+    // An unrecognised reason is still a skip; carry brew's own words rather than
+    // inventing a category or, worse, reporting an upgrade that did not happen.
+    return reason.replace(/\.$/, "");
+  }
+
+  // "<name> <version> already installed" — a formula that was brought up to date
+  // as a dependency of an earlier package in the same run is the common case.
+  if (new RegExp(`^.*\\b${escaped} \\S+ already installed\\b`, "im").test(output)) {
+    return "Already up to date";
+  }
+
+  // "The cask '<token>' cannot be upgraded as-is."
+  if (new RegExp(`The cask '${escaped}' cannot be upgraded as-is`, "i").test(output)) {
+    return "Cannot be upgraded as-is — reinstall it";
+  }
+
+  return undefined;
+}
+
+/**
+ * Pattern to detect Homebrew refusing to act on a pinned package.
+ *
+ * Upgrade, named explicitly (cmd/upgrade.rb, cask/upgrade.rb):
+ *   "Error: Not upgrading 1 pinned package."
+ * Uninstall, either kind (uninstall.rb, cask/uninstall.rb):
+ *   "Error: <name> is pinned. You must unpin it to uninstall."
+ *
+ * The extension reads pin state from disk before naming a package, so this is
+ * the backstop for a pin that lands between that check and the command.
+ *
+ * NOTE: it only fires where brew actually FAILS. A named pinned upgrade is
+ * `ofail` (exit 1) and reaches a catch. A pinned UNINSTALL is `onoe`, which
+ * does not set `Homebrew.failed`, so brew exits 0 and no catch runs — see
+ * TODO.md. Do not assume a caller is covered because it calls this.
+ */
+const PINNED_REFUSAL_PATTERN = /Not upgrading \d+ pinned package|is pinned\. You must unpin it/i;
+
+/**
+ * Whether Homebrew refused this operation because the package is pinned.
+ */
+export function isPinnedRefusal(error: unknown): boolean {
+  return PINNED_REFUSAL_PATTERN.test(getErrorMessage(error));
+}
+
+/**
  * Pattern to detect disabled/discontinued packages.
  * Matches: "Error: Cask 'name' has been disabled because it is discontinued upstream! It was disabled on 2024-12-16."
  * Or: "Error: Formula 'name' has been disabled because ..."

--- a/extensions/brew/src/utils/errors.ts
+++ b/extensions/brew/src/utils/errors.ts
@@ -325,6 +325,12 @@ const BREW_LOCK_PATTERNS = [
   /brew upgrade.*process has already/i,
 ];
 
+/** Optional `<owner>/<repo>/`. Brew rejects extra slashes in a tap name, not punctuation. */
+const TAP_PREFIX = "(?:[^\\s/]+/[^\\s/]+/)?";
+
+/** Start of line or a separator, so a short name cannot match mid-token. */
+const WORD_START = "(?:^|[\\s'\"])";
+
 /**
  * Why Homebrew declined to upgrade a package it was explicitly named.
  *
@@ -332,18 +338,17 @@ const BREW_LOCK_PATTERNS = [
  * and exits 0. Without reading them the run reports the package as upgraded
  * when nothing happened — a success message for work that was declined.
  *
- * The shapes differ per kind and are quoted from the installed source; they do
- * NOT all share the `Not upgrading <name>` prefix, which an earlier version of
- * this function assumed:
+ * The shapes differ per kind, are quoted from the installed source, and do NOT
+ * all share the `Not upgrading <name>` prefix:
  *
  *   cask/upgrade.rb   "Not upgrading <token>, it is disabled because …"
  *                     "Not upgrading <token>, no version is available for the current platform"
  *                     "Not upgrading <token>, the downloaded artifact has not changed"
  *                     "Not upgrading <token>, the latest version is already installed"
- *                     "Not upgrading <token>, the installed version is not below the minimum version …"
  *                     "The cask '<token>' cannot be upgraded as-is. To fix this, run: …"
  *   cmd/upgrade.rb    "<name> <version> already installed"
  *                     "Not upgrading <name>, the installed version is not below the minimum version …"
+ *                     (that last one covers casks too — it is emitted from cmd/upgrade.rb)
  *
  * Deprecation is deliberately absent: brew warns about a deprecated package and
  * upgrades it anyway (formula_installer.rb, cask/installer.rb), so treating it
@@ -367,12 +372,8 @@ export function upgradeSkipReason(output: string, name: string): string | undefi
   //  - A VERSION SUFFIX is not. `python` must not absorb `python@3.14`'s
   //    warning: those are different formulae.
   const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  // Homebrew rejects extra slashes in a tap name, not punctuation
-  // (tap_constants.rb) — so the segments are "anything but a slash or space".
-  const tap = "(?:[^\\s/]+/[^\\s/]+/)?";
-  const before = "(?:^|[\\s'\"])";
 
-  const named = new RegExp(`Not upgrading ${tap}${escaped}, ([^\n]+)`, "i").exec(output);
+  const named = new RegExp(`Not upgrading ${TAP_PREFIX}${escaped}, ([^\n]+)`, "i").exec(output);
   if (named) {
     const reason = named[1];
     if (/it is disabled/i.test(reason)) return "Disabled by Homebrew";
@@ -386,12 +387,12 @@ export function upgradeSkipReason(output: string, name: string): string | undefi
 
   // "<name> <version> already installed" — a formula brought up to date as a
   // dependency of an earlier package in the same run is the common case.
-  if (new RegExp(`${before}${tap}${escaped} \\S+ already installed\\b`, "im").test(output)) {
+  if (new RegExp(`${WORD_START}${TAP_PREFIX}${escaped} \\S+ already installed\\b`, "im").test(output)) {
     return "Already up to date";
   }
 
   // "The cask '<token>' cannot be upgraded as-is."
-  if (new RegExp(`The cask '${tap}${escaped}' cannot be upgraded as-is`, "i").test(output)) {
+  if (new RegExp(`The cask '${TAP_PREFIX}${escaped}' cannot be upgraded as-is`, "i").test(output)) {
     return "Cannot be upgraded as-is — reinstall it";
   }
 
@@ -402,7 +403,7 @@ export function upgradeSkipReason(output: string, name: string): string | undefi
  * Pattern to detect Homebrew refusing to act on a pinned package.
  *
  * Upgrade, named explicitly (cmd/upgrade.rb, cask/upgrade.rb):
- *   "Error: Not upgrading 1 pinned package."
+ *   "Error: Not upgrading 1 pinned package:"
  * Uninstall, either kind (uninstall.rb, cask/uninstall.rb):
  *   "Error: <name> is pinned. You must unpin it to uninstall."
  *

--- a/extensions/brew/src/utils/index.ts
+++ b/extensions/brew/src/utils/index.ts
@@ -16,6 +16,8 @@ export type {
   Versions,
   OutdatedFormula,
   OutdatedCask,
+  Pinnable,
+  PinKind,
   InstallableResults,
   OutdatedResults,
   InstalledMap,

--- a/extensions/brew/src/utils/index.ts
+++ b/extensions/brew/src/utils/index.ts
@@ -49,6 +49,8 @@ export {
   isBrewError,
   isNetworkError,
   isBrewLockError,
+  isPinnedRefusal,
+  upgradeSkipReason,
   isDownloadTimeoutError,
   isStaleProcessError,
   isPackageDisabledError,

--- a/extensions/brew/src/utils/installed.ts
+++ b/extensions/brew/src/utils/installed.ts
@@ -14,15 +14,18 @@ export const showInstalledPackages = (
     ? allFormulae.filter((formula) => formula.installed.some((version) => version.installed_on_request))
     : allFormulae;
 
+  const allCasks =
+    filter !== InstallableFilterType.formulae && installed?.casks instanceof Map
+      ? Array.from(installed.casks.values())
+      : [];
+
   return {
     formulae: formulae.filter((formula) => !formula.pinned),
     // Split from the pre-dependency-filter array: a pin is an explicit user
     // decision, so a pinned dependency must stay visible even when
     // "Exclude Dependencies" is on.
     pinnedFormulae: allFormulae.filter((formula) => formula.pinned),
-    casks:
-      filter !== InstallableFilterType.formulae && installed?.casks instanceof Map
-        ? Array.from(installed.casks.values())
-        : [],
+    casks: allCasks.filter((cask) => !cask.pinned),
+    pinnedCasks: allCasks.filter((cask) => cask.pinned),
   } as const;
 };

--- a/extensions/brew/src/utils/toast.ts
+++ b/extensions/brew/src/utils/toast.ts
@@ -4,7 +4,7 @@
  * Provides functions for displaying toast notifications.
  */
 
-import { Clipboard, Toast, showHUD } from "@raycast/api";
+import { Clipboard, Toast, showHUD, showToast } from "@raycast/api";
 import { ExecError } from "./types";
 import { uiLogger } from "./logger";
 import { isRecoverableError, getErrorMessage, isBrewLockError } from "./errors";
@@ -34,6 +34,26 @@ export interface ActionToastHandle {
   showFailureHUD: (message: string) => Promise<void>;
   /** Hide the toast */
   hide: () => void;
+}
+
+/**
+ * Finish an in-progress action toast.
+ *
+ * Raycast's toast update/hide messages carry no toast id: they act on whichever
+ * toast is currently on screen. Mutating the animated toast in place therefore
+ * risks leaving its "Cancel" action attached to a finished operation. Showing a
+ * fresh toast makes that structurally impossible: `showToast` replaces the
+ * visible toast outright, so it needs no `hide()` first — and adding one would
+ * open an `await` gap in which another writer could claim the slot.
+ */
+async function settle(toast: Toast, style: Toast.Style, title: string, hudMessage: string): Promise<void> {
+  if (preferences.closeAfterAction) {
+    // Close window and show HUD. Dismissal is best-effort: it must not gate the HUD.
+    toast.hide().catch((err) => uiLogger.log("Failed to hide action toast", err));
+    await showHUD(hudMessage);
+  } else {
+    await showToast({ style, title });
+  }
 }
 
 /**
@@ -72,30 +92,10 @@ export function showActionToast(actionOptions: ActionToastOptions): ActionToastH
       toast.title = title;
     },
     showSuccessHUD: async (message: string) => {
-      if (preferences.closeAfterAction) {
-        toast.hide();
-        // Close window and show HUD
-        await showHUD(`✅ ${message}`);
-      } else {
-        // Keep window open - update existing toast in-place to avoid stale detail HUD
-        toast.style = Toast.Style.Success;
-        toast.title = message;
-        toast.message = undefined;
-        toast.primaryAction = undefined;
-      }
+      await settle(toast, Toast.Style.Success, message, `✅ ${message}`);
     },
     showFailureHUD: async (message: string) => {
-      if (preferences.closeAfterAction) {
-        toast.hide();
-        // Close window and show HUD
-        await showHUD(`❌ ${message}`);
-      } else {
-        // Keep window open - update existing toast in-place to avoid stale detail HUD
-        toast.style = Toast.Style.Failure;
-        toast.title = message;
-        toast.message = undefined;
-        toast.primaryAction = undefined;
-      }
+      await settle(toast, Toast.Style.Failure, message, `❌ ${message}`);
     },
     hide: () => {
       toast.hide();

--- a/extensions/brew/src/utils/types.ts
+++ b/extensions/brew/src/utils/types.ts
@@ -24,7 +24,8 @@ export interface Nameable {
 }
 
 interface Installable {
-  tap: string;
+  /** Null for a formula loaded from a path or URL, and for a tapless cask. */
+  tap: string | null;
   desc?: string;
   homepage: string;
   versions: Versions;
@@ -56,6 +57,10 @@ export interface Cask extends Installable {
 
 export interface CaskDependency {
   macos?: { [key: string]: string[] };
+  /** Casks can depend on formulae and other casks, not just an OS version. */
+  formula?: string[];
+  cask?: string[];
+  arch?: { type: string; bits?: number }[];
 }
 
 /// Formula Types

--- a/extensions/brew/src/utils/types.ts
+++ b/extensions/brew/src/utils/types.ts
@@ -47,6 +47,9 @@ export interface Cask extends Installable {
   /** Unix seconds when this cask was installed or last upgraded. */
   installed_time?: number;
   auto_updates: boolean;
+  /** Casks have been pinnable since Homebrew 5.1.12. */
+  pinned: boolean;
+  pinned_version?: string | null;
   depends_on: CaskDependency;
   conflicts_with?: { cask: string[] };
 }
@@ -64,16 +67,20 @@ export interface Formula extends Installable, Nameable {
   build_dependencies: string[];
   installed: InstalledVersion[];
   keg_only: boolean;
-  linked_key: string;
+  linked_keg: string | null;
   pinned: boolean;
   conflicts_with?: string[];
 }
 
 export interface InstalledVersion {
   version: string;
-  installed_as_dependency: boolean;
+  /**
+   * False when Homebrew installed this only to satisfy another package's
+   * dependency. Homebrew removed `installed_as_dependency` in 5.1.9 and treats
+   * this as the source of truth, so derive "is a dependency" from `!installed_on_request`.
+   */
   installed_on_request: boolean;
-  /** Unix seconds when this version was installed. Absent on the fast list path. */
+  /** Unix seconds when this version was installed. Absent from the web API. */
   time?: number;
 }
 
@@ -82,6 +89,15 @@ export interface Versions {
   head?: string;
   bottle: boolean;
 }
+
+/**
+ * Anything the extension can pin. `OutdatedCask` carries only the token that
+ * `normalizeOutdatedResults` synthesises, so pin operations take an explicit
+ * kind rather than depending on that normalization having run.
+ */
+export type Pinnable = Formula | OutdatedFormula | Cask | OutdatedCask;
+
+export type PinKind = "formula" | "cask";
 
 /// Outdated Types
 
@@ -97,11 +113,25 @@ export interface OutdatedFormula extends Outdated {
 
 export interface OutdatedCask extends Outdated {
   /**
+   * Synthesised, not reported by brew: `brew outdated --json=v2` gives casks a
+   * `name` and no `token`, but `isCask()` — and therefore `brewCaskOption`,
+   * `brewIdentifier` and every argv built from them — keys off `token`. Without
+   * it an outdated cask is indistinguishable from a formula and gets
+   * formula-shaped brew commands.
+   *
+   * `normalizeOutdatedResults` fills it in. EVERY ingress must call it: both
+   * parsers of that payload, and any read of a cached snapshot that may predate
+   * this field. A path that skips it silently reintroduces the bug.
+   */
+  token: string;
+  /**
    * Array of installed versions, same shape as for formulae.
    * `brew outdated --json=v2` returns an array for casks; this was previously
    * (incorrectly) declared as a string.
    */
   installed_versions: string[];
+  pinned_version?: string;
+  pinned: boolean;
 }
 
 /// Result Types

--- a/extensions/brew/src/utils/upgrade-selection.test.ts
+++ b/extensions/brew/src/utils/upgrade-selection.test.ts
@@ -11,6 +11,7 @@
 import { describe, expect, it } from "vitest";
 import { brewName, brewUninstallCommand, brewUpgradeCommand, isCask, normalizeOutdatedResults } from "./brew/helpers";
 import { preferences } from "./preferences";
+import { isPinnedRefusal, upgradeSkipReason } from "./errors";
 import {
   applyPinChange,
   applyPinOverrides,
@@ -454,5 +455,124 @@ describe("test preferences mirror the declared defaults", () => {
 
   it("gives pinnedFirst its declared default of true", () => {
     expect(preferences.pinnedFirst).toBe(true);
+  });
+});
+
+/**
+ * Homebrew's own refusals, quoted from the installed source. The extension reads
+ * pin state from disk before naming a package, so these are the backstop for a
+ * pin that lands between that check and the command.
+ */
+describe("pinned refusal detection", () => {
+  it("matches the named-upgrade refusal", () => {
+    // cmd/upgrade.rb: "Not upgrading #{pinned.count} pinned #{pluralize("package", …)}:"
+    expect(isPinnedRefusal(new Error("Error: Not upgrading 1 pinned package:"))).toBe(true);
+    expect(isPinnedRefusal(new Error("Error: Not upgrading 3 pinned packages:"))).toBe(true);
+  });
+
+  it("matches the uninstall refusal for either kind", () => {
+    // uninstall.rb and cask/uninstall.rb, verbatim
+    expect(isPinnedRefusal(new Error("asc is pinned. You must unpin it to uninstall."))).toBe(true);
+    expect(isPinnedRefusal(new Error("1password is pinned. You must unpin it to uninstall."))).toBe(true);
+  });
+
+  it("does not match brew's OTHER 'Not upgrading' refusals", () => {
+    // cask/upgrade.rb:48 — deprecated/disabled, a different problem with a
+    // different remedy. Offering "unpin and force" here would be nonsense.
+    expect(isPinnedRefusal(new Error("Not upgrading zoom, it is deprecated because it is discontinued"))).toBe(false);
+    expect(isPinnedRefusal(new Error("Not upgrading warp, no version is available for the current platform"))).toBe(
+      false,
+    );
+  });
+
+  it("does not match unrelated failures", () => {
+    expect(isPinnedRefusal(new Error("Error: Another active Homebrew process is already running"))).toBe(false);
+    expect(isPinnedRefusal(undefined)).toBe(false);
+  });
+});
+
+/**
+ * Homebrew warns and skips rather than failing for these, exiting 0 — so the run
+ * would otherwise report an upgrade that never happened. Every string below is
+ * quoted from the installed source, not invented: an earlier version of this
+ * suite asserted a "Not upgrading <formula>, it is deprecated" message that brew
+ * does not emit (it warns about deprecation and upgrades anyway).
+ */
+describe("declined upgrades are read from brew's warnings", () => {
+  it("keeps each cask reason distinct rather than collapsing them", () => {
+    // cask/upgrade.rb, verbatim shapes
+    expect(upgradeSkipReason("Warning: Not upgrading zoom, it is disabled because it is discontinued!", "zoom")).toBe(
+      "Disabled by Homebrew",
+    );
+    expect(
+      upgradeSkipReason("Warning: Not upgrading warp, no version is available for the current platform", "warp"),
+    ).toBe("No version for this platform");
+    expect(upgradeSkipReason("Warning: Not upgrading zed, the downloaded artifact has not changed", "zed")).toBe(
+      "Already up to date",
+    );
+    expect(upgradeSkipReason("Warning: Not upgrading zed, the latest version is already installed", "zed")).toBe(
+      "Already up to date",
+    );
+  });
+
+  it("reads the minimum-version skip, which both kinds emit", () => {
+    // cmd/upgrade.rb for formulae and casks alike. "not below" includes equal,
+    // so the wording must not claim the installed one is strictly newer.
+    expect(
+      upgradeSkipReason(
+        "Warning: Not upgrading docker, the installed version is not below the minimum version 4.0",
+        "docker",
+      ),
+    ).toBe("Installed version is not older");
+  });
+
+  it("reads the formula already-installed skip, which has no 'Not upgrading' prefix", () => {
+    // cmd/upgrade.rb: opoo "#{f.full_specified_name} #{latest_keg.version} already installed"
+    // Reached whenever an earlier package in the same run upgraded this one as a dependency.
+    expect(upgradeSkipReason("Warning: aom 3.15.0 already installed", "aom")).toBe("Already up to date");
+  });
+
+  it("reads the cask cannot-be-upgraded-as-is skip", () => {
+    // cask/upgrade.rb
+    expect(upgradeSkipReason("Warning: The cask 'docker' cannot be upgraded as-is. To fix this, run:", "docker")).toBe(
+      "Cannot be upgraded as-is — reinstall it",
+    );
+  });
+
+  it("does NOT treat deprecation as a skip", () => {
+    // brew warns about a deprecated package and upgrades it anyway
+    // (formula_installer.rb, cask/installer.rb). Calling that a skip would
+    // report a real upgrade as declined.
+    expect(upgradeSkipReason("Warning: zoom has been deprecated because it is discontinued", "zoom")).toBeUndefined();
+  });
+
+  it("carries an unrecognised reason through rather than claiming an upgrade", () => {
+    expect(upgradeSkipReason("Warning: Not upgrading fd, some future reason.", "fd")).toBe("some future reason");
+  });
+
+  it("does not attribute another package's warning to this one", () => {
+    expect(upgradeSkipReason("Warning: Not upgrading zoom, it is disabled because x", "zed")).toBeUndefined();
+    // A versioned sibling is a DIFFERENT package: `python` must not absorb
+    // `python@3.14`'s warning.
+    expect(
+      upgradeSkipReason(
+        "Warning: Not upgrading python@3.14, no version is available for the current platform",
+        "python",
+      ),
+    ).toBeUndefined();
+    expect(upgradeSkipReason("Warning: python@3.14 3.14.0 already installed", "python")).toBeUndefined();
+  });
+
+  it("returns nothing for a clean upgrade", () => {
+    expect(upgradeSkipReason("==> Upgrading zed\n==> Downloading...", "zed")).toBeUndefined();
+  });
+
+  it("handles a versioned name without treating @ as a pattern", () => {
+    expect(
+      upgradeSkipReason(
+        "Warning: Not upgrading warp@preview, no version is available for the current platform",
+        "warp@preview",
+      ),
+    ).toBe("No version for this platform");
   });
 });

--- a/extensions/brew/src/utils/upgrade-selection.test.ts
+++ b/extensions/brew/src/utils/upgrade-selection.test.ts
@@ -4,10 +4,13 @@
  * Fixtures below reproduce real `brew outdated --json=v2` payloads captured
  * from Homebrew 6.x (2026-07-30) — not the type declarations. In particular:
  * `installed_versions` is an array for casks as well as formulae, and
- * `pinned` / `pinned_version` are reported for both.
+ * `pinned` / `pinned_version` are reported for both. Casks have been pinnable
+ * since Homebrew 5.1.12.
  */
 
 import { describe, expect, it } from "vitest";
+import { brewName, brewUninstallCommand, brewUpgradeCommand, isCask, normalizeOutdatedResults } from "./brew/helpers";
+import { preferences } from "./preferences";
 import {
   applyPinChange,
   applyPinOverrides,
@@ -57,6 +60,13 @@ const OUTDATED_JSON = `{
       "current_version": "1.100.0",
       "pinned": false,
       "pinned_version": null
+    },
+    {
+      "name": "docker",
+      "installed_versions": ["4.30.0"],
+      "current_version": "4.31.0",
+      "pinned": true,
+      "pinned_version": "4.30.0"
     }
   ]
 }`;
@@ -133,14 +143,33 @@ describe("mergeSelectionState", () => {
     expect(merged.get(selectionKey("formula", "jq"))).toBe(true);
   });
 
-  it("casks are default-selected like unpinned formulae — they carry no pin state before Homebrew 6", () => {
+  it("unpinned casks are default-selected like unpinned formulae", () => {
     const packages: SelectablePackage[] = [
       { kind: "formula", name: "wget", pinned: false },
-      { kind: "cask", name: "firefox" },
+      { kind: "cask", name: "firefox", pinned: false },
     ];
     const merged = mergeSelectionState(new Map(), packages);
     expect(merged.get(selectionKey("cask", "firefox"))).toBe(true);
     expect(selectedPackages(packages, merged)).toEqual(packages);
+  });
+
+  it("excludes a pinned cask, exactly as it excludes a pinned formula", () => {
+    const packages: SelectablePackage[] = [
+      { kind: "cask", name: "raycast", pinned: false },
+      { kind: "cask", name: "docker", pinned: true },
+    ];
+    const merged = mergeSelectionState(new Map(), packages);
+    expect(merged.get(selectionKey("cask", "raycast"))).toBe(true);
+    expect(merged.get(selectionKey("cask", "docker"))).toBe(false);
+    expect(selectedPackages(packages, merged)).toEqual([{ kind: "cask", name: "raycast", pinned: false }]);
+  });
+
+  it("unpinning a cask in the review includes it, like a formula", () => {
+    const packages: SelectablePackage[] = [{ kind: "cask", name: "docker", pinned: true }];
+    const state = mergeSelectionState(new Map(), packages);
+    const key = selectionKey("cask", "docker");
+    expect(state.get(key)).toBe(false);
+    expect(applyPinChange(state, key, false).get(key)).toBe(true);
   });
 
   it("drops packages that are no longer outdated", () => {
@@ -361,5 +390,96 @@ describe("outdated payload contract", () => {
     expect(Array.isArray(outdated.formulae[0].installed_versions)).toBe(true);
     expect(Array.isArray(outdated.casks[0].installed_versions)).toBe(true);
     expect(outdated.casks[0].installed_versions[0]).toBe("1.99.0");
+  });
+});
+
+/**
+ * `brew outdated --json=v2` omits `token` from casks, but `isCask()` — and so
+ * every brew argv built from `brewCaskOption` / `brewIdentifier` — keys off it.
+ * Several formula-vs-cask conflations in this work passed a clean typecheck
+ * before normalization existed, so pin the discriminator down here.
+ */
+describe("outdated casks are distinguishable from formulae", () => {
+  // Parsed exactly as the production ingresses parse it: raw brew JSON, then
+  // normalized. Stamping the token by hand here would test the contract while
+  // leaving the ingress — the thing that actually broke — uncovered.
+  const parsed = normalizeOutdatedResults(JSON.parse(OUTDATED_JSON) as OutdatedResults);
+  const outdatedCask = parsed.casks[0];
+  const outdatedFormula = parsed.formulae[0];
+
+  it("synthesises a token brew does not report", () => {
+    // Guards the ingress: raw brew JSON has no token at all.
+    const raw = JSON.parse(OUTDATED_JSON) as OutdatedResults;
+    expect(raw.casks[0].token).toBeUndefined();
+    expect(outdatedCask.token).toBe(outdatedCask.name);
+  });
+
+  it("leaves an already-normalized payload alone", () => {
+    const again = normalizeOutdatedResults(parsed);
+    expect(again.casks[0].token).toBe(outdatedCask.name);
+  });
+
+  it("identifies an outdated cask as a cask", () => {
+    expect(isCask(outdatedCask)).toBe(true);
+    expect(isCask(outdatedFormula)).toBe(false);
+  });
+
+  it("builds cask-shaped upgrade and uninstall commands", () => {
+    expect(brewUpgradeCommand(outdatedCask)).toContain("--cask");
+    expect(brewUpgradeCommand(outdatedCask)).toContain(outdatedCask.name);
+    expect(brewUninstallCommand(outdatedCask)).toContain("--cask");
+  });
+
+  it("leaves formula commands without --cask", () => {
+    expect(brewUpgradeCommand(outdatedFormula)).not.toContain("--cask");
+  });
+
+  it("renders the whole name, not its first character", () => {
+    // An OutdatedCask's `name` is a string where a Cask's is an array; indexing
+    // blindly turns "raycast" into "r".
+    expect(brewName(outdatedCask)).toBe(outdatedCask.name);
+  });
+});
+
+/**
+ * The `@raycast/api` stub must hand back the DECLARED preference defaults. With
+ * an empty object every preference reads `undefined`, so a test can pass by
+ * exercising a falsy branch that no real user is ever in.
+ */
+describe("test preferences mirror the declared defaults", () => {
+  it("gives zapCask its declared default rather than undefined", () => {
+    // zapCask defaults to false, but it must be a real boolean, not absent.
+    expect(typeof preferences.zapCask).toBe("boolean");
+  });
+
+  it("gives pinnedFirst its declared default of true", () => {
+    expect(preferences.pinnedFirst).toBe(true);
+  });
+});
+
+/**
+ * Download attribution reads brew's own `Fetching <name> from <tap>` line
+ * (cmd/fetch.rb). A substring scan over arbitrary progress text mis-fires: real
+ * download lines carry full URLs, so a package named "git" matches an unrelated
+ * package's GitHub URL, and the batch header names every package at once.
+ */
+describe("prefetch attribution", () => {
+  const FETCHING_PACKAGE = /Fetching (\S+) from\s/;
+  const announced = (message: string) => FETCHING_PACKAGE.exec(message)?.[1];
+
+  it("attributes brew's per-package announcement", () => {
+    expect(announced("==> Fetching warp@preview from homebrew/cask")).toBe("warp@preview");
+  });
+
+  it("ignores the batch header naming every package", () => {
+    expect(announced("Fetching: aom, git, zed")).toBeUndefined();
+  });
+
+  it("does not attribute a URL that merely contains a package name", () => {
+    expect(announced("==> Downloading https://github.com/zed-industries/zed/releases/git-2.0.tgz")).toBeUndefined();
+  });
+
+  it("does not attribute the synthetic command echo", () => {
+    expect(announced("Running: brew fetch aom git zed")).toBeUndefined();
   });
 });

--- a/extensions/brew/src/utils/upgrade-selection.test.ts
+++ b/extensions/brew/src/utils/upgrade-selection.test.ts
@@ -456,30 +456,3 @@ describe("test preferences mirror the declared defaults", () => {
     expect(preferences.pinnedFirst).toBe(true);
   });
 });
-
-/**
- * Download attribution reads brew's own `Fetching <name> from <tap>` line
- * (cmd/fetch.rb). A substring scan over arbitrary progress text mis-fires: real
- * download lines carry full URLs, so a package named "git" matches an unrelated
- * package's GitHub URL, and the batch header names every package at once.
- */
-describe("prefetch attribution", () => {
-  const FETCHING_PACKAGE = /Fetching (\S+) from\s/;
-  const announced = (message: string) => FETCHING_PACKAGE.exec(message)?.[1];
-
-  it("attributes brew's per-package announcement", () => {
-    expect(announced("==> Fetching warp@preview from homebrew/cask")).toBe("warp@preview");
-  });
-
-  it("ignores the batch header naming every package", () => {
-    expect(announced("Fetching: aom, git, zed")).toBeUndefined();
-  });
-
-  it("does not attribute a URL that merely contains a package name", () => {
-    expect(announced("==> Downloading https://github.com/zed-industries/zed/releases/git-2.0.tgz")).toBeUndefined();
-  });
-
-  it("does not attribute the synthetic command echo", () => {
-    expect(announced("Running: brew fetch aom git zed")).toBeUndefined();
-  });
-});

--- a/extensions/brew/src/utils/upgrade-selection.test.ts
+++ b/extensions/brew/src/utils/upgrade-selection.test.ts
@@ -9,7 +9,14 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { brewName, brewUninstallCommand, brewUpgradeCommand, isCask, normalizeOutdatedResults } from "./brew/helpers";
+import {
+  brewName,
+  brewUninstallCommand,
+  brewUpgradeCommand,
+  isCask,
+  normalizeOutdatedResults,
+  pinLookupKey,
+} from "./brew/helpers";
 import { preferences } from "./preferences";
 import { isPinnedRefusal, upgradeSkipReason } from "./errors";
 import {
@@ -550,6 +557,28 @@ describe("declined upgrades are read from brew's warnings", () => {
     expect(upgradeSkipReason("Warning: Not upgrading fd, some future reason.", "fd")).toBe("some future reason");
   });
 
+  it("matches a tap-qualified warning against the short name", () => {
+    // Homebrew names the package with `full_specified_name`, which carries the
+    // tap outside homebrew/core — but `brew info --json=v2 --installed` gives
+    // the short name, so the single-package path passes the short form.
+    expect(upgradeSkipReason("Warning: steipete/tap/birdclaw 1.0.2 already installed", "birdclaw")).toBe(
+      "Already up to date",
+    );
+    expect(
+      upgradeSkipReason(
+        "Warning: Not upgrading cameroncooke/axe/axe, no version is available for the current platform",
+        "axe",
+      ),
+    ).toBe("No version for this platform");
+    // Homebrew rejects extra slashes in a tap name but not punctuation
+    // (tap_constants.rb), so the segments cannot be a \w-only class.
+    expect(upgradeSkipReason("Warning: acme/tools!/widget 1.0 already installed", "widget")).toBe("Already up to date");
+    // …and against the qualified name, which `brew outdated --json=v2` returns.
+    expect(upgradeSkipReason("Warning: steipete/tap/birdclaw 1.0.2 already installed", "steipete/tap/birdclaw")).toBe(
+      "Already up to date",
+    );
+  });
+
   it("does not attribute another package's warning to this one", () => {
     expect(upgradeSkipReason("Warning: Not upgrading zoom, it is disabled because x", "zed")).toBeUndefined();
     // A versioned sibling is a DIFFERENT package: `python` must not absorb
@@ -561,6 +590,8 @@ describe("declined upgrades are read from brew's warnings", () => {
       ),
     ).toBeUndefined();
     expect(upgradeSkipReason("Warning: python@3.14 3.14.0 already installed", "python")).toBeUndefined();
+    // A tap prefix must not let one package absorb another's warning either.
+    expect(upgradeSkipReason("Warning: steipete/tap/birdclaw 1.0 already installed", "claw")).toBeUndefined();
   });
 
   it("returns nothing for a clean upgrade", () => {
@@ -574,5 +605,25 @@ describe("declined upgrades are read from brew's warnings", () => {
         "warp@preview",
       ),
     ).toBe("No version for this platform");
+  });
+});
+
+/**
+ * Homebrew pins a formula at HOMEBREW_PINNED_KEGS/<formula.name> — the SHORT
+ * name (formula_pin.rb) — but `brew outdated --json=v2` reports a tapped
+ * formula by its qualified `full_name`. Looking a pin up by the qualified name
+ * misses it entirely, and the package is then handed to a named `brew upgrade`
+ * that Homebrew refuses.
+ */
+describe("pin lookup key", () => {
+  it("reduces a tap-qualified formula to the name its pin is stored under", () => {
+    expect(pinLookupKey("steipete/tap/birdclaw")).toBe("birdclaw");
+    expect(pinLookupKey("cameroncooke/axe/axe")).toBe("axe");
+  });
+
+  it("leaves an unqualified name alone", () => {
+    expect(pinLookupKey("brotli")).toBe("brotli");
+    expect(pinLookupKey("python@3.14")).toBe("python@3.14");
+    expect(pinLookupKey("1password")).toBe("1password");
   });
 });

--- a/extensions/brew/src/utils/upgrade-selection.test.ts
+++ b/extensions/brew/src/utils/upgrade-selection.test.ts
@@ -484,8 +484,8 @@ describe("pinned refusal detection", () => {
   });
 
   it("does not match brew's OTHER 'Not upgrading' refusals", () => {
-    // cask/upgrade.rb:48 — deprecated/disabled, a different problem with a
-    // different remedy. Offering "unpin and force" here would be nonsense.
+    // A different problem with a different remedy — offering "unpin and force"
+    // here would be nonsense.
     expect(isPinnedRefusal(new Error("Not upgrading zoom, it is deprecated because it is discontinued"))).toBe(false);
     expect(isPinnedRefusal(new Error("Not upgrading warp, no version is available for the current platform"))).toBe(
       false,
@@ -500,10 +500,9 @@ describe("pinned refusal detection", () => {
 
 /**
  * Homebrew warns and skips rather than failing for these, exiting 0 — so the run
- * would otherwise report an upgrade that never happened. Every string below is
- * quoted from the installed source, not invented: an earlier version of this
- * suite asserted a "Not upgrading <formula>, it is deprecated" message that brew
- * does not emit (it warns about deprecation and upgrades anyway).
+ * would otherwise report an upgrade that never happened. The message shapes are
+ * taken from the installed source; the unrecognised-reason case below is a
+ * deliberate synthetic fixture.
  */
 describe("declined upgrades are read from brew's warnings", () => {
   it("keeps each cask reason distinct rather than collapsing them", () => {

--- a/extensions/brew/vitest.config.ts
+++ b/extensions/brew/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+
+/**
+ * `@raycast/api` has no resolvable entry outside the Raycast runtime, so any
+ * module that transitively imports it — including pure helpers like
+ * `utils/brew/helpers.ts` — cannot be unit tested without a stand-in.
+ */
+const extensionRoot = fileURLToPath(new URL(".", import.meta.url));
+
+// The @raycast/api stub reads this extension's manifest for its declared
+// preference defaults. Hand it the root explicitly: resolving from the working
+// directory breaks when vitest is invoked from anywhere but this folder.
+process.env.RAYCAST_EXTENSION_ROOT = extensionRoot;
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@raycast/api": fileURLToPath(new URL("./src/utils/__mocks__/raycast-api.ts", import.meta.url)),
+    },
+  },
+});


### PR DESCRIPTION
## Description

Adds **cask pinning**, moves the extension to **Homebrew 6.0+**, and fixes a family of bugs where the code lost track of whether a package was a formula or a cask and built brew commands without `--cask`.

The three tracks are in one PR because they are entangled: cask pinning is what surfaced most of the discriminator bugs, and both depend on the same `pinned` / `token` plumbing.

cc @nhojb — you approved dropping 5.x support, and cask pinning was the follow-up you'd scoped. One correction to that plan: `brew pin --cask` is not a 6.0 feature. `git describe --tags --contains 7a078066` puts it in **5.1.12**, so it was available earlier than the previous CHANGELOG entry claimed.

### Cask pinning

<img width="862" height="587" alt="image" src="https://github.com/user-attachments/assets/3c286338-c314-425d-ad00-06996c9aa174" />

- Casks can be pinned like formulae: their own section in Show Installed and Show Upgrades, excluded from upgrades, same pin icon and actions throughout.
- Pinning a cask that updates itself surfaces brew's own warning rather than implying the version is frozen.

<img width="862" height="587" alt="image" src="https://github.com/user-attachments/assets/599ff9d0-87f3-4cf1-9cba-10f6b1114970" />

- Uninstalling a pinned package (either kind — brew refuses both) explains what happened and offers "Unpin and Force Uninstall" as an explicit choice, instead of a raw brew error.
- A pinned row is never offered an upgrade action or a copy/terminal command that brew would reject.

### Formulae & Cask pinning position

In Raycast, the "pin" usually means to persistently cause a list item to float to the top, but in Homebrew, it means to exclude from upgrade processes (e.g. like to pin a butterfly, so that it doesn't change). This extension prioritizes Homebrew's use of the verb, but now also provide a preference to float pinned items to the top of lists or not.

<img width="540" height="105" alt="image" src="https://github.com/user-attachments/assets/7e6db53c-d590-44fd-ae8b-dc0a3cb185dd" />

### Homebrew 6.0+

- **Breaking:** the extension now requires 6.0 or later.
- The "Use internal API" preference is removed. Homebrew 6 uses that API by default and deprecates `HOMEBREW_USE_INTERNAL_API` — and under `HOMEBREW_DEVELOPER`, setting it makes brew **abort** rather than warn, so it broke the extension outright for those users.
- Retired the stale 5.0 copy in the README, comments and log labels.

### Fixes

- A pinned cask was included in Upgrade All and reported as a **failed** upgrade. We name every package explicitly, and brew errors (exit 1) on a named pinned package rather than just warning.
- `brew outdated --json=v2` reports casks with a `name` and no `token`, but `isCask()` keys off `token` — so outdated casks got formula-shaped argv for upgrade, uninstall and the copy/terminal commands. Normalized at every ingress.
- `brewFetchCaskInfo` ran `brew info --json=v2 <token>` without `--cask`; brew's resolver prefers a same-named formula and returns an empty `casks` array.
- The "D" dependency badge never rendered — Homebrew removed `installed_as_dependency` in 5.1.9; it now derives from `installed_on_request`.
- `linked_key` was a typo for `linked_keg`, so the field was always empty.
- Pinning or unpinning a cask did not refresh the installed list — cask pins live in `var/homebrew/pinned_casks`, which the cache wasn't watching.
- "Sort by Popularity" moved from ⇧⌘P to ⇧⌘S: ⇧⌘P is `Keyboard.Shortcut.Common.Pin`, which now shares the panel.

### Housekeeping

- Renamed the `Upgrade` command to **Upgrade All** to distinguish it from the reviewed Show Upgrades flow.
- Added `categories` to the manifest, which was missing.
- Added vitest coverage for the selection and formula/cask discriminator logic (43 tests). `@raycast/api` has no resolvable entry under vitest, so `vitest.config.ts` aliases it to a stub returning the manifest's declared preference defaults.
- Added `CONTRIBUTING.md`.
- Removed an unused two-phase installed-loading path (`brewFetchInstalledFast`) that had no caller.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I ran `npm run lint` and `npx tsc --noEmit` — both clean, and `npm test` passes (43/43)
- [x] I checked that this change does not break existing commands or removes any functionality
- [x] I updated `CHANGELOG.md` per the changelog conventions
