### PR TITLE
HackMD: Add workspace and profile browser actions

### DIFF
--- a/extensions/hackmd/CHANGELOG.md
+++ b/extensions/hackmd/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HackMD Changelog
 
+## [Workspace Browser Actions] - {PR_MERGE_DATE}
+
+- Add Open Workspace in Browser and Open Profile in Browser actions to Browse Notes for personal and team workspaces, including empty note lists.
+- Add Open Profile in Browser to history notes for the selected note’s team or author.
+
 ## [Add Action Panel and Keyboard Shortcuts] - 2026-05-06
 
 - Add copy shortcut for note links

--- a/extensions/hackmd/CHANGELOG.md
+++ b/extensions/hackmd/CHANGELOG.md
@@ -1,6 +1,6 @@
 # HackMD Changelog
 
-## [Workspace Browser Actions] - {PR_MERGE_DATE}
+## [Workspace Browser Actions] - 2026-09-08
 
 - Add Open Workspace in Browser and Open Profile in Browser actions to Browse Notes for personal and team workspaces, including empty note lists.
 - Add Open Profile in Browser to history notes for the selected note’s team or author.

--- a/extensions/hackmd/src/browse-notes.tsx
+++ b/extensions/hackmd/src/browse-notes.tsx
@@ -1,10 +1,12 @@
-import { Icon, Image, List } from "@raycast/api";
+import { Action, ActionPanel, Icon, Image, List } from "@raycast/api";
 import { useCachedPromise, useCachedState } from "@raycast/utils";
 import { useMemo } from "react";
 import NotesList from "./components/NotesList";
 import api from "./lib/api";
+import { getPreferences } from "./lib/preference";
 
 export default function BrowseNotes() {
+  const { instance_url } = getPreferences();
   const { data: user } = useCachedPromise(() => api.getMe());
 
   const teams = useMemo(() => user?.teams ?? [], [user]);
@@ -53,12 +55,28 @@ export default function BrowseNotes() {
     return team ? team.name : "Team Workspace";
   }, [teamPath, teams]);
 
