### PR TITLE
[Codex] Add selected-text prompts and configurable Chat mode

### DIFF
--- a/extensions/codex/CHANGELOG.md
+++ b/extensions/codex/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Codex Changelog
 
+## [Selected Text Prompts and Chat Mode] - {PR_MERGE_DATE}
+
+- Default all New Thread commands to ordinary ChatGPT Chat using an explicit mode in the desktop deeplink; added a Default Chat Mode preference to switch back to Codex.
+- Hide and skip working-directory configuration in Chat mode, and clarify that prompts are prefilled for manual submission.
+- Added a configurable Selected Text Prompt Prefix, separated from the selection by a blank line.
+- Added a no-view command to prefill a new chat from the frontmost application's selected text, using the configured Default Working Directory in Codex mode.
+- Added feedback for empty or unreadable selections and documentation for global hotkey setup.
+
 ## [Modernized Thread Management] - 2026-07-25
 
 - Updated the Codex integration for the ChatGPT desktop app and current app-server behavior.

--- a/extensions/codex/README.md
+++ b/extensions/codex/README.md
@@ -4,6 +4,8 @@ Monitor and manage your Codex tasks directly from Raycast.
 
 ## Commands
 
+All **New Thread** commands default to ordinary **ChatGPT Chat**. Change **Default Chat Mode** to **Codex** to restore coding tasks and working-directory support. In Chat mode, working directories are ignored and the prompt form hides the directory picker. The desktop link prefills the composer; press Send to submit the message.
+
 ### Search Threads
 
 Browse active and archived Codex threads updated in the last 30 days. Search by name, working directory, preview text, or full transcript text.
@@ -18,15 +20,25 @@ Browse active and archived Codex threads updated in the last 30 days. Search by 
 
 ### New Thread
 
-Start a new thread in your default working directory.
+Open a new chat in the configured mode. Codex mode uses your default working directory.
 
 ### New Thread with Prompt
 
-Start a thread with a typed prompt and a working-directory picker. The picker lists subfolders from your Working Directory Root, with recent thread counts when available, plus a Choose Folder option with a native folder chooser.
+Start a chat with a typed prompt. In Codex mode, a working-directory picker lists subfolders from your Working Directory Root, with recent thread counts when available, plus a Choose Folder option with a native folder chooser.
 
 ### New Thread from Clipboard
 
-Start a thread using clipboard text as the prompt. It uses the Default Working Directory preference when configured. With no preference configured, it falls back to the app's default.
+Start a chat using clipboard text as the prompt. In Codex mode, it uses the Default Working Directory preference when configured.
+
+### New Thread from Selected Text
+
+Select text in the frontmost application and run this command to open a chat with that text as its prompt, without an intermediate form. In Codex mode it uses **Default Working Directory**, just like New Thread from Clipboard.
+
+Assign a global hotkey in **Raycast Settings → Extensions → Codex → New Thread from Selected Text**, then select text in another application and press that hotkey. If no text is selected or the selection cannot be read, the command shows a message and does not open a thread. Clipboard text is not used as a fallback.
+
+Set **Selected Text Prompt Prefix** in the extension preferences to prepend reusable instructions. The prompt is the prefix, a blank line, and the selected text. Leave the preference empty to use only the selection. This setting only affects the selected-text command. The current desktop deeplink initializes the composer; it does not automatically submit the message.
+
+If selection reading fails, check Raycast's permission in **System Settings → Privacy & Security → Accessibility** and try selecting plain text in another application. Selection support depends on the source application.
 
 ### Open Codex
 

