### PR TITLE
Update in the time zone extension

### DIFF
--- a/extensions/in-the-time-zone/CHANGELOG.md
+++ b/extensions/in-the-time-zone/CHANGELOG.md
@@ -1,5 +1,11 @@
 # In The Timezone Changelog
 
+## [City Ordering] - {PR_MERGE_DATE}
+
+- Cities are now sorted by GMT offset by default (west → east), in both the list and timeline views
+- Added a "City Order" preference: GMT Offset (West → East), GMT Offset (East → West), or Custom
+- With Custom order, new Move Up / Move Down actions (⌘⇧↑ / ⌘⇧↓) let you arrange cities manually
+
 ## [System Time Format] - 2026-08-31
 
 - Respect the system 12/24-hour format, with preferences to override it

--- a/extensions/in-the-time-zone/CHANGELOG.md
+++ b/extensions/in-the-time-zone/CHANGELOG.md
@@ -1,6 +1,6 @@
 # In The Timezone Changelog
 
-## [City Ordering] - {PR_MERGE_DATE}
+## [City Ordering] - 2026-09-08
 
 - Cities are now sorted by GMT offset by default (west → east), in both the list and timeline views
 - Added a "City Order" preference: GMT Offset (West → East), GMT Offset (East → West), or Custom

--- a/extensions/in-the-time-zone/package.json
+++ b/extensions/in-the-time-zone/package.json
@@ -5,6 +5,9 @@
   "description": "Visualize and scrub time across multiple time zones",
   "icon": "icon.png",
   "author": "i_idz",
+  "contributors": [
+    "ridemountainpig"
+  ],
   "platforms": [
     "macOS"
   ],

