### PR TITLE
Update ccusage extension

### DIFF
--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Claude Usage (ccusage) Changelog
 
-## [Fix npx failure with missing npm prefix and surface CLI errors] - {PR_MERGE_DATE}
+## [Fix npx failure with missing npm prefix and surface CLI errors] - 2026-09-07
 
 ### Fixed
 

--- a/extensions/ccusage/CHANGELOG.md
+++ b/extensions/ccusage/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Claude Usage (ccusage) Changelog
 
+## [Fix npx failure with missing npm prefix and surface CLI errors] - {PR_MERGE_DATE}
+
+### Fixed
+
+- Only set `npm_config_prefix` to `~/.npm-global` when that directory exists — pointing npm at a missing prefix made npx fail with ENOENT on nvm/Homebrew installs, breaking every command
+- Report the actual failure reason (spawn error, exit code, signal, or timeout, with stderr) when the ccusage CLI fails, instead of a misleading "No output received"
+
 ## [Fable support and per-model limits] - 2026-08-29
 
 ### Added

--- a/extensions/ccusage/src/hooks/useCCUsageBlocksCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageBlocksCli.ts
@@ -4,7 +4,7 @@ import { useExec } from "@raycast/utils";
 import { BlocksCommandResponse, BlocksCommandResponseSchema } from "../types/usage-types";
 import { getExecOptions } from "../utils/exec-options";
 import { stringToJSON } from "../utils/string-to-json-schema";
-import { describeParseFailure } from "../utils/parse-diagnostics";
+import { describeExecFailure, describeParseFailure } from "../utils/parse-diagnostics";
 import { getCcusageVersionSync } from "../utils/ccusage-version";
 import { preferences } from "../preferences";
 