+  const workspaceUrl = new URL(teamPath ? `team/${encodeURIComponent(teamPath)}` : "", instance_url);
+  workspaceUrl.searchParams.set("nav", "overview");
+  const profilePath = teamPath || user?.userPath;
+  const workspaceActions = (
+    <ActionPanel.Section title={workspaceName}>
+      <Action.OpenInBrowser title="Open Workspace in Browser" url={workspaceUrl.toString()} />
+      {profilePath && (
+        <Action.OpenInBrowser
+          title="Open Profile in Browser"
+          url={new URL(`@${encodeURIComponent(profilePath)}`, instance_url).toString()}
+        />
+      )}
+    </ActionPanel.Section>
+  );
+
   return (
     <NotesList
       notes={notes}
       mutate={mutateFn}
       isLoading={isNotesLoading}
       unpinnedSectionTitle={workspaceName}
+      additionalActions={workspaceActions}
       searchBarAccessory={
         <List.Dropdown tooltip="Select a Workspace" onChange={(path) => setTeamPath(path)} storeValue>
           <List.Dropdown.Item

--- a/extensions/hackmd/src/components/NoteListItem.tsx
+++ b/extensions/hackmd/src/components/NoteListItem.tsx
@@ -1,12 +1,25 @@
 import type { Note } from "@hackmd/api/dist/type";
 import { Action, ActionPanel, Color, Icon, List } from "@raycast/api";
+import { getPreferences } from "../lib/preference";
 import NoteDetail from "./NoteDetail";
 import NoteActions from "./NoteActions";
 import { usePinnedNotes } from "../hooks/usePinnedNotes";
 
-export default function NoteListItem({ note, mutate }: { note: Note; mutate?: () => void }) {
+export default function NoteListItem({
+  note,
+  mutate,
+  additionalActions,
+  showProfileAction,
+}: {
+  note: Note;
+  mutate?: () => void;
+  additionalActions?: ActionPanel.Props["children"];
+  showProfileAction?: boolean;
+}) {
   const { isPinned } = usePinnedNotes();
   const pinned = isPinned(note);
+  const { instance_url } = getPreferences();
+  const profilePath = note.teamPath || note.userPath;
 
   return (
     <List.Item
@@ -32,6 +45,15 @@ export default function NoteListItem({ note, mutate }: { note: Note; mutate?: ()
           />
 
           {note && <NoteActions note={note} mutate={mutate} onDeleteCallback={mutate} />}
+          {showProfileAction && profilePath && (
+            <ActionPanel.Section>
+              <Action.OpenInBrowser
+                title="Open Profile in Browser"
+                url={new URL(`@${encodeURIComponent(profilePath)}`, instance_url).toString()}
+              />
+            </ActionPanel.Section>
+          )}
+          {additionalActions}
         </ActionPanel>
       }
     />

--- a/extensions/hackmd/src/components/NotesList.tsx
+++ b/extensions/hackmd/src/components/NotesList.tsx
@@ -1,6 +1,6 @@
 import type { Note } from "@hackmd/api/dist/type";
 import { type ReactElement, useMemo } from "react";
-import { List } from "@raycast/api";
+import { ActionPanel, List } from "@raycast/api";
 import NoteListItem from "./NoteListItem";
 import { usePinnedNotes } from "../hooks/usePinnedNotes";
 
@@ -28,6 +28,8 @@ export default function NotesList({
   searchBarAccessory,
   sortByCategory,
   unpinnedSectionTitle,
+  additionalActions,
+  showProfileAction,
 }: {
   notes?: Note[];
   mutate?: () => void;
@@ -35,6 +37,8 @@ export default function NotesList({
   searchBarAccessory?: ReactElement<List.Dropdown.Props, string>;
   sortByCategory?: boolean;
   unpinnedSectionTitle?: string;
+  additionalActions?: ActionPanel.Props["children"];
+  showProfileAction?: boolean;
 }) {
   const { isPinned, pinnedNotesMap } = usePinnedNotes();
 
@@ -106,10 +110,17 @@ export default function NotesList({
 
   return (
     <List isLoading={isLoading} searchBarAccessory={searchBarAccessory}>
+      {additionalActions && <List.EmptyView actions={<ActionPanel>{additionalActions}</ActionPanel>} />}
       {pinnedNotes.length > 0 && (
         <List.Section title="Pinned" subtitle={`${pinnedNotes.length}`}>
           {pinnedNotes.map((note) => (
-            <NoteListItem note={note} key={note.id} mutate={mutate} />
+            <NoteListItem
+              note={note}
+              key={note.id}
+              mutate={mutate}
+              additionalActions={additionalActions}
+              showProfileAction={showProfileAction}
+            />
           ))}
         </List.Section>
       )}
@@ -118,21 +129,39 @@ export default function NotesList({
         groupedNotesByCategory.map(([category, notes]) => (
           <List.Section key={category} title={category}>
             {notes.map((note) => (
-              <NoteListItem note={note} key={note.id} mutate={mutate} />
+              <NoteListItem
+                note={note}
+                key={note.id}
+                mutate={mutate}
+                additionalActions={additionalActions}
+                showProfileAction={showProfileAction}
+              />
             ))}
           </List.Section>
         ))
       ) : unpinnedSectionTitle ? (
         <List.Section title={unpinnedSectionTitle}>
           {unpinnedNotes.map((note) => (
-            <NoteListItem note={note} key={note.id} mutate={mutate} />
+            <NoteListItem
+              note={note}
+              key={note.id}
+              mutate={mutate}
+              additionalActions={additionalActions}
+              showProfileAction={showProfileAction}
+            />
           ))}
         </List.Section>
       ) : (
         groupedNotesByWorkspace.map(([workspace, notes]) => (
           <List.Section key={workspace} title={workspace === "Personal Workspace" ? workspace : `Team: ${workspace}`}>
             {notes.map((note) => (
-              <NoteListItem note={note} key={note.id} mutate={mutate} />
+              <NoteListItem
+                note={note}
+                key={note.id}
+                mutate={mutate}
+                additionalActions={additionalActions}
+                showProfileAction={showProfileAction}
+              />
             ))}
           </List.Section>
         ))

--- a/extensions/hackmd/src/view-history.tsx
+++ b/extensions/hackmd/src/view-history.tsx
@@ -5,5 +5,7 @@ import api from "./lib/api";
 export default function ViewHistory() {
   const { data, isLoading, mutate } = useCachedPromise(() => api.getHistory(), []);
 
-  return <NotesList isLoading={isLoading} notes={data} mutate={mutate} unpinnedSectionTitle="Recent" />;
+  return (
+    <NotesList isLoading={isLoading} notes={data} mutate={mutate} unpinnedSectionTitle="Recent" showProfileAction />
+  );
 }


### PR DESCRIPTION
## Description

Add browser actions to HackMD so users can navigate directly from notes to workspace overviews and profiles.

- Browse Notes: add **Open Workspace in Browser** and **Open Profile in Browser** for the selected personal or team workspace, including empty lists.
- View History: add **Open Profile in Browser** for the selected note's team or author; hide it when neither profile path is available.
- Use the configured HackMD instance URL and encode profile and team paths.
- Update the changelog.

Validation: `npm run build`, `npm run lint`, and `git diff --check` passed. Interactive testing in Raycast has not been performed.

## Screencast

Not included; this change adds actions to existing commands.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
