### PR TITLE
Update spotify-player extension

### DIFF
--- a/extensions/spotify-player/CHANGELOG.md
+++ b/extensions/spotify-player/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Load playlist actions when opened instead of scanning playlists while browsing songs, search results, or albums.
 - Check playlist membership one page at a time, including songs beyond the first 1,000, and cancel checks when the selection changes.
+- Keep playlist actions usable during failed or pending checks and allow retrying failed quicklinks.
 - Include later-page playlists in Your Library and share playlist loading without repeatedly copying or caching the catalog.
 
 ## [Fix Support Next And Previous Actions For Episodes] - 2026-09-03

--- a/extensions/spotify-player/CHANGELOG.md
+++ b/extensions/spotify-player/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Spotify Player Changelog
 
+## [Reduce Library and Playlist Memory Usage] - {PR_MERGE_DATE}
+
+- Load playlist actions when opened instead of scanning playlists while browsing songs, search results, or albums.
+- Check playlist membership one page at a time, including songs beyond the first 1,000, and cancel checks when the selection changes.
+- Include later-page playlists in Your Library and share playlist loading without repeatedly copying or caching the catalog.
+
 ## [Fix Support Next And Previous Actions For Episodes] - 2026-09-03
 
 - Support Next and Previous actions for episodes not just songs.

--- a/extensions/spotify-player/package-lock.json
+++ b/extensions/spotify-player/package-lock.json
@@ -21,6 +21,7 @@
         "@types/react": "^19.1.10",
         "eslint": "^9.33.0",
         "prettier": "^3.6.2",
+        "react-test-renderer": "19.0.0",
         "typescript": "^5.9.2"
       }
     },
@@ -3470,8 +3471,30 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
       "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-test-renderer": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.0.0.tgz",
