### PR TITLE
Update app-updates extension

### DIFF
--- a/extensions/app-updates/CHANGELOG.md
+++ b/extensions/app-updates/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Bounded Sparkle Scanning] - {PR_MERGE_DATE}
 
 - Limit how many `defaults` processes the Sparkle scan spawns at once: reading the `Info.plist` of every app in `/Applications` used to fan out one process per installed app, which could stall the extension host on machines with a large number of apps
-- Peak concurrency is now capped at a batch of 8 regardless of how many apps are installed (measured on a 32-app machine: 31 concurrent processes before, 8 after, with an identical scan result)
+- Apps are now scanned in batches of eight, allowing up to 24 concurrent `defaults` processes per scan regardless of how many apps are installed (measured on a 32-app machine: 31 concurrent processes before, 8 after, with an identical scan result)
 
 ## [Raycast 2 Compatibility] - 2026-08-27
 

--- a/extensions/app-updates/CHANGELOG.md
+++ b/extensions/app-updates/CHANGELOG.md
@@ -1,5 +1,10 @@
 # App Updates Changelog
 
+## [Bounded Sparkle Scanning] - {PR_MERGE_DATE}
+
+- Limit how many `defaults` processes the Sparkle scan spawns at once: reading the `Info.plist` of every app in `/Applications` used to fan out one process per installed app, which could stall the extension host on machines with a large number of apps
+- Peak concurrency is now capped at a batch of 8 regardless of how many apps are installed (measured on a 32-app machine: 31 concurrent processes before, 8 after, with an identical scan result)
+
 ## [Raycast 2 Compatibility] - 2026-08-27
 
 - Updated to `@raycast/api` 2.x and `@raycast/utils` 2.x

--- a/extensions/app-updates/CHANGELOG.md
+++ b/extensions/app-updates/CHANGELOG.md
@@ -1,6 +1,6 @@
 # App Updates Changelog
 
-## [Bounded Sparkle Scanning] - {PR_MERGE_DATE}
+## [Bounded Sparkle Scanning] - 2026-09-08
 
 - Limit how many `defaults` processes the Sparkle scan spawns at once: reading the `Info.plist` of every app in `/Applications` used to fan out one process per installed app, which could stall the extension host on machines with a large number of apps
 - Apps are now scanned in batches of eight, allowing up to 24 concurrent `defaults` processes per scan regardless of how many apps are installed (measured on a 32-app machine: 31 concurrent processes before, 8 after, with an identical scan result)

--- a/extensions/app-updates/src/utils/sparkle-scanner.ts
+++ b/extensions/app-updates/src/utils/sparkle-scanner.ts
@@ -33,38 +33,61 @@ function listApps(dir: string): { name: string; path: string }[] {
   }
 }
 
