### PR TITLE
[Raycast Ollama] add "Paste in Active App" action for all commands

### DIFF
--- a/extensions/raycast-ollama/CHANGELOG.md
+++ b/extensions/raycast-ollama/CHANGELOG.md
@@ -1,6 +1,6 @@
 # raycast-ollama Changelog
 
-## [Improvement] - {PR_MERGE_DATE}
+## [Improvement] - 2026-09-07
 
 - [Improvement] added "Paste in Active App" action for all commands, which pastes the answer on the active application.
 

--- a/extensions/raycast-ollama/CHANGELOG.md
+++ b/extensions/raycast-ollama/CHANGELOG.md
@@ -1,5 +1,9 @@
 # raycast-ollama Changelog
 
+## [Improvement] - {PR_MERGE_DATE}
+
+- [Improvement] added "Paste in Active App" action for all commands, which pastes the answer on the active application.
+
 ## [Fix] - 2026-09-04
 
 - Fixed model discovery timing out too quickly and showing connection failures as an empty installed-model list.

--- a/extensions/raycast-ollama/package-lock.json
+++ b/extensions/raycast-ollama/package-lock.json
@@ -2458,9 +2458,9 @@
       }
     },
     "node_modules/file-type": {
-      "version": "21.3.1",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.1.tgz",
-      "integrity": "sha512-SrzXX46I/zsRDjTb82eucsGg0ODq2NpGDp4HcsFKApPy8P8vACjpJRDoGGMfEzhFC0ry61ajd7f72J3603anBA==",
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
       "license": "MIT",
       "dependencies": {
         "@tokenizer/inflate": "^0.4.1",

--- a/extensions/raycast-ollama/package-lock.json
+++ b/extensions/raycast-ollama/package-lock.json
@@ -1270,7 +1270,6 @@
       "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -1337,7 +1336,6 @@
       "integrity": "sha512-l4b0DhWioGg6Gt2ebGlvfkFMOjRsauxtsnDRwUSRX1qHq3HdTfQHV8wW9zEXeciai6HfeaKOedQn2Zoofx3WBw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.69.0",
         "@typescript-eslint/types": "8.69.0",
@@ -1555,7 +1553,6 @@
       "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2077,7 +2074,6 @@
       "integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -2328,7 +2324,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2724,7 +2719,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
       "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3283,7 +3277,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
       "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3328,7 +3321,6 @@
       "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3794,7 +3786,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3985,7 +3976,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/extensions/raycast-ollama/package.json
+++ b/extensions/raycast-ollama/package.json
@@ -6,7 +6,8 @@
   "icon": "icon.png",
   "author": "massimiliano_pasquini",
   "contributors": [
-    "0xdhrv"
+    "0xdhrv",
+    "ashokbaruaakas"
   ],
   "platforms": [
     "macOS",

--- a/extensions/raycast-ollama/package.json
+++ b/extensions/raycast-ollama/package.json
@@ -7,7 +7,8 @@
   "author": "massimiliano_pasquini",
   "contributors": [
     "0xdhrv",
-    "ashokbaruaakas"
+    "ashokbaruaakas",
+    "pernielsentikaer"
   ],
   "platforms": [
     "macOS",

--- a/extensions/raycast-ollama/src/lib/ui/AnswerView/main.tsx
+++ b/extensions/raycast-ollama/src/lib/ui/AnswerView/main.tsx
@@ -107,7 +107,6 @@ export function AnswerView(props: props): React.JSX.Element {
     return (
       <ActionPanel title="Actions">
         <Action.CopyToClipboard content={answer} />
-        <Action.Paste content={answer} />
         <Action
           title={showAnswerMetadata ? "Hide Metadata" : "Show Metadata"}
           icon={showAnswerMetadata ? Icon.EyeDisabled : Icon.Eye}
@@ -141,6 +140,7 @@ export function AnswerView(props: props): React.JSX.Element {
             shortcut={Shortcut.New}
           />
         )}
+        <Action.Paste content={answer} />
       </ActionPanel>
     );
   }

--- a/extensions/raycast-ollama/src/lib/ui/AnswerView/main.tsx
+++ b/extensions/raycast-ollama/src/lib/ui/AnswerView/main.tsx
@@ -107,6 +107,7 @@ export function AnswerView(props: props): React.JSX.Element {
     return (
       <ActionPanel title="Actions">
         <Action.CopyToClipboard content={answer} />
+        <Action.Paste content={answer} />
         <Action
           title={showAnswerMetadata ? "Hide Metadata" : "Show Metadata"}
           icon={showAnswerMetadata ? Icon.EyeDisabled : Icon.Eye}

--- a/extensions/raycast-ollama/src/lib/ui/ChatView/main.tsx
+++ b/extensions/raycast-ollama/src/lib/ui/ChatView/main.tsx
@@ -163,6 +163,7 @@ export function ChatView(): React.JSX.Element {
               <Action title="No" icon={Icon.XMarkCircle} />
             </ActionPanel.Submenu>
           )}
+          {answer && <Action.Paste title="Paste Answer" content={answer.content as string} />}
         </ActionPanel.Section>
         {Chat && !IsLoading && (
           <ActionPanel.Section title="Attach">

--- a/extensions/raycast-ollama/src/lib/ui/ChatView/main.tsx
+++ b/extensions/raycast-ollama/src/lib/ui/ChatView/main.tsx
@@ -96,6 +96,10 @@ export function ChatView(): React.JSX.Element {
   function ActionMessage(props: { message?: RaycastChatMessage }): React.JSX.Element {
     const question = props.message?.messages.find((v) => v.role === OllamaApiChatMessageRole.USER);
     const answer = props.message?.messages.find((v) => v.role === OllamaApiChatMessageRole.ASSISTANT);
+    const answerText = props.message?.messages
+      .filter((message) => message.role === OllamaApiChatMessageRole.ASSISTANT)
+      .map((message) => message.content)
+      .join("");
     return (
       <ActionPanel>
         {!IsLoading && Query && Chat && ChatModelsAvailable && (
@@ -163,7 +167,7 @@ export function ChatView(): React.JSX.Element {
               <Action title="No" icon={Icon.XMarkCircle} />
             </ActionPanel.Submenu>
           )}
-          {answer && <Action.Paste title="Paste Answer" content={answer.content as string} />}
+          {answerText && <Action.Paste title="Paste Answer" content={answerText} />}
         </ActionPanel.Section>
         {Chat && !IsLoading && (
           <ActionPanel.Section title="Attach">


### PR DESCRIPTION
## Description

It will add "Paste in Active App" action for all commands

## Screencast

<img width="798" height="526" alt="image" src="https://github.com/user-attachments/assets/61cdd228-a57a-4f1c-bef7-1e97d30f82c9" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
