### PR TITLE
Clockify: fix project dropdown resetting selection and timer failing to start

### DIFF
--- a/extensions/clockify/CHANGELOG.md
+++ b/extensions/clockify/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Clockify Changelog
 
+## [Fix project selection resetting and timer failing to start] - {PR_MERGE_DATE}
+
+- Fixed the project dropdown resetting to the first project on every selection in both "Start New Timer" and "Add Time Entry".
+- Fixed "Timer could not be started" caused by the selected project never reaching the form values.
+- Fixed the resulting loop of task requests, which triggered Clockify rate limiting (HTTP 429).
+
 ## [Fix cached workspace data] - 2026-05-15
 
 - Fixed cached projects, tags, and tasks falling back incorrectly when Clockify returns no data.

--- a/extensions/clockify/CHANGELOG.md
+++ b/extensions/clockify/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Clockify Changelog
 
-## [Fix project selection resetting and timer failing to start] - {PR_MERGE_DATE}
+## [Fix project selection resetting and timer failing to start] - 2026-09-08
 
 - Fixed the project dropdown resetting to the first project on every selection in both "Start New Timer" and "Add Time Entry".
 - Fixed "Timer could not be started" caused by the selected project never reaching the form values.

--- a/extensions/clockify/package.json
+++ b/extensions/clockify/package.json
@@ -14,7 +14,8 @@
     "constantins2001",
     "xmok",
     "pcamminadi",
-    "riccardogiorato"
+    "riccardogiorato",
+    "tony_gauderman"
   ],
   "license": "MIT",
   "preferences": [

--- a/extensions/clockify/src/index.tsx
+++ b/extensions/clockify/src/index.tsx
@@ -224,7 +224,7 @@ function NewEntry({ updateTimeEntries }: { updateTimeEntries: () => void }) {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const { pop } = useNavigation();
 
-  const { handleSubmit, itemProps } = useForm<{
+  const { handleSubmit, itemProps, values } = useForm<{
     projectId: string;
     taskId?: string;
     description?: string;
@@ -275,6 +275,13 @@ function NewEntry({ updateTimeEntries }: { updateTimeEntries: () => void }) {
     getAllProjectsAndTagsOnWorkspace();
   }, [config, isValidToken]);
 
+  // Driven off the form value rather than the Dropdown's onChange: overriding onChange after
+  // spreading itemProps drops useForm's own handler, which leaves projectId unset and the
+  // controlled value pinned to null, so the selection snaps back and re-emits onChange forever.
+  useEffect(() => {
+    if (values.projectId) fetchTasksForProject(values.projectId);
+  }, [values.projectId]);
+
   async function fetchTasksForProject(projectId: string): Promise<void> {
     setIsLoading(true);
 
@@ -299,7 +306,7 @@ function NewEntry({ updateTimeEntries }: { updateTimeEntries: () => void }) {
         </ActionPanel>
       }
     >
-      <Form.Dropdown {...itemProps.projectId} title="Project" onChange={(projectId) => fetchTasksForProject(projectId)}>
+      <Form.Dropdown {...itemProps.projectId} title="Project">
         {projects.map((project: Project) => (
           <Form.Dropdown.Item
             key={project.id}
@@ -514,6 +521,11 @@ function AddTimeEntry({ updateTimeEntries }: { updateTimeEntries: () => void }) 
     getAllProjectsAndTags();
   }, [config]);
 
+  // See NewEntry: overriding the Dropdown's onChange would drop useForm's handler and loop.
+  useEffect(() => {
+    if (values.projectId) fetchTasksForProject(values.projectId);
+  }, [values.projectId]);
+
   async function fetchTasksForProject(projectId: string): Promise<void> {
     setIsLoading(true);
 
@@ -537,7 +549,7 @@ function AddTimeEntry({ updateTimeEntries }: { updateTimeEntries: () => void }) 
         </ActionPanel>
       }
     >
-      <Form.Dropdown {...itemProps.projectId} title="Project" onChange={(projectId) => fetchTasksForProject(projectId)}>
+      <Form.Dropdown {...itemProps.projectId} title="Project">
         {projects.map((project: Project) => (
           <Form.Dropdown.Item
             key={project.id}


### PR DESCRIPTION
## Description

Fixes the project dropdown in the Clockify extension resetting to the first project on every selection, which also made "Start Timer" fail with "Timer could not be started".

### Root cause

Both project dropdowns declared `onChange` *after* spreading `itemProps`:

```tsx
<Form.Dropdown {...itemProps.projectId} title="Project" onChange={(projectId) => fetchTasksForProject(projectId)}>
```

Because the later prop wins, this replaced the `onChange` that `useForm` supplies via `itemProps`. `values.projectId` was therefore never written. `itemProps` returns a *controlled* `value` (`useForm` deliberately returns `null` rather than `undefined` so the field isn't uncontrolled), so on the next render the dropdown was forced back to `null`, the selection snapped to the first item, and that re-emitted `onChange` — an unbounded loop of `/projects/{id}/tasks` requests, which in turn triggers Clockify rate limiting (HTTP 429).

The same missing write is why submitting the form failed: `onSubmit` received no `projectId`, so `POST /time-entries` was rejected and `addNewTimeEntry` showed "Timer could not be started".

### Fix

Drive the task fetch off the form value instead of intercepting the dropdown's `onChange`, leaving `useForm`'s handler intact:

```tsx
useEffect(() => {
  if (values.projectId) fetchTasksForProject(values.projectId);
}, [values.projectId]);
```

Applied to both `NewEntry` ("Start New Timer") and `AddTimeEntry` ("Add Time Entry"), which had identical code. No other `itemProps` spread in the extension overrides a handler.

Likely fixes #29613, and may be the same root cause behind #28716.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
