### PR TITLE
docs: correct eight Keyboard.Shortcut.Common bindings against the shipped runtime

### DIFF
--- a/docs/api-reference/keyboard.md
+++ b/docs/api-reference/keyboard.md
@@ -77,15 +77,15 @@ A collection of shortcuts that are commonly used throughout Raycast. Using them 
 | Save            | ⌘ + S     | `ctrl` + S           |
 | Duplicate       | ⌘ + D     | `ctrl` + `shift` + S |
 | Edit            | ⌘ + E     | `ctrl` + E           |
-| MoveDown        | ⌘ + ⌥ + ↓ | `ctrl` + `shift` + ↓ |
-| MoveUp          | ⌘ + ⌥ + ↑ | `ctrl` + `shift` + ↑ |
+| MoveDown        | ⌘ + ⌥ + ↓ | `ctrl` + `alt` + ↓   |
+| MoveUp          | ⌘ + ⌥ + ↑ | `ctrl` + `alt` + ↑   |
 | New             | ⌘ + N     | `ctrl` + N           |
 | Open            | ⌘ + O     | `ctrl` + O           |
 | OpenWith        | ⌘ + ⇧ + O | `ctrl` + `shift` + O |
 | Pin             | ⌘ + .     | `ctrl` + .           |
 | Refresh         | ⌘ + R     | `ctrl` + R           |
 | Remove          | ⌃ + X     | `ctrl` + D           |
-| RemoveAll       | ⌃ + ⇧ + X | `ctrl` + `shift` + D |
+| RemoveAll       | ⌃ + ⇧ + X | `ctrl` + `alt` + D   |
 | ToggleQuickLook | ⌘ + Y     | `ctrl` + Y           |
 
 ### Keyboard.KeyEquivalent

--- a/docs/api-reference/keyboard.md
+++ b/docs/api-reference/keyboard.md
@@ -72,17 +72,17 @@ A collection of shortcuts that are commonly used throughout Raycast. Using them 
 | --------------- | --------- | -------------------- |
 | Copy            | ⌘ + ⇧ + C | `ctrl` + `shift` + C |
 | CopyDeeplink    | ⌘ + ⇧ + C | `ctrl` + `shift` + C |
-| CopyName        | ⌘ + ⇧ + . | `ctrl` + `alt` + C   |
-| CopyPath        | ⌘ + ⇧ + , | `alt` + `shift` + C  |
+| CopyName        | ⌘ + ⌥ + C | `ctrl` + `alt` + C   |
+| CopyPath        | ⌘ + ⌃ + C | `alt` + `shift` + C  |
 | Save            | ⌘ + S     | `ctrl` + S           |
 | Duplicate       | ⌘ + D     | `ctrl` + `shift` + S |
 | Edit            | ⌘ + E     | `ctrl` + E           |
-| MoveDown        | ⌘ + ⇧ + ↓ | `ctrl` + `shift` + ↓ |
-| MoveUp          | ⌘ + ⇧ + ↑ | `ctrl` + `shift` + ↑ |
+| MoveDown        | ⌘ + ⌥ + ↓ | `ctrl` + `shift` + ↓ |
+| MoveUp          | ⌘ + ⌥ + ↑ | `ctrl` + `shift` + ↑ |
 | New             | ⌘ + N     | `ctrl` + N           |
 | Open            | ⌘ + O     | `ctrl` + O           |
 | OpenWith        | ⌘ + ⇧ + O | `ctrl` + `shift` + O |
-| Pin             | ⌘ + ⇧ + P | `ctrl` + .           |
+| Pin             | ⌘ + .     | `ctrl` + .           |
 | Refresh         | ⌘ + R     | `ctrl` + R           |
 | Remove          | ⌃ + X     | `ctrl` + D           |
 | RemoveAll       | ⌃ + ⇧ + X | `ctrl` + `shift` + D |


### PR DESCRIPTION
## Description

Eight cells in the `Keyboard.Shortcut.Common` table do not match what Raycast ships. Five are in the macOS column, three in the Windows column, across six rows.

Values read from the runtime bundled with the installed app — **Raycast 2.2.0.0**, `Raycast.app/Contents/Resources/.../api/node_modules/@raycast/api/index.js`. That bundle is the authority for these values: `ray build` leaves `@raycast/api` external, and the app launches extension workers against its own bundled API. The npm package ships the `Common` declarations (`Pin: Shortcut`) but no shortcut values, so it cannot be the source.

| Name | Column | Documented | Runtime |
| --- | --- | --- | --- |
| CopyName | macOS | ⌘ + ⇧ + . | ⌘ + ⌥ + C |
| CopyPath | macOS | ⌘ + ⇧ + , | ⌘ + ⌃ + C |
| MoveDown | macOS | ⌘ + ⇧ + ↓ | ⌘ + ⌥ + ↓ |
| MoveUp | macOS | ⌘ + ⇧ + ↑ | ⌘ + ⌥ + ↑ |
| Pin | macOS | ⌘ + ⇧ + P | ⌘ + . |
| MoveDown | Windows | `ctrl` + `shift` + ↓ | `ctrl` + `alt` + ↓ |
| MoveUp | Windows | `ctrl` + `shift` + ↑ | `ctrl` + `alt` + ↑ |
| RemoveAll | Windows | `ctrl` + `shift` + D | `ctrl` + `alt` + D |

Raw, for the two least obvious:

```js
Pin:{macOS:{modifiers:["cmd"],key:"."},Windows:{modifiers:["ctrl"],key:"."}}
RemoveAll:{macOS:{modifiers:["ctrl","shift"],key:"x"},Windows:{modifiers:["ctrl","alt"],key:"d"}}
```

The other eleven rows match and are untouched.

### `Pin` has been corrected before and was reverted

[#30538](https://github.com/raycast/extensions/pull/30538) (`ae06b19`, 26 Aug) changed `Pin` to `⌘ + .`. The next day, `bca7163` — "Docs: update for the new API release" — changed it back to `⌘ + ⇧ + P`, along with reverting that PR's formatting.

So this table appears to be regenerated or re-synced from a source that still holds the old values, and a fix applied only here is likely to be reverted again. Worth checking whatever feeds `sync-api-docs.yml` / the upstream docs source, not just this file.

### Why it's worth fixing

These are the shortcuts extension authors are told to use for consistency, so a wrong value propagates into extensions and into review. `Pin` in particular has produced repeat false "duplicate shortcut" findings from automated reviewers, which resolve `Common.Pin` to `⌘ + ⇧ + P` from this page and then flag a collision with an action genuinely bound to `⌘ + ⇧ + P`.

Docs-only; no extension code is affected.

### Scope of the evidence

This establishes a mismatch against **Raycast 2.2.0.0**. I have not established when the values changed, or that they were wrong in every earlier release — only that the current table does not describe what currently ships.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] This is a documentation-only change; no extension code is touched