@@ -25,7 +25,12 @@ export const useCCUsageBlocksCli = () => {
   const result = useExec(command, args, {
     ...getExecOptions(),
     initialData,
-    parseOutput: ({ stdout }) => {
+    parseOutput: ({ stdout, stderr, error, exitCode, signal, timedOut }) => {
+      const failure = describeExecFailure("ccusage blocks command", { error, exitCode, signal, timedOut, stderr });
+      if (failure) {
+        throw new Error(failure);
+      }
+
       if (!stdout) {
         return { blocks: [] };
       }

--- a/extensions/ccusage/src/hooks/useCCUsageDailyCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageDailyCli.ts
@@ -4,7 +4,7 @@ import { useExec } from "@raycast/utils";
 import { DailyUsageCommandResponse, DailyUsageCommandResponseSchema } from "../types/usage-types";
 import { getExecOptions } from "../utils/exec-options";
 import { stringToJSON } from "../utils/string-to-json-schema";
-import { describeParseFailure } from "../utils/parse-diagnostics";
+import { describeExecFailure, describeParseFailure } from "../utils/parse-diagnostics";
 import { getCcusageVersionSync } from "../utils/ccusage-version";
 import { preferences } from "../preferences";
 
@@ -24,7 +24,12 @@ export const useCCUsageDailyCli = () => {
   const result = useExec(command, args, {
     ...getExecOptions(),
     initialData,
-    parseOutput: ({ stdout }) => {
+    parseOutput: ({ stdout, stderr, error, exitCode, signal, timedOut }) => {
+      const failure = describeExecFailure("ccusage daily command", { error, exitCode, signal, timedOut, stderr });
+      if (failure) {
+        throw new Error(failure);
+      }
+
       if (!stdout) {
         throw new Error("No output received from ccusage daily command");
       }

--- a/extensions/ccusage/src/hooks/useCCUsageMonthlyCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageMonthlyCli.ts
@@ -4,7 +4,7 @@ import { useExec } from "@raycast/utils";
 import { MonthlyUsageCommandResponse, MonthlyUsageCommandResponseSchema } from "../types/usage-types";
 import { getExecOptions } from "../utils/exec-options";
 import { stringToJSON } from "../utils/string-to-json-schema";
-import { describeParseFailure } from "../utils/parse-diagnostics";
+import { describeExecFailure, describeParseFailure } from "../utils/parse-diagnostics";
 import { getCcusageVersionSync } from "../utils/ccusage-version";
 import { preferences } from "../preferences";
 
@@ -25,7 +25,12 @@ export const useCCUsageMonthlyCli = () => {
   const result = useExec(command, args, {
     ...getExecOptions(),
     initialData,
-    parseOutput: ({ stdout }) => {
+    parseOutput: ({ stdout, stderr, error, exitCode, signal, timedOut }) => {
+      const failure = describeExecFailure("ccusage monthly command", { error, exitCode, signal, timedOut, stderr });
+      if (failure) {
+        throw new Error(failure);
+      }
+
       if (!stdout) {
         throw new Error("No output received from ccusage monthly command");
       }

--- a/extensions/ccusage/src/hooks/useCCUsageSessionCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageSessionCli.ts
@@ -4,7 +4,7 @@ import { useExec } from "@raycast/utils";
 import { SessionUsageCommandResponse, SessionUsageCommandResponseSchema } from "../types/usage-types";
 import { getExecOptions } from "../utils/exec-options";
 import { stringToJSON } from "../utils/string-to-json-schema";
-import { describeParseFailure } from "../utils/parse-diagnostics";
+import { describeExecFailure, describeParseFailure } from "../utils/parse-diagnostics";
 import { getCcusageVersionSync } from "../utils/ccusage-version";
 import { preferences } from "../preferences";
 
@@ -25,7 +25,12 @@ export const useCCUsageSessionCli = () => {
   const result = useExec(command, args, {
     ...getExecOptions(),
     initialData,
-    parseOutput: ({ stdout }) => {
+    parseOutput: ({ stdout, stderr, error, exitCode, signal, timedOut }) => {
+      const failure = describeExecFailure("ccusage session command", { error, exitCode, signal, timedOut, stderr });
+      if (failure) {
+        throw new Error(failure);
+      }
+
       if (!stdout) {
         return { sessions: [] };
       }

--- a/extensions/ccusage/src/hooks/useCCUsageTotalCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageTotalCli.ts
@@ -4,7 +4,7 @@ import { useExec } from "@raycast/utils";
 import { TotalUsageResponse, TotalUsageResponseSchema } from "../types/usage-types";
 import { getExecOptions } from "../utils/exec-options";
 import { stringToJSON } from "../utils/string-to-json-schema";
-import { describeParseFailure } from "../utils/parse-diagnostics";
+import { describeExecFailure, describeParseFailure } from "../utils/parse-diagnostics";
 import { getCcusageVersionSync } from "../utils/ccusage-version";
 import { preferences } from "../preferences";
 
@@ -25,7 +25,12 @@ export const useCCUsageTotalCli = () => {
   const result = useExec(command, args, {
     ...getExecOptions(),
     initialData,
-    parseOutput: ({ stdout }) => {
+    parseOutput: ({ stdout, stderr, error, exitCode, signal, timedOut }) => {
+      const failure = describeExecFailure("ccusage command", { error, exitCode, signal, timedOut, stderr });
+      if (failure) {
+        throw new Error(failure);
+      }
+
       if (!stdout) {
         throw new Error("No output received from ccusage command");
       }

--- a/extensions/ccusage/src/hooks/useCCUsageWeeklyCli.ts
+++ b/extensions/ccusage/src/hooks/useCCUsageWeeklyCli.ts
@@ -4,7 +4,7 @@ import { useExec } from "@raycast/utils";
 import { WeeklyUsageCommandResponse, WeeklyUsageCommandResponseSchema } from "../types/usage-types";
 import { getExecOptions } from "../utils/exec-options";
 import { stringToJSON } from "../utils/string-to-json-schema";
-import { describeParseFailure } from "../utils/parse-diagnostics";
+import { describeExecFailure, describeParseFailure } from "../utils/parse-diagnostics";
 import { getCcusageVersionSync } from "../utils/ccusage-version";
 import { preferences } from "../preferences";
 
@@ -25,7 +25,12 @@ export const useCCUsageWeeklyCli = () => {
   const result = useExec(command, args, {
     ...getExecOptions(),
     initialData,
-    parseOutput: ({ stdout }) => {
+    parseOutput: ({ stdout, stderr, error, exitCode, signal, timedOut }) => {
+      const failure = describeExecFailure("ccusage weekly command", { error, exitCode, signal, timedOut, stderr });
+      if (failure) {
+        throw new Error(failure);
+      }
+
       if (!stdout) {
         throw new Error("No output received from ccusage weekly command");
       }

--- a/extensions/ccusage/src/utils/exec-options.ts
+++ b/extensions/ccusage/src/utils/exec-options.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "fs";
 import { getEnhancedNodePaths, resolveFnmBaseDir } from "./node-path-resolver";
 import { dirname } from "path";
 import { getCustomNpxPath } from "../preferences";
@@ -26,8 +27,11 @@ export const getExecOptions = () => {
         env.FNM_DIR = fnmBaseDir;
       }
     }
-    if (!process.env.npm_config_prefix) {
-      env.npm_config_prefix = `${process.env.HOME}/.npm-global`;
+    // Pointing npm at a prefix directory that does not exist makes npx fail
+    // with ENOENT (exit code 254), so only opt in when the user actually has one.
+    const npmGlobalPrefix = `${process.env.HOME}/.npm-global`;
+    if (!process.env.npm_config_prefix && existsSync(npmGlobalPrefix)) {
+      env.npm_config_prefix = npmGlobalPrefix;
     }
   }
 

--- a/extensions/ccusage/src/utils/parse-diagnostics.ts
+++ b/extensions/ccusage/src/utils/parse-diagnostics.ts
@@ -50,6 +50,38 @@ function valueAtPath(root: unknown, path: ReadonlyArray<string | number>): unkno
   return current;
 }
 
+// `useExec` invokes `parseOutput` even when the process failed: spawn errors
+// (e.g. npx missing from PATH), non-zero exits, kill signals, and timeouts all
+// arrive here with an empty stdout. Checking stdout alone would report every
+// one of them as "no output", hiding the actual failure from the user.
+
+type ExecOutcome = {
+  error?: Error;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  timedOut: boolean;
+  stderr: string;
+};
+
+const STDERR_TAIL_LINES = 5;
+
+export function describeExecFailure(label: string, outcome: ExecOutcome): string | null {
+  const reason = outcome.timedOut
+    ? "timed out"
+    : outcome.error
+      ? `failed to start (${outcome.error.message})`
+      : outcome.signal
+        ? `was terminated by signal ${outcome.signal}`
+        : outcome.exitCode !== null && outcome.exitCode !== 0
+          ? `exited with code ${outcome.exitCode}`
+          : null;
+
+  if (!reason) return null;
+
+  const stderrTail = outcome.stderr.trim().split("\n").slice(-STDERR_TAIL_LINES).join("\n").trim();
+  return stderrTail ? `${label} ${reason}:\n${stderrTail}` : `${label} ${reason}.`;
+}
+
 /**
  * Builds a privacy-preserving, traceable error message for a ccusage schema
  * mismatch: the ccusage version, the overall output shape, and the actual key


### PR DESCRIPTION
## Description
### Fixed

- Only set `npm_config_prefix` to `~/.npm-global` when that directory exists — pointing npm at a missing prefix made npx fail with ENOENT on nvm/Homebrew installs, breaking every command
- Report the actual failure reason (spawn error, exit code, signal, or timeout, with stderr) when the ccusage CLI fails, instead of a misleading "No output received"
<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast
### Before
<img width="1612" height="1049" alt="CleanShot 2026-09-07 at 3 37 03 PM@2x" src="https://github.com/user-attachments/assets/6121ddbc-0321-4cec-b3c9-9bf2e6ae543d" />

### After
<img width="1588" height="1022" alt="CleanShot 2026-09-07 at 3 39 31 PM@2x" src="https://github.com/user-attachments/assets/c8cc875a-738c-4134-b8c1-7f8a959c408a" />

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