+// Runs `fn` over `items` a batch at a time instead of all at once. Every plist
+// read spawns a `defaults` process, so an unbounded fan-out over /Applications
+// forks one process per installed app — unnoticeable with 30 apps, enough to
+// stall the extension host with a few hundred.
+async function mapInBatches<T, R>(
+  items: T[],
+  batchSize: number,
+  fn: (item: T) => Promise<R>,
+  onBatch?: (current: number, total: number) => void,
+): Promise<R[]> {
+  const results: R[] = [];
+
+  for (let i = 0; i < items.length; i += batchSize) {
+    const batch = items.slice(i, i + batchSize);
+    onBatch?.(Math.min(i + batchSize, items.length), items.length);
+    results.push(...(await Promise.all(batch.map(fn))));
+  }
+
+  return results;
+}
+
+// An app with a feed costs 4 `defaults` calls (the feed URL, then 3 in
+// parallel), so a batch of 8 peaks at ~32 concurrent processes.
+const PLIST_BATCH_SIZE = 8;
+
+async function readAppInfo(app: { name: string; path: string }): Promise<AppInfo | null> {
+  const plistPath = `${app.path}/Contents/Info`;
+  const plistFile = `${app.path}/Contents/Info.plist`;
+
+  if (!existsSync(plistFile)) return null;
+
+  const feedUrl = await readPlistKey(plistPath, "SUFeedURL");
+  if (!feedUrl || feedUrl === "NULL") return null;
+
+  const [name, version, bundleId] = await Promise.all([
+    readPlistKey(plistPath, "CFBundleName"),
+    readPlistKey(plistPath, "CFBundleShortVersionString"),
+    readPlistKey(plistPath, "CFBundleIdentifier"),
+  ]);
+
+  return {
+    name: name || app.name.replace(".app", ""),
+    version: version || "unknown",
+    feedUrl,
+    appPath: app.path,
+    bundleId: bundleId || "",
+  };
+}
+
 async function getSparkleApps(): Promise<AppInfo[]> {
   const appsDirs = ["/Applications", `${homedir()}/Applications`];
-  const apps: AppInfo[] = [];
-
   const allApps = appsDirs.flatMap((dir) => listApps(dir));
 
-  const checks = allApps.map(async (app) => {
-    const plistPath = `${app.path}/Contents/Info`;
-    const plistFile = `${app.path}/Contents/Info.plist`;
-
-    if (!existsSync(plistFile)) return;
-
-    const feedUrl = await readPlistKey(plistPath, "SUFeedURL");
-    if (!feedUrl || feedUrl === "NULL") return;
-
-    const [name, version, bundleId] = await Promise.all([
-      readPlistKey(plistPath, "CFBundleName"),
-      readPlistKey(plistPath, "CFBundleShortVersionString"),
-      readPlistKey(plistPath, "CFBundleIdentifier"),
-    ]);
-
-    apps.push({
-      name: name || app.name.replace(".app", ""),
-      version: version || "unknown",
-      feedUrl,
-      appPath: app.path,
-      bundleId: bundleId || "",
-    });
-  });
-
-  await Promise.all(checks);
-  return apps;
+  const infos = await mapInBatches(allApps, PLIST_BATCH_SIZE, readAppInfo);
+  return infos.filter((info): info is AppInfo => info !== null);
 }
 
 function extractLatestVersion(xml: string): { version: string; url: string } | null {
@@ -159,17 +182,7 @@ async function checkApp(app: AppInfo): Promise<AppUpdate | null> {
 
 export async function scanSparkleUpdates(onProgress?: (current: number, total: number) => void): Promise<AppUpdate[]> {
   const apps = await getSparkleApps();
-  const updates: AppUpdate[] = [];
 
-  for (let i = 0; i < apps.length; i += BATCH_SIZE) {
-    const batch = apps.slice(i, i + BATCH_SIZE);
-    onProgress?.(Math.min(i + BATCH_SIZE, apps.length), apps.length);
-
-    const results = await Promise.all(batch.map(checkApp));
-    for (const result of results) {
-      if (result) updates.push(result);
-    }
-  }
-
-  return updates;
+  const results = await mapInBatches(apps, BATCH_SIZE, checkApp, onProgress);
+  return results.filter((update): update is AppUpdate => update !== null);
 }

--- a/extensions/app-updates/src/utils/sparkle-scanner.ts
+++ b/extensions/app-updates/src/utils/sparkle-scanner.ts
@@ -54,8 +54,9 @@ async function mapInBatches<T, R>(
   return results;
 }
 
-// An app with a feed costs 4 `defaults` calls (the feed URL, then 3 in
-// parallel), so a batch of 8 peaks at ~32 concurrent processes.
+// An app with a feed costs 4 `defaults` calls, but never all at once: the feed
+// lookup is awaited before the other three run in parallel. A batch of 8 is
+// therefore bounded by 8 * 3 = 24 concurrent processes.
 const PLIST_BATCH_SIZE = 8;
 
 async function readAppInfo(app: { name: string; path: string }): Promise<AppInfo | null> {


### PR DESCRIPTION
## Description

The Sparkle scanner read the `Info.plist` of every app in `/Applications` and `~/Applications` through an unbounded `Promise.all`, spawning one `defaults` process per installed app at once — plus three more for each app that declares a `SUFeedURL`. With a handful of apps that is invisible; with a few hundred it forks hundreds of processes simultaneously.

This batches the plist reads the same way the appcast fetches were already batched, and reuses a single `mapInBatches` helper for both paths instead of duplicating the loop inline.

Measured on a 32-app machine, with an identical scan result in both runs (7 Sparkle apps found, 52 `defaults` invocations):

| | before | after |
|---|---|---|
| peak concurrent `defaults` processes | 31 | 8 |
| wall clock | 1.17s | 0.81s |

The bound no longer scales with the number of installed apps: a batch of 8 apps allows at most 24 concurrent `defaults` processes (the feed lookup is awaited first, then 3 reads run in parallel per app). The 8 in the table is the peak *measured* here, where only 7 of 32 apps declare a feed — not the guaranteed bound.

For context: the extension's error reporting shows a single `Request frontend:main.extensionHost.render timed out after 5000ms`. I could not reproduce it — a full scan here takes about a second — so this is a mitigation for the one place in the scan that scales badly with the number of installed apps, not a confirmed fix for that report.

## Screencast

No visible changes. This only affects how the Sparkle scan schedules its work; commands, UI and results are unchanged.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder

Note on the third box: I validated the change with `ray build -e dist` (which type-checks — the plain dev build does not) and `ray lint`, both clean, but I have left it unticked because I did not open the distribution build in Raycast itself.