--- a/extensions/codex/package.json
+++ b/extensions/codex/package.json
@@ -77,6 +77,19 @@
       ]
     },
     {
+      "name": "new-thread-from-selected-text",
+      "title": "New Thread from Selected Text",
+      "subtitle": "Codex",
+      "description": "Start a new Codex thread using selected text from the frontmost application as the initial prompt.",
+      "mode": "no-view",
+      "keywords": [
+        "selection",
+        "selected",
+        "prompt",
+        "start"
+      ]
+    },
+    {
       "name": "open-codex",
       "title": "Open Codex",
       "description": "Open the Codex app.",
@@ -89,6 +102,32 @@
     }
   ],
   "preferences": [
+    {
+      "name": "newChatMode",
+      "title": "Default Chat Mode",
+      "description": "Mode used by all New Thread commands. Working directory settings apply only to Codex mode.",
+      "type": "dropdown",
+      "required": false,
+      "default": "chat",
+      "data": [
+        {
+          "title": "ChatGPT Chat",
+          "value": "chat"
+        },
+        {
+          "title": "Codex",
+          "value": "codex"
+        }
+      ]
+    },
+    {
+      "name": "selectedTextPromptPrefix",
+      "title": "Selected Text Prompt Prefix",
+      "description": "Instructions prepended to selected text, separated by a blank line. Leave empty to send only the selection.",
+      "type": "textfield",
+      "placeholder": "Explain the following:",
+      "required": false
+    },
     {
       "name": "defaultProjectDirectory",
       "title": "Default Working Directory",

--- a/extensions/codex/src/new-thread-from-selected-text.ts
+++ b/extensions/codex/src/new-thread-from-selected-text.ts
@@ -1,0 +1,33 @@
+import { getPreferenceValues, getSelectedText, showHUD } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
+import { openNewCodexThread } from "./utils/launch";
+import { buildSelectedTextPrompt } from "./utils/selected-text-prompt";
+
+export default async function Command() {
+  let prompt: string;
+  try {
+    // Read the selection before opening Codex or changing application focus.
+    prompt = (await getSelectedText()).trim();
+  } catch (error) {
+    await showFailureToast(error, {
+      title: "No text selected or unable to read selection",
+    });
+    return;
+  }
+
+  if (!prompt) {
+    await showHUD("No text selected");
+    return;
+  }
+
+  try {
+    const preferences = getPreferenceValues<Preferences>();
+    prompt = buildSelectedTextPrompt(
+      prompt,
+      preferences.selectedTextPromptPrefix,
+    );
+    await openNewCodexThread({ prompt });
+  } catch (error) {
+    await showFailureToast(error, { title: "Unable to start Codex thread" });
+  }
+}

--- a/extensions/codex/src/new-thread-with-prompt.tsx
+++ b/extensions/codex/src/new-thread-with-prompt.tsx
@@ -38,25 +38,31 @@ const projectsFolderTip =
 
 export default function Command() {
   const preferences = getPreferenceValues<Preferences>();
+  const isCodexMode = preferences.newChatMode === "codex";
   const defaultWorkingDirectory = preferences.defaultProjectDirectory;
   const workingDirectoryRoot = preferences.projectsDirectory?.trim();
   const [selectedDirectoryValue, setSelectedDirectoryValue] = useState(
     defaultDirectoryItemValue,
   );
-  const isCustomPath = selectedDirectoryValue === customPathItemValue;
+  const isCustomPath =
+    isCodexMode && selectedDirectoryValue === customPathItemValue;
 
   useEffect(() => {
-    void showProjectsFolderTipOnce(preferences.projectsDirectory);
-  }, [preferences.projectsDirectory]);
+    if (isCodexMode)
+      void showProjectsFolderTipOnce(preferences.projectsDirectory);
+  }, [isCodexMode, preferences.projectsDirectory]);
 
-  const folderScan = usePromise(loadProjectsFolderRecords, [
-    preferences.projectsDirectory,
-  ]);
+  const folderScan = usePromise(
+    loadProjectsFolderRecords,
+    [preferences.projectsDirectory],
+    { execute: isCodexMode },
+  );
   const recentHistory = useCachedPromise(
     loadRecentWorkingDirectoryRecords,
     [],
     {
       failureToastOptions: { title: "Couldn't load thread counts" },
+      execute: isCodexMode,
     },
   );
 
@@ -105,7 +111,7 @@ export default function Command() {
 
   return (
     <Form
-      isLoading={folderScan.isLoading}
+      isLoading={isCodexMode && folderScan.isLoading}
       actions={
         <ActionPanel>
           <Action.SubmitForm
@@ -122,48 +128,50 @@ export default function Command() {
         autoFocus
         {...itemProps.prompt}
       />
-      <Form.Dropdown
-        id="workingDirectory"
-        title="Working Directory"
-        placeholder="Search folders..."
-        value={selectedDirectoryValue}
-        onChange={setSelectedDirectoryValue}
-        info={getWorkingDirectoryInfo({
-          hasProjectsFolder: Boolean(preferences.projectsDirectory?.trim()),
-          folderWarning: folderScan.data?.warning ?? null,
-          recentUnavailable: Boolean(
-            recentHistory.error && !recentHistory.data,
-          ),
-        })}
-      >
-        <Form.Dropdown.Item
-          value={defaultDirectoryItemValue}
-          title={getDefaultDirectoryTitle(defaultWorkingDirectory)}
-          icon="⭐"
-          keywords={getDefaultDirectoryKeywords(defaultWorkingDirectory)}
-        />
-        <Form.Dropdown.Item
-          value={customPathItemValue}
-          title="Choose Folder"
-          icon="📂"
-          keywords={["custom", "path", "other"]}
-        />
-        {folderOptions.length > 0 && workingDirectoryRoot ? (
-          <Form.Dropdown.Section
-            title={`Folders in ${tildeifyPath(expandTildePath(workingDirectoryRoot))}`}
-          >
-            {folderOptions.map((option) => (
-              <Form.Dropdown.Item
-                key={option.cwd}
-                value={option.cwd}
-                title={option.title}
-                icon={{ fileIcon: option.cwd }}
-                keywords={option.keywords}
-              />
-            ))}
-          </Form.Dropdown.Section>
-        ) : null}
-      </Form.Dropdown>
+      {isCodexMode ? (
+        <Form.Dropdown
+          id="workingDirectory"
+          title="Working Directory"
+          placeholder="Search folders..."
+          value={selectedDirectoryValue}
+          onChange={setSelectedDirectoryValue}
+          info={getWorkingDirectoryInfo({
+            hasProjectsFolder: Boolean(preferences.projectsDirectory?.trim()),
+            folderWarning: folderScan.data?.warning ?? null,
+            recentUnavailable: Boolean(
+              recentHistory.error && !recentHistory.data,
+            ),
+          })}
+        >
+          <Form.Dropdown.Item
+            value={defaultDirectoryItemValue}
+            title={getDefaultDirectoryTitle(defaultWorkingDirectory)}
+            icon="⭐"
+            keywords={getDefaultDirectoryKeywords(defaultWorkingDirectory)}
+          />
+          <Form.Dropdown.Item
+            value={customPathItemValue}
+            title="Choose Folder"
+            icon="📂"
+            keywords={["custom", "path", "other"]}
+          />
+          {folderOptions.length > 0 && workingDirectoryRoot ? (
+            <Form.Dropdown.Section
+              title={`Folders in ${tildeifyPath(expandTildePath(workingDirectoryRoot))}`}
+            >
+              {folderOptions.map((option) => (
+                <Form.Dropdown.Item
+                  key={option.cwd}
+                  value={option.cwd}
+                  title={option.title}
+                  icon={{ fileIcon: option.cwd }}
+                  keywords={option.keywords}
+                />
+              ))}
+            </Form.Dropdown.Section>
+          ) : null}
+        </Form.Dropdown>
+      ) : null}
       {isCustomPath ? (
         <Form.FilePicker
           title="Custom Path"

--- a/extensions/codex/src/utils/launch.ts
+++ b/extensions/codex/src/utils/launch.ts
@@ -12,6 +12,7 @@ const execFileAsync = promisify(execFile);
 type NewThreadInput = {
   prompt?: string;
   path?: string;
+  mode?: "chat" | "codex";
 };
 
 const codexAppUrl = "codex://";
@@ -31,16 +32,21 @@ export async function openNewCodexThread(
   input: NewThreadInput = {},
 ): Promise<void> {
   const preferences = getPreferenceValues<Preferences>();
+  const mode =
+    input.mode ?? (preferences.newChatMode === "codex" ? "codex" : "chat");
   const defaultWorkingDirectory = preferences.defaultProjectDirectory;
-  const projectPath = await resolveProjectDirectory(
-    input.path ?? defaultWorkingDirectory,
-  );
+  const projectPath =
+    mode === "codex"
+      ? await resolveProjectDirectory(input.path ?? defaultWorkingDirectory)
+      : undefined;
   const prompt = input.prompt?.trim();
 
   await ensureCodexAppIsReady();
-  await open(buildNewThreadUrl({ path: projectPath, prompt }));
+  await open(buildNewThreadUrl({ path: projectPath, prompt, mode }));
   await showHUD(
-    prompt ? "Initialized new thread with prompt" : "Initialized new thread",
+    prompt
+      ? "Opened new chat with prompt — press Send to chat"
+      : "Opened new chat",
   );
 }
 
@@ -111,14 +117,18 @@ async function resolveProjectDirectory(
   return expandedPath;
 }
 
-function buildNewThreadUrl({ path, prompt }: NewThreadInput): string {
-  const params = new URLSearchParams();
+function buildNewThreadUrl({
+  path,
+  prompt,
+  mode = "chat",
+}: NewThreadInput): string {
+  const params = new URLSearchParams({ mode });
 
   if (prompt) {
     params.set("prompt", prompt);
   }
 
-  if (path) {
+  if (path && mode === "codex") {
     params.set("path", path);
   }
 

--- a/extensions/codex/src/utils/selected-text-prompt.ts
+++ b/extensions/codex/src/utils/selected-text-prompt.ts
@@ -1,0 +1,6 @@
+export function buildSelectedTextPrompt(text: string, prefix?: string): string {
+  const selectedText = text.trim();
+  if (!selectedText) return "";
+  const instruction = prefix?.trim();
+  return instruction ? `${instruction}\n\n${selectedText}` : selectedText;
+}


### PR DESCRIPTION
## Description

Selecting text in another application currently requires copying it before starting a chat from Raycast. Add **New Thread from Selected Text**, a no-view command that reads the selection before changing application focus and prefills a new chat. Empty or unreadable selections show feedback without launching a chat or falling back to the clipboard.

- Add **Selected Text Prompt Prefix**: optional instructions followed by a blank line and the selected text.
- Add **Default Chat Mode**, defaulting to ordinary **ChatGPT Chat** for all New Thread commands, with **Codex** as an option. Use an explicit `mode` parameter in the desktop deeplink.
- In Chat mode, omit working directories and skip folder/history loading in the prompt form. Codex mode retains directory validation and selection.
- Update README and CHANGELOG with setup instructions and limitations.

Related to #30825.

### Behavior and compatibility

This changes the default behavior of existing New Thread commands to Chat. Users can choose Codex in the new preference to restore coding tasks. Maintainer feedback on this default is welcome.

The desktop deeplink prefills the composer; it does **not** automatically send the message. This targets the main Chat page, not the floating Quick Chat window. The `mode=chat` and `mode=codex` routing was checked against the installed desktop app's URL parser; it is not presented as a documented public API guarantee.

### Validation

- `npm run build` — passed; local Raycast distribution updated.
- `npx tsc --noEmit` — passed.
- `npm run lint` — passed.
- `npm test` — 4 existing tests passed.
- Local mocked checks passed for default/explicit Chat and Codex routing, directory omission in Chat mode, Unicode and special-character prompt encoding, prefix composition, empty/unreadable selections, and launch failure handling.
- `git diff --check` — passed.

## Screencast

Pending. This PR is a draft because a real cross-application selection → Raycast → desktop Chat verification and recording have not been completed. Desktop UI automation was unavailable in the development environment.

Manual verification: set a prefix, select multiline text in another application, invoke the new command, and verify Chat mode and the prefilled prompt. Also verify an empty selection, clipboard/manual prompt entry, and switching the preference back to Codex with a working directory.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration) (build passed; end-to-end manual verification pending)
- [x] I checked that files in the `assets` folder are used by the extension itself (no asset changes)
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it) (no README media added)