--- a/extensions/in-the-time-zone/package.json
+++ b/extensions/in-the-time-zone/package.json
@@ -45,6 +45,28 @@
       "required": false
     },
     {
+      "name": "cityOrder",
+      "type": "dropdown",
+      "title": "City Order",
+      "description": "How cities are ordered. Custom keeps your own arrangement via the Move Up/Down actions.",
+      "data": [
+        {
+          "title": "GMT Offset (West → East)",
+          "value": "offset-asc"
+        },
+        {
+          "title": "GMT Offset (East → West)",
+          "value": "offset-desc"
+        },
+        {
+          "title": "Custom",
+          "value": "custom"
+        }
+      ],
+      "default": "offset-asc",
+      "required": false
+    },
+    {
       "name": "defaultScrubMinutes",
       "type": "dropdown",
       "title": "Arrow Key Scrub Minutes",

--- a/extensions/in-the-time-zone/src/in-the-time-zone.tsx
+++ b/extensions/in-the-time-zone/src/in-the-time-zone.tsx
@@ -20,7 +20,7 @@ import {
   resolveTimeFormat,
 } from "./time-utils";
 import { TimelineView } from "./timeline-view";
-import { DEFAULT_TIME_ZONES, getCityName, getTimezone } from "./timezones";
+import { CityOrderPreference, DEFAULT_TIME_ZONES, getCityName, getTimezone, sortZoneIds } from "./timezones";
 
 const STORAGE_KEY = "selectedTimeZones";
 const BASE_CITY_KEY = "baseCityId";
@@ -37,6 +37,7 @@ export default function Command() {
   const scrubMinutes = parseInt(preferences.defaultScrubMinutes, 10) || 60;
   const optionScrubMinutes = parseInt(preferences.optionScrubMinutes, 10) || 30;
   const timeFormat = resolveTimeFormat(preferences.timeFormat as ClockFormatPreference);
+  const cityOrder = (preferences.cityOrder as CityOrderPreference) ?? "offset-asc";
 
   useEffect(() => {
     const load = async () => {
@@ -109,15 +110,33 @@ export default function Command() {
     await saveSelectedZones(currentIds.filter((id) => id !== cityId));
   }
 
+  async function moveCity(cityId: string, delta: -1 | 1) {
+    const currentIds = [...(selectedZoneIds ?? [])];
+    const from = currentIds.indexOf(cityId);
+    if (from === -1) return;
+    let to = from + delta;
+    // Skip over the base city, which is displayed in its own section
+    while (to >= 0 && to < currentIds.length && currentIds[to] === baseCityId) to += delta;
+    if (to < 0 || to >= currentIds.length) return;
+    currentIds.splice(from, 1);
+    currentIds.splice(to, 0, cityId);
+    await saveSelectedZones(currentIds);
+  }
+
   // Use selected base city or fall back to system timezone
   const baseZoneId = baseCityId ? getTimezone(baseCityId) : Intl.DateTimeFormat().resolvedOptions().timeZone;
   const base = useMemo(() => DateTime.fromISO(baseISO).setZone(baseZoneId), [baseISO, baseZoneId]);
 
+  // Apply the configured ordering (GMT offset or custom arrangement)
+  const sortedZoneIds = useMemo(
+    () => sortZoneIds(selectedZoneIds ?? [], baseISO, cityOrder),
+    [selectedZoneIds, baseISO, cityOrder],
+  );
+
   // Filter out the base city from the list (it's shown separately)
   const otherCities = useMemo(() => {
-    const zoneIds = selectedZoneIds ?? [];
-    return zoneIds.filter((id) => id !== baseCityId);
-  }, [selectedZoneIds, baseCityId]);
+    return sortedZoneIds.filter((id) => id !== baseCityId);
+  }, [sortedZoneIds, baseCityId]);
 
   // Search results
   const searchResults = useMemo(() => {
@@ -173,7 +192,7 @@ export default function Command() {
       <TimelineView
         baseISO={baseISO}
         baseCityId={baseCityId}
-        selectedZoneIds={selectedZoneIds ?? []}
+        selectedZoneIds={sortedZoneIds}
         onShiftMinutes={shiftMinutes}
         onSetBaseISO={setBaseISO}
         onToggleView={() => setViewMode("list")}
@@ -316,6 +335,22 @@ export default function Command() {
                       onAction={() => setViewMode("timeline")}
                       shortcut={{ modifiers: ["cmd"], key: "l" }}
                     />
+                    {cityOrder === "custom" && (
+                      <ActionPanel.Section title="Arrange">
+                        <Action
+                          title="Move up"
+                          icon={Icon.ArrowUp}
+                          onAction={() => void moveCity(row.key, -1)}
+                          shortcut={{ modifiers: ["cmd", "shift"], key: "arrowUp" }}
+                        />
+                        <Action
+                          title="Move Down"
+                          icon={Icon.ArrowDown}
+                          onAction={() => void moveCity(row.key, 1)}
+                          shortcut={{ modifiers: ["cmd", "shift"], key: "arrowDown" }}
+                        />
+                      </ActionPanel.Section>
+                    )}
                     <ActionPanel.Section title="Scrub Time">
                       <Action
                         title={formatScrubTitle(-scrubMinutes)}

--- a/extensions/in-the-time-zone/src/timezones.ts
+++ b/extensions/in-the-time-zone/src/timezones.ts
@@ -1,6 +1,9 @@
+import { DateTime } from "luxon";
 import { lookupCity, parseCityId } from "./citySearch";
 
 export type TimeZoneEntry = { id: string; label: string };
+
+export type CityOrderPreference = "offset-asc" | "offset-desc" | "custom";
 
 // IDs use format: "timezone|cityName" (e.g., "America/Los_Angeles|San Francisco")
 export const DEFAULT_TIME_ZONES: TimeZoneEntry[] = [
@@ -14,6 +17,18 @@ export const DEFAULT_TIME_ZONES: TimeZoneEntry[] = [
 
 export function getTimezone(id: string): string {
   return parseCityId(id).timezone;
+}
+
+export function sortZoneIds(zoneIds: string[], baseISO: string, order: CityOrderPreference): string[] {
+  if (order === "custom") return zoneIds;
+  const direction = order === "offset-desc" ? -1 : 1;
+  // Resolve offsets at the scrubbed time so DST transitions are respected
+  return [...zoneIds].sort((a, b) => {
+    const offsetA = DateTime.fromISO(baseISO).setZone(getTimezone(a)).offset;
+    const offsetB = DateTime.fromISO(baseISO).setZone(getTimezone(b)).offset;
+    if (offsetA !== offsetB) return (offsetA - offsetB) * direction;
+    return getCityName(a).localeCompare(getCityName(b));
+  });
 }
 
 export function getCityName(id: string): string {


### PR DESCRIPTION
## Description

- Cities are now sorted by GMT offset by default (west → east), in both the list and timeline views
- Added a "City Order" preference: GMT Offset (West → East), GMT Offset (East → West), or Custom
- With Custom order, new Move Up / Move Down actions (⌘⇧↑ / ⌘⇧↓) let you arrange cities manually
- Close #28435
- Close #27626

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