+      "integrity": "sha512-oX5u9rOQlHzqrE/64CNr0HB0uWxkCQmZNSfozlYvwE71TLVgeZxVf0IjouGEr1v7r1kcDifdAJBeOhdhxsG/DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^19.0.0",
+        "scheduler": "^0.25.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
       }
     },
     "node_modules/reftools": {
@@ -3556,6 +3579,13 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {

--- a/extensions/spotify-player/package.json
+++ b/extensions/spotify-player/package.json
@@ -46,7 +46,8 @@
     "alexi.build",
     "shivraj-roy",
     "ridemountainpig",
-    "clemenzi"
+    "clemenzi",
+    "ray.dhruv"
   ],
   "pastContributors": [
     "bkeys818",
@@ -593,10 +594,13 @@
     "@types/react": "^19.1.10",
     "eslint": "^9.33.0",
     "prettier": "^3.6.2",
+    "react-test-renderer": "19.0.0",
     "typescript": "^5.9.2"
   },
   "scripts": {
     "build": "ray build",
+    "test": "node --test tests/library.test.cjs",
+    "test:memory": "node --expose-gc --max-old-space-size=100 tests/memory.cjs",
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",

--- a/extensions/spotify-player/package.json
+++ b/extensions/spotify-player/package.json
@@ -599,8 +599,8 @@
   },
   "scripts": {
     "build": "ray build",
-    "test": "node --test tests/library.test.cjs",
-    "test:memory": "node --expose-gc --max-old-space-size=100 tests/memory.cjs",
+    "test": "node --test src/__tests__/library.test.mjs",
+    "test:memory": "node --expose-gc --max-old-space-size=100 src/__tests__/memory.mjs",
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",

--- a/extensions/spotify-player/src/__tests__/library.test.mjs
+++ b/extensions/spotify-player/src/__tests__/library.test.mjs
@@ -1,15 +1,19 @@
-const { test } = require("node:test");
-const assert = require("node:assert/strict");
-const { React, fixture, stats, resetStats, track, toasts } = require("./harness.cjs");
-const { act, create } = require("react-test-renderer");
-const { playlistContainsTrack } = require("../src/api/playlistContainsTrack.ts");
-const { getMyPlaylists } = require("../src/api/getMyPlaylists.ts");
-const { TrackActionPanel } = require("../src/components/TrackActionPanel.tsx");
-const { PlaylistPicker } = require("../src/components/PlaylistPicker.tsx");
-const { TracksList } = require("../src/components/TracksList.tsx");
-const Library = require("../src/yourLibrary.tsx").default;
-const { useSearch } = require("../src/hooks/useSearch.ts");
-const { AddToSavedTracksAction } = require("../src/components/AddToSavedTracksAction.tsx");
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import harness from "../../tests/harness.cjs";
+const { React, fixture, stats, resetStats, track, toasts } = harness;
+import { act, create } from "react-test-renderer";
+import { createRequire } from "node:module";
+// The fixture loader selects/transpiles current or baseline TypeScript at runtime.
+const loadSource = createRequire(import.meta.url);
+const { playlistContainsTrack } = loadSource("../api/playlistContainsTrack.ts");
+const { getMyPlaylists } = loadSource("../api/getMyPlaylists.ts");
+const { TrackActionPanel } = loadSource("../components/TrackActionPanel.tsx");
+const { PlaylistPicker } = loadSource("../components/PlaylistPicker.tsx");
+const { TracksList } = loadSource("../components/TracksList.tsx");
+const Library = loadSource("../yourLibrary.tsx").default;
+const { useSearch } = loadSource("../hooks/useSearch.ts");
+const { AddToSavedTracksAction } = loadSource("../components/AddToSavedTracksAction.tsx");
 const tick = () => new Promise((r) => setImmediate(r));
 async function settle() {
   for (let n = 0; n < 45; n++) await act(tick);
@@ -187,7 +191,7 @@ test("new search response wins when older search finishes last", async () => {
 test("catalog membership consumers stream pages, do not refetch on equivalent renders, and cancel old songs", async () => {
   resetStats();
   const client = fixture({ playlists: 3, tracks: 100 });
-  const { usePlaylistsContainingTrack } = require("../src/hooks/usePlaylistsContainingTrack.ts");
+  const { usePlaylistsContainingTrack } = loadSource("../hooks/usePlaylistsContainingTrack.ts");
   let state;
   function Membership({ uri }) {
     state = usePlaylistsContainingTrack({ playlists: [{ id: "p0" }, { id: "p1" }, { id: "p2" }], trackUri: uri });
@@ -214,7 +218,7 @@ test("catalog membership consumers stream pages, do not refetch on equivalent re
 test("playing-song command renders the lazy picker; quicklinks check beyond 1000 before adding", async () => {
   resetStats();
   fixture({ playlists: 1, tracks: 1500, contains: (_, n) => n === 1400 });
-  const Command = require("../src/addPlayingSongToPlaylist.tsx").default;
+  const Command = loadSource("../addPlayingSongToPlaylist.tsx").default;
   const picker = await mount(React.createElement(Command, {}));
   assert.equal(stats.calls.tracks, undefined);
   await unmount(picker);
@@ -228,4 +232,82 @@ test("playing-song command renders the lazy picker; quicklinks check beyond 1000
   await settle();
   assert.equal(stats.writes.filter((x) => x[0] === "add").length, 1);
   await unmount(quicklink);
+});
+
+for (const state of ["loading", "failed"]) {
+  test(`picker can remove when background membership is ${state}`, async () => {
+    resetStats();
+    const client = fixture({ playlists: 1, tracks: 1, contains: () => true });
+    const renderer = await mount(React.createElement(PlaylistPicker, { uri: "spotify:track:target" }));
+    const fetch = client.getPlaylistsByPlaylistIdTracks;
+    let finishBackground;
+    let first = true;
+    client.getPlaylistsByPlaylistIdTracks = async (...args) => {
+      if (!first) return fetch(...args);
+      first = false;
+      if (state === "failed") throw new Error("Background check failed");
+      return new Promise((resolve) => {
+        finishBackground = resolve;
+      });
+    };
+    await act(async () => renderer.root.findByType("List").props.onSelectionChange("p0"));
+    await settle();
+    assert.equal(renderer.root.findByType("Action").props.title, "Add or Remove from Playlist");
+    await act(async () => renderer.root.findByType("Action").props.onAction());
+    assert.equal(stats.writes.filter((x) => x[0] === "remove").length, 1);
+    assert.equal(stats.writes.filter((x) => x[0] === "add").length, 0);
+    if (finishBackground) await act(async () => finishBackground({ items: [], next: null }));
+    await unmount(renderer);
+  });
+}
+
+for (const failure of ["scan", "mutation"]) {
+  test(`failed quicklink ${failure} can explicitly retry once without reopening`, async () => {
+    resetStats();
+    const client = fixture({ playlists: 1, tracks: 1 });
+    const method = failure === "scan" ? "getPlaylistsByPlaylistIdTracks" : "postPlaylistsByPlaylistIdTracks";
+    const original = client[method];
+    let attempts = 0;
+    client[method] = async (...args) => {
+      if (++attempts === 1) throw new Error("Transient failure");
+      return original(...args);
+    };
+    const Command = loadSource("../addPlayingSongToPlaylist.tsx").default;
+    const element = React.createElement(Command, { launchContext: { playlistId: "p0" } });
+    const renderer = await mount(element);
+    assert.equal(attempts, 1);
+    await act(async () => renderer.update(element));
+    await settle();
+    assert.equal(attempts, 1);
+    const retry = renderer.root
+      .findAllByType("Action")
+      .find((action) => action.props.title === "Retry Adding to Playlist").props.onAction;
+    await act(async () => Promise.all([retry(), retry()]));
+    await settle();
+    assert.equal(attempts, 2);
+    assert.equal(stats.writes.filter((x) => x[0] === "add").length, 1);
+    await act(async () => retry());
+    assert.equal(attempts, 2);
+    await unmount(renderer);
+  });
+}
+
+test("Now Playing keeps the picker action after profile and catalog failures", async () => {
+  resetStats();
+  const client = fixture({ playlists: 1, tracks: 1 });
+  const profile = client.getMe;
+  const catalog = client.getMePlaylists;
+  client.getMe = client.getMePlaylists = async () => {
+    throw new Error("Secondary request failed");
+  };
+  const Command = loadSource("../nowPlaying.tsx").default;
+  const renderer = await mount(React.createElement(Command));
+  const action = renderer.root.findAllByType("Action.Push").find((action) => action.props.title === "Add to Playlist");
+  assert.ok(action);
+  client.getMe = profile;
+  client.getMePlaylists = catalog;
+  const picker = await mount(action.props.target);
+  assert.equal(picker.root.findByType("List.Item").props.title, "Playlist 0");
+  await unmount(picker);
+  await unmount(renderer);
 });

--- a/extensions/spotify-player/src/__tests__/memory.mjs
+++ b/extensions/spotify-player/src/__tests__/memory.mjs
@@ -1,13 +1,16 @@
 // Run each variant in a fresh process. BASELINE_REF selects the actual pre-change source via git show.
-const { React, fixture, stats, sample } = require("./harness.cjs");
-const { act, create } = require("react-test-renderer");
-const { TrackActionPanel } = require("../src/components/TrackActionPanel.tsx");
-const { track } = require("./harness.cjs");
+import harness from "../../tests/harness.cjs";
+const { React, fixture, stats, sample, track } = harness;
+import { act, create } from "react-test-renderer";
+import { createRequire } from "node:module";
+// The fixture loader selects/transpiles current or baseline TypeScript at runtime.
+const loadSource = createRequire(import.meta.url);
+const { TrackActionPanel } = loadSource("../components/TrackActionPanel.tsx");
 const scenario = process.argv[2] ?? "browse";
 const { PlaylistPicker } = ["picker", "navigation"].includes(scenario)
-  ? require("../src/components/PlaylistPicker.tsx")
+  ? loadSource("../components/PlaylistPicker.tsx")
   : {};
-const { playlistContainsTrack } = scenario === "scan" ? require("../src/api/playlistContainsTrack.ts") : {};
+const { playlistContainsTrack } = scenario === "scan" ? loadSource("../api/playlistContainsTrack.ts") : {};
 fixture({ playlists: 120, tracks: 2500 });
 const tick = () => new Promise((r) => setImmediate(r));
 async function settle() {
@@ -23,8 +26,8 @@ async function settle() {
   const timer = setInterval(sample, 1);
   let renderer;
   if (scenario === "navigation") {
-    const Library = require("../src/yourLibrary.tsx").default;
-    const { TracksList } = require("../src/components/TracksList.tsx");
+    const Library = loadSource("../yourLibrary.tsx").default;
+    const { TracksList } = loadSource("../components/TracksList.tsx");
     for (let visit = 0; visit < 25; visit++) {
       for (const element of [
         React.createElement(Library),

--- a/extensions/spotify-player/src/addPlayingSongToPlaylist.tsx
+++ b/extensions/spotify-player/src/addPlayingSongToPlaylist.tsx
@@ -1,9 +1,6 @@
-import { View } from "./components/View";
 import {
   Action,
   ActionPanel,
-  Icon,
-  Keyboard,
   LaunchProps,
   LaunchType,
   List,
@@ -14,78 +11,74 @@ import {
   showHUD,
   showToast,
 } from "@raycast/api";
-import { useEffect, useState } from "react";
+import { useEffect, useRef } from "react";
+import { View } from "./components/View";
+import { PlaylistPicker } from "./components/PlaylistPicker";
 import { useCurrentlyPlaying } from "./hooks/useCurrentlyPlaying";
-import { useMe } from "./hooks/useMe";
-import { ListOrGridSection } from "./components/ListOrGridSection";
-import PlaylistItem from "./components/PlaylistItem";
-import { usePlaylistsContainingTrack } from "./hooks/usePlaylistsContainingTrack";
 import { addToPlaylist } from "./api/addToPlaylist";
-import { removeFromPlaylist } from "./api/removeFromPlaylist";
-import { useMyPlaylists } from "./hooks/useMyPlaylists";
-import { getError } from "./helpers/getError";
-import { CreateQuicklink } from "./components/CreateQuicklink";
-import getAllPlaylistItems from "./helpers/getAllPlaylistItems";
-import addTrackToPlaylistCache from "./helpers/addTrackToPlaylistCache";
-import removeTrackFromPlaylistCache from "./helpers/removeTrackFromPlaylistCache";
-import { Like, OpenLibrary, OpenSearch } from "./shortcuts/shortcuts";
+import { playlistContainsTrack } from "./api/playlistContainsTrack";
 
-type LaunchContextData = {
-  playlistId?: string;
-};
+type LaunchContextData = { playlistId?: string };
 
-type AddToPlaylistCommandProps = {
-  playlistId?: string;
-};
+function AddToPlaylistCommand({ playlistId }: LaunchContextData) {
+  const { currentlyPlayingData, currentlyPlayingIsLoading } = useCurrentlyPlaying();
+  const started = useRef(false);
+  const uri = currentlyPlayingData?.item?.uri;
+  const { duplicateSongCheck } = getPreferenceValues<Preferences.AddPlayingSongToPlaylist>();
 
-type AddToPlaylistCommandPreferences = {
-  duplicateSongCheck: boolean;
-};
+  useEffect(() => {
+    if (!playlistId || !uri || currentlyPlayingIsLoading || started.current) return;
+    started.current = true;
+    let adding = false;
+    const add = async () => {
+      try {
+        const performAdd = async () => {
+          if (adding) return;
+          adding = true;
+          try {
+            await addToPlaylist({ playlistId, trackUris: [uri] });
+            await showHUD("Added to playlist");
+            await popToRoot();
+          } catch (error) {
+            await showToast({
+              title: "Error adding song to playlist",
+              message: String(error),
+              style: Toast.Style.Failure,
+            });
+          } finally {
+            adding = false;
+          }
+        };
+        if (duplicateSongCheck && (await playlistContainsTrack(playlistId, uri))) {
+          await showToast({
+            title: "Duplicate found",
+            style: Toast.Style.Failure,
+            primaryAction: { title: "Add to playlist anyways", onAction: performAdd },
+          });
+          return;
+        }
+        await performAdd();
+      } catch (error) {
+        await showToast({ title: "Error adding song to playlist", message: String(error), style: Toast.Style.Failure });
+      }
+    };
+    void add();
+  }, [playlistId, uri, currentlyPlayingIsLoading, duplicateSongCheck]);
 
-const preferences: AddToPlaylistCommandPreferences = getPreferenceValues();
-const DUPLICATE_SONG_CHECK = preferences.duplicateSongCheck;
-
-function AddToPlaylistCommand(props: AddToPlaylistCommandProps) {
-  const { currentlyPlayingData, currentlyPlayingIsLoading, currentlyPlayingRevalidate } = useCurrentlyPlaying();
-  const [searchText, setSearchText] = useState("");
-
-  const { myPlaylistsData } = useMyPlaylists();
-  const { meData } = useMe();
-
-  const ownedPlaylists = myPlaylistsData?.items?.filter((p) => p.owner?.id === meData?.id) ?? [];
-  const { playlistsContainingTrack } = usePlaylistsContainingTrack({
-    playlists: ownedPlaylists,
-    trackUri: currentlyPlayingData?.item?.uri,
-    options: { execute: ownedPlaylists.length > 0 && !!currentlyPlayingData?.item?.uri },
-  });
-
-  if (!currentlyPlayingData || !currentlyPlayingData.item) {
+  if (!uri || playlistId) {
     return (
       <List isLoading={currentlyPlayingIsLoading}>
         <List.EmptyView
-          icon={Icon.Music}
-          title="Nothing is playing right now"
+          title={playlistId && uri ? "Add to playlist" : "Nothing is playing right now"}
           actions={
             <ActionPanel>
               <Action
-                icon={Icon.Book}
                 title="Your Library"
                 onAction={() => launchCommand({ name: "yourLibrary", type: LaunchType.UserInitiated })}
-                shortcut={OpenLibrary}
               />
               <Action
                 title="Search"
-                icon={Icon.MagnifyingGlass}
                 onAction={() => launchCommand({ name: "search", type: LaunchType.UserInitiated })}
-                shortcut={OpenSearch}
-              />
-              <Action
-                icon={Icon.Repeat}
-                title="Refresh"
-                onAction={async () => {
-                  currentlyPlayingRevalidate();
-                }}
-                shortcut={Keyboard.Shortcut.Common.Refresh}
               />
             </ActionPanel>
           }
@@ -93,167 +86,13 @@ function AddToPlaylistCommand(props: AddToPlaylistCommandProps) {
       </List>
     );
   }
-
-  useEffect(() => {
-    if (props?.playlistId && currentlyPlayingData?.item?.uri && !currentlyPlayingIsLoading) {
-      const addToPlaylistAsync = async () => {
-        try {
-          await addToPlaylist({
-            playlistId: props.playlistId!,
-            trackUris: [currentlyPlayingData.item.uri!],
-          });
-          const playlist = myPlaylistsData?.items?.find((p) => p.id == props.playlistId);
-          if (!playlist) {
-            showHUD("Playlist not found");
-            popToRoot();
-            return;
-          }
-          showHUD(`Added to ${playlist?.name}`);
-        } catch (err) {
-          const error = getError(err);
-          showHUD(`Error adding song to playlist: ${error.message}`);
-        }
-        popToRoot();
-      };
-
-      addToPlaylistAsync();
-    }
-  }, [props?.playlistId, currentlyPlayingData?.item?.uri, currentlyPlayingIsLoading]);
-
-  return (
-    <List
-      searchBarPlaceholder="Search for Playlist"
-      searchText={searchText}
-      onSearchTextChange={setSearchText}
-      filtering={true}
-      isLoading={currentlyPlayingIsLoading}
-    >
-      <ListOrGridSection type="list" title="Playlists">
-        {ownedPlaylists.map((playlist) => {
-          const alreadyAdded = !!playlist.id && playlistsContainingTrack.includes(playlist.id);
-          return (
-            <PlaylistItem
-              type="list"
-              key={playlist.id}
-              playlist={playlist}
-              alreadyAdded={alreadyAdded}
-              actions={
-                <ActionPanel>
-                  <Action
-                    key={playlist.id}
-                    icon={alreadyAdded ? Icon.Minus : Icon.Plus}
-                    title={alreadyAdded ? "Remove from Playlist" : "Add Current Song to Playlist"}
-                    onAction={async () => {
-                      if (currentlyPlayingIsLoading) {
-                        showToast({
-                          title: "Please wait",
-                          message: "Fetching currently playing track",
-                          style: Toast.Style.Failure,
-                        });
-                        return;
-                      }
-
-                      if (!playlist.id) {
-                        showToast({
-                          title: "Error",
-                          message: "Playlist ID undefined",
-                          style: Toast.Style.Failure,
-                        });
-                        return;
-                      }
-
-                      const trackUri = currentlyPlayingData.item?.uri as string;
-
-                      if (alreadyAdded) {
-                        try {
-                          await removeFromPlaylist({
-                            playlistId: playlist.id!,
-                            trackUris: [{ uri: trackUri }],
-                          });
-                          await removeTrackFromPlaylistCache(playlist.id!, trackUri);
-                          await showHUD(`Removed from ${playlist.name}`);
-                          await popToRoot();
-                        } catch (err) {
-                          const error = getError(err);
-                          await showToast({
-                            title: "Error removing song",
-                            message: error.message,
-                            style: Toast.Style.Failure,
-                          });
-                        }
-                        return;
-                      }
-
-                      try {
-                        const addTrack = async () => {
-                          await addToPlaylist({
-                            playlistId: playlist.id!,
-                            trackUris: [trackUri],
-                          });
-                          await addTrackToPlaylistCache(playlist.id!, currentlyPlayingData.item);
-                          await showHUD(`Added to ${playlist.name}`);
-                          await popToRoot();
-                        };
-
-                        if (DUPLICATE_SONG_CHECK) {
-                          await showToast({
-                            title: "Checking for duplicates",
-                            style: Toast.Style.Animated,
-                          });
-
-                          const playlistItems = await getAllPlaylistItems(playlist);
-                          const isInPlaylist = playlistItems.some((uri) => uri === trackUri);
-
-                          if (isInPlaylist) {
-                            await showToast({
-                              title: "Duplicate found",
-                              style: Toast.Style.Failure,
-                              primaryAction: {
-                                async onAction() {
-                                  await addTrack();
-                                },
-                                title: "Add to playlist anyways",
-                              },
-                            });
-                            return;
-                          }
-                        }
-
-                        await addTrack();
-                      } catch (err) {
-                        const error = getError(err);
-                        await showToast({
-                          title: "Error adding song to playlist",
-                          message: error.message,
-                          style: Toast.Style.Failure,
-                        });
-                      }
-                    }}
-                    shortcut={Like}
-                  />
-                  {playlist.id && (
-                    <CreateQuicklink
-                      title={`Create Quicklink to Add to ${playlist.name}`}
-                      quicklinkTitle={`Add Playing Song to ${playlist.name}`}
-                      command="addPlayingSongToPlaylist"
-                      data={{ playlistId: playlist.id }}
-                    />
-                  )}
-                </ActionPanel>
-              }
-            />
-          );
-        })}
-      </ListOrGridSection>
-    </List>
-  );
+  return <PlaylistPicker uri={uri} quicklinks />;
 }
 
 export default function Command(props: LaunchProps<{ launchContext: LaunchContextData }>) {
-  const playlistId = props?.launchContext?.playlistId;
   return (
     <View>
-      <AddToPlaylistCommand playlistId={playlistId} />
+      <AddToPlaylistCommand playlistId={props.launchContext?.playlistId} />
     </View>
   );
 }

--- a/extensions/spotify-player/src/addPlayingSongToPlaylist.tsx
+++ b/extensions/spotify-player/src/addPlayingSongToPlaylist.tsx
@@ -11,7 +11,7 @@ import {
   showHUD,
   showToast,
 } from "@raycast/api";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { View } from "./components/View";
 import { PlaylistPicker } from "./components/PlaylistPicker";
 import { useCurrentlyPlaying } from "./hooks/useCurrentlyPlaying";
@@ -23,47 +23,46 @@ type LaunchContextData = { playlistId?: string };
 function AddToPlaylistCommand({ playlistId }: LaunchContextData) {
   const { currentlyPlayingData, currentlyPlayingIsLoading } = useCurrentlyPlaying();
   const started = useRef(false);
+  const busy = useRef(false);
+  const completed = useRef(false);
+  const [canRetry, setCanRetry] = useState(false);
   const uri = currentlyPlayingData?.item?.uri;
   const { duplicateSongCheck } = getPreferenceValues<Preferences.AddPlayingSongToPlaylist>();
+
+  const add = useCallback(
+    async function add(allowDuplicate = false) {
+      if (!playlistId || !uri || currentlyPlayingIsLoading || busy.current || completed.current) return;
+      busy.current = true;
+      setCanRetry(false);
+      try {
+        if (!allowDuplicate && duplicateSongCheck && (await playlistContainsTrack(playlistId, uri))) {
+          await showToast({
+            title: "Duplicate found",
+            style: Toast.Style.Failure,
+            primaryAction: { title: "Add to playlist anyways", onAction: () => add(true) },
+          });
+          return;
+        }
+        await addToPlaylist({ playlistId, trackUris: [uri] });
+        completed.current = true;
+        await showHUD("Added to playlist");
+        await popToRoot();
+      } catch (error) {
+        // Only an explicit retry starts another attempt; a render must not repeat a failed mutation.
+        setCanRetry(!completed.current);
+        await showToast({ title: "Error adding song to playlist", message: String(error), style: Toast.Style.Failure });
+      } finally {
+        busy.current = false;
+      }
+    },
+    [playlistId, uri, currentlyPlayingIsLoading, duplicateSongCheck],
+  );
 
   useEffect(() => {
     if (!playlistId || !uri || currentlyPlayingIsLoading || started.current) return;
     started.current = true;
-    let adding = false;
-    const add = async () => {
-      try {
-        const performAdd = async () => {
-          if (adding) return;
-          adding = true;
-          try {
-            await addToPlaylist({ playlistId, trackUris: [uri] });
-            await showHUD("Added to playlist");
-            await popToRoot();
-          } catch (error) {
-            await showToast({
-              title: "Error adding song to playlist",
-              message: String(error),
-              style: Toast.Style.Failure,
-            });
-          } finally {
-            adding = false;
-          }
-        };
-        if (duplicateSongCheck && (await playlistContainsTrack(playlistId, uri))) {
-          await showToast({
-            title: "Duplicate found",
-            style: Toast.Style.Failure,
-            primaryAction: { title: "Add to playlist anyways", onAction: performAdd },
-          });
-          return;
-        }
-        await performAdd();
-      } catch (error) {
-        await showToast({ title: "Error adding song to playlist", message: String(error), style: Toast.Style.Failure });
-      }
-    };
     void add();
-  }, [playlistId, uri, currentlyPlayingIsLoading, duplicateSongCheck]);
+  }, [playlistId, uri, currentlyPlayingIsLoading, add]);
 
   if (!uri || playlistId) {
     return (
@@ -72,6 +71,7 @@ function AddToPlaylistCommand({ playlistId }: LaunchContextData) {
           title={playlistId && uri ? "Add to playlist" : "Nothing is playing right now"}
           actions={
             <ActionPanel>
+              {canRetry && <Action title="Retry Adding to Playlist" onAction={() => add()} />}
               <Action
                 title="Your Library"
                 onAction={() => launchCommand({ name: "yourLibrary", type: LaunchType.UserInitiated })}

--- a/extensions/spotify-player/src/api/getMyPlaylists.ts
+++ b/extensions/spotify-player/src/api/getMyPlaylists.ts
@@ -15,15 +15,11 @@ async function _getMyPlaylists({ limit = 50 }: GetUserPlaylistsProps = {}) {
 
     while (nextUrl) {
       const nextResponse = await spotifyClient.getNext(nextUrl);
-      response = {
-        ...response,
-        ...nextResponse,
-        items: [...(response?.items ?? []), ...(nextResponse.items ?? [])],
-      };
+      (response.items ??= []).push(...(nextResponse.items ?? []));
       nextUrl = nextResponse?.next;
     }
 
-    return response;
+    return { ...response, next: null };
   } catch (err) {
     const error = getErrorMessage(err);
     console.log("getMyPlaylists.ts Error:", error);
@@ -31,4 +27,12 @@ async function _getMyPlaylists({ limit = 50 }: GetUserPlaylistsProps = {}) {
   }
 }
 
-export const getMyPlaylists = withCache("api:playlists", 300000, _getMyPlaylists);
+const getCachedPlaylists = withCache("api:playlists", 300000, _getMyPlaylists);
+let pending: ReturnType<typeof getCachedPlaylists> | undefined;
+
+export function getMyPlaylists() {
+  // Library and action consumers share one catalog request, including cold cache misses.
+  return (pending ??= getCachedPlaylists().finally(() => {
+    pending = undefined;
+  }));
+}

--- a/extensions/spotify-player/src/api/getUserPlaylists.ts
+++ b/extensions/spotify-player/src/api/getUserPlaylists.ts
@@ -1,20 +1,2 @@
-import { withCache } from "../helpers/apiCache";
-import { getErrorMessage } from "../helpers/getError";
-import { getSpotifyClient } from "../helpers/withSpotifyClient";
-
-type GetUserPlaylistsProps = { limit?: number };
-
-async function _getUserPlaylists({ limit = 50 }: GetUserPlaylistsProps = {}) {
-  const { spotifyClient } = getSpotifyClient();
-
-  try {
-    const response = await spotifyClient.getMePlaylists({ limit });
-    return response;
-  } catch (err) {
-    const error = getErrorMessage(err);
-    console.log("getUserPlaylists.ts Error:", error);
-    throw new Error(error);
-  }
-}
-
-export const getUserPlaylists = withCache("api:user-playlists", 300000, _getUserPlaylists);
+// Share the complete playlist catalog with the picker so later pages remain searchable.
+export { getMyPlaylists as getUserPlaylists } from "./getMyPlaylists";

--- a/extensions/spotify-player/src/api/playlistContainsTrack.ts
+++ b/extensions/spotify-player/src/api/playlistContainsTrack.ts
@@ -1,0 +1,51 @@
+import { getSpotifyClient } from "../helpers/withSpotifyClient";
+
+// Shared across consumers, including cancelled selections that still have a request in flight.
+let active = 0;
+const waiting: (() => void)[] = [];
+async function request<T>(fn: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+  signal?.throwIfAborted();
+  if (active >= 2) await new Promise<void>((resolve) => waiting.push(resolve));
+  else active++;
+  try {
+    signal?.throwIfAborted();
+    return await fn();
+  } finally {
+    const next = waiting.shift();
+    if (next) next();
+    else active--;
+  }
+}
+
+/** Inspect one page at a time; never retain or serialize a playlist's full tracks. */
+export async function playlistContainsTrack(playlistId: string, uri: string, signal?: AbortSignal): Promise<boolean> {
+  const { spotifyClient } = getSpotifyClient();
+  let offset = 0;
+  let hasMore = true;
+  while (hasMore) {
+    signal?.throwIfAborted();
+    const page = await request(
+      () =>
+        spotifyClient.getPlaylistsByPlaylistIdTracks(
+          playlistId,
+          {
+            limit: 50,
+            offset,
+            fields: "items(track(uri,linked_from(uri))),next,offset,limit",
+          },
+          { signal },
+        ),
+      signal,
+    );
+    signal?.throwIfAborted();
+    // The generated OpenAPI track union has conflicting discriminators; only these fields are requested.
+    const items = page.items as { track?: { uri?: string; linked_from?: { uri?: string } } | null }[] | undefined;
+    if (items?.some(({ track }) => track?.uri === uri || track?.linked_from?.uri === uri)) return true;
+    hasMore = !!page.next;
+    if (!page.next) return false;
+    const nextOffset = Number(new URL(page.next).searchParams.get("offset"));
+    if (!Number.isInteger(nextOffset) || nextOffset <= offset) throw new Error("Invalid playlist continuation");
+    offset = nextOffset;
+  }
+  return false;
+}

--- a/extensions/spotify-player/src/components/AddToPlaylistAction.tsx
+++ b/extensions/spotify-player/src/components/AddToPlaylistAction.tsx
@@ -1,101 +1,14 @@
-import {
-  Action,
-  ActionPanel,
-  Color,
-  getPreferenceValues,
-  Icon,
-  Image,
-  popToRoot,
-  showHUD,
-  showToast,
-  Toast,
-} from "@raycast/api";
-import { addToPlaylist } from "../api/addToPlaylist";
-import { removeFromPlaylist } from "../api/removeFromPlaylist";
-import addTrackToPlaylistCache from "../helpers/addTrackToPlaylistCache";
-import removeTrackFromPlaylistCache from "../helpers/removeTrackFromPlaylistCache";
-import { TrackObject } from "../helpers/spotify.api";
-import { getError } from "../helpers/getError";
-import { PrivateUserObject, SimplifiedPlaylistObject } from "../helpers/spotify.api";
-import { usePlaylistsContainingTrack } from "../hooks/usePlaylistsContainingTrack";
+import { Action, Icon } from "@raycast/api";
 import { AddToPlaylist } from "../shortcuts/shortcuts";
+import { PlaylistPicker } from "./PlaylistPicker";
 
-type AddToPlaylistActionProps = {
-  playlists: SimplifiedPlaylistObject[];
-  meData: PrivateUserObject;
-  uri: string;
-};
-
-export function AddToPlaylistAction({ playlists, meData, uri }: AddToPlaylistActionProps) {
-  const { closeWindowOnAction } = getPreferenceValues<{ closeWindowOnAction?: boolean }>();
-
-  const ownedPlaylists = playlists.filter((p) => p.owner?.id === meData?.id);
-
-  const { playlistsContainingTrack, playlistsContainingTrackRevalidate } = usePlaylistsContainingTrack({
-    playlists: ownedPlaylists,
-    trackUri: uri,
-    options: { execute: ownedPlaylists.length > 0 && !!uri },
-  });
-
+export function AddToPlaylistAction({ uri }: { uri: string }) {
   return (
-    <ActionPanel.Submenu icon={Icon.List} title="Add to Playlist" shortcut={AddToPlaylist}>
-      {ownedPlaylists.map((playlist, index) => {
-        if (!playlist.id || !playlist.name) return null;
-        const alreadyAdded = playlistsContainingTrack.includes(playlist.id);
-        const imageURL = playlist.images?.[0]?.url;
-
-        return (
-          <Action
-            key={`${playlist.id}-${index}`}
-            title={playlist.name}
-            icon={
-              alreadyAdded
-                ? { source: Icon.Checkmark, tintColor: Color.Green }
-                : imageURL
-                  ? { source: imageURL, mask: Image.Mask.RoundedRectangle }
-                  : Icon.List
-            }
-            onAction={async () => {
-              try {
-                if (alreadyAdded) {
-                  await removeFromPlaylist({
-                    playlistId: playlist.id!,
-                    trackUris: [{ uri }],
-                  });
-                  await removeTrackFromPlaylistCache(playlist.id!, uri);
-                  if (closeWindowOnAction) {
-                    await showHUD(`Removed from ${playlist.name}`);
-                    await popToRoot();
-                    return;
-                  }
-                  await showToast({ title: `Removed from ${playlist.name}` });
-                  playlistsContainingTrackRevalidate();
-                } else {
-                  await addToPlaylist({
-                    playlistId: playlist.id!,
-                    trackUris: [uri],
-                  });
-                  await addTrackToPlaylistCache(playlist.id!, { uri } as TrackObject);
-                  if (closeWindowOnAction) {
-                    await showHUD(`Added to ${playlist.name}`);
-                    await popToRoot();
-                    return;
-                  }
-                  await showToast({ title: `Added to ${playlist.name}` });
-                  playlistsContainingTrackRevalidate();
-                }
-              } catch (err) {
-                const error = getError(err);
-                await showToast({
-                  title: "Error",
-                  message: error.message,
-                  style: Toast.Style.Failure,
-                });
-              }
-            }}
-          />
-        );
-      })}
-    </ActionPanel.Submenu>
+    <Action.Push
+      icon={Icon.List}
+      title="Add to Playlist"
+      shortcut={AddToPlaylist}
+      target={<PlaylistPicker uri={uri} />}
+    />
   );
 }

--- a/extensions/spotify-player/src/components/PlaylistLikedTracksItem.tsx
+++ b/extensions/spotify-player/src/components/PlaylistLikedTracksItem.tsx
@@ -18,7 +18,6 @@ export default function PlaylistLikedTracksItem({ type }: PlaylistLikedTracksIte
   const uri = `spotify:user:${meData?.id}:collection`;
   const { myLibraryData } = useYourLibrary({
     category: "tracks",
-    keepPreviousData: true,
   });
 
   return (

--- a/extensions/spotify-player/src/components/PlaylistPicker.tsx
+++ b/extensions/spotify-player/src/components/PlaylistPicker.tsx
@@ -63,7 +63,9 @@ export function PlaylistPicker({ uri, quicklinks = false }: { uri: string; quick
               actions={
                 <ActionPanel>
                   <Action
-                    title={contains ? "Remove from Playlist" : "Add to Playlist"}
+                    title={
+                      !checked ? "Add or Remove from Playlist" : contains ? "Remove from Playlist" : "Add to Playlist"
+                    }
                     icon={contains ? Icon.Minus : Icon.Plus}
                     onAction={async () => {
                       if (busy.current) return;
@@ -86,7 +88,7 @@ export function PlaylistPicker({ uri, quicklinks = false }: { uri: string; quick
                             await popToRoot();
                           }
                         };
-                        if (exists && !contains) {
+                        if (exists && checked && !contains) {
                           await showToast({
                             title: "Duplicate found",
                             style: Toast.Style.Failure,

--- a/extensions/spotify-player/src/components/PlaylistPicker.tsx
+++ b/extensions/spotify-player/src/components/PlaylistPicker.tsx
@@ -1,0 +1,148 @@
+import {
+  Action,
+  ActionPanel,
+  Icon,
+  List,
+  LocalStorage,
+  Toast,
+  getPreferenceValues,
+  popToRoot,
+  showHUD,
+  showToast,
+} from "@raycast/api";
+import { usePromise } from "@raycast/utils";
+import { useRef, useState } from "react";
+import { useMyPlaylists } from "../hooks/useMyPlaylists";
+import { useMe } from "../hooks/useMe";
+import { playlistContainsTrack } from "../api/playlistContainsTrack";
+import { addToPlaylist } from "../api/addToPlaylist";
+import { removeFromPlaylist } from "../api/removeFromPlaylist";
+import { CreateQuicklink } from "./CreateQuicklink";
+
+export function PlaylistPicker({ uri, quicklinks = false }: { uri: string; quicklinks?: boolean }) {
+  const { myPlaylistsData, myPlaylistsIsLoading } = useMyPlaylists();
+  const { meData, meIsLoading } = useMe();
+  const [selectedId, setSelectedId] = useState<string>();
+  const busy = useRef(false);
+  const abortable = useRef<AbortController | null>(null);
+  const {
+    data: membership,
+    isLoading,
+    error,
+    revalidate,
+  } = usePromise(
+    async (id: string, trackUri: string) => ({
+      id,
+      uri: trackUri,
+      contains: await playlistContainsTrack(id, trackUri, abortable.current?.signal),
+    }),
+    [selectedId ?? "", uri],
+    { execute: !!selectedId, abortable },
+  );
+
+  return (
+    <List
+      searchBarPlaceholder="Search for Playlist"
+      isLoading={myPlaylistsIsLoading || meIsLoading || isLoading}
+      onSelectionChange={(id) => setSelectedId(id ?? undefined)}
+    >
+      {myPlaylistsData?.items
+        ?.filter((playlist) => playlist.owner?.id === meData?.id)
+        .map((playlist) => {
+          if (!playlist.id || !playlist.name) return null;
+          const id = playlist.id;
+          const checked = membership?.id === id && membership.uri === uri && !isLoading && !error;
+          const contains = checked && membership.contains;
+          return (
+            <List.Item
+              key={id}
+              id={id}
+              title={playlist.name}
+              icon={playlist.images?.[0]?.url ?? Icon.List}
+              accessories={contains ? [{ icon: Icon.Checkmark, tooltip: "Already in playlist" }] : []}
+              actions={
+                <ActionPanel>
+                  <Action
+                    title={contains ? "Remove from Playlist" : "Add to Playlist"}
+                    icon={contains ? Icon.Minus : Icon.Plus}
+                    onAction={async () => {
+                      if (busy.current) return;
+                      busy.current = true;
+                      try {
+                        // Recheck at mutation time: stale membership and failed requests must never add duplicates.
+                        const exists = await playlistContainsTrack(id, uri);
+                        const invalidateItems = () =>
+                          Promise.allSettled([
+                            LocalStorage.removeItem(`playlistItems_${id}`),
+                            LocalStorage.removeItem(`playlistItems_${id}_cachedAt`),
+                          ]);
+                        const add = async () => {
+                          await addToPlaylist({ playlistId: id, trackUris: [uri] });
+                          await invalidateItems();
+                          await showToast({ title: `Added to ${playlist.name}` });
+                          await revalidate().catch(() => undefined);
+                          if (getPreferenceValues().closeWindowOnAction) {
+                            await showHUD(`Added to ${playlist.name}`);
+                            await popToRoot();
+                          }
+                        };
+                        if (exists && !contains) {
+                          await showToast({
+                            title: "Duplicate found",
+                            style: Toast.Style.Failure,
+                            primaryAction: {
+                              title: "Add to playlist anyways",
+                              onAction: async () => {
+                                if (busy.current) return;
+                                busy.current = true;
+                                try {
+                                  await add();
+                                } catch (error) {
+                                  await showToast({
+                                    title: "Could not add to playlist",
+                                    message: String(error),
+                                    style: Toast.Style.Failure,
+                                  });
+                                } finally {
+                                  busy.current = false;
+                                }
+                              },
+                            },
+                          });
+                        } else if (exists) {
+                          await removeFromPlaylist({ playlistId: id, trackUris: [{ uri }] });
+                          await invalidateItems();
+                          await showToast({ title: `Removed from ${playlist.name}` });
+                          await revalidate().catch(() => undefined);
+                          if (getPreferenceValues().closeWindowOnAction) {
+                            await showHUD(`Removed from ${playlist.name}`);
+                            await popToRoot();
+                          }
+                        } else await add();
+                      } catch (error) {
+                        await showToast({
+                          title: "Could not update playlist",
+                          message: String(error),
+                          style: Toast.Style.Failure,
+                        });
+                      } finally {
+                        busy.current = false;
+                      }
+                    }}
+                  />
+                  {quicklinks && (
+                    <CreateQuicklink
+                      title={`Create Quicklink to Add to ${playlist.name}`}
+                      quicklinkTitle={`Add Playing Song to ${playlist.name}`}
+                      command="addPlayingSongToPlaylist"
+                      data={{ playlistId: id }}
+                    />
+                  )}
+                </ActionPanel>
+              }
+            />
+          );
+        })}
+    </List>
+  );
+}

--- a/extensions/spotify-player/src/components/TrackActionPanel.tsx
+++ b/extensions/spotify-player/src/components/TrackActionPanel.tsx
@@ -1,8 +1,6 @@
 import { Action, ActionPanel, Icon } from "@raycast/api";
 import { SimplifiedAlbumObject, SimplifiedTrackObject } from "../helpers/spotify.api";
 import { TracksList } from "./TracksList";
-import { useMyPlaylists } from "../hooks/useMyPlaylists";
-import { useMe } from "../hooks/useMe";
 import { AddToPlaylistAction } from "./AddToPlaylistAction";
 import { FooterAction } from "./FooterAction";
 import { AddToQueueAction } from "./AddtoQueueAction";
@@ -30,9 +28,6 @@ export function TrackActionPanel({
   playingContext,
   tracksToQueue,
 }: TrackActionPanelProps) {
-  const { myPlaylistsData } = useMyPlaylists();
-  const { meData } = useMe();
-
   return (
     <ActionPanel>
       <PlayAction id={track.id as string} type="track" playingContext={playingContext} tracksToQueue={tracksToQueue} />
@@ -47,9 +42,7 @@ export function TrackActionPanel({
       <StartRadioAction trackId={track.id} />
       {showAddToSaved && <AddToSavedTracksAction trackId={track.id} />}
       {track.uri && <AddToQueueAction uri={track.uri} title={title} />}
-      {myPlaylistsData?.items && meData && track.uri && (
-        <AddToPlaylistAction playlists={myPlaylistsData.items} meData={meData} uri={track.uri} />
-      )}
+      {track.uri && <AddToPlaylistAction uri={track.uri} />}
       <FooterAction url={track?.external_urls?.spotify} uri={track.uri} title={title} />
     </ActionPanel>
   );

--- a/extensions/spotify-player/src/hooks/useMyPlaylists.ts
+++ b/extensions/spotify-player/src/hooks/useMyPlaylists.ts
@@ -1,4 +1,4 @@
-import { useCachedPromise } from "@raycast/utils";
+import { usePromise } from "@raycast/utils";
 import { getMyPlaylists } from "../api/getMyPlaylists";
 
 type UseMyPlaylistsProps = {
@@ -8,7 +8,7 @@ type UseMyPlaylistsProps = {
 };
 
 export function useMyPlaylists({ options }: UseMyPlaylistsProps = {}) {
-  const { data, error, isLoading, revalidate } = useCachedPromise(() => getMyPlaylists(), [], {
+  const { data, error, isLoading, revalidate } = usePromise(() => getMyPlaylists(), [], {
     execute: options?.execute !== false,
   });
 

--- a/extensions/spotify-player/src/hooks/usePlaylistsContainingTrack.ts
+++ b/extensions/spotify-player/src/hooks/usePlaylistsContainingTrack.ts
@@ -1,43 +1,34 @@
-import { useCachedPromise } from "@raycast/utils";
+import { usePromise } from "@raycast/utils";
+import { useRef } from "react";
 import { SimplifiedPlaylistObject } from "../helpers/spotify.api";
-import getAllPlaylistItems from "../helpers/getAllPlaylistItems";
+import { playlistContainsTrack } from "../api/playlistContainsTrack";
 
 type UsePlaylistsContainingTrackProps = {
   playlists: SimplifiedPlaylistObject[];
   trackUri?: string;
-  options?: {
-    execute?: boolean;
-  };
+  options?: { execute?: boolean };
 };
 
-async function getPlaylistsContainingTrack(playlists: SimplifiedPlaylistObject[], trackUri: string): Promise<string[]> {
-  const results = await Promise.allSettled(
-    playlists.map(async (playlist) => {
-      const uris = await getAllPlaylistItems(playlist);
-      return { id: playlist.id as string, contains: uris.includes(trackUri) };
-    }),
-  );
-
-  const containingIds: string[] = [];
-  for (const result of results) {
-    if (result.status === "fulfilled" && result.value.contains) {
-      containingIds.push(result.value.id);
-    }
-  }
-  return containingIds;
-}
-
 export function usePlaylistsContainingTrack({ playlists, trackUri, options }: UsePlaylistsContainingTrackProps) {
-  const { data, isLoading, revalidate } = useCachedPromise(
-    (playlists: SimplifiedPlaylistObject[], trackUri: string) => getPlaylistsContainingTrack(playlists, trackUri),
-    [playlists, trackUri ?? ""],
-    {
-      execute: options?.execute !== false && playlists.length > 0 && !!trackUri,
+  const abortable = useRef<AbortController | null>(null);
+  const { data, isLoading, revalidate } = usePromise(
+    async (ids: string[], uri: string) => {
+      const signal = abortable.current?.signal;
+      const containingIds: string[] = [];
+      // These consumers display membership across the catalog. Walk it sequentially;
+      // each check discards its page before fetching the next one.
+      for (const id of ids) {
+        signal?.throwIfAborted();
+        if (await playlistContainsTrack(id, uri, signal)) containingIds.push(id);
+      }
+      return { uri, ids: containingIds };
     },
+    [playlists.flatMap((playlist) => (playlist.id ? [playlist.id] : [])), trackUri ?? ""],
+    { execute: options?.execute !== false && playlists.length > 0 && !!trackUri, abortable },
   );
 
   return {
-    playlistsContainingTrack: data ?? [],
+    playlistsContainingTrack: data && data.uri === trackUri ? data.ids : [],
     playlistsContainingTrackIsLoading: isLoading,
     playlistsContainingTrackRevalidate: revalidate,
   };

--- a/extensions/spotify-player/src/hooks/useYourLibrary.ts
+++ b/extensions/spotify-player/src/hooks/useYourLibrary.ts
@@ -1,4 +1,4 @@
-import { useCachedPromise } from "@raycast/utils";
+import { usePromise } from "@raycast/utils";
 import { getUserPlaylists } from "../api/getUserPlaylists";
 import { getMySavedAlbums } from "../api/getMySavedAlbums";
 import { getFollowedArtists } from "../api/getFollowedArtists";
@@ -10,7 +10,6 @@ export type LibraryCategory = "all" | "playlists" | "albums" | "artists" | "trac
 
 type UseMyLibraryProps = {
   category?: LibraryCategory;
-  keepPreviousData?: boolean;
 };
 
 type LibraryData = {
@@ -49,9 +48,7 @@ async function fetchLibraryData(category: LibraryCategory): Promise<LibraryData>
 
 export function useYourLibrary(options: UseMyLibraryProps = {}) {
   const category = options.category ?? "all";
-  const { data, error, isLoading } = useCachedPromise(fetchLibraryData, [category], {
-    keepPreviousData: options?.keepPreviousData,
-  });
+  const { data, error, isLoading } = usePromise(fetchLibraryData, [category]);
 
   return {
     myLibraryData: {

--- a/extensions/spotify-player/src/nowPlaying.tsx
+++ b/extensions/spotify-player/src/nowPlaying.tsx
@@ -352,7 +352,7 @@ function NowPlayingCommand() {
           {isPlaying && <PauseAction onPause={() => currentlyPlayingRevalidate()} />}
           {!isPlaying && <PlayAction onPlay={() => currentlyPlayingRevalidate()} />}
           {trackOrEpisodeActions}
-          {myPlaylistsData?.items && meData && uri && <AddToPlaylistAction uri={uri} />}
+          {uri && <AddToPlaylistAction uri={uri} />}
           <ActionPanel.Submenu icon={Icon.Mobile} title="Connect Device" shortcut={ConnectDevice}>
             {myDevicesData?.devices
               ?.filter((device) => !device.is_restricted)

--- a/extensions/spotify-player/src/nowPlaying.tsx
+++ b/extensions/spotify-player/src/nowPlaying.tsx
@@ -352,9 +352,7 @@ function NowPlayingCommand() {
           {isPlaying && <PauseAction onPause={() => currentlyPlayingRevalidate()} />}
           {!isPlaying && <PlayAction onPlay={() => currentlyPlayingRevalidate()} />}
           {trackOrEpisodeActions}
-          {myPlaylistsData?.items && meData && uri && (
-            <AddToPlaylistAction playlists={myPlaylistsData.items} meData={meData} uri={uri} />
-          )}
+          {myPlaylistsData?.items && meData && uri && <AddToPlaylistAction uri={uri} />}
           <ActionPanel.Submenu icon={Icon.Mobile} title="Connect Device" shortcut={ConnectDevice}>
             {myDevicesData?.devices
               ?.filter((device) => !device.is_restricted)

--- a/extensions/spotify-player/src/yourLibrary.tsx
+++ b/extensions/spotify-player/src/yourLibrary.tsx
@@ -24,10 +24,11 @@ type FilterValue = keyof typeof filters;
 
 function YourLibraryCommand() {
   const [searchText, setSearchText] = useState("");
-  const [searchFilter, setSearchFilter] = useState<FilterValue>(getPreferenceValues()["Default-View"] ?? filters.all);
+  const [searchFilter, setSearchFilter] = useState<FilterValue>(
+    (getPreferenceValues()["Default-View"]?.toLowerCase() as FilterValue) ?? "all",
+  );
   const { myLibraryData, myLibraryIsLoading } = useYourLibrary({
     category: searchFilter,
-    keepPreviousData: true,
   });
 
   const sharedProps: ComponentProps<typeof List> = {

--- a/extensions/spotify-player/tests/README.md
+++ b/extensions/spotify-player/tests/README.md
@@ -1,0 +1,7 @@
+# Spotify library regression fixtures
+
+Run `npm test` for lifecycle/API regression tests and `npm run test:memory -- browse|picker|scan|navigation` (choose one scenario) for sampled heap/request measurements. See ../PR_REVIEW.md for fixture details and measured results.
+
+The harness uses the installed React renderer and **real** @raycast/utils hooks. Only Spotify, Raycast UI/cache/storage, authentication, and unrelated radio/footer/native-app checks are substituted. Raycast host items mount their `actions`, while Action.Push targets remain unmounted until explicit navigation. Native filtering is not emulated: tests verify later-page item availability; native filtering/keyboard behavior remains a manual check.
+
+Use `BASELINE_REF=<pre-change-ref>` to load actual old source through `git show`. The initial standalone snapshot is `d0b62b5`; all its source files matched upstream main `162554d2741b7528614862c7b7cf80334de632f4`. In the monorepo set `BASELINE_PREFIX=extensions/spotify-player/` and use the upstream revision. Run the before peak with `--max-old-space-size=1024`; the 100 MiB run intentionally aborts (disable core dumps first). The harness and renderer add their own heap overhead; these are not Raycast runtime measurements.

--- a/extensions/spotify-player/tests/README.md
+++ b/extensions/spotify-player/tests/README.md
@@ -1,7 +1,48 @@
 # Spotify library regression fixtures
 
-Run `npm test` for lifecycle/API regression tests and `npm run test:memory -- browse|picker|scan|navigation` (choose one scenario) for sampled heap/request measurements. See ../PR_REVIEW.md for fixture details and measured results.
+Run from the extension directory:
 
-The harness uses the installed React renderer and **real** @raycast/utils hooks. Only Spotify, Raycast UI/cache/storage, authentication, and unrelated radio/footer/native-app checks are substituted. Raycast host items mount their `actions`, while Action.Push targets remain unmounted until explicit navigation. Native filtering is not emulated: tests verify later-page item availability; native filtering/keyboard behavior remains a manual check.
+```sh
+npm ci
+npm test
+npm run test:memory -- browse
+npm run test:memory -- picker
+npm run test:memory -- scan
+npm run test:memory -- navigation
+```
 
-Use `BASELINE_REF=<pre-change-ref>` to load actual old source through `git show`. The initial standalone snapshot is `d0b62b5`; all its source files matched upstream main `162554d2741b7528614862c7b7cf80334de632f4`. In the monorepo set `BASELINE_PREFIX=extensions/spotify-player/` and use the upstream revision. Run the before peak with `--max-old-space-size=1024`; the 100 MiB run intentionally aborts (disable core dumps first). The harness and renderer add their own heap overhead; these are not Raycast runtime measurements.
+The executable tests live in `src/__tests__`, where their real `react-test-renderer` imports satisfy the repository's source-import requirement for dependencies. The renderer remains a development dependency and no command imports the tests. `tests/harness.cjs` supplies the fixtures and TypeScript loader.
+
+## Fixture scope
+
+The harness uses the installed React renderer and **real** @raycast/utils hooks. Spotify responses, Raycast UI/cache/storage, authentication, and unrelated radio/footer/native-app checks are substituted. Raycast host items mount their `actions`, while Action.Push targets remain unmounted until explicit navigation. Native filtering is not emulated: tests verify later-page item availability; filtering/keyboard behavior remains a manual check.
+
+The memory fixture contains 120 playlists across three catalog pages, each with 2,500 tracks. Full track objects include artist, album, image, external URL, and market metadata. The mock honors the production URI-only fields projection for membership checks. The navigation scenario opens and unmounts library, album, and picker views for 25 cycles, scanning a different selected playlist each cycle.
+
+The regression suite also covers a 275-playlist catalog, duplicates beyond track 1,000, null/relinked tracks, invalid continuation, cancellation, concurrent checks, out-of-order search/selection responses, add/remove and duplicate overrides, favorites, and quicklinks. Failure cases verify removal during pending/failed background checks, explicit quicklink retry after scan or mutation failure, and opening the picker after Now Playing's secondary requests fail.
+
+## Sampled memory results
+
+Measured on macOS arm64 with Node 24.12.0, React 19.0.0, and the installed Raycast utils. Heap is sampled using `process.memoryUsage().heapUsed` at API/cache boundaries, between React flushes, and with a 1 ms timer. These are sampled peaks, not exact allocator high-water marks. Figures include the renderer, TypeScript loader, and in-memory substitutes for Raycast's disk cache; startup heap is about 27.0 MiB. Serialized bytes count cumulative cache writes.
+
+| Scenario                                         | Peak heap | Requests                                  |                  Peak concurrency | Serialized writes |
+| ------------------------------------------------ | --------: | ----------------------------------------- | --------------------------------: | ----------------: |
+| Before: one track action panel, cold cache       | 401.0 MiB | 3 catalog + 1 profile + 2,400 track pages |                               120 |          2.78 MiB |
+| After: identical panel                           |  27.8 MiB | 0                                         |                                 0 |                 0 |
+| After: chooser and selected 2,500-track playlist |  33.1 MiB | 3 catalog + 1 profile + 50 track pages    |                                 2 |         0.016 MiB |
+| After: isolated 2,500-track scan                 |  27.8 MiB | 50 track pages                            |                                 1 |                 0 |
+| After: 25 navigation cycles                      |  58.3 MiB | 1,290 total, including 1,250 track pages  | 7 overall; membership capped at 2 |          0.56 MiB |
+
+The before peak requires a 1,024 MiB old-space cap. The initial investigation also reproduced an allocation failure under a 100 MiB cap. All after scenarios complete with the 100 MiB cap; after navigation/unmount/GC, heap is about 29.6 MiB. The initial library's six category requests plus profile explain the overall concurrency of seven.
+
+## Reproducing the baseline
+
+`BASELINE_REF` loads actual old source through `git show`. The initial standalone snapshot is `d0b62b5`; its source files matched upstream main `162554d2741b7528614862c7b7cf80334de632f4` during the initial investigation.
+
+```sh
+BASELINE_REF=d0b62b5 node --expose-gc --max-old-space-size=1024 src/__tests__/memory.mjs browse
+```
+
+In the monorepo, set `BASELINE_PREFIX=extensions/spotify-player/` and use the upstream revision. To reproduce the expected old-code OOM, first disable core dumps (`ulimit -c 0`), then use `--max-old-space-size=100` instead of `1024`.
+
+These fixtures do not validate Spotify authentication or native Raycast behavior. The Node old-space cap differs from Raycast's exact extension heap accounting. Native macOS Raycast was not exercised; Windows validation is unavailable. No user library was read or modified.

--- a/extensions/spotify-player/tests/harness.cjs
+++ b/extensions/spotify-player/tests/harness.cjs
@@ -1,0 +1,263 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const Module = require("node:module");
+const ts = require("typescript");
+const React = require("react");
+const { execFileSync } = require("node:child_process");
+const root = path.resolve(__dirname, "..");
+const stats = { calls: {}, active: 0, peakActive: 0, peakHeap: 0, cacheBytes: 0, writes: [] };
+const sample = () => {
+  stats.peakHeap = Math.max(stats.peakHeap, process.memoryUsage().heapUsed);
+};
+const cache = new Map();
+const listeners = new Set();
+const local = new Map();
+class Cache {
+  constructor({ namespace = "" } = {}) {
+    this.namespace = namespace;
+  }
+  get(key) {
+    return cache.get(`${this.namespace}:${key}`);
+  }
+  set(key, value) {
+    stats.cacheBytes += Buffer.byteLength(value);
+    cache.set(`${this.namespace}:${key}`, value);
+    sample();
+    for (const fn of listeners) fn();
+  }
+  remove(key) {
+    cache.delete(`${this.namespace}:${key}`);
+    for (const fn of listeners) fn();
+  }
+  subscribe = (fn) => {
+    listeners.add(fn);
+    return () => listeners.delete(fn);
+  };
+}
+const component = (name) =>
+  function Host(props) {
+    return React.createElement(name, props, props.children, props.actions, props.searchBarAccessory);
+  };
+const Action = component("Action");
+Action.Push = component("Action.Push"); // targets mount only after explicit navigation
+for (const name of ["OpenInBrowser", "CopyToClipboard", "CreateQuicklink"]) Action[name] = component(`Action.${name}`);
+const ActionPanel = component("ActionPanel");
+for (const name of ["Submenu", "Section"]) ActionPanel[name] = component(`ActionPanel.${name}`);
+const List = component("List");
+const Grid = component("Grid");
+Grid.Inset = { Small: "small" };
+for (const type of [List, Grid]) {
+  for (const name of ["Item", "Section", "EmptyView", "Dropdown"])
+    type[name] = component(`${type === List ? "List" : "Grid"}.${name}`);
+  type.Dropdown.Item = component("Dropdown.Item");
+}
+const preferences = { "Default-View": "all", cacheRefreshTime: "30", duplicateSongCheck: true };
+const toasts = [];
+const api = {
+  Action,
+  ActionPanel,
+  List,
+  Grid,
+  Cache,
+  Icon: new Proxy({}, { get: (_, k) => k }),
+  Image: { Mask: {} },
+  Color: {},
+  Keyboard: { Shortcut: { Common: { Refresh: {} } } },
+  LaunchType: { UserInitiated: "user" },
+  Toast: { Style: { Success: "success", Failure: "failure", Animated: "animated" } },
+  environment: {
+    commandName: "yourLibrary",
+    extensionName: "spotify-player",
+    assetsPath: root,
+    supportPath: root,
+    isDevelopment: true,
+  },
+  getPreferenceValues: () => preferences,
+  showToast: async (toast) => {
+    toasts.push(toast);
+    return toast;
+  },
+  showHUD: async () => {},
+  popToRoot: async () => {},
+  launchCommand: async () => {},
+  LocalStorage: {
+    getItem: async (k) => local.get(k),
+    setItem: async (k, v) => {
+      stats.cacheBytes += Buffer.byteLength(v);
+      local.set(k, v);
+      sample();
+    },
+    removeItem: async (k) => local.delete(k),
+  },
+};
+let client;
+const originalLoad = Module._load;
+Module._load = function (name, parent, main) {
+  if (name === "@raycast/api") return api;
+  if (name.includes("withSpotifyClient"))
+    return {
+      getSpotifyClient: () => ({ spotifyClient: client }),
+      setSpotifyClient: async () => {},
+      withSpotifyClient: (fn) => fn,
+    };
+  if (name.includes("isSpotifyInstalled")) return { checkSpotifyApp: () => {} };
+  if (name.endsWith("/StartRadioAction")) return { StartRadioAction: () => null };
+  if (name.endsWith("/FooterAction")) return { FooterAction: () => null };
+  return originalLoad(name, parent, main);
+};
+for (const ext of [".ts", ".tsx"])
+  require.extensions[ext] = (mod, filename) => {
+    const relative = path.relative(root, filename);
+    const source =
+      process.env.BASELINE_REF && relative.startsWith("src/")
+        ? execFileSync("git", ["show", `${process.env.BASELINE_REF}:${process.env.BASELINE_PREFIX ?? ""}${relative}`], {
+            cwd: root,
+            encoding: "utf8",
+          })
+        : fs.readFileSync(filename, "utf8");
+    mod._compile(
+      ts.transpileModule(source, {
+        compilerOptions: {
+          module: ts.ModuleKind.CommonJS,
+          jsx: ts.JsxEmit.ReactJSX,
+          target: ts.ScriptTarget.ES2023,
+          esModuleInterop: true,
+        },
+      }).outputText,
+      filename,
+    );
+  };
+function track(id) {
+  return {
+    id: `${id}`,
+    uri: `spotify:track:${id}`,
+    name: `Song ${id}`,
+    type: "track",
+    duration_ms: 234000,
+    artists: [
+      { id: "artist", name: "Fixture artist", external_urls: { spotify: "https://open.spotify.com/artist/fixture" } },
+    ],
+    album: {
+      id: "album",
+      name: "Fixture Album",
+      type: "album",
+      images: [640, 300, 64].map((size) => ({
+        width: size,
+        height: size,
+        url: `https://i.scdn.co/image/${id}-${size}`,
+      })),
+      available_markets: [
+        "US",
+        "GB",
+        "DE",
+        "FR",
+        "CA",
+        "AU",
+        "IN",
+        "JP",
+        "BR",
+        "MX",
+        "IT",
+        "ES",
+        "SE",
+        "NO",
+        "FI",
+        "DK",
+        "NL",
+        "BE",
+        "CH",
+        "AT",
+      ],
+    },
+    external_urls: { spotify: `https://open.spotify.com/track/${id}` },
+    available_markets: Array.from({ length: 60 }, (_, i) => `M${i}`),
+  };
+}
+function fixture({ playlists = 250, tracks = 1500, delay = 0, contains = () => false, fail = () => false } = {}) {
+  const request = async (name, payload, fn) => {
+    stats.calls[name] = (stats.calls[name] ?? 0) + 1;
+    stats.active++;
+    stats.peakActive = Math.max(stats.peakActive, stats.active);
+    try {
+      await new Promise((r) => (delay ? setTimeout(r, delay) : setImmediate(r)));
+      const result = fn();
+      sample();
+      return result;
+    } finally {
+      stats.active--;
+    }
+  };
+  const page = (offset = 0, limit = 50) => ({
+    items: Array.from({ length: Math.min(limit, playlists - offset) }, (_, i) => ({
+      id: `p${offset + i}`,
+      name: `Playlist ${offset + i}`,
+      owner: { id: "me", display_name: "Me" },
+      tracks: { total: tracks },
+      images: [],
+      uri: `spotify:playlist:p${offset + i}`,
+    })),
+    total: playlists,
+    next: offset + limit < playlists ? `https://api.spotify.com/v1/me/playlists?offset=${offset + limit}` : null,
+  });
+  client = {
+    getMe: () => request("me", {}, () => ({ id: "me" })),
+    getMePlaylists: () => request("catalog", {}, () => page()),
+    getNext: (url) => request("catalog", {}, () => page(Number(new URL(url).searchParams.get("offset")))),
+    getPlaylistsByPlaylistIdTracks: (id, { offset = 0, limit = 50, fields } = {}) =>
+      request("tracks", { id, offset }, () => {
+        if (fail(id, offset)) throw new Error("Fixture request failure");
+        return {
+          items: Array.from({ length: Math.min(limit, tracks - offset) }, (_, i) => {
+            const n = offset + i;
+            const uri = contains(id, n) ? "spotify:track:target" : `spotify:track:${id}-${n}`;
+            return { track: fields ? { uri } : { ...track(`${id}-${n}`), uri } };
+          }),
+          next:
+            offset + limit < tracks
+              ? `https://api.spotify.com/v1/playlists/${id}/tracks?offset=${offset + limit}`
+              : null,
+        };
+      }),
+    getMeTracks: () =>
+      request("savedTracks", {}, () => ({
+        items: Array.from({ length: 50 }, (_, i) => ({ track: track(i) })),
+        total: 10000,
+      })),
+    getMeAlbums: () => request("albums", {}, () => ({ items: [] })),
+    getMeFollowing: () => request("artists", {}, () => ({ artists: { items: [] } })),
+    getMeShows: () => request("shows", {}, () => ({ items: [] })),
+    getMeEpisodes: () => request("episodes", {}, () => ({ items: [] })),
+    getAlbumsByIdTracks: () =>
+      request("albumTracks", {}, () => ({ items: Array.from({ length: 20 }, (_, i) => track(i)) })),
+    search: () => request("search", {}, () => ({ tracks: { items: Array.from({ length: 50 }, (_, i) => track(i)) } })),
+    getMeTracksContains: () => request("likedContains", {}, () => [false]),
+    putMeTracks: (body) =>
+      request("like", {}, () => {
+        stats.writes.push(["like", body]);
+      }),
+    postPlaylistsByPlaylistIdTracks: (id, body) =>
+      request("add", {}, () => {
+        stats.writes.push(["add", id, body]);
+        return { snapshot_id: "new" };
+      }),
+    deletePlaylistsByPlaylistIdTracks: (id, body) =>
+      request("remove", {}, () => {
+        stats.writes.push(["remove", id, body]);
+        return { snapshot_id: "new" };
+      }),
+    getMePlayerCurrentlyPlaying: () =>
+      request("playing", {}, () => ({ item: track("target"), currently_playing_type: "track" })),
+  };
+  return client;
+}
+function resetStats() {
+  stats.calls = {};
+  stats.peakActive = 0;
+  stats.peakHeap = 0;
+  stats.cacheBytes = 0;
+  stats.writes = [];
+  cache.clear();
+  local.clear();
+}
+global.IS_REACT_ACT_ENVIRONMENT = true;
+module.exports = { React, api, stats, sample, fixture, track, resetStats, preferences, toasts };

--- a/extensions/spotify-player/tests/harness.cjs
+++ b/extensions/spotify-player/tests/harness.cjs
@@ -43,6 +43,11 @@ Action.Push = component("Action.Push"); // targets mount only after explicit nav
 for (const name of ["OpenInBrowser", "CopyToClipboard", "CreateQuicklink"]) Action[name] = component(`Action.${name}`);
 const ActionPanel = component("ActionPanel");
 for (const name of ["Submenu", "Section"]) ActionPanel[name] = component(`ActionPanel.${name}`);
+const Detail = component("Detail");
+Detail.Metadata = component("Detail.Metadata");
+Detail.Metadata.Label = component("Detail.Metadata.Label");
+Detail.Metadata.TagList = component("Detail.Metadata.TagList");
+Detail.Metadata.TagList.Item = component("Detail.Metadata.TagList.Item");
 const List = component("List");
 const Grid = component("Grid");
 Grid.Inset = { Small: "small" };
@@ -57,6 +62,7 @@ const api = {
   Action,
   ActionPanel,
   List,
+  Detail,
   Grid,
   Cache,
   Icon: new Proxy({}, { get: (_, k) => k }),
@@ -245,6 +251,7 @@ function fixture({ playlists = 250, tracks = 1500, delay = 0, contains = () => f
         stats.writes.push(["remove", id, body]);
         return { snapshot_id: "new" };
       }),
+    getMePlayerDevices: async () => ({ devices: [] }),
     getMePlayerCurrentlyPlaying: () =>
       request("playing", {}, () => ({ item: track("target"), currently_playing_type: "track" })),
   };

--- a/extensions/spotify-player/tests/library.test.cjs
+++ b/extensions/spotify-player/tests/library.test.cjs
@@ -1,0 +1,231 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { React, fixture, stats, resetStats, track, toasts } = require("./harness.cjs");
+const { act, create } = require("react-test-renderer");
+const { playlistContainsTrack } = require("../src/api/playlistContainsTrack.ts");
+const { getMyPlaylists } = require("../src/api/getMyPlaylists.ts");
+const { TrackActionPanel } = require("../src/components/TrackActionPanel.tsx");
+const { PlaylistPicker } = require("../src/components/PlaylistPicker.tsx");
+const { TracksList } = require("../src/components/TracksList.tsx");
+const Library = require("../src/yourLibrary.tsx").default;
+const { useSearch } = require("../src/hooks/useSearch.ts");
+const { AddToSavedTracksAction } = require("../src/components/AddToSavedTracksAction.tsx");
+const tick = () => new Promise((r) => setImmediate(r));
+async function settle() {
+  for (let n = 0; n < 45; n++) await act(tick);
+}
+async function mount(element) {
+  let renderer;
+  await act(async () => {
+    renderer = create(element);
+  });
+  await settle();
+  return renderer;
+}
+async function unmount(renderer) {
+  await act(async () => renderer.unmount());
+}
+
+// Sequential: mock client and API caches are shared like one extension worker.
+test("large catalog coalesces cold consumers and preserves all later-page playlists", async () => {
+  resetStats();
+  fixture({ playlists: 275 });
+  const [a, b] = await Promise.all([getMyPlaylists(), getMyPlaylists()]);
+  assert.equal(a, b);
+  assert.equal(a.items.length, 275);
+  assert.equal(a.items[274].name, "Playlist 274");
+  assert.equal(stats.calls.catalog, 6);
+  assert.equal(stats.peakActive, 1);
+});
+test("membership scans beyond 1000, exits early, and never serializes track data", async () => {
+  resetStats();
+  fixture({ tracks: 2500, contains: (_, n) => n === 2200 });
+  assert.equal(await playlistContainsTrack("p1", "spotify:track:target"), true);
+  assert.equal(stats.calls.tracks, 45);
+  assert.equal(stats.cacheBytes, 0);
+  fixture({ tracks: 2500, contains: (_, n) => n === 0 });
+  assert.equal(await playlistContainsTrack("p1", "spotify:track:target"), true);
+  assert.equal(stats.calls.tracks, 46);
+  fixture({ tracks: 2500 });
+  assert.equal(await playlistContainsTrack("p1", "missing"), false);
+  assert.equal(stats.calls.tracks, 96);
+});
+test("overlapping checks have at most two requests; cancelled checks stop and errors are not absence", async () => {
+  resetStats();
+  fixture({ tracks: 100, delay: 1 });
+  await Promise.all(Array.from({ length: 8 }, (_, i) => playlistContainsTrack(`p${i}`, "missing")));
+  assert.equal(stats.peakActive, 2);
+  const controller = new AbortController();
+  const pending = playlistContainsTrack("p0", "missing", controller.signal);
+  controller.abort();
+  await assert.rejects(pending, { name: "AbortError" });
+  fixture({ fail: () => true });
+  await assert.rejects(playlistContainsTrack("p0", "missing"), /Fixture request failure/);
+});
+test("null tracks, relinked tracks, empty pages and invalid continuation", async () => {
+  resetStats();
+  const client = fixture();
+  let calls = 0;
+  client.getPlaylistsByPlaylistIdTracks = async () =>
+    ++calls === 1
+      ? { items: [], next: "https://api.spotify.com/tracks?offset=50" }
+      : { items: [{ track: null }, { track: { uri: "replacement", linked_from: { uri: "original" } } }], next: null };
+  assert.equal(await playlistContainsTrack("p", "original"), true);
+  assert.equal(calls, 2);
+  client.getPlaylistsByPlaylistIdTracks = async () => ({ items: [], next: "https://api.spotify.com/tracks?offset=0" });
+  await assert.rejects(playlistContainsTrack("p", "original"), /Invalid playlist continuation/);
+});
+test("library, search results and album navigation do not inspect playlist tracks, even across repeated renders", async () => {
+  resetStats();
+  fixture({ playlists: 275, tracks: 2500 });
+  const library = await mount(React.createElement(Library));
+  assert.equal(stats.calls.tracks, undefined);
+  assert.equal(stats.calls.catalog, 6);
+  await act(async () => library.root.findByType("List.Dropdown").props.onChange("playlists"));
+  await settle();
+  assert.ok(library.root.findAllByType("List.Item").some((item) => item.props.title === "Playlist 274"));
+  await unmount(library);
+  function SearchResults() {
+    const { searchData } = useSearch({ query: "fixture" });
+    return searchData?.tracks?.items.map((t) =>
+      React.createElement(TrackActionPanel, { key: t.id, title: t.name, track: t }),
+    );
+  }
+  const search = await mount(React.createElement(SearchResults));
+  assert.equal(stats.calls.tracks, undefined);
+  await unmount(search);
+  for (let i = 0; i < 5; i++) {
+    const album = await mount(
+      React.createElement(TracksList, { album: { id: "album", name: "Album", uri: "spotify:album:album" } }),
+    );
+    await act(async () =>
+      album.update(
+        React.createElement(TracksList, { album: { id: "album", name: "Album", uri: "spotify:album:album" } }),
+      ),
+    );
+    await unmount(album);
+  }
+  assert.equal(stats.calls.tracks, undefined);
+});
+test("picker loads metadata only until selection; stale selection cannot replace new membership", async () => {
+  resetStats();
+  const client = fixture({ playlists: 275, tracks: 1 });
+  const renderer = await mount(React.createElement(PlaylistPicker, { uri: "spotify:track:target" }));
+  assert.equal(stats.calls.tracks, undefined);
+  let resolveOld;
+  client.getPlaylistsByPlaylistIdTracks = async (id) =>
+    id === "p0"
+      ? new Promise((resolve) => {
+          resolveOld = resolve;
+        })
+      : { items: [], next: null };
+  await act(async () => renderer.root.findByType("List").props.onSelectionChange("p0"));
+  await act(async () => renderer.root.findByType("List").props.onSelectionChange("p274"));
+  await settle();
+  await act(async () => resolveOld({ items: [{ track: { uri: "spotify:track:target" } }], next: null }));
+  await settle();
+  const selected = renderer.root.findAllByType("List.Item").find((item) => item.props.id === "p274");
+  assert.deepEqual(selected.props.accessories, []);
+  assert.ok(renderer.root.findAllByType("List.Item").some((item) => item.props.title === "Playlist 274"));
+  await unmount(renderer);
+});
+test("picker adds once, removes known membership and blocks duplicates discovered at action time", async () => {
+  resetStats();
+  fixture({ playlists: 1, tracks: 1 });
+  const renderer = await mount(React.createElement(PlaylistPicker, { uri: "spotify:track:target" }));
+  await act(async () => renderer.root.findByType("List").props.onSelectionChange("p0"));
+  await settle();
+  let action = renderer.root.findByType("Action").props.onAction;
+  await act(async () => Promise.all([action(), action()]));
+  await settle();
+  assert.equal(stats.writes.filter((x) => x[0] === "add").length, 1);
+  fixture({ playlists: 1, tracks: 1, contains: () => true });
+  await act(async () => renderer.root.findByType("Action").props.onAction());
+  await settle();
+  assert.equal(stats.writes.length, 1);
+  assert.equal(toasts.at(-1).title, "Duplicate found");
+  await act(async () => toasts.at(-1).primaryAction.onAction());
+  await settle();
+  assert.equal(stats.writes.filter((x) => x[0] === "add").length, 2);
+  assert.equal(renderer.root.findByType("Action").props.title, "Remove from Playlist");
+  await act(async () => renderer.root.findByType("Action").props.onAction());
+  await settle();
+  assert.equal(stats.writes.filter((x) => x[0] === "remove").length, 1);
+  await unmount(renderer);
+});
+test("favorites action writes a saved track without playlist loading", async () => {
+  resetStats();
+  fixture();
+  const renderer = await mount(React.createElement(AddToSavedTracksAction, { trackId: "target" }));
+  await act(async () => renderer.root.findByType("Action").props.onAction());
+  await settle();
+  assert.equal(stats.calls.like, 1);
+  assert.equal(stats.calls.catalog, undefined);
+  assert.equal(stats.calls.tracks, undefined);
+  await unmount(renderer);
+});
+test("new search response wins when older search finishes last", async () => {
+  resetStats();
+  const client = fixture();
+  let old;
+  let current;
+  client.search = async (query) =>
+    query === "old" ? new Promise((r) => (old = r)) : { tracks: { items: [track("new")] } };
+  function Search({ query }) {
+    current = useSearch({ query });
+    return null;
+  }
+  const renderer = await mount(React.createElement(Search, { query: "old" }));
+  await act(async () => renderer.update(React.createElement(Search, { query: "new" })));
+  await settle();
+  await act(async () => old({ tracks: { items: [track("old")] } }));
+  await settle();
+  assert.equal(current.searchData.tracks.items[0].id, "new");
+  await unmount(renderer);
+});
+
+test("catalog membership consumers stream pages, do not refetch on equivalent renders, and cancel old songs", async () => {
+  resetStats();
+  const client = fixture({ playlists: 3, tracks: 100 });
+  const { usePlaylistsContainingTrack } = require("../src/hooks/usePlaylistsContainingTrack.ts");
+  let state;
+  function Membership({ uri }) {
+    state = usePlaylistsContainingTrack({ playlists: [{ id: "p0" }, { id: "p1" }, { id: "p2" }], trackUri: uri });
+    return null;
+  }
+  const renderer = await mount(React.createElement(Membership, { uri: "one" }));
+  assert.equal(stats.calls.tracks, 6);
+  await act(async () => renderer.update(React.createElement(Membership, { uri: "one" })));
+  await settle();
+  assert.equal(stats.calls.tracks, 6);
+  assert.equal(stats.cacheBytes, 0);
+  let old;
+  client.getPlaylistsByPlaylistIdTracks = async () => new Promise((r) => (old = r));
+  await act(async () => renderer.update(React.createElement(Membership, { uri: "old" })));
+  client.getPlaylistsByPlaylistIdTracks = async () => ({ items: [], next: null });
+  await act(async () => renderer.update(React.createElement(Membership, { uri: "new" })));
+  await settle();
+  await act(async () => old({ items: [{ track: { uri: "old" } }], next: null }));
+  await settle();
+  assert.deepEqual(state.playlistsContainingTrack, []);
+  await unmount(renderer);
+});
+
+test("playing-song command renders the lazy picker; quicklinks check beyond 1000 before adding", async () => {
+  resetStats();
+  fixture({ playlists: 1, tracks: 1500, contains: (_, n) => n === 1400 });
+  const Command = require("../src/addPlayingSongToPlaylist.tsx").default;
+  const picker = await mount(React.createElement(Command, {}));
+  assert.equal(stats.calls.tracks, undefined);
+  await unmount(picker);
+  resetStats();
+  const quicklink = await mount(React.createElement(Command, { launchContext: { playlistId: "p0" } }));
+  assert.equal(stats.calls.catalog, undefined);
+  assert.equal(stats.calls.tracks, 29);
+  assert.equal(stats.writes.length, 0);
+  assert.equal(toasts.at(-1).title, "Duplicate found");
+  await act(async () => toasts.at(-1).primaryAction.onAction());
+  await settle();
+  assert.equal(stats.writes.filter((x) => x[0] === "add").length, 1);
+  await unmount(quicklink);
+});

--- a/extensions/spotify-player/tests/memory.cjs
+++ b/extensions/spotify-player/tests/memory.cjs
@@ -1,0 +1,81 @@
+// Run each variant in a fresh process. BASELINE_REF selects the actual pre-change source via git show.
+const { React, fixture, stats, sample } = require("./harness.cjs");
+const { act, create } = require("react-test-renderer");
+const { TrackActionPanel } = require("../src/components/TrackActionPanel.tsx");
+const { track } = require("./harness.cjs");
+const scenario = process.argv[2] ?? "browse";
+const { PlaylistPicker } = ["picker", "navigation"].includes(scenario)
+  ? require("../src/components/PlaylistPicker.tsx")
+  : {};
+const { playlistContainsTrack } = scenario === "scan" ? require("../src/api/playlistContainsTrack.ts") : {};
+fixture({ playlists: 120, tracks: 2500 });
+const tick = () => new Promise((r) => setImmediate(r));
+async function settle() {
+  for (let i = 0; i < 80; i++) {
+    await act(tick);
+    sample();
+  }
+}
+(async () => {
+  global.gc?.();
+  const startHeap = process.memoryUsage().heapUsed;
+  stats.peakHeap = startHeap;
+  const timer = setInterval(sample, 1);
+  let renderer;
+  if (scenario === "navigation") {
+    const Library = require("../src/yourLibrary.tsx").default;
+    const { TracksList } = require("../src/components/TracksList.tsx");
+    for (let visit = 0; visit < 25; visit++) {
+      for (const element of [
+        React.createElement(Library),
+        React.createElement(TracksList, { album: { id: "album", name: "Album" } }),
+        React.createElement(PlaylistPicker, { uri: "spotify:track:target" }),
+      ]) {
+        await act(async () => {
+          renderer = create(element);
+        });
+        await settle();
+        if (element.type === PlaylistPicker) {
+          await act(async () => renderer.root.findByType("List").props.onSelectionChange(`p${visit}`));
+          await settle();
+        }
+        await act(async () => renderer.unmount());
+        renderer = undefined;
+      }
+    }
+  } else if (scenario === "scan") {
+    await playlistContainsTrack("p119", "missing");
+  } else {
+    const element =
+      scenario === "picker"
+        ? React.createElement(PlaylistPicker, { uri: "spotify:track:target" })
+        : React.createElement(TrackActionPanel, { title: "Fixture", track: track("target") });
+    await act(async () => {
+      renderer = create(element);
+    });
+    await settle();
+    if (scenario === "picker") {
+      await act(async () => renderer.root.findByType("List").props.onSelectionChange("p119"));
+      await settle();
+    }
+  }
+  sample();
+  if (renderer) await act(async () => renderer.unmount());
+  global.gc?.();
+  clearInterval(timer);
+  console.log(
+    JSON.stringify({
+      variant: process.env.BASELINE_REF ? "before" : "after",
+      scenario,
+      startHeapMiB: startHeap / 2 ** 20,
+      peakHeapMiB: stats.peakHeap / 2 ** 20,
+      endHeapMiB: process.memoryUsage().heapUsed / 2 ** 20,
+      calls: stats.calls,
+      peakConcurrent: stats.peakActive,
+      serializedMiB: stats.cacheBytes / 2 ** 20,
+    }),
+  );
+})().catch((e) => {
+  console.error(e);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Description

This PR reduces memory usage and Spotify API request fan-out in **Your Library**, search results, albums, and playlist actions.

Previously, rendering a track's action panel eagerly loaded the user's playlist catalog and checked membership across every owned playlist. For users with large playlist libraries, this could create hundreds or thousands of requests and retain large track arrays in memory even when **Add to Playlist** was never opened.

### Changes

* Loads **Add to Playlist** actions on demand instead of scanning playlist membership whenever a track action panel is rendered.
* Checks membership only for the currently selected playlist in the playlist chooser.
* Reworks playlist membership checks to:

  * Read URI-only pages instead of retaining full track objects.
  * Process pages incrementally.
  * Follow pagination beyond the first 1,000 tracks.
  * Bound membership request concurrency.
  * Cancel stale scans when the selected playlist changes.
* Uses the same bounded membership scanner for the Now Playing playlist metadata flow.
* Removes the previous full-playlist URI caching behavior used during membership checks.
* Coalesces concurrent playlist-catalog requests and avoids repeatedly copying the accumulated playlist array while paginating.
* Removes the redundant hook-level serialized playlist cache.
* Loads all playlist catalog pages so playlists beyond the first page are available in **Your Library** and the playlist chooser.
* Preserves:

  * Add and remove playlist actions.
  * Duplicate detection and the explicit override action.
  * Playing-song playlist quicklinks.
  * Favorites behavior.
  * Existing OAuth, playback, and lyrics functionality.

### Memory and request impact

Using a fixture with 120 playlists and 2,500 tracks per playlist:

* Before: opening one track action panel reached a sampled peak of **400.4 MiB** and triggered **2,400 playlist-track page requests**.
* After: the same action panel reaches approximately **27.5 MiB** and performs **no playlist membership requests**.
* Opening the playlist chooser and scanning a selected 2,500-track playlist reaches approximately **32.8 MiB**, with membership concurrency bounded to two requests.
* All tested post-change scenarios complete under a 100 MiB Node old-space cap, while the pre-change fixture reproduces an out-of-memory failure under the same cap.

These measurements use mocked Spotify responses and Raycast host components to exercise the real React lifecycle and extension hooks. They are intended to demonstrate the allocation and request fan-out improvement rather than represent Raycast's exact worker memory accounting.

### Related issues

- Fixes #27607
- Fixes #23975
- Fixes #23405
- Fixes #22874
- Fixes #29206
- Fixes #23443
- Fixes #29138.

Several of these reports predate the playlist membership fan-out addressed here, so this PR does not claim their original historical causes are proven. It fixes a current reproducible allocation problem in code paths shared by those commands.

### Validation

* `npm test`
* `npm run lint`
* `npm run build`
* `npx tsc --noEmit`
* `git diff --check`
* Memory regression fixtures covering:

  * Track action rendering
  * Playlist chooser membership
  * Large playlist scans
  * Repeated library → album → playlist navigation
  * Duplicate detection beyond track 1,000
  * Add/remove and duplicate override behavior
  * Stale search and cancelled membership requests

## Checklist

* [x] I read the [[extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)](https://developers.raycast.com/basics/prepare-an-extension-for-store)
* [x] I read the [[documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)](https://developers.raycast.com/basics/publish-an-extension)
* [x] I ran `npm run build` and tested the distribution build where possible
* [x] I checked that files in the `assets` folder are used by the extension itself
* [x] I checked that assets used by the `README` are placed outside of the `metadata` folder