### PR TITLE
windows-terminal: add New Tab Menu order preference

### DIFF
--- a/extensions/windows-terminal/CHANGELOG.md
+++ b/extensions/windows-terminal/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Windows Terminal Changelog
 
+## [New Tab Menu Preference] - 2026-09-08
+
+- Added the `Use New Tab Menu order` preference. When enabled, profiles are filtered and ordered to match Windows Terminal's `newTabMenu` setting (`profile`, `matchProfiles`, `folder`, and `remainingProfiles` entries), instead of the raw `settings.json` list order.
+
 ## [Always Open Administrator in a Normal Window] - 2026-07-22
 
 - "Open as Administrator" now always launches into a regular window, regardless of the `Open profiles in quake window` preference. Elevated quake windows don't respond to Windows Terminal's global quake shortcut (Win+`), so routing admin through quake left users unable to summon the drop-down back once it lost focus. The separate "Open as Administrator (Non-Quake)" action added in the previous release is no longer needed and has been removed.

--- a/extensions/windows-terminal/CHANGELOG.md
+++ b/extensions/windows-terminal/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Windows Terminal Changelog
 
-## [New Tab Menu Preference] - 2026-09-08
+## [New Tab Menu Preference] - {PR_MERGE_DATE}
 
 - Added the `Use New Tab Menu order` preference. When enabled, profiles are filtered and ordered to match Windows Terminal's `newTabMenu` setting (`profile`, `matchProfiles`, `folder`, and `remainingProfiles` entries), instead of the raw `settings.json` list order.
 

--- a/extensions/windows-terminal/package.json
+++ b/extensions/windows-terminal/package.json
@@ -23,6 +23,15 @@
       "type": "checkbox",
       "required": false,
       "default": false
+    },
+    {
+      "name": "useNewTabMenu",
+      "title": "New Tab Menu",
+      "label": "Use New Tab Menu order",
+      "description": "When enabled, shows profiles in the order defined by Windows Terminal's New Tab Menu setting (newTabMenu in settings.json) instead of the raw profile list order.",
+      "type": "checkbox",
+      "required": false,
+      "default": false
     }
   ],
   "dependencies": {

--- a/extensions/windows-terminal/package.json
+++ b/extensions/windows-terminal/package.json
@@ -51,6 +51,7 @@
     "lint": "ray lint",
     "fix-lint": "ray lint --fix",
     "build": "ray build",
+    "test": "node --test src/new-tab-menu.test.ts",
     "publish": "npx @raycast/api@latest publish"
   },
   "author": "lunaris",

--- a/extensions/windows-terminal/src/new-tab-menu.test.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.test.ts
@@ -37,13 +37,6 @@ describe("buildProfileMatcher", () => {
     assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "[" }), null);
   });
 
-  it("rejects patterns that can backtrack exponentially", () => {
-    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "(a+)+" }), null);
-    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "(a|aa)*" }), null);
-    assert.equal(buildProfileMatcher({ type: "matchProfiles", commandline: "((ab)+)+" }), null);
-    assert.equal(buildProfileMatcher({ type: "matchProfiles", source: "(a{1,2})+" }), null);
-  });
-
   it("keeps patterns that only look nested", () => {
     assert.deepEqual(matchedNames({ type: "matchProfiles", name: "(Power)+Shell" }), ["PowerShell"]);
     assert.deepEqual(matchedNames({ type: "matchProfiles", name: "(?:Power|Command)\\s.*" }), ["Command Prompt"]);
@@ -51,6 +44,28 @@ describe("buildProfileMatcher", () => {
       "PowerShell",
       "Command Prompt",
     ]);
+  });
+
+  it("keeps a repeated group whose alternatives are disjoint", () => {
+    assert.deepEqual(matchedNames({ type: "matchProfiles", commandline: "(pwsh|cmd)+\\.exe" }), [
+      "PowerShell",
+      "Command Prompt",
+    ]);
+    assert.deepEqual(matchedNames({ type: "matchProfiles", name: "(a|b)+" }), []);
+  });
+
+  it("bounds pathological patterns instead of rejecting or hanging on them", () => {
+    // (a+)+, (a?a?)+, ((ab)+)+, (a|aa)* all cause exponential backtracking in a native regex
+    // engine. The matcher still builds (the pattern is valid syntax) and returns fast with no
+    // match, instead of freezing or silently dropping a pattern that could otherwise be safe.
+    const adversarialName = "a".repeat(40) + "!";
+    for (const pattern of ["(a+)+", "(a?a?)+", "((ab)+)+", "(a|aa)*"]) {
+      const start = Date.now();
+      const matcher = buildProfileMatcher({ type: "matchProfiles", name: pattern });
+      assert.notEqual(matcher, null, pattern);
+      assert.equal(matcher!({ ...powershell, name: adversarialName }), false, pattern);
+      assert.ok(Date.now() - start < 1000, `${pattern} took too long`);
+    }
   });
 });
 

--- a/extensions/windows-terminal/src/new-tab-menu.test.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.test.ts
@@ -105,6 +105,35 @@ describe("buildProfileMatcher", () => {
     const matcher = buildProfileMatcher({ type: "matchProfiles", name: "a?".repeat(5000) + "b" });
     assert.equal(matcher!({ ...powershell, name: "b" }), true);
   });
+
+  it("treats \\b and \\B as word boundaries, not literal letters", () => {
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "\\bPowerShell\\b" })!(powershell), true);
+    assert.deepEqual(matchedNames({ type: "matchProfiles", name: "\\bCommand\\b Prompt" }), ["Command Prompt"]);
+    // There's no boundary mid-word, so \b can't split PowerShell between "Power" and "Shell".
+    assert.deepEqual(matchedNames({ type: "matchProfiles", name: "Power\\bShell" }), []);
+    assert.deepEqual(matchedNames({ type: "matchProfiles", name: "Power\\BShell" }), ["PowerShell"]);
+  });
+
+  it("honors the (?i) inline case-insensitivity flag", () => {
+    assert.deepEqual(matchedNames({ type: "matchProfiles", name: "(?i)powershell" }), ["PowerShell"]);
+    assert.deepEqual(matchedNames({ type: "matchProfiles", name: "(?i:power)Shell" }), ["PowerShell"]);
+    assert.deepEqual(matchedNames({ type: "matchProfiles", name: "(?i)[p]owershell" }), ["PowerShell"]);
+    // The flag lapses at the end of the group that set it, so "SHELL" stays case-sensitive.
+    assert.deepEqual(matchedNames({ type: "matchProfiles", name: "(?:(?i)power)SHELL" }), []);
+  });
+
+  it("rejects an escape it doesn't implement instead of matching it as a literal", () => {
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "\\p{L}+" }), null);
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "(PowerShell)\\1" }), null);
+  });
+
+  it("refuses a pattern whose nested repetitions compile to a huge program", () => {
+    const start = Date.now();
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "(a{1000}){1000}" }), null);
+    assert.ok(Date.now() - start < 1000, "compiling took too long");
+    // A merely long pattern still compiles and matches.
+    assert.deepEqual(matchedNames({ type: "matchProfiles", name: "(?:PowerShell){1}" }), ["PowerShell"]);
+  });
 });
 
 describe("resolveNewTabMenuOrder", () => {

--- a/extensions/windows-terminal/src/new-tab-menu.test.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.test.ts
@@ -78,6 +78,55 @@ describe("buildProfileMatcher", () => {
     assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "PowerShell$?" }), null);
     assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "^*PowerShell" }), null);
     assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "^{2}PowerShell" }), null);
+    // \b/\B are zero-width assertions too — a quantifier's always-valid zero-rep path would
+    // otherwise silently accept \b* without the assertion ever actually holding.
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "a\\b*b" }), null);
+  });
+
+  it("rejects a character class range that's out of order", () => {
+    // [z-a] can never match anything; reject it rather than silently compiling an always-false
+    // predicate a config author would have no way to notice.
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "[z-a]" }), null);
+    // A properly-ordered range still works.
+    assert.deepEqual(matchedNames({ type: "matchProfiles", commandline: "[a-z]+\\.exe" }), [
+      "PowerShell",
+      "Command Prompt",
+    ]);
+  });
+
+  it("forms a range from an escaped boundary character, not just a plain one", () => {
+    // parseClassAtom resolves \- or \] to their literal character before the range check runs,
+    // so an escaped boundary (needed for a char like "-" that can't appear unescaped there)
+    // still participates in the range instead of silently becoming disjoint literals.
+    assert.equal(
+      buildProfileMatcher({ type: "matchProfiles", name: "[\\--9]+" })!({ ...powershell, name: "1.2.3" }),
+      true,
+    );
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "[X-\\]]+" })!({ ...powershell, name: "]" }), true);
+    // A multi-character escape (\d, \w, \s) can't anchor or end a range — there's no single
+    // character to range from/to.
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "[a-\\d]" }), null);
+  });
+
+  it("rejects a quantifier bound with an implausible number of digits", () => {
+    // A 300+ digit bound overflows parseInt to Infinity, which would pass the "max < min"
+    // ordering check (Infinity < Infinity is false) as if it were a legitimate {n,}. Checked on
+    // the parsed value, not the digit-string length, so a zero-padded bound isn't wrongly
+    // rejected as "too large" just for having a lot of leading zeros.
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "a{" + "9".repeat(310) + "}" }), null);
+    assert.notEqual(buildProfileMatcher({ type: "matchProfiles", name: "a{100000000}" }), null);
+    assert.equal(
+      buildProfileMatcher({ type: "matchProfiles", name: "a{0000000005,10}" })!({ ...powershell, name: "aaaaa" }),
+      true,
+    );
+  });
+
+  it("rejects a pattern nested too deeply instead of overflowing the call stack", () => {
+    const deep = "(".repeat(5000) + "a" + ")".repeat(5000);
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: deep }), null);
+    // A realistic amount of nesting still compiles fine.
+    const shallow = "(".repeat(50) + "a" + ")".repeat(50);
+    assert.notEqual(buildProfileMatcher({ type: "matchProfiles", name: shallow }), null);
   });
 
   it("matches a long linear value without excessive cost", () => {
@@ -171,31 +220,39 @@ describe("buildProfileMatcher", () => {
     assert.equal(matcher!({ ...powershell, name: "a" }), false);
   });
 
-  it("reaches the minimum of a large counted repeat whose body can match empty", () => {
-    // (|a){2,4000} needs one empty rep plus one "a" rep to satisfy min=2 while consuming a
-    // single character. Reaching that requires revisiting the repeat instruction at a higher
-    // count within the same position — a plain identity-only visited set stops after the first
-    // visit and never gets there, silently rejecting a value that should match.
-    const matcher = buildProfileMatcher({ type: "matchProfiles", name: "(|a){2,4000}" });
-    assert.notEqual(matcher, null);
-    assert.equal(matcher!({ ...powershell, name: "a" }), true);
-    assert.equal(matcher!({ ...powershell, name: "aa" }), true);
-    assert.equal(matcher!({ ...powershell, name: "b" }), false);
+  it("rejects a large counted repeat whose body doesn't consume a fixed number of characters", () => {
+    // Every rep of a large counted repeat must consume the same fixed number of characters —
+    // otherwise different combinations of alternatives can reach the same string position after
+    // a different number of reps, and the dedup key's capping can only tell those apart when
+    // every rep advances the position by the same fixed amount. Rather than silently mismatch
+    // near `max`, this is rejected outright, the same as a nested quantifier.
+    // A nullable alternative (0 characters) differs from a nonzero one.
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "(|a){2,4000}" }), null);
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "(a?){2,25}" }), null);
+    // Two nonzero but differently-sized alternatives (1 vs 2 characters) — confirmed by exhaustive
+    // DP-vs-engine comparison to silently mismatch near `max` before this rejection existed.
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "(a|aa){21,30}" }), null);
+    // Every alternative the same fixed nonzero length is fine.
+    assert.notEqual(buildProfileMatcher({ type: "matchProfiles", name: "(a|b){2,25}" }), null);
   });
 
-  it("still enforces the maximum of a large counted repeat whose body can match empty", () => {
-    // Capping the dedup key at `min` must not affect the actual reps count `repeat` compares
-    // against `max` — only how many equivalent states get explored at one position.
-    const matcher = buildProfileMatcher({ type: "matchProfiles", name: "a{2,10}" });
-    assert.equal(matcher!({ ...powershell, name: "a".repeat(10) }), true);
-    assert.equal(matcher!({ ...powershell, name: "a".repeat(11) }), false);
+  it("matches correctly right up to the maximum of a large counted repeat, not just at the minimum", () => {
+    // A prior fix reached `min` correctly but the dedup key still collapsed distinct in-progress
+    // counts near `max`, dropping counts required to reach the top of the range.
+    const matcher = buildProfileMatcher({ type: "matchProfiles", name: "a{2,25}" });
+    assert.equal(matcher!({ ...powershell, name: "a".repeat(2) }), true);
+    assert.equal(matcher!({ ...powershell, name: "a".repeat(24) }), true);
+    assert.equal(matcher!({ ...powershell, name: "a".repeat(25) }), true);
+    assert.equal(matcher!({ ...powershell, name: "a".repeat(26) }), false);
   });
 
-  it("doesn't blow up matching a large counted repeat whose body can match empty", () => {
-    const matcher = buildProfileMatcher({ type: "matchProfiles", name: "(|a){2,4000}" });
-    const start = Date.now();
-    matcher!({ ...powershell, name: "a".repeat(2000) });
-    assert.ok(Date.now() - start < 200, "matching took too long");
+  it("keeps two sequential large counted repeats independent within one match", () => {
+    // Exiting the first repeat must not leave its count/countFor attached to the thread going
+    // into the second — the second repeat's own instruction would then see a stale, unrelated
+    // count, corrupting its own reps tracking and dedup key.
+    const matcher = buildProfileMatcher({ type: "matchProfiles", name: "a{5,4000}a{5,4000}" });
+    assert.equal(matcher!({ ...powershell, name: "a".repeat(10) }), true, "5+5 split");
+    assert.equal(matcher!({ ...powershell, name: "a".repeat(8) }), false, "second field below its min");
   });
 
   it("keeps each field's counted repeat independent when an entry has more than one field", () => {

--- a/extensions/windows-terminal/src/new-tab-menu.test.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.test.ts
@@ -100,6 +100,11 @@ describe("buildProfileMatcher", () => {
   it("supports negated escape classes inside a bracket expression", () => {
     assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "[\\D]+" })!(powershell), true);
   });
+
+  it("doesn't overflow the call stack on a long flat run of optional atoms", () => {
+    const matcher = buildProfileMatcher({ type: "matchProfiles", name: "a?".repeat(5000) + "b" });
+    assert.equal(matcher!({ ...powershell, name: "b" }), true);
+  });
 });
 
 describe("resolveNewTabMenuOrder", () => {

--- a/extensions/windows-terminal/src/new-tab-menu.test.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.test.ts
@@ -197,6 +197,30 @@ describe("buildProfileMatcher", () => {
     matcher!({ ...powershell, name: "a".repeat(2000) });
     assert.ok(Date.now() - start < 200, "matching took too long");
   });
+
+  it("keeps each field's counted repeat independent when an entry has more than one field", () => {
+    // Each field compiles to its own program. A field's repeat metadata must stay tied to that
+    // field's own program, not leak into whichever field happened to compile last.
+    const matcher = buildProfileMatcher({
+      type: "matchProfiles",
+      name: "a{5,4000}",
+      commandline: "b{50,4000}",
+    });
+    assert.notEqual(matcher, null);
+    assert.equal(matcher!({ ...powershell, name: "a".repeat(5), commandline: "x" }), true);
+    assert.equal(matcher!({ ...powershell, name: "x", commandline: "b".repeat(50) }), true);
+    // Below commandline's own min (50), even though name's min (5) would already be satisfied.
+    assert.equal(matcher!({ ...powershell, name: "x", commandline: "b".repeat(5) }), false);
+
+    // The field with no counted repeat at all, compiled after the one that has one, previously
+    // reset shared state the first field's program depended on and crashed matching entirely.
+    const reordered = buildProfileMatcher({
+      type: "matchProfiles",
+      name: "a{0,4000}",
+      commandline: "pwsh.exe",
+    });
+    assert.equal(reordered!({ ...powershell, name: "aaa", commandline: "nope.exe" }), true);
+  });
 });
 
 describe("resolveNewTabMenuOrder", () => {

--- a/extensions/windows-terminal/src/new-tab-menu.test.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.test.ts
@@ -127,30 +127,48 @@ describe("buildProfileMatcher", () => {
     assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "(PowerShell)\\1" }), null);
   });
 
-  it("rejects a single quantifier bound above 200, the per-quantifier repeat limit", () => {
-    assert.notEqual(buildProfileMatcher({ type: "matchProfiles", name: "a{200}" }), null);
-    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "a{201}" }), null);
-    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "a{0,4000}" }), null);
+  it("compiles and matches a large bounded quantifier on a simple atom, not just a small one", () => {
+    // (a|b){0,4000} and a{0,12000} are the exact patterns raised in review: a large bound on a
+    // simple atom is valid ICU syntax and must actually match, not be rejected outright.
+    const wide = buildProfileMatcher({ type: "matchProfiles", name: "(a|b){0,4000}" });
+    assert.notEqual(wide, null);
+    assert.equal(wide!({ ...powershell, name: "a".repeat(4000) }), true);
+    assert.equal(wide!({ ...powershell, name: "ab".repeat(2000) }), true);
+    assert.equal(wide!({ ...powershell, name: "a".repeat(4001) }), false);
+    assert.equal(wide!({ ...powershell, name: "c".repeat(4000) }), false);
+
+    const literal = buildProfileMatcher({ type: "matchProfiles", commandline: "a{0,12000}" });
+    assert.notEqual(literal, null);
+    assert.equal(literal!({ ...powershell, commandline: "a".repeat(2000) }), true);
+    assert.equal(literal!({ ...powershell, commandline: "a".repeat(12000) }), true);
+    assert.equal(literal!({ ...powershell, commandline: "a".repeat(12001) }), false);
   });
 
-  it("refuses a pattern whose nested repetitions compile to a huge program", () => {
-    // Each quantifier here (200) is within the per-quantifier bound on its own; nesting them
-    // multiplies the compiled size past MAX_PROGRAM_SIZE, which is what must catch this case.
+  it("matches a large bounded quantifier quickly, since it no longer scales with the bound", () => {
+    const matcher = buildProfileMatcher({ type: "matchProfiles", commandline: "a{0,12000}" });
+    const start = Date.now();
+    matcher!({ ...powershell, commandline: "a".repeat(2000) });
+    assert.ok(Date.now() - start < 200, "matching took too long");
+  });
+
+  it("rejects a large quantifier wrapping content that has its own quantifier", () => {
+    // compileCountedRepeat's counter can't represent two independently-active repeats, so this
+    // falls back to being rejected (consistent with any other unsupported construct) rather than
+    // silently compiling something that would count wrong.
     const start = Date.now();
     assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "((a|b){200}){200}" }), null);
     assert.ok(Date.now() - start < 1000, "compiling took too long");
-    // A merely long pattern still compiles and matches.
-    assert.deepEqual(matchedNames({ type: "matchProfiles", name: "(?:PowerShell){1}" }), ["PowerShell"]);
+    // A large quantifier around plain (unquantified) content is unaffected.
+    assert.deepEqual(matchedNames({ type: "matchProfiles", name: "(?:PowerShell){1,200}" }), ["PowerShell"]);
   });
 
-  it("matches correctly, not just quickly, right up to the per-quantifier bound", () => {
-    // A quantifier at the 200 bound isn't just fast to reject — a legitimately matching value at
-    // that length must actually match, not silently fail because matching work is bounded too.
-    const matcher = buildProfileMatcher({ type: "matchProfiles", name: "(a|b){0,200}" });
-    assert.notEqual(matcher, null);
-    assert.equal(matcher!({ ...powershell, name: "a".repeat(200) }), true);
-    assert.equal(matcher!({ ...powershell, name: "ab".repeat(100) }), true);
-    assert.equal(matcher!({ ...powershell, name: "c".repeat(200) }), false);
+  it("still unrolls a small quantifier, so it can nest inside another quantifier", () => {
+    // (a?)* mixes two quantifiers, one nested in the other — only possible because both are
+    // small enough to unroll; compileCountedRepeat's single counter couldn't represent this.
+    const matcher = buildProfileMatcher({ type: "matchProfiles", name: "(a{2,5})*" });
+    assert.equal(matcher!({ ...powershell, name: "aaa" }), true);
+    assert.equal(matcher!({ ...powershell, name: "aaaaa" + "aaa" }), true);
+    assert.equal(matcher!({ ...powershell, name: "a" }), false);
   });
 });
 

--- a/extensions/windows-terminal/src/new-tab-menu.test.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.test.ts
@@ -221,9 +221,22 @@ describe("buildProfileMatcher", () => {
     // ĳ has no expansion in CaseFolding.txt: it's Ĳ's fold, not "ij".
     assert.equal(matches("(?i)ĳ", "Ĳ"), true);
     assert.equal(matches("(?i)ij", "ĳ"), false);
-    // A class admits single-code-point case variants only; ß's uppercase "SS" doesn't put it in [A-Z].
+    // A class is closed over simple case folding, as ICU closes the set: [A-Z] takes a-z, ſ (folds
+    // to s), and K (Kelvin, folds to k) — but not ı, whose fold is itself, nor ß, whose fold "ss"
+    // is no single member. [ſ] takes s and S the same way.
     assert.equal(matches("(?i)[a-z]+", "STRASSE"), true);
     assert.equal(matches("(?i)[a-z]+", "straße"), false);
+    assert.equal(matches("(?i)[A-Z]+", "ı"), false);
+    assert.equal(matches("(?i)[A-Z]", "ſ"), true);
+    assert.equal(matches("(?i)[A-Z]", String.fromCodePoint(0x212a)), true);
+    assert.equal(matches("(?i)[ſ]", "S"), true);
+    assert.equal(matches("(?i)[ſ]", "s"), true);
+    assert.equal(matches("(?i)[ẞ]", "ß"), true);
+    assert.equal(matches("(?i)[ß]", "S"), false);
+    assert.equal(matches("(?i)[^a]", "A"), false);
+    assert.equal(matches("(?i)[\\da-f]+", "1F"), true);
+    assert.equal(matches("(?i)[\\]\\\\-]+", "]\\-"), true);
+    assert.equal(matches("[A-Z]", "a"), false);
     // Case-sensitive matching is untouched.
     assert.equal(matches("straße", "STRASSE"), false);
     assert.equal(matches("ss", "ß"), false);

--- a/extensions/windows-terminal/src/new-tab-menu.test.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.test.ts
@@ -170,6 +170,33 @@ describe("buildProfileMatcher", () => {
     assert.equal(matcher!({ ...powershell, name: "aaaaa" + "aaa" }), true);
     assert.equal(matcher!({ ...powershell, name: "a" }), false);
   });
+
+  it("reaches the minimum of a large counted repeat whose body can match empty", () => {
+    // (|a){2,4000} needs one empty rep plus one "a" rep to satisfy min=2 while consuming a
+    // single character. Reaching that requires revisiting the repeat instruction at a higher
+    // count within the same position — a plain identity-only visited set stops after the first
+    // visit and never gets there, silently rejecting a value that should match.
+    const matcher = buildProfileMatcher({ type: "matchProfiles", name: "(|a){2,4000}" });
+    assert.notEqual(matcher, null);
+    assert.equal(matcher!({ ...powershell, name: "a" }), true);
+    assert.equal(matcher!({ ...powershell, name: "aa" }), true);
+    assert.equal(matcher!({ ...powershell, name: "b" }), false);
+  });
+
+  it("still enforces the maximum of a large counted repeat whose body can match empty", () => {
+    // Capping the dedup key at `min` must not affect the actual reps count `repeat` compares
+    // against `max` — only how many equivalent states get explored at one position.
+    const matcher = buildProfileMatcher({ type: "matchProfiles", name: "a{2,10}" });
+    assert.equal(matcher!({ ...powershell, name: "a".repeat(10) }), true);
+    assert.equal(matcher!({ ...powershell, name: "a".repeat(11) }), false);
+  });
+
+  it("doesn't blow up matching a large counted repeat whose body can match empty", () => {
+    const matcher = buildProfileMatcher({ type: "matchProfiles", name: "(|a){2,4000}" });
+    const start = Date.now();
+    matcher!({ ...powershell, name: "a".repeat(2000) });
+    assert.ok(Date.now() - start < 200, "matching took too long");
+  });
 });
 
 describe("resolveNewTabMenuOrder", () => {

--- a/extensions/windows-terminal/src/new-tab-menu.test.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.test.ts
@@ -36,6 +36,22 @@ describe("buildProfileMatcher", () => {
     assert.equal(buildProfileMatcher({ type: "matchProfiles" }), null);
     assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "[" }), null);
   });
+
+  it("rejects patterns that can backtrack exponentially", () => {
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "(a+)+" }), null);
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "(a|aa)*" }), null);
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", commandline: "((ab)+)+" }), null);
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", source: "(a{1,2})+" }), null);
+  });
+
+  it("keeps patterns that only look nested", () => {
+    assert.deepEqual(matchedNames({ type: "matchProfiles", name: "(Power)+Shell" }), ["PowerShell"]);
+    assert.deepEqual(matchedNames({ type: "matchProfiles", name: "(?:Power|Command)\\s.*" }), ["Command Prompt"]);
+    assert.deepEqual(matchedNames({ type: "matchProfiles", commandline: "[a-z]+\\.exe" }), [
+      "PowerShell",
+      "Command Prompt",
+    ]);
+  });
 });
 
 describe("resolveNewTabMenuOrder", () => {

--- a/extensions/windows-terminal/src/new-tab-menu.test.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.test.ts
@@ -134,6 +134,17 @@ describe("buildProfileMatcher", () => {
     // A merely long pattern still compiles and matches.
     assert.deepEqual(matchedNames({ type: "matchProfiles", name: "(?:PowerShell){1}" }), ["PowerShell"]);
   });
+
+  it("bounds total matching work for a wide quantifier against a long value", () => {
+    // (a|b){0,4000} compiles (its program fits under MAX_PROGRAM_SIZE) but keeps thousands of
+    // live threads; without a bound on total matching work, running it against a value this long
+    // would take tens of millions of steps synchronously during rendering.
+    const matcher = buildProfileMatcher({ type: "matchProfiles", name: "(a|b){0,4000}" });
+    assert.notEqual(matcher, null);
+    const start = Date.now();
+    matcher!({ ...powershell, name: "a".repeat(4000) });
+    assert.ok(Date.now() - start < 500, "wide quantifier against a long value took too long");
+  });
 });
 
 describe("resolveNewTabMenuOrder", () => {

--- a/extensions/windows-terminal/src/new-tab-menu.test.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { buildProfileMatcher, resolveNewTabMenuOrder } from "./new-tab-menu.ts";
+import type { NewTabMenuEntry, Profile } from "./new-tab-menu.ts";
+
+const powershell: Profile = { guid: "{p1}", name: "PowerShell", commandline: "pwsh.exe" };
+const commandPrompt: Profile = { guid: "{p2}", name: "Command Prompt", commandline: "cmd.exe" };
+const ubuntu: Profile = { guid: "{p3}", name: "Ubuntu", source: "Microsoft.WSL" };
+const azure: Profile = { guid: "{p4}", name: "Azure Cloud Shell", source: "Windows.Terminal.Azure" };
+const profiles = [powershell, commandPrompt, ubuntu, azure];
+
+function matchedNames(entry: NewTabMenuEntry) {
+  const matcher = buildProfileMatcher(entry);
+  return matcher ? profiles.filter(matcher).map((p) => p.name) : null;
+}
+
+describe("buildProfileMatcher", () => {
+  it("never matches an empty source", () => {
+    assert.deepEqual(matchedNames({ type: "matchProfiles", source: ".*" }), ["Ubuntu", "Azure Cloud Shell"]);
+  });
+
+  it("never matches an empty commandline", () => {
+    assert.deepEqual(matchedNames({ type: "matchProfiles", commandline: ".*" }), ["PowerShell", "Command Prompt"]);
+  });
+
+  it("matches the whole field, not a substring", () => {
+    assert.deepEqual(matchedNames({ type: "matchProfiles", name: "Power" }), []);
+    assert.deepEqual(matchedNames({ type: "matchProfiles", name: "Power.*" }), ["PowerShell"]);
+  });
+
+  it("matches when any single field matches", () => {
+    assert.deepEqual(matchedNames({ type: "matchProfiles", name: "Nothing", source: "Microsoft.WSL" }), ["Ubuntu"]);
+  });
+
+  it("matches nothing without patterns or with a malformed regex", () => {
+    assert.equal(buildProfileMatcher({ type: "matchProfiles" }), null);
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "[" }), null);
+  });
+});
+
+describe("resolveNewTabMenuOrder", () => {
+  it("places an explicit profile after remainingProfiles", () => {
+    const order = resolveNewTabMenuOrder(profiles, [
+      { type: "remainingProfiles" },
+      { type: "profile", profile: "PowerShell" },
+    ]);
+    assert.deepEqual(order, ["{p2}", "{p3}", "{p4}", "{p1}"]);
+  });
+
+  it("counts references inside folders when expanding the remainder", () => {
+    const order = resolveNewTabMenuOrder(profiles, [
+      { type: "remainingProfiles" },
+      { type: "folder", entries: [{ type: "matchProfiles", source: ".*" }] },
+    ]);
+    assert.deepEqual(order, ["{p1}", "{p2}", "{p3}", "{p4}"]);
+  });
+});

--- a/extensions/windows-terminal/src/new-tab-menu.test.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.test.ts
@@ -212,6 +212,15 @@ describe("buildProfileMatcher", () => {
     assert.equal(matches("(?i)s", "ß"), false);
     assert.equal(matches("(?i)ß+", "ẞß"), true);
     assert.equal(matches("(?i)ß+", "ss"), false);
+    // Dotless ı uppercases to I but, per CaseFolding.txt, never folds to i — ICU keeps them apart.
+    assert.equal(matches("(?i)i", "ı"), false);
+    assert.equal(matches("(?i)ı", "I"), false);
+    assert.equal(matches("(?i)ıı", "II"), false);
+    assert.equal(matches("(?i)ı", "ı"), true);
+    assert.equal(matches("(?i)I", "i"), true);
+    // ĳ has no expansion in CaseFolding.txt: it's Ĳ's fold, not "ij".
+    assert.equal(matches("(?i)ĳ", "Ĳ"), true);
+    assert.equal(matches("(?i)ij", "ĳ"), false);
     // A class admits single-code-point case variants only; ß's uppercase "SS" doesn't put it in [A-Z].
     assert.equal(matches("(?i)[a-z]+", "STRASSE"), true);
     assert.equal(matches("(?i)[a-z]+", "straße"), false);

--- a/extensions/windows-terminal/src/new-tab-menu.test.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.test.ts
@@ -174,6 +174,51 @@ describe("buildProfileMatcher", () => {
     assert.deepEqual(matchedNames({ type: "matchProfiles", name: "(?:(?i)power)SHELL" }), []);
   });
 
+  it("uses ICU's character classes, not JavaScript's ASCII-only ones", () => {
+    // Windows Terminal matches with ICU, where \w, \d, \b, and \s cover every script.
+    const matches = (pattern: string, name: string) =>
+      buildProfileMatcher({ type: "matchProfiles", name: pattern })!({ ...powershell, name });
+    assert.equal(matches("\\w+", "Développement"), true);
+    assert.equal(matches("\\bÉquipe\\b", "Équipe"), true);
+    assert.equal(matches("\\d+", "١٢٣"), true);
+    assert.equal(matches("\\D+", "١٢٣"), false);
+    assert.equal(matches("\\W+", "Développement"), false);
+    assert.equal(matches("a\\sb", "a b"), true);
+    assert.equal(matches("(?i)équipe", "ÉQUIPE"), true);
+  });
+
+  it("matches by code point, so one . consumes a whole emoji", () => {
+    const matches = (pattern: string, name: string) =>
+      buildProfileMatcher({ type: "matchProfiles", name: pattern })!({ ...powershell, name });
+    assert.equal(matches(".", "🚀"), true);
+    assert.equal(matches("..", "🚀"), false);
+    assert.equal(matches("🚀+", "🚀🚀"), true);
+    assert.equal(matches("[^a]", "🚀"), true);
+    assert.equal(matches("[🚀-🚂]", "🚁"), true);
+  });
+
+  it("doesn't let . match a line terminator, like ICU without its DOTALL flag", () => {
+    const matcher = buildProfileMatcher({ type: "matchProfiles", name: "a.b" });
+    assert.equal(matcher!({ ...powershell, name: "a b" }), true);
+    assert.equal(matcher!({ ...powershell, name: "a\nb" }), false);
+    assert.equal(matcher!({ ...powershell, name: "a b" }), false);
+    // \s still covers it, so a pattern that means to cross a line can.
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "a\\sb" })!({ ...powershell, name: "a\nb" }), true);
+  });
+
+  it("reports a possessive quantifier as unsupported rather than malformed", () => {
+    // a++ is valid ICU; treating the second "+" as a stray one would quietly match nothing.
+    for (const pattern of ["a++", "a*+", "a?+", "a{2}+"]) {
+      assert.throws(
+        () => buildProfileMatcher({ type: "matchProfiles", name: pattern }),
+        UnsupportedPatternError,
+        pattern,
+      );
+    }
+    // A lazy quantifier is still fine.
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "a+?" })!({ ...powershell, name: "aaa" }), true);
+  });
+
   it("reports an escape it doesn't implement instead of matching it as a literal", () => {
     // These are valid for Windows Terminal, so unlike a malformed pattern (null: matches nothing
     // there either) they're surfaced to the caller — the message names the offending pattern.

--- a/extensions/windows-terminal/src/new-tab-menu.test.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.test.ts
@@ -184,7 +184,40 @@ describe("buildProfileMatcher", () => {
     assert.equal(matches("\\D+", "١٢٣"), false);
     assert.equal(matches("\\W+", "Développement"), false);
     assert.equal(matches("a\\sb", "a b"), true);
+    // \s is \p{White_Space}: vertical tab and next line count, the byte order mark doesn't.
+    assert.equal(matches("a\\sb", "a" + String.fromCodePoint(0x0b) + "b"), true);
+    assert.equal(matches("a\\sb", "a" + String.fromCodePoint(0x85) + "b"), true);
+    assert.equal(matches("a\\sb", "a" + String.fromCodePoint(0xfeff) + "b"), false);
     assert.equal(matches("(?i)équipe", "ÉQUIPE"), true);
+  });
+
+  it("folds case like ICU under (?i), where a literal run can change length", () => {
+    const matches = (pattern: string, name: string) =>
+      buildProfileMatcher({ type: "matchProfiles", name: pattern })!({ ...powershell, name });
+    // Two or more adjacent literals fold fully, so ß and SS are the same string.
+    assert.equal(matches("(?i)straße", "STRASSE"), true);
+    assert.equal(matches("(?i)straße", "Straße"), true);
+    assert.equal(matches("(?i)strasse", "STRAẞE"), true);
+    assert.equal(matches("(?i)ss", "ß"), true);
+    assert.equal(matches("(?i)ssx", "ßx"), true);
+    assert.equal(matches("(?i)sss", "ßs"), true);
+    // A run can't end partway through a folded character: ß is two units, and "ss" against "sß"
+    // would take only the first of them.
+    assert.equal(matches("(?i)ss", "sß"), false);
+    assert.equal(matches("(?i)ss", "ßs"), false);
+    // A lone literal, or one under a quantifier, folds simply — one code point to one — so ß is ẞ
+    // but never SS.
+    assert.equal(matches("(?i)ß", "ẞ"), true);
+    assert.equal(matches("(?i)ß", "SS"), false);
+    assert.equal(matches("(?i)s", "ß"), false);
+    assert.equal(matches("(?i)ß+", "ẞß"), true);
+    assert.equal(matches("(?i)ß+", "ss"), false);
+    // A class admits single-code-point case variants only; ß's uppercase "SS" doesn't put it in [A-Z].
+    assert.equal(matches("(?i)[a-z]+", "STRASSE"), true);
+    assert.equal(matches("(?i)[a-z]+", "straße"), false);
+    // Case-sensitive matching is untouched.
+    assert.equal(matches("straße", "STRASSE"), false);
+    assert.equal(matches("ss", "ß"), false);
   });
 
   it("matches by code point, so one . consumes a whole emoji", () => {

--- a/extensions/windows-terminal/src/new-tab-menu.test.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.test.ts
@@ -195,6 +195,12 @@ describe("buildProfileMatcher", () => {
     assert.equal(matches("🚀+", "🚀🚀"), true);
     assert.equal(matches("[^a]", "🚀"), true);
     assert.equal(matches("[🚀-🚂]", "🚁"), true);
+    // Ranges compare code points, not UTF-16 strings: [ｿ-🚀] (U+FF7F to U+1F680) is ascending,
+    // and [a-￿] (up to U+FFFF) stops short of the astral 🚀.
+    assert.equal(matches("[ｿ-🚀]+", "ｿ🚀"), true);
+    assert.equal(matches("[a-￿]", "🚀"), false);
+    assert.equal(matches("[a-￿]", "ｿ"), true);
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "[🚀-ｿ]" }), null);
   });
 
   it("doesn't let . match a line terminator, like ICU without its DOTALL flag", () => {

--- a/extensions/windows-terminal/src/new-tab-menu.test.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.test.ts
@@ -73,6 +73,13 @@ describe("buildProfileMatcher", () => {
     assert.deepEqual(matchedNames({ type: "matchProfiles", name: "^Power.*$" }), ["PowerShell"]);
   });
 
+  it("rejects a quantified anchor, matching Windows Terminal's regex engine", () => {
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "^?PowerShell" }), null);
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "PowerShell$?" }), null);
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "^*PowerShell" }), null);
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "^{2}PowerShell" }), null);
+  });
+
   it("doesn't exhaust its step budget on a long but linear match", () => {
     const longCommandline = "C:\\tools\\" + "a".repeat(1000) + ".exe";
     const matcher = buildProfileMatcher({ type: "matchProfiles", commandline: "C:\\\\tools\\\\.*\\.exe" });

--- a/extensions/windows-terminal/src/new-tab-menu.test.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.test.ts
@@ -200,7 +200,7 @@ describe("buildProfileMatcher", () => {
     assert.ok(Date.now() - start < 200, "matching took too long");
   });
 
-  it("rejects a large quantifier wrapping content that has its own quantifier", () => {
+  it("rejects a large quantifier wrapping another large quantifier", () => {
     // compileCountedRepeat's counter can't represent two independently-active repeats, so this
     // falls back to being rejected (consistent with any other unsupported construct) rather than
     // silently compiling something that would count wrong.
@@ -209,6 +209,14 @@ describe("buildProfileMatcher", () => {
     assert.ok(Date.now() - start < 1000, "compiling took too long");
     // A large quantifier around plain (unquantified) content is unaffected.
     assert.deepEqual(matchedNames({ type: "matchProfiles", name: "(?:PowerShell){1,200}" }), ["PowerShell"]);
+    // A *small* quantifier inside unrolls, so it nests inside a large one just fine.
+    const nested = buildProfileMatcher({ type: "matchProfiles", name: "(a?){2,4000}" });
+    assert.equal(nested!({ ...powershell, name: "a" }), true);
+    assert.equal(nested!({ ...powershell, name: "a".repeat(30) }), true);
+    assert.equal(nested!({ ...powershell, name: "a".repeat(30) + "b" }), false);
+    const fixed = buildProfileMatcher({ type: "matchProfiles", name: "(a{2}){2,4000}" });
+    assert.equal(fixed!({ ...powershell, name: "a".repeat(4) }), true);
+    assert.equal(fixed!({ ...powershell, name: "a".repeat(5) }), false);
   });
 
   it("still unrolls a small quantifier, so it can nest inside another quantifier", () => {
@@ -220,20 +228,36 @@ describe("buildProfileMatcher", () => {
     assert.equal(matcher!({ ...powershell, name: "a" }), false);
   });
 
-  it("rejects a large counted repeat whose body doesn't consume a fixed number of characters", () => {
-    // Every rep of a large counted repeat must consume the same fixed number of characters —
-    // otherwise different combinations of alternatives can reach the same string position after
-    // a different number of reps, and the dedup key's capping can only tell those apart when
-    // every rep advances the position by the same fixed amount. Rather than silently mismatch
-    // near `max`, this is rejected outright, the same as a nested quantifier.
-    // A nullable alternative (0 characters) differs from a nonzero one.
-    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "(|a){2,4000}" }), null);
-    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "(a?){2,25}" }), null);
-    // Two nonzero but differently-sized alternatives (1 vs 2 characters) — confirmed by exhaustive
-    // DP-vs-engine comparison to silently mismatch near `max` before this rejection existed.
-    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "(a|aa){21,30}" }), null);
-    // Every alternative the same fixed nonzero length is fine.
-    assert.notEqual(buildProfileMatcher({ type: "matchProfiles", name: "(a|b){2,25}" }), null);
+  it("matches a large counted repeat whose body doesn't consume a fixed number of characters", () => {
+    // Different combinations of alternatives can reach the same string position after a different
+    // number of reps. Threads inside a counted repeat dedupe by their exact count, so both
+    // trajectories survive and the one that still fits under `max` gets to match.
+    // A nullable alternative: one empty rep plus one consuming rep satisfies the minimum of 2.
+    const nullable = buildProfileMatcher({ type: "matchProfiles", name: "(|a){2,4000}" });
+    assert.equal(nullable!({ ...powershell, name: "a" }), true);
+    assert.equal(nullable!({ ...powershell, name: "b" }), false);
+    // A large minimum on a nullable body is free to satisfy with empty reps, so it can't turn a
+    // long value into budget-exhausting work either.
+    const bigMin = buildProfileMatcher({ type: "matchProfiles", name: "(|a){3000,4000}" });
+    assert.equal(bigMin!({ ...powershell, name: "a".repeat(2000) }), true);
+    assert.equal(bigMin!({ ...powershell, name: "a".repeat(4001) }), false);
+    // Two nonzero but differently-sized alternatives (1 vs 2 characters).
+    const mixed = buildProfileMatcher({ type: "matchProfiles", name: "(a|aa){21,30}" });
+    assert.equal(mixed!({ ...powershell, name: "a".repeat(21) }), true);
+    assert.equal(mixed!({ ...powershell, name: "a".repeat(60) }), true);
+    assert.equal(mixed!({ ...powershell, name: "a".repeat(20) }), false);
+    assert.equal(mixed!({ ...powershell, name: "a".repeat(61) }), false);
+  });
+
+  it("keeps counts apart when the prefix can enter a large counted repeat at two positions", () => {
+    // (?:x|xa) enters a{0,25} at position 1 or 2, so at every later position two threads share
+    // the repeat's instructions with counts one apart. Only the position-2 entry has room for all
+    // 26 trailing a's (25 of them under the quantifier); collapsing both threads onto one dedup
+    // key kept whichever arrived first, and the wrong one hid the match.
+    const matcher = buildProfileMatcher({ type: "matchProfiles", name: "(?:x|xa)a{0,25}" });
+    assert.equal(matcher!({ ...powershell, name: "x" + "a".repeat(26) }), true);
+    assert.equal(matcher!({ ...powershell, name: "x" + "a".repeat(25) }), true);
+    assert.equal(matcher!({ ...powershell, name: "x" + "a".repeat(27) }), false);
   });
 
   it("matches correctly right up to the maximum of a large counted repeat, not just at the minimum", () => {

--- a/extensions/windows-terminal/src/new-tab-menu.test.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.test.ts
@@ -67,6 +67,17 @@ describe("buildProfileMatcher", () => {
       assert.ok(Date.now() - start < 1000, `${pattern} took too long`);
     }
   });
+
+  it("treats ^ and $ as anchors, not literal characters", () => {
+    assert.deepEqual(matchedNames({ type: "matchProfiles", name: "^PowerShell$" }), ["PowerShell"]);
+    assert.deepEqual(matchedNames({ type: "matchProfiles", name: "^Power.*$" }), ["PowerShell"]);
+  });
+
+  it("doesn't exhaust its step budget on a long but linear match", () => {
+    const longCommandline = "C:\\tools\\" + "a".repeat(1000) + ".exe";
+    const matcher = buildProfileMatcher({ type: "matchProfiles", commandline: "C:\\\\tools\\\\.*\\.exe" });
+    assert.ok(matcher!({ ...powershell, commandline: longCommandline }));
+  });
 });
 
 describe("resolveNewTabMenuOrder", () => {

--- a/extensions/windows-terminal/src/new-tab-menu.test.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { buildProfileMatcher, resolveNewTabMenuOrder } from "./new-tab-menu.ts";
+import { UnsupportedPatternError, buildProfileMatcher, resolveNewTabMenuOrder } from "./new-tab-menu.ts";
 import type { NewTabMenuEntry, Profile } from "./new-tab-menu.ts";
 
 const powershell: Profile = { guid: "{p1}", name: "PowerShell", commandline: "pwsh.exe" };
@@ -113,7 +113,10 @@ describe("buildProfileMatcher", () => {
     // ordering check (Infinity < Infinity is false) as if it were a legitimate {n,}. Checked on
     // the parsed value, not the digit-string length, so a zero-padded bound isn't wrongly
     // rejected as "too large" just for having a lot of leading zeros.
-    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "a{" + "9".repeat(310) + "}" }), null);
+    assert.throws(
+      () => buildProfileMatcher({ type: "matchProfiles", name: "a{" + "9".repeat(310) + "}" }),
+      UnsupportedPatternError,
+    );
     assert.notEqual(buildProfileMatcher({ type: "matchProfiles", name: "a{100000000}" }), null);
     assert.equal(
       buildProfileMatcher({ type: "matchProfiles", name: "a{0000000005,10}" })!({ ...powershell, name: "aaaaa" }),
@@ -121,9 +124,9 @@ describe("buildProfileMatcher", () => {
     );
   });
 
-  it("rejects a pattern nested too deeply instead of overflowing the call stack", () => {
+  it("reports a pattern nested too deeply instead of overflowing the call stack", () => {
     const deep = "(".repeat(5000) + "a" + ")".repeat(5000);
-    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: deep }), null);
+    assert.throws(() => buildProfileMatcher({ type: "matchProfiles", name: deep }), UnsupportedPatternError);
     // A realistic amount of nesting still compiles fine.
     const shallow = "(".repeat(50) + "a" + ")".repeat(50);
     assert.notEqual(buildProfileMatcher({ type: "matchProfiles", name: shallow }), null);
@@ -171,9 +174,45 @@ describe("buildProfileMatcher", () => {
     assert.deepEqual(matchedNames({ type: "matchProfiles", name: "(?:(?i)power)SHELL" }), []);
   });
 
-  it("rejects an escape it doesn't implement instead of matching it as a literal", () => {
-    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "\\p{L}+" }), null);
-    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "(PowerShell)\\1" }), null);
+  it("reports an escape it doesn't implement instead of matching it as a literal", () => {
+    // These are valid for Windows Terminal, so unlike a malformed pattern (null: matches nothing
+    // there either) they're surfaced to the caller — the message names the offending pattern.
+    assert.throws(
+      () => buildProfileMatcher({ type: "matchProfiles", name: "\\p{L}+" }),
+      (error: unknown) => error instanceof UnsupportedPatternError && error.message.includes('"\\p{L}+"'),
+    );
+    assert.throws(
+      () => buildProfileMatcher({ type: "matchProfiles", name: "(PowerShell)\\1" }),
+      UnsupportedPatternError,
+    );
+    assert.throws(() => buildProfileMatcher({ type: "matchProfiles", name: "(?<=a)b" }), UnsupportedPatternError);
+    // ICU set syntax that would otherwise parse as literals — [[:alpha:]] read as "[[:alph]" then
+    // a literal "]" matched "a]" but not "a".
+    assert.throws(() => buildProfileMatcher({ type: "matchProfiles", name: "[[:alpha:]]+" }), UnsupportedPatternError);
+    assert.throws(() => buildProfileMatcher({ type: "matchProfiles", name: "[a-z&&[^m]]+" }), UnsupportedPatternError);
+    assert.throws(() => buildProfileMatcher({ type: "matchProfiles", name: "[a-z&&b]+" }), UnsupportedPatternError);
+  });
+
+  it("reports a repeat whose counts can't merge when it exhausts the budget, rather than a non-match", () => {
+    // Count ranges only merge when they're contiguous. (a|aaa) reaches counts two apart at the
+    // same position, so below `min` every one is its own thread and a long value runs the budget
+    // out. A known ceiling — but a visible one: the profile isn't silently dropped.
+    const matcher = buildProfileMatcher({ type: "matchProfiles", name: "(a|aaa){1000,4000}" });
+    assert.throws(() => matcher!({ ...powershell, name: "a".repeat(3000) }), UnsupportedPatternError);
+    // The same body is fine once `.*` fills every count in between.
+    const filled = buildProfileMatcher({ type: "matchProfiles", name: ".*(a|aaa){1000,4000}" });
+    assert.equal(filled!({ ...powershell, name: "a".repeat(3000) }), true);
+  });
+
+  it("reports a match that exhausts the step budget instead of calling it a non-match", () => {
+    // A large quantifier inside a large quantifier unrolls the inner one (see below), so the
+    // compiled program is big and a long value keeps thousands of states live at every position.
+    // That's a limit of this engine, not a fact about the profile — so it's an error, not `false`.
+    const matcher = buildProfileMatcher({ type: "matchProfiles", commandline: "(a{0,4000}){21}" });
+    assert.throws(
+      () => matcher!({ ...powershell, commandline: "a".repeat(3000) }),
+      (error: unknown) => error instanceof UnsupportedPatternError && error.message.includes('"(a{0,4000}){21}"'),
+    );
   });
 
   it("compiles and matches a large bounded quantifier on a simple atom, not just a small one", () => {
@@ -200,16 +239,27 @@ describe("buildProfileMatcher", () => {
     assert.ok(Date.now() - start < 200, "matching took too long");
   });
 
-  it("rejects a large quantifier wrapping another large quantifier", () => {
-    // compileCountedRepeat's counter can't represent two independently-active repeats, so this
-    // falls back to being rejected (consistent with any other unsupported construct) rather than
-    // silently compiling something that would count wrong.
+  it("unrolls the inner quantifier when a large quantifier wraps another large one", () => {
+    // compileCountedRepeat's counter can't represent two independently-active repeats, so the
+    // inner one is unrolled into plain instructions instead — (a{21}){21} is 441 a's exactly, and
+    // matches with ICU, so it has to match here rather than being rejected.
+    const nestedLarge = buildProfileMatcher({ type: "matchProfiles", name: "(a{21}){21}" });
+    assert.equal(nestedLarge!({ ...powershell, name: "a".repeat(441) }), true);
+    assert.equal(nestedLarge!({ ...powershell, name: "a".repeat(440) }), false);
+    assert.equal(nestedLarge!({ ...powershell, name: "a".repeat(442) }), false);
     const start = Date.now();
-    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "((a|b){200}){200}" }), null);
+    const wide = buildProfileMatcher({ type: "matchProfiles", name: "((a|b){200}){200}" });
     assert.ok(Date.now() - start < 1000, "compiling took too long");
+    assert.equal(wide!({ ...powershell, name: "ab".repeat(20000) }), true);
+    assert.equal(wide!({ ...powershell, name: "a".repeat(39999) }), false);
+    // The unrolled body is still subject to the total program size cap.
+    assert.throws(
+      () => buildProfileMatcher({ type: "matchProfiles", name: "((a{1000}){1000}){1000}" }),
+      UnsupportedPatternError,
+    );
     // A large quantifier around plain (unquantified) content is unaffected.
     assert.deepEqual(matchedNames({ type: "matchProfiles", name: "(?:PowerShell){1,200}" }), ["PowerShell"]);
-    // A *small* quantifier inside unrolls, so it nests inside a large one just fine.
+    // A *small* quantifier inside unrolls too, as it always did.
     const nested = buildProfileMatcher({ type: "matchProfiles", name: "(a?){2,4000}" });
     assert.equal(nested!({ ...powershell, name: "a" }), true);
     assert.equal(nested!({ ...powershell, name: "a".repeat(30) }), true);
@@ -220,17 +270,34 @@ describe("buildProfileMatcher", () => {
   });
 
   it("still unrolls a small quantifier, so it can nest inside another quantifier", () => {
-    // (a?)* mixes two quantifiers, one nested in the other — only possible because both are
-    // small enough to unroll; compileCountedRepeat's single counter couldn't represent this.
+    // (a{2,5})* mixes two quantifiers, one nested in the other; both are small enough to unroll,
+    // so no counted repeat is involved at all.
     const matcher = buildProfileMatcher({ type: "matchProfiles", name: "(a{2,5})*" });
     assert.equal(matcher!({ ...powershell, name: "aaa" }), true);
     assert.equal(matcher!({ ...powershell, name: "aaaaa" + "aaa" }), true);
     assert.equal(matcher!({ ...powershell, name: "a" }), false);
   });
 
+  it("matches a large minimum reached from every position, without exhausting the budget", () => {
+    // .* can enter a{1000,4000} at every position, so at position p the repeat is live with every
+    // count from 0 to p — and below `min` none of those counts can stand in for another. Tracked
+    // one by one that's O(n × min) work and the budget runs out on a 2,000-character value; kept
+    // as one count range per thread it's linear.
+    const matcher = buildProfileMatcher({ type: "matchProfiles", commandline: ".*a{1000,4000}" });
+    const start = Date.now();
+    assert.equal(matcher!({ ...powershell, commandline: "a".repeat(2000) }), true);
+    assert.equal(matcher!({ ...powershell, commandline: "b" + "a".repeat(4000) }), true);
+    assert.equal(matcher!({ ...powershell, commandline: "a".repeat(999) }), false);
+    assert.equal(matcher!({ ...powershell, commandline: "a".repeat(4000) + "b" }), false);
+    assert.ok(Date.now() - start < 1000, "matching took too long");
+    // The same with a minimum of 3000 out of a 3900-character value.
+    const higher = buildProfileMatcher({ type: "matchProfiles", commandline: ".*a{3000,4000}" });
+    assert.equal(higher!({ ...powershell, commandline: "a".repeat(3900) }), true);
+  });
+
   it("matches a large counted repeat whose body doesn't consume a fixed number of characters", () => {
     // Different combinations of alternatives can reach the same string position after a different
-    // number of reps. Threads inside a counted repeat dedupe by their exact count, so both
+    // number of reps. Threads inside a counted repeat are tracked by their exact counts, so both
     // trajectories survive and the one that still fits under `max` gets to match.
     // A nullable alternative: one empty rep plus one consuming rep satisfies the minimum of 2.
     const nullable = buildProfileMatcher({ type: "matchProfiles", name: "(|a){2,4000}" });
@@ -319,5 +386,24 @@ describe("resolveNewTabMenuOrder", () => {
       { type: "folder", entries: [{ type: "matchProfiles", source: ".*" }] },
     ]);
     assert.deepEqual(order, ["{p1}", "{p2}", "{p3}", "{p4}"]);
+  });
+
+  it("surfaces a pattern it can't evaluate instead of returning an order with profiles missing", () => {
+    // A malformed pattern matches nothing, as in Windows Terminal, and the order still resolves.
+    const order = resolveNewTabMenuOrder(profiles, [
+      { type: "matchProfiles", name: "[" },
+      { type: "remainingProfiles" },
+    ]);
+    assert.deepEqual(order, ["{p1}", "{p2}", "{p3}", "{p4}"]);
+    // A pattern valid in Windows Terminal but unsupported here would silently move PowerShell into
+    // the remainder — so it throws for the caller to report instead.
+    assert.throws(
+      () =>
+        resolveNewTabMenuOrder(profiles, [
+          { type: "folder", entries: [{ type: "matchProfiles", name: "\\p{L}+" }] },
+          { type: "remainingProfiles" },
+        ]),
+      UnsupportedPatternError,
+    );
   });
 });

--- a/extensions/windows-terminal/src/new-tab-menu.test.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.test.ts
@@ -127,23 +127,30 @@ describe("buildProfileMatcher", () => {
     assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "(PowerShell)\\1" }), null);
   });
 
+  it("rejects a single quantifier bound above 200, the per-quantifier repeat limit", () => {
+    assert.notEqual(buildProfileMatcher({ type: "matchProfiles", name: "a{200}" }), null);
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "a{201}" }), null);
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "a{0,4000}" }), null);
+  });
+
   it("refuses a pattern whose nested repetitions compile to a huge program", () => {
+    // Each quantifier here (200) is within the per-quantifier bound on its own; nesting them
+    // multiplies the compiled size past MAX_PROGRAM_SIZE, which is what must catch this case.
     const start = Date.now();
-    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "(a{1000}){1000}" }), null);
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "((a|b){200}){200}" }), null);
     assert.ok(Date.now() - start < 1000, "compiling took too long");
     // A merely long pattern still compiles and matches.
     assert.deepEqual(matchedNames({ type: "matchProfiles", name: "(?:PowerShell){1}" }), ["PowerShell"]);
   });
 
-  it("bounds total matching work for a wide quantifier against a long value", () => {
-    // (a|b){0,4000} compiles (its program fits under MAX_PROGRAM_SIZE) but keeps thousands of
-    // live threads; without a bound on total matching work, running it against a value this long
-    // would take tens of millions of steps synchronously during rendering.
-    const matcher = buildProfileMatcher({ type: "matchProfiles", name: "(a|b){0,4000}" });
+  it("matches correctly, not just quickly, right up to the per-quantifier bound", () => {
+    // A quantifier at the 200 bound isn't just fast to reject — a legitimately matching value at
+    // that length must actually match, not silently fail because matching work is bounded too.
+    const matcher = buildProfileMatcher({ type: "matchProfiles", name: "(a|b){0,200}" });
     assert.notEqual(matcher, null);
-    const start = Date.now();
-    matcher!({ ...powershell, name: "a".repeat(4000) });
-    assert.ok(Date.now() - start < 500, "wide quantifier against a long value took too long");
+    assert.equal(matcher!({ ...powershell, name: "a".repeat(200) }), true);
+    assert.equal(matcher!({ ...powershell, name: "ab".repeat(100) }), true);
+    assert.equal(matcher!({ ...powershell, name: "c".repeat(200) }), false);
   });
 });
 

--- a/extensions/windows-terminal/src/new-tab-menu.test.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.test.ts
@@ -80,10 +80,25 @@ describe("buildProfileMatcher", () => {
     assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "^{2}PowerShell" }), null);
   });
 
-  it("doesn't exhaust its step budget on a long but linear match", () => {
+  it("matches a long linear value without excessive cost", () => {
     const longCommandline = "C:\\tools\\" + "a".repeat(1000) + ".exe";
     const matcher = buildProfileMatcher({ type: "matchProfiles", commandline: "C:\\\\tools\\\\.*\\.exe" });
     assert.ok(matcher!({ ...powershell, commandline: longCommandline }));
+  });
+
+  it("doesn't overflow the call stack on a long value", () => {
+    const longCommandline = "a".repeat(2000);
+    const matcher = buildProfileMatcher({ type: "matchProfiles", commandline: ".*" });
+    assert.equal(matcher!({ ...powershell, commandline: longCommandline }), true);
+  });
+
+  it("doesn't let a zero-length repetition block the rest of the pattern", () => {
+    const matcher = buildProfileMatcher({ type: "matchProfiles", name: "(a?)*b" });
+    assert.equal(matcher!({ ...powershell, name: "b" }), true);
+  });
+
+  it("supports negated escape classes inside a bracket expression", () => {
+    assert.equal(buildProfileMatcher({ type: "matchProfiles", name: "[\\D]+" })!(powershell), true);
   });
 });
 

--- a/extensions/windows-terminal/src/new-tab-menu.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.ts
@@ -1,0 +1,93 @@
+export interface Profile {
+  guid: string;
+  name: string;
+  hidden?: boolean;
+  source?: string;
+  commandline?: string;
+}
+
+export interface NewTabMenuEntry {
+  type: string;
+  profile?: string;
+  name?: string;
+  commandline?: string;
+  source?: string;
+  entries?: NewTabMenuEntry[];
+}
+
+// A matchProfiles entry matches a profile when ANY provided field (name/commandline/source)
+// fully matches that field's regex — mirrors Windows Terminal's MatchProfilesEntry. Empty profile
+// fields never match, so "source": ".*" skips local profiles and "commandline": ".*" skips
+// profiles without a command line. An entry with no patterns, or a malformed regex, matches
+// nothing rather than crashing or matching all.
+export function buildProfileMatcher(entry: NewTabMenuEntry): ((profile: Profile) => boolean) | null {
+  const specs: { pattern: string; get: (profile: Profile) => string }[] = [];
+  if (entry.name !== undefined) specs.push({ pattern: entry.name, get: (p) => p.name });
+  if (entry.commandline !== undefined) specs.push({ pattern: entry.commandline, get: (p) => p.commandline ?? "" });
+  if (entry.source !== undefined) specs.push({ pattern: entry.source, get: (p) => p.source ?? "" });
+  if (specs.length === 0) return null;
+
+  let matchers: { regex: RegExp; get: (profile: Profile) => string }[];
+  try {
+    matchers = specs.map(({ pattern, get }) => ({ regex: new RegExp(`^(?:${pattern})$`), get }));
+  } catch {
+    return null;
+  }
+
+  return (profile: Profile) =>
+    matchers.some(({ regex, get }) => {
+      const value = get(profile);
+      return value.length > 0 && regex.test(value);
+    });
+}
+
+// Mirrors Windows Terminal's own newTabMenu resolution (CascadiaSettingsSerialization.cpp):
+// two passes over the tree. Pass 1 collects every profile referenced by a "profile" or
+// "matchProfiles" entry anywhere (including inside folders). Pass 2 walks the tree again to
+// build the final order — "remainingProfiles" expands to profiles NOT in that pass-1 set, at
+// the position it appears, so a later explicit reference still lands after the remainder.
+export function resolveNewTabMenuOrder(profiles: Profile[], newTabMenu: NewTabMenuEntry[]): string[] {
+  const referenced = new Set<string>();
+
+  function collectReferenced(entries: NewTabMenuEntry[]) {
+    for (const entry of entries) {
+      if (entry.type === "profile" && entry.profile) {
+        const match = profiles.find((p) => p.guid === entry.profile || p.name === entry.profile);
+        if (match) referenced.add(match.guid);
+      } else if (entry.type === "matchProfiles") {
+        const matcher = buildProfileMatcher(entry);
+        if (matcher) profiles.forEach((p) => matcher(p) && referenced.add(p.guid));
+      } else if (entry.type === "folder" && entry.entries) {
+        collectReferenced(entry.entries);
+      }
+    }
+  }
+  collectReferenced(newTabMenu);
+
+  const order: string[] = [];
+  const placed = new Set<string>();
+  function addGuid(guid: string) {
+    if (placed.has(guid)) return;
+    placed.add(guid);
+    order.push(guid);
+  }
+
+  function build(entries: NewTabMenuEntry[]) {
+    for (const entry of entries) {
+      if (entry.type === "profile" && entry.profile) {
+        const match = profiles.find((p) => p.guid === entry.profile || p.name === entry.profile);
+        if (match) addGuid(match.guid);
+      } else if (entry.type === "matchProfiles") {
+        const matcher = buildProfileMatcher(entry);
+        if (matcher) profiles.forEach((p) => matcher(p) && addGuid(p.guid));
+      } else if (entry.type === "folder" && entry.entries) {
+        build(entry.entries);
+      } else if (entry.type === "remainingProfiles") {
+        profiles.forEach((p) => !referenced.has(p.guid) && addGuid(p.guid));
+      }
+    }
+  }
+  build(newTabMenu);
+
+  return order;
+}

--- a/extensions/windows-terminal/src/new-tab-menu.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.ts
@@ -66,27 +66,35 @@ function parsePattern(pattern: string): AltNode {
     const atom = parseAtom();
     let min = 1;
     let max = 1;
+    let quantified = false;
     const c = peek();
     if (c === "*") {
       min = 0;
       max = Infinity;
+      quantified = true;
       i++;
     } else if (c === "+") {
       min = 1;
       max = Infinity;
+      quantified = true;
       i++;
     } else if (c === "?") {
       min = 0;
       max = 1;
+      quantified = true;
       i++;
     } else if (c === "{") {
       const braces = /^\{(\d+)(,(\d*))?\}/.exec(pattern.slice(i));
       if (braces) {
         min = parseInt(braces[1], 10);
         max = braces[2] === undefined ? min : braces[3] === "" ? Infinity : parseInt(braces[3], 10);
+        quantified = true;
         i += braces[0].length;
       }
     }
+    // Windows Terminal's regex engine rejects a quantified anchor (^?, $*, ^{2}...) as a syntax
+    // error rather than matching it literally or ignoring the quantifier, so mirror that here.
+    if (quantified && (atom.kind === "start" || atom.kind === "end")) return fail("quantified anchor");
     let greedy = true;
     if (peek() === "?") {
       greedy = false;

--- a/extensions/windows-terminal/src/new-tab-menu.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.ts
@@ -330,20 +330,26 @@ function compileProgram(alt: AltNode): Inst {
 // zero-width loop like (a?)* from spinning forever: once its `split` has been visited at a given
 // position, revisiting it adds nothing new, so the closure always terminates after at most one
 // visit per instruction, and the pattern's remainder (matching past the loop) still gets explored.
-function addThread(list: Inst[], visited: Set<Inst>, inst: Inst, pos: number, str: string): void {
-  if (visited.has(inst)) return;
-  visited.add(inst);
-  if (inst.op === "split") {
-    addThread(list, visited, inst.next!, pos, str);
-    addThread(list, visited, inst.next2!, pos, str);
-  } else if (inst.op === "nop") {
-    addThread(list, visited, inst.next!, pos, str);
-  } else if (inst.op === "start") {
-    if (pos === 0) addThread(list, visited, inst.next!, pos, str);
-  } else if (inst.op === "end") {
-    if (pos === str.length) addThread(list, visited, inst.next!, pos, str);
-  } else {
-    list.push(inst);
+// Walked with an explicit stack, not recursion — a flat run of thousands of optional atoms
+// (a?a?a?...) chains that many `split`s in a row, and recursing that chain would grow the JS call
+// stack with the pattern's size, independent of how long the string being matched is.
+function addThread(list: Inst[], visited: Set<Inst>, start: Inst, pos: number, str: string): void {
+  const stack: Inst[] = [start];
+  while (stack.length > 0) {
+    const inst = stack.pop()!;
+    if (visited.has(inst)) continue;
+    visited.add(inst);
+    if (inst.op === "split") {
+      stack.push(inst.next2!, inst.next!);
+    } else if (inst.op === "nop") {
+      stack.push(inst.next!);
+    } else if (inst.op === "start") {
+      if (pos === 0) stack.push(inst.next!);
+    } else if (inst.op === "end") {
+      if (pos === str.length) stack.push(inst.next!);
+    } else {
+      list.push(inst);
+    }
   }
 }
 

--- a/extensions/windows-terminal/src/new-tab-menu.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.ts
@@ -40,14 +40,23 @@ class RegexSyntaxError extends Error {}
 class RegexTooLargeError extends Error {}
 
 // compileQuant unrolls {n,m} into that many copies of the atom, and nesting multiplies them: the
-// program for (a{1000}){1000} is a million instructions even though neither quantifier is
-// unreasonable on its own. So the cap is on the size of the whole compiled program rather than on
-// any single quantifier. It's set well above what a real matchProfiles pattern needs (a long
-// literal alternation is still only a few hundred instructions) but far below that million, which
-// keeps compilation bounded in both memory and time, and bounds matching too — the Pike VM does at
-// most program-size work per character, so a refused pattern is also the only kind that could
-// have made rendering the profile list crawl.
+// program for (a{200}){200} is 40,000+ instructions even though MAX_QUANT_REPEAT below allows
+// each 200 individually. So this cap is on the size of the whole compiled program, catching that
+// multiplication regardless of how deep the nesting goes. It's set well above what a real
+// matchProfiles pattern needs (a long literal alternation is still only a few hundred
+// instructions) but far below what nesting a few max-sized quantifiers can reach, which keeps
+// compilation bounded in both memory and time.
 const MAX_PROGRAM_SIZE = 50000;
+
+// A single {n,m} unrolls into that many copies of its atom (compileQuant), one split per optional
+// copy. Matching cost for that isn't just O(program size × value length): at any position, every
+// still-reachable "how many reps have I skipped so far" copy is a separate live NFA thread, so an
+// optional quantifier's cost is closer to O(bound²) — measured, a 2-way alternation with an
+// explicit bound of 200 against a value of that length needs ~240,000 steps, 300 needs ~540,000.
+// A real matchProfiles pattern never needs to repeat anything anywhere near this many times, so
+// the bound is capped well before that quadratic cost gets expensive. Nested multiplication like
+// (a{200}){200} is still caught by MAX_PROGRAM_SIZE.
+const MAX_QUANT_REPEAT = 200;
 
 // Parses the subset of ICU regex syntax (the flavor Windows Terminal itself matches with) that
 // matchProfiles patterns actually use: literals, `.`, escapes (`\d\w\s` and their negations, `\.`
@@ -115,6 +124,9 @@ function parsePattern(pattern: string): AltNode {
         min = parseInt(braces[1], 10);
         max = braces[2] === undefined ? min : braces[3] === "" ? Infinity : parseInt(braces[3], 10);
         if (max < min) return fail("quantifier bounds out of order");
+        if (min > MAX_QUANT_REPEAT || (max !== Infinity && max > MAX_QUANT_REPEAT)) {
+          return fail("quantifier bound too large");
+        }
         quantified = true;
         i += braces[0].length;
       }
@@ -268,8 +280,8 @@ type PatchSlot =
 type Frag = { start: Inst; out: PatchSlot[] };
 
 // Every instruction is created through here, so the running total covers nested repetitions too —
-// the budget is spent as (a{1000}){1000} unrolls, and compilation gives up partway through rather
-// than after building the whole million-instruction program.
+// the budget is spent as (a{200}){200} unrolls, and compilation gives up partway through rather
+// than after building the whole 40,000+-instruction program.
 let instructionCount = 0;
 
 function newInst<T extends Inst>(inst: T): T {
@@ -385,14 +397,15 @@ function compileProgram(alt: AltNode): Inst {
   return frag.start;
 }
 
-// matchFull's total work is O(program size × value length): the NFA can't backtrack exponentially,
-// but a program well within MAX_PROGRAM_SIZE run against a long field value is still a lot of
-// arithmetic — e.g. (a|b){0,4000} compiles to a modest program but keeps thousands of live threads,
-// and matching it against a long commandline could take tens of millions of steps, run
-// synchronously during rendering, once per profile per resolution pass. This budget bounds that
-// total, independent of both factors, the same "give up and report no match" fallback
-// MAX_PROGRAM_SIZE already uses for a pattern that's too large to compile at all.
-const MAX_MATCH_STEPS = 200000;
+// A safety net behind MAX_QUANT_REPEAT, not the primary defense against slow matching — that's
+// now the quantifier bound above, which keeps realistic patterns fast in the first place. This
+// budget exists for constructs MAX_QUANT_REPEAT doesn't cover: a long value matched against a
+// small program (e.g. ".*"), or several moderate quantifiers/alternations compounding within one
+// pattern. It's set with headroom above the worst case MAX_QUANT_REPEAT actually allows (a 5-way
+// alternation at the bound measured ~390,000 steps) so a legitimately matching pattern within that
+// bound always finishes rather than being silently cut off — MAX_QUANT_REPEAT is what keeps this
+// budget from ever being the thing standing between a valid pattern and a correct answer.
+const MAX_MATCH_STEPS = 1000000;
 type StepBudget = { remaining: number };
 
 // \b sits between a word character and a non-word one, counting the space off either end of the

--- a/extensions/windows-terminal/src/new-tab-menu.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.ts
@@ -138,20 +138,11 @@ function parsePattern(pattern: string): AltNode {
   // call stack.
   let groupDepth = 0;
   const MAX_GROUP_DEPTH = 100;
-  // Under (?i) a class or predicate also admits a character's single-code-point case variants —
-  // an approximation of ICU closing the set over case. Only single code points: "ß" uppercases to
-  // "SS", and testing that against [A-Z] would wrongly admit ß.
-  const isSingle = (s: string) => Array.from(s).length === 1;
-  const foldCase = (test: (ch: string) => boolean) => {
-    if (!ignoreCase) return test;
-    return (ch: string) => {
-      if (test(ch) || test(simpleFold(ch))) return true;
-      const lower = ch.toLowerCase();
-      const upper = ch.toUpperCase();
-      return (isSingle(lower) && test(lower)) || (isSingle(upper) && test(upper));
-    };
-  };
-  const charAtom = (test: (ch: string) => boolean): AtomNode => ({ kind: "char", test: foldCase(test) });
+  // \d, \w, \s and their negations — sets already closed over case, so (?i) changes nothing.
+  const charAtom = (test: (ch: string) => boolean): AtomNode => ({ kind: "char", test });
+  // A code point spelled for a native RegExp source with the `u` flag, so a class member that's
+  // special there ("]", "\", "-", "^") needs no escaping of its own — see parseClass.
+  const codePointEscape = (code: number) => `\\u{${code.toString(16)}}`;
   // A literal character. Under (?i) it compares simple case folds, one code point to one — unless
   // parseSeq finds it in a run of two or more, which switches the run to full folding.
   const literalAtom = (c: string): AtomNode => {
@@ -353,6 +344,8 @@ function parsePattern(pattern: string): AltNode {
       i++;
     }
     const tests: ((ch: string) => boolean)[] = [];
+    // Literal members and ranges, as code points, for the case-insensitive path below.
+    const members: string[] = [];
     while (i < n && peek() !== "]") {
       // ICU reads an unescaped "[" inside a set as a nested set ([[:alpha:]], [a-z[0-9]]) and "&&"
       // as set intersection ([a-z&&[^m]]). Neither is implemented; reading them as literals would
@@ -378,19 +371,28 @@ function parsePattern(pattern: string): AltNode {
         // A descending range like [z-a] can never match anything; real regex engines reject it
         // as malformed rather than silently compiling a predicate that's always false.
         if (high < low) return fail(`character range "${start}-${end}" out of order`);
+        members.push(`${codePointEscape(low)}-${codePointEscape(high)}`);
         tests.push((ch) => {
           const code = ch.codePointAt(0)!;
           return code >= low && code <= high;
         });
       } else {
+        members.push(codePointEscape(start.codePointAt(0)!));
         tests.push((ch) => ch === start);
       }
     }
     if (peek() !== "]") return fail("unbalanced bracket");
     i++;
-    // Case folding has to happen inside the negation, not around it: (?i)[^a] means "neither a
-    // nor A", so folding the finished (already negated) test would let it match "A".
-    const member = foldCase((ch) => tests.some((test) => test(ch)));
+    // Under (?i), ICU closes the set over case: a character is in if any member shares its simple
+    // case fold, so [A-Z] gains a-z, ſ, and K (Kelvin) — but not ı, whose fold is itself — and
+    // [ſ] gains s and S. Deriving that from toUpperCase/toLowerCase gets ı and ſ wrong; the
+    // native RegExp with the `i` and `u` flags implements exactly it (Canonicalize on both
+    // sides), so the literal and range members are handed to one. The regex is a one-character
+    // class against one character — nothing for it to backtrack over. \d, \w, \s and their
+    // negations are already closed over case and stay as predicates. Folding sits inside the
+    // negation, not around it: (?i)[^a] means "neither a nor A".
+    const native = ignoreCase && members.length > 0 ? new RegExp(`^[${members.join("")}]$`, "iu") : null;
+    const member = (ch: string) => (native !== null && native.test(ch)) || tests.some((test) => test(ch));
     return { kind: "char", test: (ch) => negate !== member(ch) };
   }
 

--- a/extensions/windows-terminal/src/new-tab-menu.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.ts
@@ -21,31 +21,40 @@ export interface NewTabMenuEntry {
 // the call stack on a long value even for a safe pattern like ".*". This engine avoids both: it
 // compiles the pattern into a Thompson NFA (compileProgram) and matches by advancing every
 // reachable state together, one input character at a time (matchFull) — the technique RE2 and
-// Rust's regex crate use for guaranteed linear-time matching with no backtracking. So nothing needs
-// to be rejected up front and nothing needs a step budget — a repeated group with safe
-// alternatives, like (dev|prod)+, still matches normally.
+// Rust's regex crate use for guaranteed linear-time matching with no backtracking. So no pattern
+// needs rejecting for how it might backtrack — a repeated group with safe alternatives, like
+// (dev|prod)+, still matches normally, and so does (a+)+ — only the compiled program's sheer size
+// is capped (MAX_PROGRAM_SIZE).
 type AtomNode =
   | { kind: "char"; test: (ch: string) => boolean }
   | { kind: "any" }
   | { kind: "group"; alt: AltNode }
   | { kind: "start" }
-  | { kind: "end" };
+  | { kind: "end" }
+  | { kind: "boundary"; negate: boolean };
 type QuantNode = { atom: AtomNode; min: number; max: number; greedy: boolean };
 type SeqNode = { atoms: QuantNode[] };
 type AltNode = { options: SeqNode[] };
 
 class RegexSyntaxError extends Error {}
+class RegexTooLargeError extends Error {}
 
-// compileQuant below unrolls an explicit {n,m} into n or m literal copies of the atom, so a bound
-// this large would blow up the compiled instruction count regardless of the input being matched.
-// matchProfiles patterns never legitimately need more than this.
-const MAX_QUANT_BOUND = 1000;
+// compileQuant unrolls {n,m} into that many copies of the atom, and nesting multiplies them: the
+// program for (a{1000}){1000} is a million instructions even though neither quantifier is
+// unreasonable on its own. So the cap is on the size of the whole compiled program rather than on
+// any single quantifier. It's set well above what a real matchProfiles pattern needs (a long
+// literal alternation is still only a few hundred instructions) but far below that million, which
+// keeps compilation bounded in both memory and time, and bounds matching too — the Pike VM does at
+// most program-size work per character, so a refused pattern is also the only kind that could
+// have made rendering the profile list crawl.
+const MAX_PROGRAM_SIZE = 50000;
 
-// Parses the subset of ECMAScript regex syntax matchProfiles patterns actually use: literals,
-// `.`, escapes (`\d\w\s` and their negations, `\.` etc.), `[...]` classes, `(...)`/`(?:...)`
-// groups, `|` alternation, and `* + ? {n,m}` quantifiers (with lazy `?` variants). Anything else
-// — lookaround, backreferences, unicode property escapes — is unsupported and throws, which
-// buildProfileMatcher treats the same as any other malformed pattern.
+// Parses the subset of ICU regex syntax (the flavor Windows Terminal itself matches with) that
+// matchProfiles patterns actually use: literals, `.`, escapes (`\d\w\s` and their negations, `\.`
+// etc.), the `\b`/`\B` word-boundary assertions, `[...]` classes, `(...)`/`(?:...)` groups, the
+// `(?i)`/`(?i:...)` case-insensitivity flag, `|` alternation, and `* + ? {n,m}` quantifiers (with
+// lazy `?` variants). Anything else — lookaround, backreferences, unicode property escapes — is
+// unsupported and throws, which buildProfileMatcher treats the same as a malformed pattern.
 function parsePattern(pattern: string): AltNode {
   let i = 0;
   const n = pattern.length;
@@ -53,6 +62,16 @@ function parsePattern(pattern: string): AltNode {
   const fail = (msg: string): never => {
     throw new RegexSyntaxError(msg);
   };
+
+  // Set by (?i) and restored when the enclosing group closes, mirroring ICU: the flag runs from
+  // where it appears to the end of that group, subsequent `|` branches included. It's applied as
+  // each character test is built, so the compiled program needs no notion of case at all.
+  let ignoreCase = false;
+  const foldCase = (test: (ch: string) => boolean) => {
+    if (!ignoreCase) return test;
+    return (ch: string) => test(ch) || test(ch.toLowerCase()) || test(ch.toUpperCase());
+  };
+  const charAtom = (test: (ch: string) => boolean): AtomNode => ({ kind: "char", test: foldCase(test) });
 
   function parseAlt(): AltNode {
     const options = [parseSeq()];
@@ -95,9 +114,7 @@ function parsePattern(pattern: string): AltNode {
       if (braces) {
         min = parseInt(braces[1], 10);
         max = braces[2] === undefined ? min : braces[3] === "" ? Infinity : parseInt(braces[3], 10);
-        if (max < min || min > MAX_QUANT_BOUND || (max !== Infinity && max > MAX_QUANT_BOUND)) {
-          return fail("quantifier bound out of range");
-        }
+        if (max < min) return fail("quantifier bounds out of order");
         quantified = true;
         i += braces[0].length;
       }
@@ -119,11 +136,23 @@ function parsePattern(pattern: string): AltNode {
     if (c === "*" || c === "+" || c === "?" || c === ")") return fail(`unexpected "${c}"`);
     if (c === "(") {
       i++;
-      if (pattern.slice(i, i + 2) === "?:") i += 2;
-      else if (peek() === "?") return fail("unsupported group modifier");
+      const outerIgnoreCase = ignoreCase;
+      if (peek() === "?") {
+        // "?:" plain group, "?i)" / "?-i)" a flag switch, "?i:" a flag scoped to this group.
+        const modifier = /^\?(-?)(i*)([:)])/.exec(pattern.slice(i));
+        if (!modifier) return fail("unsupported group modifier");
+        const [consumed, disable, flags, delimiter] = modifier;
+        if (flags === "" && delimiter === ")") return fail("empty inline flags");
+        if (flags !== "") ignoreCase = disable !== "-";
+        i += consumed.length;
+        // (?i) is a switch, not a group: it matches nothing itself, and deliberately leaves
+        // ignoreCase set for whatever follows it in the enclosing group.
+        if (delimiter === ")") return { kind: "group", alt: { options: [{ atoms: [] }] } };
+      }
       const alt = parseAlt();
       if (peek() !== ")") return fail("unbalanced parenthesis");
       i++;
+      ignoreCase = outerIgnoreCase;
       return { kind: "group", alt };
     }
     if (c === "[") return parseClass();
@@ -146,22 +175,32 @@ function parsePattern(pattern: string): AltNode {
       return parseEscape();
     }
     i++;
-    return { kind: "char", test: (ch) => ch === c };
+    return charAtom((ch) => ch === c);
   }
+
+  const escapePredicates: Record<string, (ch: string) => boolean> = {
+    d: (ch) => ch >= "0" && ch <= "9",
+    D: (ch) => !(ch >= "0" && ch <= "9"),
+    w: (ch) => /\w/.test(ch),
+    W: (ch) => !/\w/.test(ch),
+    s: (ch) => /\s/.test(ch),
+    S: (ch) => !/\s/.test(ch),
+  };
 
   function parseEscape(): AtomNode {
     const c = pattern[i];
     i++;
     if (c === undefined) return fail("trailing backslash");
-    const predicates: Record<string, (ch: string) => boolean> = {
-      d: (ch) => ch >= "0" && ch <= "9",
-      D: (ch) => !(ch >= "0" && ch <= "9"),
-      w: (ch) => /\w/.test(ch),
-      W: (ch) => !/\w/.test(ch),
-      s: (ch) => /\s/.test(ch),
-      S: (ch) => !/\s/.test(ch),
-    };
-    return { kind: "char", test: predicates[c] ?? ((ch) => ch === c) };
+    // \b and \B are zero-width assertions about the surrounding characters, not the letters
+    // "b"/"B" — reading them literally is what made \bPowerShell\b miss the PowerShell profile.
+    if (c === "b" || c === "B") return { kind: "boundary", negate: c === "B" };
+    const predicate = escapePredicates[c];
+    if (predicate) return charAtom(predicate);
+    // An escaped letter or digit that isn't one of the above is a construct this engine doesn't
+    // implement (\A, \p{...}, a backreference). Reject the pattern rather than matching it as a
+    // literal, which would silently match the wrong profiles.
+    if (/[A-Za-z0-9]/.test(c)) return fail(`unsupported escape "\\${c}"`);
+    return charAtom((ch) => ch === c);
   }
 
   function parseClass(): AtomNode {
@@ -178,12 +217,10 @@ function parsePattern(pattern: string): AltNode {
         i++;
         const esc = pattern[i];
         i++;
-        if (esc === "d") tests.push((ch) => ch >= "0" && ch <= "9");
-        else if (esc === "D") tests.push((ch) => !(ch >= "0" && ch <= "9"));
-        else if (esc === "w") tests.push((ch) => /\w/.test(ch));
-        else if (esc === "W") tests.push((ch) => !/\w/.test(ch));
-        else if (esc === "s") tests.push((ch) => /\s/.test(ch));
-        else if (esc === "S") tests.push((ch) => !/\s/.test(ch));
+        if (esc === undefined) return fail("trailing backslash");
+        const predicate = escapePredicates[esc];
+        if (predicate) tests.push(predicate);
+        else if (/[A-Za-z0-9]/.test(esc)) return fail(`unsupported escape "\\${esc}"`);
         else tests.push((ch) => ch === esc);
         continue;
       }
@@ -199,7 +236,10 @@ function parsePattern(pattern: string): AltNode {
     }
     if (peek() !== "]") return fail("unbalanced bracket");
     i++;
-    return { kind: "char", test: (ch) => negate !== tests.some((test) => test(ch)) };
+    // Case folding has to happen inside the negation, not around it: (?i)[^a] means "neither a
+    // nor A", so folding the finished (already negated) test would let it match "A".
+    const member = foldCase((ch) => tests.some((test) => test(ch)));
+    return { kind: "char", test: (ch) => negate !== member(ch) };
   }
 
   const result = parseAlt();
@@ -216,15 +256,26 @@ type CharInst = { op: "char"; test: (ch: string) => boolean; next?: Inst };
 type AnyInst = { op: "any"; next?: Inst };
 type StartInst = { op: "start"; next?: Inst };
 type EndInst = { op: "end"; next?: Inst };
+type BoundaryInst = { op: "boundary"; negate: boolean; next?: Inst };
 type SplitInst = { op: "split"; next?: Inst; next2?: Inst };
 type NopInst = { op: "nop"; next?: Inst };
 type MatchInst = { op: "match" };
-type Inst = CharInst | AnyInst | StartInst | EndInst | SplitInst | NopInst | MatchInst;
+type Inst = CharInst | AnyInst | StartInst | EndInst | BoundaryInst | SplitInst | NopInst | MatchInst;
 
 type PatchSlot =
-  | { inst: CharInst | AnyInst | StartInst | EndInst | NopInst | SplitInst; slot: "next" }
+  | { inst: CharInst | AnyInst | StartInst | EndInst | BoundaryInst | NopInst | SplitInst; slot: "next" }
   | { inst: SplitInst; slot: "next2" };
 type Frag = { start: Inst; out: PatchSlot[] };
+
+// Every instruction is created through here, so the running total covers nested repetitions too —
+// the budget is spent as (a{1000}){1000} unrolls, and compilation gives up partway through rather
+// than after building the whole million-instruction program.
+let instructionCount = 0;
+
+function newInst<T extends Inst>(inst: T): T {
+  if (++instructionCount > MAX_PROGRAM_SIZE) throw new RegexTooLargeError("pattern is too large to compile");
+  return inst;
+}
 
 function patch(out: PatchSlot[], target: Inst): void {
   for (const p of out) {
@@ -234,7 +285,7 @@ function patch(out: PatchSlot[], target: Inst): void {
 }
 
 function emptyFrag(): Frag {
-  const inst: NopInst = { op: "nop" };
+  const inst: NopInst = newInst({ op: "nop" });
   return { start: inst, out: [{ inst, slot: "next" }] };
 }
 
@@ -250,27 +301,35 @@ function concatAll(frags: Frag[]): Frag {
 function compileAtom(atom: AtomNode): Frag {
   if (atom.kind === "group") return compileAlt(atom.alt);
   if (atom.kind === "char") {
-    const inst: CharInst = { op: "char", test: atom.test };
+    const inst: CharInst = newInst({ op: "char", test: atom.test });
     return { start: inst, out: [{ inst, slot: "next" }] };
   }
   if (atom.kind === "any") {
-    const inst: AnyInst = { op: "any" };
+    const inst: AnyInst = newInst({ op: "any" });
     return { start: inst, out: [{ inst, slot: "next" }] };
   }
   if (atom.kind === "start") {
-    const inst: StartInst = { op: "start" };
+    const inst: StartInst = newInst({ op: "start" });
     return { start: inst, out: [{ inst, slot: "next" }] };
   }
-  const inst: EndInst = { op: "end" };
+  if (atom.kind === "end") {
+    const inst: EndInst = newInst({ op: "end" });
+    return { start: inst, out: [{ inst, slot: "next" }] };
+  }
+  const inst: BoundaryInst = newInst({ op: "boundary", negate: atom.negate });
   return { start: inst, out: [{ inst, slot: "next" }] };
 }
 
+// Counts up rather than building the array first, so an absurd count like a{999999999} trips the
+// instruction budget partway through instead of trying to size an array for all of it.
 function repeatFrag(atom: AtomNode, count: number): Frag {
-  return concatAll(Array.from({ length: count }, () => compileAtom(atom)));
+  const frags: Frag[] = [];
+  for (let copy = 0; copy < count; copy++) frags.push(compileAtom(atom));
+  return concatAll(frags);
 }
 
 function starFrag(atom: AtomNode): Frag {
-  const split: SplitInst = { op: "split" };
+  const split: SplitInst = newInst({ op: "split" });
   const body = compileAtom(atom);
   patch(body.out, split);
   split.next = body.start;
@@ -278,7 +337,7 @@ function starFrag(atom: AtomNode): Frag {
 }
 
 function plusFrag(atom: AtomNode): Frag {
-  const split: SplitInst = { op: "split" };
+  const split: SplitInst = newInst({ op: "split" });
   const body = compileAtom(atom);
   patch(body.out, split);
   split.next = body.start;
@@ -286,7 +345,7 @@ function plusFrag(atom: AtomNode): Frag {
 }
 
 function optionalFrag(atom: AtomNode): Frag {
-  const split: SplitInst = { op: "split" };
+  const split: SplitInst = newInst({ op: "split" });
   const body = compileAtom(atom);
   split.next = body.start;
   return { start: split, out: [...body.out, { inst: split, slot: "next2" }] };
@@ -300,8 +359,9 @@ function compileQuant(q: QuantNode): Frag {
     if (q.min === 0) return starFrag(q.atom);
     return concat(repeatFrag(q.atom, q.min - 1), plusFrag(q.atom));
   }
-  const optionals = concatAll(Array.from({ length: q.max - q.min }, () => optionalFrag(q.atom)));
-  return concat(repeatFrag(q.atom, q.min), optionals);
+  const optionals: Frag[] = [];
+  for (let copy = q.min; copy < q.max; copy++) optionals.push(optionalFrag(q.atom));
+  return concat(repeatFrag(q.atom, q.min), concatAll(optionals));
 }
 
 function compileSeq(seq: SeqNode): Frag {
@@ -310,7 +370,7 @@ function compileSeq(seq: SeqNode): Frag {
 
 function compileAlt(alt: AltNode): Frag {
   return alt.options.map(compileSeq).reduceRight((rest, option) => {
-    const split: SplitInst = { op: "split" };
+    const split: SplitInst = newInst({ op: "split" });
     split.next = option.start;
     split.next2 = rest.start;
     return { start: split, out: [...option.out, ...rest.out] };
@@ -318,10 +378,19 @@ function compileAlt(alt: AltNode): Frag {
 }
 
 function compileProgram(alt: AltNode): Inst {
+  instructionCount = 0;
   const frag = compileAlt(alt);
-  const matchInst: MatchInst = { op: "match" };
+  const matchInst: MatchInst = newInst({ op: "match" });
   patch(frag.out, matchInst);
   return frag.start;
+}
+
+// \b sits between a word character and a non-word one, counting the space off either end of the
+// value as non-word — so it holds at both ends of "PowerShell" but not inside it.
+const isWordChar = (ch: string | undefined) => ch !== undefined && /\w/.test(ch);
+
+function isWordBoundary(str: string, pos: number): boolean {
+  return isWordChar(str[pos - 1]) !== isWordChar(str[pos]);
 }
 
 // Epsilon-closure: follows the zero-width instructions (`split`, `nop`, and the anchors when their
@@ -347,6 +416,8 @@ function addThread(list: Inst[], visited: Set<Inst>, start: Inst, pos: number, s
       if (pos === 0) stack.push(inst.next!);
     } else if (inst.op === "end") {
       if (pos === str.length) stack.push(inst.next!);
+    } else if (inst.op === "boundary") {
+      if (isWordBoundary(str, pos) !== inst.negate) stack.push(inst.next!);
     } else {
       list.push(inst);
     }
@@ -381,8 +452,9 @@ function matchFull(prog: Inst, str: string): boolean {
 // A matchProfiles entry matches a profile when ANY provided field (name/commandline/source)
 // fully matches that field's regex — mirrors Windows Terminal's MatchProfilesEntry. Empty profile
 // fields never match, so "source": ".*" skips local profiles and "commandline": ".*" skips
-// profiles without a command line. An entry with no patterns, or a malformed or unsupported
-// regex, matches nothing rather than crashing or matching all.
+// profiles without a command line. An entry with no patterns, or a regex that is malformed,
+// unsupported, or too large to compile, matches nothing rather than crashing or matching all —
+// compilation happens here, once per entry, so a refused pattern can't throw during rendering.
 export function buildProfileMatcher(entry: NewTabMenuEntry): ((profile: Profile) => boolean) | null {
   const specs: { pattern: string; get: (profile: Profile) => string }[] = [];
   if (entry.name !== undefined) specs.push({ pattern: entry.name, get: (p) => p.name });

--- a/extensions/windows-terminal/src/new-tab-menu.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.ts
@@ -15,52 +15,230 @@ export interface NewTabMenuEntry {
   entries?: NewTabMenuEntry[];
 }
 
-// JavaScript regex matching can't be interrupted once it starts, so an exponentially
-// backtracking pattern — (a+)+, (a|aa)*, ((ab)+)+ — would freeze the profile list while it
-// renders. Every such pattern quantifies a group that itself repeats or alternates, so reject
-// that shape up front. Conservative: a harmless pattern like (a|b)+ is rejected too, which
-// costs one unmatched menu entry instead of a hung command.
-function hasRiskyBacktracking(pattern: string): boolean {
-  // Escapes and character classes can't open a group, so reduce them to a plain character first.
-  let rest = pattern.replace(/\\./g, "a").replace(/\[[^\]]*\]/g, "a");
-  const innermostGroup = /\(([^()]*)\)(\*|\+|\?|\{\d+(?:,\d*)?\})?/;
+// A minimal backtracking regex engine, used instead of JavaScript's native RegExp. Native regex
+// matching can't be interrupted once it starts, so a pathological pattern — (a+)+, (a?a?)+,
+// ((ab)+)+ — would freeze the profile list while it renders. This engine bounds itself with a
+// step counter instead: every recursive attempt costs one step, and once the budget is spent the
+// match fails rather than exploring further. That makes ALL patterns safe to run, including ones
+// that look risky, so nothing needs to be rejected up front — a repeated group with safe
+// alternatives, like (dev|prod)+, still matches normally.
+type AtomNode = { kind: "char"; test: (ch: string) => boolean } | { kind: "any" } | { kind: "group"; alt: AltNode };
+type QuantNode = { atom: AtomNode; min: number; max: number; greedy: boolean };
+type SeqNode = { atoms: QuantNode[] };
+type AltNode = { options: SeqNode[] };
 
-  // Collapse groups from the inside out. A group that repeats collapses to "a+" so an enclosing
-  // quantifier still sees a repeat inside it; anything else collapses to a plain "a".
-  for (let match = innermostGroup.exec(rest); match; match = innermostGroup.exec(rest)) {
-    const [whole, body, quantifier] = match;
-    const repeats = quantifier !== undefined && quantifier !== "?";
-    if (repeats && /[*+|]|\{\d*,\d*\}/.test(body)) return true;
-    rest = rest.replace(whole, repeats ? "a+" : "a");
+class RegexSyntaxError extends Error {}
+
+// Parses the subset of ECMAScript regex syntax matchProfiles patterns actually use: literals,
+// `.`, escapes (`\d\w\s` and their negations, `\.` etc.), `[...]` classes, `(...)`/`(?:...)`
+// groups, `|` alternation, and `* + ? {n,m}` quantifiers (with lazy `?` variants). Anything else
+// — lookaround, backreferences, unicode property escapes — is unsupported and throws, which
+// buildProfileMatcher treats the same as any other malformed pattern.
+function parsePattern(pattern: string): AltNode {
+  let i = 0;
+  const n = pattern.length;
+  const peek = () => pattern[i];
+  const fail = (msg: string): never => {
+    throw new RegexSyntaxError(msg);
+  };
+
+  function parseAlt(): AltNode {
+    const options = [parseSeq()];
+    while (peek() === "|") {
+      i++;
+      options.push(parseSeq());
+    }
+    return { options };
   }
 
-  return false;
+  function parseSeq(): SeqNode {
+    const atoms: QuantNode[] = [];
+    while (i < n && peek() !== "|" && peek() !== ")") atoms.push(parseQuant());
+    return { atoms };
+  }
+
+  function parseQuant(): QuantNode {
+    const atom = parseAtom();
+    let min = 1;
+    let max = 1;
+    const c = peek();
+    if (c === "*") {
+      min = 0;
+      max = Infinity;
+      i++;
+    } else if (c === "+") {
+      min = 1;
+      max = Infinity;
+      i++;
+    } else if (c === "?") {
+      min = 0;
+      max = 1;
+      i++;
+    } else if (c === "{") {
+      const braces = /^\{(\d+)(,(\d*))?\}/.exec(pattern.slice(i));
+      if (braces) {
+        min = parseInt(braces[1], 10);
+        max = braces[2] === undefined ? min : braces[3] === "" ? Infinity : parseInt(braces[3], 10);
+        i += braces[0].length;
+      }
+    }
+    let greedy = true;
+    if (peek() === "?") {
+      greedy = false;
+      i++;
+    }
+    return { atom, min, max, greedy };
+  }
+
+  function parseAtom(): AtomNode {
+    const c = peek();
+    if (c === undefined) return fail("unexpected end of pattern");
+    if (c === "*" || c === "+" || c === "?" || c === ")") return fail(`unexpected "${c}"`);
+    if (c === "(") {
+      i++;
+      if (pattern.slice(i, i + 2) === "?:") i += 2;
+      else if (peek() === "?") return fail("unsupported group modifier");
+      const alt = parseAlt();
+      if (peek() !== ")") return fail("unbalanced parenthesis");
+      i++;
+      return { kind: "group", alt };
+    }
+    if (c === "[") return parseClass();
+    if (c === ".") {
+      i++;
+      return { kind: "any" };
+    }
+    if (c === "\\") {
+      i++;
+      return parseEscape();
+    }
+    i++;
+    return { kind: "char", test: (ch) => ch === c };
+  }
+
+  function parseEscape(): AtomNode {
+    const c = pattern[i];
+    i++;
+    if (c === undefined) return fail("trailing backslash");
+    const predicates: Record<string, (ch: string) => boolean> = {
+      d: (ch) => ch >= "0" && ch <= "9",
+      D: (ch) => !(ch >= "0" && ch <= "9"),
+      w: (ch) => /\w/.test(ch),
+      W: (ch) => !/\w/.test(ch),
+      s: (ch) => /\s/.test(ch),
+      S: (ch) => !/\s/.test(ch),
+    };
+    return { kind: "char", test: predicates[c] ?? ((ch) => ch === c) };
+  }
+
+  function parseClass(): AtomNode {
+    i++; // consume "["
+    let negate = false;
+    if (peek() === "^") {
+      negate = true;
+      i++;
+    }
+    const tests: ((ch: string) => boolean)[] = [];
+    while (i < n && peek() !== "]") {
+      const start = peek();
+      if (start === "\\") {
+        i++;
+        const esc = pattern[i];
+        i++;
+        if (esc === "d") tests.push((ch) => ch >= "0" && ch <= "9");
+        else if (esc === "w") tests.push((ch) => /\w/.test(ch));
+        else if (esc === "s") tests.push((ch) => /\s/.test(ch));
+        else tests.push((ch) => ch === esc);
+        continue;
+      }
+      i++;
+      if (peek() === "-" && pattern[i + 1] !== "]" && i + 1 < n) {
+        i++; // consume "-"
+        const end = pattern[i];
+        i++;
+        tests.push((ch) => ch >= start && ch <= end);
+      } else {
+        tests.push((ch) => ch === start);
+      }
+    }
+    if (peek() !== "]") return fail("unbalanced bracket");
+    i++;
+    return { kind: "char", test: (ch) => negate !== tests.some((test) => test(ch)) };
+  }
+
+  const result = parseAlt();
+  if (i !== n) fail("unexpected trailing characters");
+  return result;
+}
+
+// Every recursive attempt below — descending into a group, trying one more quantifier repeat,
+// trying an alternation branch — spends one step. Legitimate matchProfiles patterns against
+// profile-sized strings need at most a few hundred; this budget leaves headroom for that while
+// still cutting off exponential blowups almost immediately.
+const STEP_BUDGET = 2000;
+
+// Continuation-passing backtracking matcher, fully anchored (matches only if it consumes the
+// whole string). `k` is "what to try once this piece has matched"; quantifiers try repeating
+// (greedy) or stopping (lazy) first, per their `greedy` flag, and fall back to the other on
+// failure — same shape as a native regex engine, just with a hard step ceiling.
+function matchFull(alt: AltNode, str: string): boolean {
+  let steps = 0;
+  const withinBudget = () => ++steps <= STEP_BUDGET;
+
+  function matchAtomOnce(atom: AtomNode, pos: number, k: (pos: number) => boolean): boolean {
+    if (!withinBudget()) return false;
+    if (atom.kind === "char") return pos < str.length && atom.test(str[pos]) && k(pos + 1);
+    if (atom.kind === "any") return pos < str.length && k(pos + 1);
+    return matchAlt(atom.alt, pos, k);
+  }
+
+  function matchQuant(q: QuantNode, pos: number, k: (pos: number) => boolean): boolean {
+    function attempt(count: number, p: number): boolean {
+      if (!withinBudget()) return false;
+      const tryMore = () => count < q.max && matchAtomOnce(q.atom, p, (np) => attempt(count + 1, np));
+      const tryStop = () => count >= q.min && k(p);
+      return q.greedy ? tryMore() || tryStop() : tryStop() || tryMore();
+    }
+    return attempt(0, pos);
+  }
+
+  function matchSeq(atoms: QuantNode[], idx: number, pos: number, k: (pos: number) => boolean): boolean {
+    if (!withinBudget()) return false;
+    if (idx === atoms.length) return k(pos);
+    return matchQuant(atoms[idx], pos, (np) => matchSeq(atoms, idx + 1, np, k));
+  }
+
+  function matchAlt(alt: AltNode, pos: number, k: (pos: number) => boolean): boolean {
+    if (!withinBudget()) return false;
+    return alt.options.some((seq) => matchSeq(seq.atoms, 0, pos, k));
+  }
+
+  return matchAlt(alt, 0, (pos) => pos === str.length);
 }
 
 // A matchProfiles entry matches a profile when ANY provided field (name/commandline/source)
 // fully matches that field's regex — mirrors Windows Terminal's MatchProfilesEntry. Empty profile
 // fields never match, so "source": ".*" skips local profiles and "commandline": ".*" skips
-// profiles without a command line. An entry with no patterns, or a malformed or exponentially
-// backtracking regex, matches nothing rather than crashing, hanging, or matching all.
+// profiles without a command line. An entry with no patterns, or a malformed or unsupported
+// regex, matches nothing rather than crashing or matching all.
 export function buildProfileMatcher(entry: NewTabMenuEntry): ((profile: Profile) => boolean) | null {
   const specs: { pattern: string; get: (profile: Profile) => string }[] = [];
   if (entry.name !== undefined) specs.push({ pattern: entry.name, get: (p) => p.name });
   if (entry.commandline !== undefined) specs.push({ pattern: entry.commandline, get: (p) => p.commandline ?? "" });
   if (entry.source !== undefined) specs.push({ pattern: entry.source, get: (p) => p.source ?? "" });
   if (specs.length === 0) return null;
-  if (specs.some(({ pattern }) => hasRiskyBacktracking(pattern))) return null;
 
-  let matchers: { regex: RegExp; get: (profile: Profile) => string }[];
+  let matchers: { alt: AltNode; get: (profile: Profile) => string }[];
   try {
-    matchers = specs.map(({ pattern, get }) => ({ regex: new RegExp(`^(?:${pattern})$`), get }));
+    matchers = specs.map(({ pattern, get }) => ({ alt: parsePattern(pattern), get }));
   } catch {
     return null;
   }
 
   return (profile: Profile) =>
-    matchers.some(({ regex, get }) => {
+    matchers.some(({ alt, get }) => {
       const value = get(profile);
-      return value.length > 0 && regex.test(value);
+      return value.length > 0 && matchFull(alt, value);
     });
 }
 

--- a/extensions/windows-terminal/src/new-tab-menu.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.ts
@@ -304,10 +304,18 @@ function parsePattern(pattern: string): AltNode {
         const endAtom = parseClassAtom();
         if ("predicate" in endAtom) return fail("a character class can't end a range");
         const end = endAtom.literal;
+        // Compared as code points, not as strings: JavaScript orders strings by UTF-16 code unit,
+        // which puts every astral character (lead surrogate D800–DBFF) below U+E000–U+FFFF, so a
+        // range like [ｿ-🚀] would read as descending and [a-￿] would admit 🚀.
+        const low = start.codePointAt(0)!;
+        const high = end.codePointAt(0)!;
         // A descending range like [z-a] can never match anything; real regex engines reject it
         // as malformed rather than silently compiling a predicate that's always false.
-        if (end < start) return fail(`character range "${start}-${end}" out of order`);
-        tests.push((ch) => ch >= start && ch <= end);
+        if (high < low) return fail(`character range "${start}-${end}" out of order`);
+        tests.push((ch) => {
+          const code = ch.codePointAt(0)!;
+          return code >= low && code <= high;
+        });
       } else {
         tests.push((ch) => ch === start);
       }

--- a/extensions/windows-terminal/src/new-tab-menu.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.ts
@@ -23,9 +23,9 @@ export interface NewTabMenuEntry {
 // reachable state together, one input character at a time (matchFull) — the technique RE2 and
 // Rust's regex crate use for guaranteed linear-time matching with no backtracking. So no pattern
 // needs rejecting for how it might backtrack — a repeated group with safe alternatives, like
-// (dev|prod)+, still matches normally, and so does (a+)+. A large bounded quantifier on a simple
-// atom, like (a|b){0,4000}, is unbounded in practice too — compileCountedRepeat gives it a counter
-// instead of unrolling it, so neither compiled size nor matching cost grows with the bound.
+// (dev|prod)+, still matches normally, and so does (a+)+. A large bounded quantifier, like
+// (a|b){0,4000} or (|a){2,4000}, is unbounded in practice too — compileCountedRepeat gives it a
+// counter instead of unrolling it, so the compiled size doesn't grow with the bound.
 type AtomNode =
   | { kind: "char"; test: (ch: string) => boolean }
   | { kind: "any" }
@@ -49,8 +49,8 @@ class RegexTooLargeError extends Error {}
 const MAX_PROGRAM_SIZE = 50000;
 
 // Below this, compileQuant unrolls a {n,m} into that many literal copies (cheap, and lets it nest
-// inside another quantifier); at or above it, compileCountedRepeat is used instead — no nesting
-// support, but the compiled size and matching cost no longer scale with the bound.
+// inside another large quantifier); at or above it, compileCountedRepeat is used instead — it can't
+// nest inside another counted repeat, but the compiled size no longer scales with the bound.
 const UNROLL_THRESHOLD = 20;
 
 // Parses the subset of ICU regex syntax (the flavor Windows Terminal itself matches with) that
@@ -410,58 +410,47 @@ function optionalFrag(atom: AtomNode): Frag {
   return { start: split, out: [...body.out, { inst: split, slot: "next2" }] };
 }
 
-// compileCountedRepeat's counter is a single (count, countFor) pair per thread, not a stack, so it
-// can't tell two active repeats apart — a quantified atom that itself contains a quantifier (e.g.
-// (a{5}){500}) can't safely go through it. Every atom below UNROLL_THRESHOLD is quantified with
-// its default {1,1} (see parseQuant), so this is only true when something was genuinely repeated.
-function hasNestedQuantifier(atom: AtomNode): boolean {
-  if (atom.kind !== "group") return false;
-  return atom.alt.options.some((seq) =>
-    seq.atoms.some((q) => q.min !== 1 || q.max !== 1 || hasNestedQuantifier(q.atom)),
-  );
+// Whether compileQuant sends this quantifier through compileCountedRepeat (a large bound) rather
+// than unrolling it (a small one) — the one place that decision lives.
+function usesCounter(q: QuantNode): boolean {
+  if (q.max === Infinity) return q.min > UNROLL_THRESHOLD;
+  return q.min > UNROLL_THRESHOLD || q.max - q.min > UNROLL_THRESHOLD;
 }
 
-// The number of characters `atom` always consumes, if every alternative consumes the same amount,
-// or null if that amount varies (including an alternative that matches empty, like (|a) — 0 counts
-// as a value here, so it can differ from a sibling alternative's nonzero length). Only meaningful
-// once hasNestedQuantifier has ruled out a real quantifier anywhere inside `atom`, so every atom in
-// every sequence occurs exactly once here — no min/max to account for.
-//
-// compileCountedRepeat needs this to be a single, nonzero value: hasVisited/markVisited collapse
-// every rep count from `min` up to `max` onto one dedup entry per position, on the assumption that
-// they're all interchangeable, which only holds when each rep advances the string position by the
-// same fixed amount. Confirmed by direct DP-vs-engine comparison that this isn't just true for a
-// zero-width alternative — (a|aa){min,max} (no alternative is empty, but they're 1 vs 2 characters)
-// reaches the same string position after a different number of reps depending on which alternatives
-// were taken, and only one of those trajectories survives the collapse, silently losing counts near
-// `max` a real match needs. Rejected the same way hasNestedQuantifier is: not unsafe to compile,
-// just not representable by this counter.
-function fixedWidth(atom: AtomNode): number | null {
-  if (atom.kind === "char" || atom.kind === "any") return 1;
-  if (atom.kind === "start" || atom.kind === "end" || atom.kind === "boundary") return 0;
-  const widths = atom.alt.options.map((seq) => {
-    let total = 0;
-    for (const q of seq.atoms) {
-      const atomWidth = fixedWidth(q.atom);
-      if (atomWidth === null) return null;
-      total += atomWidth;
-    }
-    return total;
-  });
-  return widths.every((w) => w === widths[0]) ? widths[0] : null;
+// compileCountedRepeat's counter is a single (count, countFor) pair per thread, not a stack, so it
+// can't tell two active counted repeats apart — exiting the inner one resets countFor (see the
+// "repeat" case in addThread) and loses the outer count. So a large quantifier whose body contains
+// another *large* quantifier, e.g. ((a|b){200}){200}, can't go through it. A small quantifier inside
+// the body is fine: it unrolls into plain instructions that carry the thread's count through
+// untouched, so (a?){2,4000} or (a{2}){2,4000} compile and match normally.
+function hasNestedCountedRepeat(atom: AtomNode): boolean {
+  if (atom.kind !== "group") return false;
+  return atom.alt.options.some((seq) => seq.atoms.some((q) => usesCounter(q) || hasNestedCountedRepeat(q.atom)));
+}
+
+// Whether `atom` matches the empty string unconditionally — an empty alternative, or one made only
+// of optional atoms. Anchors and \b don't count: they're zero-width but conditional on position.
+function isNullable(atom: AtomNode): boolean {
+  if (atom.kind !== "group") return false;
+  return atom.alt.options.some((seq) => seq.atoms.every((q) => q.min === 0 || isNullable(q.atom)));
 }
 
 // Compiles atom{min,max} (max possibly Infinity) as one `repeat` instruction plus one copy of the
 // atom's body, instead of unrolling — see the `repeat`/`increment` handling in addThread for how a
 // thread's counter takes the place of the copies compileQuant's other branch would otherwise make.
+// The body can be anything a small quantifier could wrap — nullable alternatives like (|a),
+// differently-sized ones like (a|aa), an unrolled quantifier — because the matcher dedupes threads
+// inside a counted repeat by their exact count (see hasVisited), never by assuming reps line up
+// with string positions.
 function compileCountedRepeat(atom: AtomNode, min: number, max: number): Frag {
-  if (hasNestedQuantifier(atom)) {
-    throw new RegexTooLargeError("a quantifier this large can't wrap another quantifier");
+  if (hasNestedCountedRepeat(atom)) {
+    throw new RegexTooLargeError("a quantifier this large can't wrap another quantifier this large");
   }
-  const width = fixedWidth(atom);
-  if (!width) {
-    throw new RegexTooLargeError("a quantifier this large needs every alternative to be the same length");
-  }
+  // A body that can always match empty makes `min` meaningless — any shortfall is made up with
+  // empty reps at no cost — so (|a){3000,4000} accepts exactly what (|a){0,4000} does. Compiling
+  // it as the latter matters for cost, not just tidiness: below `min` every count is a distinct
+  // state (see VisitedState), and a nullable body reaches all of them at every single position.
+  if (isNullable(atom)) min = 0;
   const repeat: RepeatInst = newInst({ op: "repeat", min, max, bodyStart: undefined as unknown as Inst });
   const body = compileAtom(atom);
   const increment: IncrementInst = newInst({ op: "increment", repeat });
@@ -474,17 +463,14 @@ function compileCountedRepeat(atom: AtomNode, min: number, max: number): Frag {
 // record — irrelevant here, since buildProfileMatcher only ever asks "does the whole field match"
 // (see matchFull). So greedy and lazy compile identically; `q.greedy` is parsed but never consulted.
 function compileQuant(q: QuantNode): Frag {
+  if (usesCounter(q)) return compileCountedRepeat(q.atom, q.min, q.max);
   if (q.max === Infinity) {
     if (q.min === 0) return starFrag(q.atom);
-    if (q.min <= UNROLL_THRESHOLD) return concat(repeatFrag(q.atom, q.min - 1), plusFrag(q.atom));
-    return compileCountedRepeat(q.atom, q.min, Infinity);
+    return concat(repeatFrag(q.atom, q.min - 1), plusFrag(q.atom));
   }
-  if (q.min <= UNROLL_THRESHOLD && q.max - q.min <= UNROLL_THRESHOLD) {
-    const optionals: Frag[] = [];
-    for (let copy = q.min; copy < q.max; copy++) optionals.push(optionalFrag(q.atom));
-    return concat(repeatFrag(q.atom, q.min), concatAll(optionals));
-  }
-  return compileCountedRepeat(q.atom, q.min, q.max);
+  const optionals: Frag[] = [];
+  for (let copy = q.min; copy < q.max; copy++) optionals.push(optionalFrag(q.atom));
+  return concat(repeatFrag(q.atom, q.min), concatAll(optionals));
 }
 
 function compileSeq(seq: SeqNode): Frag {
@@ -527,49 +513,52 @@ type Thread = { inst: Inst; count: number; countFor: RepeatInst | null };
 const NO_REPEAT = null;
 
 // Instructions outside any counted repeat dedupe by identity alone (`plain`) — same as before this
-// engine had a counted-repeat mechanism at all. Instructions reached *while inside* one need `count`
-// in the key too, kept in a separate structure (`scoped`): two sequential large repeats mean a
-// "just exiting the first, entering the second fresh" thread and a "already partway through the
-// second" thread can reach the second repeat's own instruction at the very same position, and they
-// must not collide just because they happen to share that instruction — see capForDedup for why
-// capping `count` at the repeat's `min` is safe rather than using it raw.
-type VisitedState = { plain: Set<Inst>; scoped: Map<Inst, Set<number>> };
+// engine had a counted-repeat mechanism at all. Instructions reached *while inside* one are keyed
+// by their exact `count` too (`scoped`): the same instruction at the same position with a
+// different count is a genuinely different state, because the count decides how many more reps
+// are still mandatory (below `min`) or still allowed (up to `max`). Nothing about the body is
+// assumed — a prefix like (?:x|xa) can enter the repeat at two different positions, so two threads
+// with different counts legitimately share an instruction at every later position, and merging
+// them (as an earlier "cap the count at min" key did) silently drops the one that could still reach
+// `max`.
+//
+// `lowestSettled` is the one pruning that IS sound: once a thread's count is at or above `min`, a
+// lower count can do everything a higher one can (exit now, or keep going — for longer), so a
+// thread whose count is ≥ min is redundant whenever a thread at the same instruction with a count
+// in [min, count] has already been queued at this position. That's what keeps something like
+// ".*a{0,12000}" linear instead of carrying every possible count along at every position.
+type VisitedState = { plain: Set<Inst>; scoped: Map<Inst, Set<number>>; lowestSettled: Map<Inst, number> };
 
 function newVisited(): VisitedState {
-  return { plain: new Set(), scoped: new Map() };
-}
-
-// Once a thread has reached `min` reps of a counted repeat, every rep beyond that is behaviorally
-// identical for reachability: `repeat` offers the exact same exit target and the exact same
-// continue-into-body target regardless of the exact count, right up to (and including) `max` —
-// forced exit at `max` reaches nothing that optional exit at `min` didn't already reach. So capping
-// the count at `min` for dedup purposes loses no reachable state, PROVIDED the body can't reach the
-// same position at two different counts in the first place — the precondition compileCountedRepeat
-// enforces is exactly that: hasNestedQuantifier rules out a real quantifier anywhere inside the
-// body, and fixedWidth requires every alternative to consume the same fixed, nonzero number of
-// characters, so a fresh entry into this repeat's scope has a single, unambiguous count at any
-// given position. Only called when thread.countFor !== NO_REPEAT (see hasVisited/markVisited), so
-// there's always a real repeat to read `min` from.
-function capForDedup(thread: Thread): number {
-  return Math.min(thread.count, thread.countFor!.min);
+  return { plain: new Set(), scoped: new Map(), lowestSettled: new Map() };
 }
 
 function hasVisited(visited: VisitedState, thread: Thread): boolean {
-  if (thread.countFor === NO_REPEAT) return visited.plain.has(thread.inst);
-  return visited.scoped.get(thread.inst)?.has(capForDedup(thread)) ?? false;
+  const { inst, count, countFor } = thread;
+  if (countFor === NO_REPEAT) return visited.plain.has(inst);
+  if (count >= countFor.min) {
+    const lowest = visited.lowestSettled.get(inst);
+    if (lowest !== undefined && lowest <= count) return true;
+  }
+  return visited.scoped.get(inst)?.has(count) ?? false;
 }
 
 function markVisited(visited: VisitedState, thread: Thread): void {
-  if (thread.countFor === NO_REPEAT) {
-    visited.plain.add(thread.inst);
+  const { inst, count, countFor } = thread;
+  if (countFor === NO_REPEAT) {
+    visited.plain.add(inst);
     return;
   }
-  let seen = visited.scoped.get(thread.inst);
+  let seen = visited.scoped.get(inst);
   if (!seen) {
     seen = new Set();
-    visited.scoped.set(thread.inst, seen);
+    visited.scoped.set(inst, seen);
   }
-  seen.add(capForDedup(thread));
+  seen.add(count);
+  if (count >= countFor.min) {
+    const lowest = visited.lowestSettled.get(inst);
+    if (lowest === undefined || count < lowest) visited.lowestSettled.set(inst, count);
+  }
 }
 
 // \b sits between a word character and a non-word one, counting the space off either end of the
@@ -646,8 +635,9 @@ function addThread(
 // the call stack never grows with the length of `str` or with the pattern's backtracking search
 // space — a 2,000-character value and a pathological pattern like (a+)+ cost the same handful of
 // stack frames as a one-character match. Work per position is bounded by the pattern's compiled
-// size — kept independent of any quantifier's bound by compileCountedRepeat — so nothing can blow
-// up exponentially or scale with a large bound; MAX_MATCH_STEPS is a backstop for what's left.
+// size times the distinct repeat counts still alive there (see VisitedState) — for any realistic
+// pattern that's a handful — so nothing can blow up exponentially; MAX_MATCH_STEPS is a backstop
+// for what's left.
 function matchFull(prog: Inst, str: string): boolean {
   const budget: StepBudget = { remaining: MAX_MATCH_STEPS };
   let current: Thread[] = [];
@@ -658,6 +648,13 @@ function matchFull(prog: Inst, str: string): boolean {
     const next: Thread[] = [];
     const visited = newVisited();
     const ch = str[pos];
+    // Lowest count first, so a thread that dominates (see VisitedState.lowestSettled) is always
+    // queued before the ones it makes redundant. The closure explores a body's first alternative
+    // first, and for something like (a|aa){21,4000} that's the higher-count path — left in that
+    // order, every count would survive at every position and the budget would run out on a
+    // perfectly ordinary long value. Counts only ever grow by one per `increment` or reset to
+    // zero on exit, so sorting here keeps that dominance order through the whole step.
+    current.sort((a, b) => a.count - b.count);
     for (const thread of current) {
       if (budget.remaining-- <= 0) return false;
       const inst = thread.inst;

--- a/extensions/windows-terminal/src/new-tab-menu.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.ts
@@ -71,6 +71,12 @@ function parsePattern(pattern: string): AltNode {
   // where it appears to the end of that group, subsequent `|` branches included. It's applied as
   // each character test is built, so the compiled program needs no notion of case at all.
   let ignoreCase = false;
+  // parseAtom recurses into parseAlt for every "(" — this bounds that recursion, since the parser
+  // (unlike matchFull's explicit-stack VM) has no other stack-safety guard. Nothing near this depth
+  // is a realistic matchProfiles pattern; it exists so a pathologically deep one fails cleanly as
+  // "malformed" like any other unsupported pattern, instead of overflowing the call stack.
+  let groupDepth = 0;
+  const MAX_GROUP_DEPTH = 100;
   const foldCase = (test: (ch: string) => boolean) => {
     if (!ignoreCase) return test;
     return (ch: string) => test(ch) || test(ch.toLowerCase()) || test(ch.toUpperCase());
@@ -118,14 +124,24 @@ function parsePattern(pattern: string): AltNode {
       if (braces) {
         min = parseInt(braces[1], 10);
         max = braces[2] === undefined ? min : braces[3] === "" ? Infinity : parseInt(braces[3], 10);
+        // A bound with enough digits overflows parseInt to Infinity, which would pass the
+        // "max < min" check below (Infinity < Infinity is false) as if it were a legitimate
+        // unbounded {n,}. Checked on the parsed value, not the digit-string length, so a
+        // zero-padded bound like {0000000005,10} isn't wrongly rejected as "too large" — no real
+        // matchProfiles pattern needs a bound anywhere near this size either way.
+        if (min > 1e9 || (max !== Infinity && max > 1e9)) return fail("quantifier bound too large");
         if (max < min) return fail("quantifier bounds out of order");
         quantified = true;
         i += braces[0].length;
       }
     }
     // Windows Terminal's regex engine rejects a quantified anchor (^?, $*, ^{2}...) as a syntax
-    // error rather than matching it literally or ignoring the quantifier, so mirror that here.
-    if (quantified && (atom.kind === "start" || atom.kind === "end")) return fail("quantified anchor");
+    // error rather than matching it literally or ignoring the quantifier, so mirror that here —
+    // \b/\B are zero-width assertions too, so without this a quantifier's always-valid zero-rep
+    // path (e.g. starFrag) would silently accept \b* without the assertion ever holding.
+    if (quantified && (atom.kind === "start" || atom.kind === "end" || atom.kind === "boundary")) {
+      return fail("quantified anchor");
+    }
     let greedy = true;
     if (peek() === "?") {
       greedy = false;
@@ -153,7 +169,9 @@ function parsePattern(pattern: string): AltNode {
         // ignoreCase set for whatever follows it in the enclosing group.
         if (delimiter === ")") return { kind: "group", alt: { options: [{ atoms: [] }] } };
       }
+      if (++groupDepth > MAX_GROUP_DEPTH) return fail("pattern nested too deeply");
       const alt = parseAlt();
+      groupDepth--;
       if (peek() !== ")") return fail("unbalanced parenthesis");
       i++;
       ignoreCase = outerIgnoreCase;
@@ -207,6 +225,26 @@ function parsePattern(pattern: string): AltNode {
     return charAtom((ch) => ch === c);
   }
 
+  // Reads one position inside a class: either a literal character (plain, or an escaped one like
+  // \- or \]) that can potentially anchor a range, or a multi-character escape predicate (\d, \w,
+  // \s, or a negation) that can't — \d-9 has no meaningful "range from a whole digit class".
+  type ClassAtom = { literal: string } | { predicate: (ch: string) => boolean };
+  function parseClassAtom(): ClassAtom {
+    const c = pattern[i];
+    if (c !== "\\") {
+      i++;
+      return { literal: c };
+    }
+    i++;
+    const esc = pattern[i];
+    i++;
+    if (esc === undefined) return fail("trailing backslash");
+    const predicate = escapePredicates[esc];
+    if (predicate !== undefined) return { predicate };
+    if (/[A-Za-z0-9]/.test(esc)) return fail(`unsupported escape "\\${esc}"`);
+    return { literal: esc };
+  }
+
   function parseClass(): AtomNode {
     i++; // consume "["
     let negate = false;
@@ -216,23 +254,20 @@ function parsePattern(pattern: string): AltNode {
     }
     const tests: ((ch: string) => boolean)[] = [];
     while (i < n && peek() !== "]") {
-      const start = peek();
-      if (start === "\\") {
-        i++;
-        const esc = pattern[i];
-        i++;
-        if (esc === undefined) return fail("trailing backslash");
-        const predicate = escapePredicates[esc];
-        if (predicate) tests.push(predicate);
-        else if (/[A-Za-z0-9]/.test(esc)) return fail(`unsupported escape "\\${esc}"`);
-        else tests.push((ch) => ch === esc);
+      const startAtom = parseClassAtom();
+      if ("predicate" in startAtom) {
+        tests.push(startAtom.predicate);
         continue;
       }
-      i++;
+      const start = startAtom.literal;
       if (peek() === "-" && pattern[i + 1] !== "]" && i + 1 < n) {
         i++; // consume "-"
-        const end = pattern[i];
-        i++;
+        const endAtom = parseClassAtom();
+        if ("predicate" in endAtom) return fail("a character class can't end a range");
+        const end = endAtom.literal;
+        // A descending range like [z-a] can never match anything; real regex engines reject it
+        // as malformed rather than silently compiling a predicate that's always false.
+        if (end < start) return fail(`character range "${start}-${end}" out of order`);
         tests.push((ch) => ch >= start && ch <= end);
       } else {
         tests.push((ch) => ch === start);
@@ -287,6 +322,7 @@ type PatchSlot =
   | { inst: CharInst | AnyInst | StartInst | EndInst | BoundaryInst | NopInst | SplitInst | RepeatInst; slot: "next" }
   | { inst: SplitInst; slot: "next2" };
 type Frag = { start: Inst; out: PatchSlot[] };
+// /Thompson NFA instruction types
 
 // Every instruction is created through here, so the running total covers nested unrolling too —
 // e.g. small quantifiers nested several levels deep, each individually under UNROLL_THRESHOLD but
@@ -320,6 +356,7 @@ function concatAll(frags: Frag[]): Frag {
   return frags.reduce(concat, emptyFrag());
 }
 
+// Compiles a single, unquantified atom into a one-instruction (or, for a group, sub-program) Frag.
 function compileAtom(atom: AtomNode): Frag {
   if (atom.kind === "group") return compileAlt(atom.alt);
   if (atom.kind === "char") {
@@ -384,12 +421,46 @@ function hasNestedQuantifier(atom: AtomNode): boolean {
   );
 }
 
+// The number of characters `atom` always consumes, if every alternative consumes the same amount,
+// or null if that amount varies (including an alternative that matches empty, like (|a) — 0 counts
+// as a value here, so it can differ from a sibling alternative's nonzero length). Only meaningful
+// once hasNestedQuantifier has ruled out a real quantifier anywhere inside `atom`, so every atom in
+// every sequence occurs exactly once here — no min/max to account for.
+//
+// compileCountedRepeat needs this to be a single, nonzero value: hasVisited/markVisited collapse
+// every rep count from `min` up to `max` onto one dedup entry per position, on the assumption that
+// they're all interchangeable, which only holds when each rep advances the string position by the
+// same fixed amount. Confirmed by direct DP-vs-engine comparison that this isn't just true for a
+// zero-width alternative — (a|aa){min,max} (no alternative is empty, but they're 1 vs 2 characters)
+// reaches the same string position after a different number of reps depending on which alternatives
+// were taken, and only one of those trajectories survives the collapse, silently losing counts near
+// `max` a real match needs. Rejected the same way hasNestedQuantifier is: not unsafe to compile,
+// just not representable by this counter.
+function fixedWidth(atom: AtomNode): number | null {
+  if (atom.kind === "char" || atom.kind === "any") return 1;
+  if (atom.kind === "start" || atom.kind === "end" || atom.kind === "boundary") return 0;
+  const widths = atom.alt.options.map((seq) => {
+    let total = 0;
+    for (const q of seq.atoms) {
+      const atomWidth = fixedWidth(q.atom);
+      if (atomWidth === null) return null;
+      total += atomWidth;
+    }
+    return total;
+  });
+  return widths.every((w) => w === widths[0]) ? widths[0] : null;
+}
+
 // Compiles atom{min,max} (max possibly Infinity) as one `repeat` instruction plus one copy of the
 // atom's body, instead of unrolling — see the `repeat`/`increment` handling in addThread for how a
 // thread's counter takes the place of the copies compileQuant's other branch would otherwise make.
 function compileCountedRepeat(atom: AtomNode, min: number, max: number): Frag {
   if (hasNestedQuantifier(atom)) {
     throw new RegexTooLargeError("a quantifier this large can't wrap another quantifier");
+  }
+  const width = fixedWidth(atom);
+  if (!width) {
+    throw new RegexTooLargeError("a quantifier this large needs every alternative to be the same length");
   }
   const repeat: RepeatInst = newInst({ op: "repeat", min, max, bodyStart: undefined as unknown as Inst });
   const body = compileAtom(atom);
@@ -455,18 +526,13 @@ type StepBudget = { remaining: number };
 type Thread = { inst: Inst; count: number; countFor: RepeatInst | null };
 const NO_REPEAT = null;
 
-// \b sits between a word character and a non-word one, counting the space off either end of the
-// value as non-word — so it holds at both ends of "PowerShell" but not inside it.
-const isWordChar = (ch: string | undefined) => ch !== undefined && /\w/.test(ch);
-
-function isWordBoundary(str: string, pos: number): boolean {
-  return isWordChar(str[pos - 1]) !== isWordChar(str[pos]);
-}
-
-// Instructions outside any counted repeat dedupe by identity alone (`plain`), same as before a
-// large quantifier could compile without unrolling. Instructions reached *inside* one (`countFor`
-// names which `repeat`) need `count` in the key too — see capForDedup for why capping it at that
-// repeat's `min` is safe rather than just using it raw.
+// Instructions outside any counted repeat dedupe by identity alone (`plain`) — same as before this
+// engine had a counted-repeat mechanism at all. Instructions reached *while inside* one need `count`
+// in the key too, kept in a separate structure (`scoped`): two sequential large repeats mean a
+// "just exiting the first, entering the second fresh" thread and a "already partway through the
+// second" thread can reach the second repeat's own instruction at the very same position, and they
+// must not collide just because they happen to share that instruction — see capForDedup for why
+// capping `count` at the repeat's `min` is safe rather than using it raw.
 type VisitedState = { plain: Set<Inst>; scoped: Map<Inst, Set<number>> };
 
 function newVisited(): VisitedState {
@@ -477,12 +543,13 @@ function newVisited(): VisitedState {
 // identical for reachability: `repeat` offers the exact same exit target and the exact same
 // continue-into-body target regardless of the exact count, right up to (and including) `max` —
 // forced exit at `max` reaches nothing that optional exit at `min` didn't already reach. So capping
-// the count at `min` for dedup purposes loses no reachable state, while bounding how many times a
-// nullable body (one that can match empty, e.g. (|a)) can loop back within a single position —
-// without the cap, each loop reaches `repeat` at a new, never-before-seen count and dedup never
-// kicks in, so a large `max` risks growing that unboundedly before a real character is consumed.
-// Only called when thread.countFor !== NO_REPEAT (see hasVisited/markVisited), so there's always a
-// real repeat to read `min` from.
+// the count at `min` for dedup purposes loses no reachable state, PROVIDED the body can't reach the
+// same position at two different counts in the first place — the precondition compileCountedRepeat
+// enforces is exactly that: hasNestedQuantifier rules out a real quantifier anywhere inside the
+// body, and fixedWidth requires every alternative to consume the same fixed, nonzero number of
+// characters, so a fresh entry into this repeat's scope has a single, unambiguous count at any
+// given position. Only called when thread.countFor !== NO_REPEAT (see hasVisited/markVisited), so
+// there's always a real repeat to read `min` from.
 function capForDedup(thread: Thread): number {
   return Math.min(thread.count, thread.countFor!.min);
 }
@@ -503,6 +570,14 @@ function markVisited(visited: VisitedState, thread: Thread): void {
     visited.scoped.set(thread.inst, seen);
   }
   seen.add(capForDedup(thread));
+}
+
+// \b sits between a word character and a non-word one, counting the space off either end of the
+// value as non-word — so it holds at both ends of "PowerShell" but not inside it.
+const isWordChar = (ch: string | undefined) => ch !== undefined && /\w/.test(ch);
+
+function isWordBoundary(str: string, pos: number): boolean {
+  return isWordChar(str[pos - 1]) !== isWordChar(str[pos]);
 }
 
 // Epsilon-closure: follows the zero-width instructions (`split`, `nop`, and the anchors when their
@@ -548,11 +623,14 @@ function addThread(
         stack.push({ inst: inst.bodyStart, count: reps, countFor: inst });
       } else if (inst.max === Infinity || reps < inst.max) {
         // Within range: try one more rep, but stopping here is also valid (mirrors optionalFrag).
-        stack.push({ inst: inst.next!, count, countFor });
+        // Exiting resets countFor to NO_REPEAT — carrying this repeat's count/countFor past
+        // `next` would let it reach a later, unrelated `repeat` instruction still tagged as
+        // "inside" this one, corrupting that instruction's own dedup key and reps count.
+        stack.push({ inst: inst.next!, count: 0, countFor: NO_REPEAT });
         stack.push({ inst: inst.bodyStart, count: reps, countFor: inst });
       } else {
         // At the maximum: no more reps allowed.
-        stack.push({ inst: inst.next!, count, countFor });
+        stack.push({ inst: inst.next!, count: 0, countFor: NO_REPEAT });
       }
     } else if (inst.op === "increment") {
       stack.push({ inst: inst.repeat, count: count + 1, countFor: inst.repeat });
@@ -561,6 +639,7 @@ function addThread(
     }
   }
 }
+// /addThread
 
 // Runs the compiled NFA over `str` breadth-first, one input position at a time (Pike's VM) instead
 // of recursing per character the way a backtracking engine would. Every thread advances together, so
@@ -592,6 +671,7 @@ function matchFull(prog: Inst, str: string): boolean {
 
   return current.some((thread) => thread.inst.op === "match");
 }
+// /matchFull
 
 // A matchProfiles entry matches a profile when ANY provided field (name/commandline/source)
 // fully matches that field's regex — mirrors Windows Terminal's MatchProfilesEntry. Empty profile

--- a/extensions/windows-terminal/src/new-tab-menu.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.ts
@@ -32,13 +32,15 @@ export interface NewTabMenuEntry {
 // buildProfileMatcher, so the caller can tell "this profile doesn't match" from "this pattern
 // couldn't be evaluated" and say so instead of quietly dropping profiles from the menu.
 type AtomNode =
-  | { kind: "char"; test: (ch: string) => boolean }
+  // `literal` is set only for a literal character under (?i) — the one case parseSeq's literal-run
+  // rule looks at; it then sets `fullFold` on every literal in a run and `endsRun` on the last.
+  | { kind: "char"; test: (ch: string) => boolean; literal?: string; fullFold?: boolean; endsRun?: boolean }
   | { kind: "any" }
   | { kind: "group"; alt: AltNode }
   | { kind: "start" }
   | { kind: "end" }
   | { kind: "boundary"; negate: boolean };
-type QuantNode = { atom: AtomNode; min: number; max: number; greedy: boolean };
+type QuantNode = { atom: AtomNode; min: number; max: number; greedy: boolean; quantified: boolean };
 type SeqNode = { atoms: QuantNode[] };
 type AltNode = { options: SeqNode[] };
 
@@ -65,17 +67,39 @@ const UNROLL_THRESHOLD = 20;
 
 // ICU's character classes, not JavaScript's ASCII-only ones — Windows Terminal matches with ICU,
 // where \w covers letters, marks, decimal digits, and connector punctuation in any script
-// ("Développement"), \d any script's decimal digits ("١٢٣"), \s is [\t\n\f\r\p{Z}], and \b is
-// defined in terms of that \w ("\bÉquipe\b"). Values and patterns are walked by code point, not
-// UTF-16 code unit, so "." consumes all of "🚀" — and, as in ICU without its DOTALL flag, "."
-// stops at a line terminator.
+// ("Développement"), \d any script's decimal digits ("١٢٣"), \s is \p{White_Space} (so vertical
+// tab and next line count, unlike JavaScript's \s), and \b is defined in terms of that \w
+// ("\bÉquipe\b"). Values and patterns are walked by code point, not UTF-16 code unit, so "."
+// consumes all of "🚀" — and, as in ICU without its DOTALL flag, "." stops at a line terminator.
 const isWordChar = (ch: string) => /[\p{Alphabetic}\p{M}\p{Nd}\p{Pc}\p{Join_Control}]/u.test(ch);
 const isDigit = (ch: string) => /\p{Nd}/u.test(ch);
-const isSpace = (ch: string) => /[\t\n\f\r\p{Z}]/u.test(ch);
+const isSpace = (ch: string) => /\p{White_Space}/u.test(ch);
 // U+000A-U+000D, U+0085, U+2028, U+2029 — ICU's line terminators (spelled as code points: U+2028/9 are
 // line separators, and a literal one would end the regex line it sits on).
 const LINE_TERMINATORS = new Set([0x0a, 0x0b, 0x0c, 0x0d, 0x85, 0x2028, 0x2029]);
 const isLineTerminator = (ch: string) => LINE_TERMINATORS.has(ch.codePointAt(0)!);
+
+// Case folding, for (?i). ICU compares case-insensitively by folding both sides, and *full*
+// folding can change a string's length — "ß" folds to "ss" — which is how (?i)straße matches
+// "STRASSE" and (?i)ss matches "ß". JavaScript has no fold function; upper-then-lower, repeated to
+// a fixed point, reaches the same canonical form for every case variant ("ß" and "ẞ" both end at
+// "ss", "ﬁ" at "fi", "ſ" at "s").
+function fullFold(s: string): string {
+  for (let round = 0; round < 3; round++) {
+    const folded = s.toUpperCase().toLowerCase();
+    if (folded === s) return s;
+    s = folded;
+  }
+  return s;
+}
+
+// *Simple* folding maps one code point to one code point and leaves the rest alone: "ẞ" becomes
+// "ß", "ſ" becomes "s", but "ß" stays "ß". ICU uses it for a lone case-insensitive literal — see
+// the literal-run rule in parseSeq.
+function simpleFold(ch: string): string {
+  const folded = ch.toUpperCase().toLowerCase();
+  return Array.from(folded).length === 1 ? folded : ch;
+}
 
 // Parses the subset of ICU regex syntax (the flavor Windows Terminal itself matches with) that
 // matchProfiles patterns actually use: literals, `.`, escapes (`\d\w\s` and their negations, `\.`
@@ -97,8 +121,9 @@ function parsePattern(pattern: string): AltNode {
   };
 
   // Set by (?i) and restored when the enclosing group closes, mirroring ICU: the flag runs from
-  // where it appears to the end of that group, subsequent `|` branches included. It's applied as
-  // each character test is built, so the compiled program needs no notion of case at all.
+  // where it appears to the end of that group, subsequent `|` branches included. Classes and lone
+  // literals apply it as their character test is built; a run of literals compiles to CharFoldInst
+  // instead (see parseSeq), the one place the compiled program knows about case.
   let ignoreCase = false;
   // parseAtom recurses into parseAlt for every "(" — this bounds that recursion, since the parser
   // (unlike matchFull's explicit-stack VM) has no other stack-safety guard. Nothing near this depth
@@ -107,11 +132,27 @@ function parsePattern(pattern: string): AltNode {
   // call stack.
   let groupDepth = 0;
   const MAX_GROUP_DEPTH = 100;
+  // Under (?i) a class or predicate also admits a character's single-code-point case variants —
+  // an approximation of ICU closing the set over case. Only single code points: "ß" uppercases to
+  // "SS", and testing that against [A-Z] would wrongly admit ß.
+  const isSingle = (s: string) => Array.from(s).length === 1;
   const foldCase = (test: (ch: string) => boolean) => {
     if (!ignoreCase) return test;
-    return (ch: string) => test(ch) || test(ch.toLowerCase()) || test(ch.toUpperCase());
+    return (ch: string) => {
+      if (test(ch) || test(simpleFold(ch))) return true;
+      const lower = ch.toLowerCase();
+      const upper = ch.toUpperCase();
+      return (isSingle(lower) && test(lower)) || (isSingle(upper) && test(upper));
+    };
   };
   const charAtom = (test: (ch: string) => boolean): AtomNode => ({ kind: "char", test: foldCase(test) });
+  // A literal character. Under (?i) it compares simple case folds, one code point to one — unless
+  // parseSeq finds it in a run of two or more, which switches the run to full folding.
+  const literalAtom = (c: string): AtomNode => {
+    if (!ignoreCase) return { kind: "char", test: (ch) => ch === c };
+    const folded = simpleFold(c);
+    return { kind: "char", test: (ch) => simpleFold(ch) === folded, literal: c };
+  };
 
   function parseAlt(): AltNode {
     const options = [parseSeq()];
@@ -125,6 +166,25 @@ function parsePattern(pattern: string): AltNode {
   function parseSeq(): SeqNode {
     const atoms: QuantNode[] = [];
     while (i < n && peek() !== "|" && peek() !== ")") atoms.push(parseQuant());
+    // ICU's case-insensitive literal rule: a run of two or more adjacent, unquantified literal
+    // characters is matched as one string under *full* case folding — (?i)straße matches "STRASSE"
+    // and (?i)ss matches "ß" — while a lone literal, or one a quantifier applies to, compares
+    // single code points under *simple* folding: (?i)ß matches "ẞ" but not "SS". A quantifier,
+    // group, class, escape class, or anchor ends a run.
+    let run: QuantNode[] = [];
+    const closeRun = () => {
+      if (run.length >= 2) {
+        for (const q of run) if (q.atom.kind === "char") q.atom.fullFold = true;
+        const last = run[run.length - 1].atom;
+        if (last.kind === "char") last.endsRun = true;
+      }
+      run = [];
+    };
+    for (const q of atoms) {
+      if (q.atom.kind === "char" && q.atom.literal !== undefined && !q.quantified) run.push(q);
+      else closeRun();
+    }
+    closeRun();
     return { atoms };
   }
 
@@ -181,7 +241,7 @@ function parsePattern(pattern: string): AltNode {
       greedy = false;
       i++;
     }
-    return { atom, min, max, greedy };
+    return { atom, min, max, greedy, quantified };
   }
 
   function parseAtom(): AtomNode {
@@ -231,7 +291,7 @@ function parsePattern(pattern: string): AltNode {
       return parseEscape();
     }
     i++;
-    return charAtom((ch) => ch === c);
+    return literalAtom(c);
   }
 
   const escapePredicates: Record<string, (ch: string) => boolean> = {
@@ -256,7 +316,7 @@ function parsePattern(pattern: string): AltNode {
     // implement (\A, \p{...}, a backreference). Reject the pattern rather than matching it as a
     // literal, which would silently match the wrong profiles.
     if (/[A-Za-z0-9]/.test(c)) return unsupported(`escape "\\${c}" not implemented`);
-    return charAtom((ch) => ch === c);
+    return literalAtom(c);
   }
 
   // Reads one position inside a class: either a literal character (plain, or an escaped one like
@@ -339,6 +399,10 @@ function parsePattern(pattern: string): AltNode {
 // successor slots ("patch list", in Thompson's original terms) still waiting to be pointed at
 // whatever comes next.
 type CharInst = { op: "char"; test: (ch: string) => boolean; next?: Inst };
+// One code point of a fully case-folded literal run (see parseSeq). It consumes one unit of the
+// input character's own full fold rather than the character itself, so "ß" (folding to "ss") can
+// satisfy two of these in a row; `last` marks the run's final unit — see matchFull.
+type CharFoldInst = { op: "charFold"; unit: string; last: boolean; next?: Inst };
 type AnyInst = { op: "any"; next?: Inst };
 type StartInst = { op: "start"; next?: Inst };
 type EndInst = { op: "end"; next?: Inst };
@@ -355,6 +419,7 @@ type RepeatInst = { op: "repeat"; min: number; max: number; bodyStart: Inst; nex
 type IncrementInst = { op: "increment"; repeat: RepeatInst };
 type Inst =
   | CharInst
+  | CharFoldInst
   | AnyInst
   | StartInst
   | EndInst
@@ -366,7 +431,10 @@ type Inst =
   | IncrementInst;
 
 type PatchSlot =
-  | { inst: CharInst | AnyInst | StartInst | EndInst | BoundaryInst | NopInst | SplitInst | RepeatInst; slot: "next" }
+  | {
+      inst: CharInst | CharFoldInst | AnyInst | StartInst | EndInst | BoundaryInst | NopInst | SplitInst | RepeatInst;
+      slot: "next";
+    }
   | { inst: SplitInst; slot: "next2" };
 type Frag = { start: Inst; out: PatchSlot[] };
 // /Thompson NFA instruction types
@@ -414,6 +482,15 @@ function concatAll(frags: Frag[]): Frag {
 function compileAtom(atom: AtomNode): Frag {
   if (atom.kind === "group") return compileAlt(atom.alt);
   if (atom.kind === "char") {
+    if (atom.fullFold) {
+      const units = Array.from(fullFold(atom.literal!));
+      const frags = units.map((unit, index): Frag => {
+        const last = atom.endsRun === true && index === units.length - 1;
+        const inst: CharFoldInst = newInst({ op: "charFold", unit, last });
+        return { start: inst, out: [{ inst, slot: "next" }] };
+      });
+      return concatAll(frags);
+    }
     const inst: CharInst = newInst({ op: "char", test: atom.test });
     return { start: inst, out: [{ inst, slot: "next" }] };
   }
@@ -736,6 +813,13 @@ function matchFull(prog: Inst, str: string): boolean {
     const next: Thread[] = [];
     const visited = newVisited();
     const ch = chars[pos];
+    // What a fully case-folded literal run (CharFoldInst) sees in place of `ch`: usually one unit,
+    // but "ß" is two ("ss"). A run consumes them one at a time, staying on this input character in
+    // between, so the character is walked in as many rounds as it has units. Everything else
+    // (`char`, `any`) consumes the character itself, in the first round. Mirroring ICU, a run that
+    // ends partway through a character's units fails — (?i)ss doesn't match "sß" — and nothing but
+    // the run's own next unit can pick up mid-character.
+    const units = Array.from(fullFold(ch));
     // Lowest count first, so a thread that dominates (see VisitedState.lowestSettled) is always
     // queued before the ones it makes redundant. The closure explores a body's first alternative
     // first, and for something like (a|aa){21,4000} that's the higher-count path — left in that
@@ -743,13 +827,38 @@ function matchFull(prog: Inst, str: string): boolean {
     // perfectly ordinary long value. Counts only ever grow by one per `increment` or reset to
     // zero on exit, so sorting here keeps that dominance order through the whole step.
     current.sort((a, b) => a.lo - b.lo);
-    for (const thread of current) {
-      spend(budget);
-      const { inst, lo, hi, countFor } = thread;
-      if (inst.op === "char" && inst.test(ch))
+    let atUnit = current;
+    for (let unit = 0; unit < units.length; unit++) {
+      const isLastUnit = unit === units.length - 1;
+      const between: Thread[] = [];
+      const betweenVisited = newVisited();
+      for (const thread of atUnit) {
+        spend(budget);
+        const { inst, lo, hi, countFor } = thread;
+        if (inst.op === "charFold") {
+          if (inst.unit !== units[unit]) continue;
+          if (!isLastUnit) {
+            if (inst.last) continue;
+            // The run's next unit, past the `nop` concatAll leaves between literals.
+            let following: Inst = inst.next!;
+            while (following.op === "nop") following = following.next!;
+            if (following.op !== "charFold") continue;
+            const kept = visit(betweenVisited, { inst: following, lo, hi, countFor });
+            if (kept) enqueue(between, betweenVisited, kept);
+            continue;
+          }
+        } else if (unit > 0) {
+          continue;
+        } else if (inst.op === "char") {
+          if (!inst.test(ch)) continue;
+        } else if (inst.op === "any") {
+          if (isLineTerminator(ch)) continue;
+        } else {
+          continue;
+        }
         addThread(next, visited, { inst: inst.next!, lo, hi, countFor }, pos + 1, chars, budget);
-      else if (inst.op === "any" && !isLineTerminator(ch))
-        addThread(next, visited, { inst: inst.next!, lo, hi, countFor }, pos + 1, chars, budget);
+      }
+      atUnit = between;
     }
     current = next;
   }

--- a/extensions/windows-terminal/src/new-tab-menu.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.ts
@@ -15,17 +15,40 @@ export interface NewTabMenuEntry {
   entries?: NewTabMenuEntry[];
 }
 
+// JavaScript regex matching can't be interrupted once it starts, so an exponentially
+// backtracking pattern — (a+)+, (a|aa)*, ((ab)+)+ — would freeze the profile list while it
+// renders. Every such pattern quantifies a group that itself repeats or alternates, so reject
+// that shape up front. Conservative: a harmless pattern like (a|b)+ is rejected too, which
+// costs one unmatched menu entry instead of a hung command.
+function hasRiskyBacktracking(pattern: string): boolean {
+  // Escapes and character classes can't open a group, so reduce them to a plain character first.
+  let rest = pattern.replace(/\\./g, "a").replace(/\[[^\]]*\]/g, "a");
+  const innermostGroup = /\(([^()]*)\)(\*|\+|\?|\{\d+(?:,\d*)?\})?/;
+
+  // Collapse groups from the inside out. A group that repeats collapses to "a+" so an enclosing
+  // quantifier still sees a repeat inside it; anything else collapses to a plain "a".
+  for (let match = innermostGroup.exec(rest); match; match = innermostGroup.exec(rest)) {
+    const [whole, body, quantifier] = match;
+    const repeats = quantifier !== undefined && quantifier !== "?";
+    if (repeats && /[*+|]|\{\d*,\d*\}/.test(body)) return true;
+    rest = rest.replace(whole, repeats ? "a+" : "a");
+  }
+
+  return false;
+}
+
 // A matchProfiles entry matches a profile when ANY provided field (name/commandline/source)
 // fully matches that field's regex — mirrors Windows Terminal's MatchProfilesEntry. Empty profile
 // fields never match, so "source": ".*" skips local profiles and "commandline": ".*" skips
-// profiles without a command line. An entry with no patterns, or a malformed regex, matches
-// nothing rather than crashing or matching all.
+// profiles without a command line. An entry with no patterns, or a malformed or exponentially
+// backtracking regex, matches nothing rather than crashing, hanging, or matching all.
 export function buildProfileMatcher(entry: NewTabMenuEntry): ((profile: Profile) => boolean) | null {
   const specs: { pattern: string; get: (profile: Profile) => string }[] = [];
   if (entry.name !== undefined) specs.push({ pattern: entry.name, get: (p) => p.name });
   if (entry.commandline !== undefined) specs.push({ pattern: entry.commandline, get: (p) => p.commandline ?? "" });
   if (entry.source !== undefined) specs.push({ pattern: entry.source, get: (p) => p.source ?? "" });
   if (specs.length === 0) return null;
+  if (specs.some(({ pattern }) => hasRiskyBacktracking(pattern))) return null;
 
   let matchers: { regex: RegExp; get: (profile: Profile) => string }[];
   try {

--- a/extensions/windows-terminal/src/new-tab-menu.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.ts
@@ -82,11 +82,17 @@ const isLineTerminator = (ch: string) => LINE_TERMINATORS.has(ch.codePointAt(0)!
 // Case folding, for (?i). ICU compares case-insensitively by folding both sides, and *full*
 // folding can change a string's length — "ß" folds to "ss" — which is how (?i)straße matches
 // "STRASSE" and (?i)ss matches "ß". JavaScript has no fold function; upper-then-lower, repeated to
-// a fixed point, reaches the same canonical form for every case variant ("ß" and "ẞ" both end at
-// "ss", "ﬁ" at "fi", "ſ" at "s").
+// a fixed point, reaches the same canonical form as Unicode's CaseFolding.txt for every case
+// variant ("ß" and "ẞ" both end at "ss", "ﬁ" at "fi", "ſ" at "s") with one exception: dotless "ı"
+// uppercases to "I", but CaseFolding.txt deliberately leaves it unfolded so it stays distinct from
+// "i" outside Turkic locales, as ICU does — so it's excluded here.
+function caseMap(s: string): string {
+  return s === "ı" ? s : s.toUpperCase().toLowerCase();
+}
+
 function fullFold(s: string): string {
   for (let round = 0; round < 3; round++) {
-    const folded = s.toUpperCase().toLowerCase();
+    const folded = caseMap(s);
     if (folded === s) return s;
     s = folded;
   }
@@ -97,7 +103,7 @@ function fullFold(s: string): string {
 // "ß", "ſ" becomes "s", but "ß" stays "ß". ICU uses it for a lone case-insensitive literal — see
 // the literal-run rule in parseSeq.
 function simpleFold(ch: string): string {
-  const folded = ch.toUpperCase().toLowerCase();
+  const folded = caseMap(ch);
   return Array.from(folded).length === 1 ? folded : ch;
 }
 

--- a/extensions/windows-terminal/src/new-tab-menu.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.ts
@@ -23,8 +23,9 @@ export interface NewTabMenuEntry {
 // reachable state together, one input character at a time (matchFull) — the technique RE2 and
 // Rust's regex crate use for guaranteed linear-time matching with no backtracking. So no pattern
 // needs rejecting for how it might backtrack — a repeated group with safe alternatives, like
-// (dev|prod)+, still matches normally, and so does (a+)+ — only the compiled program's sheer size
-// is capped (MAX_PROGRAM_SIZE).
+// (dev|prod)+, still matches normally, and so does (a+)+. A large bounded quantifier on a simple
+// atom, like (a|b){0,4000}, is unbounded in practice too — compileCountedRepeat gives it a counter
+// instead of unrolling it, so neither compiled size nor matching cost grows with the bound.
 type AtomNode =
   | { kind: "char"; test: (ch: string) => boolean }
   | { kind: "any" }
@@ -39,24 +40,18 @@ type AltNode = { options: SeqNode[] };
 class RegexSyntaxError extends Error {}
 class RegexTooLargeError extends Error {}
 
-// compileQuant unrolls {n,m} into that many copies of the atom, and nesting multiplies them: the
-// program for (a{200}){200} is 40,000+ instructions even though MAX_QUANT_REPEAT below allows
-// each 200 individually. So this cap is on the size of the whole compiled program, catching that
-// multiplication regardless of how deep the nesting goes. It's set well above what a real
-// matchProfiles pattern needs (a long literal alternation is still only a few hundred
-// instructions) but far below what nesting a few max-sized quantifiers can reach, which keeps
-// compilation bounded in both memory and time.
+// compileQuant unrolls a *small* {n,m} into that many copies of the atom — cheap, and it's what
+// lets a bounded quantifier nest freely inside another (e.g. (a?)*). A *large* bound instead
+// compiles through compileCountedRepeat, a single shared instruction the matcher's thread carries
+// a counter through, so the compiled size and matching cost stay independent of how big the bound
+// is (see MAX_MATCH_STEPS). This cap remains as a backstop against structural blowup unrelated to
+// quantifier size — e.g. an alternation with an implausible number of branches.
 const MAX_PROGRAM_SIZE = 50000;
 
-// A single {n,m} unrolls into that many copies of its atom (compileQuant), one split per optional
-// copy. Matching cost for that isn't just O(program size × value length): at any position, every
-// still-reachable "how many reps have I skipped so far" copy is a separate live NFA thread, so an
-// optional quantifier's cost is closer to O(bound²) — measured, a 2-way alternation with an
-// explicit bound of 200 against a value of that length needs ~240,000 steps, 300 needs ~540,000.
-// A real matchProfiles pattern never needs to repeat anything anywhere near this many times, so
-// the bound is capped well before that quadratic cost gets expensive. Nested multiplication like
-// (a{200}){200} is still caught by MAX_PROGRAM_SIZE.
-const MAX_QUANT_REPEAT = 200;
+// Below this, compileQuant unrolls a {n,m} into that many literal copies (cheap, and lets it nest
+// inside another quantifier); at or above it, compileCountedRepeat is used instead — no nesting
+// support, but the compiled size and matching cost no longer scale with the bound.
+const UNROLL_THRESHOLD = 20;
 
 // Parses the subset of ICU regex syntax (the flavor Windows Terminal itself matches with) that
 // matchProfiles patterns actually use: literals, `.`, escapes (`\d\w\s` and their negations, `\.`
@@ -124,9 +119,6 @@ function parsePattern(pattern: string): AltNode {
         min = parseInt(braces[1], 10);
         max = braces[2] === undefined ? min : braces[3] === "" ? Infinity : parseInt(braces[3], 10);
         if (max < min) return fail("quantifier bounds out of order");
-        if (min > MAX_QUANT_REPEAT || (max !== Infinity && max > MAX_QUANT_REPEAT)) {
-          return fail("quantifier bound too large");
-        }
         quantified = true;
         i += braces[0].length;
       }
@@ -272,16 +264,34 @@ type BoundaryInst = { op: "boundary"; negate: boolean; next?: Inst };
 type SplitInst = { op: "split"; next?: Inst; next2?: Inst };
 type NopInst = { op: "nop"; next?: Inst };
 type MatchInst = { op: "match" };
-type Inst = CharInst | AnyInst | StartInst | EndInst | BoundaryInst | SplitInst | NopInst | MatchInst;
+// A counted repeat: one shared instruction, however large `max` is. `bodyStart` is entered again
+// each rep instead of being duplicated per rep — see compileCountedRepeat and the `count`/`countFor`
+// fields threads carry through addThread/matchFull.
+type RepeatInst = { op: "repeat"; id: number; min: number; max: number; bodyStart: Inst; next?: Inst };
+// The body's own exit, patched to loop back through here rather than straight to `repeat`, so the
+// matcher can tell "just finished one more rep of this repeat" apart from "entering it fresh".
+type IncrementInst = { op: "increment"; repeat: RepeatInst };
+type Inst =
+  | CharInst
+  | AnyInst
+  | StartInst
+  | EndInst
+  | BoundaryInst
+  | SplitInst
+  | NopInst
+  | MatchInst
+  | RepeatInst
+  | IncrementInst;
 
 type PatchSlot =
-  | { inst: CharInst | AnyInst | StartInst | EndInst | BoundaryInst | NopInst | SplitInst; slot: "next" }
+  | { inst: CharInst | AnyInst | StartInst | EndInst | BoundaryInst | NopInst | SplitInst | RepeatInst; slot: "next" }
   | { inst: SplitInst; slot: "next2" };
 type Frag = { start: Inst; out: PatchSlot[] };
 
-// Every instruction is created through here, so the running total covers nested repetitions too —
-// the budget is spent as (a{200}){200} unrolls, and compilation gives up partway through rather
-// than after building the whole 40,000+-instruction program.
+// Every instruction is created through here, so the running total covers nested unrolling too —
+// e.g. small quantifiers nested several levels deep, each individually under UNROLL_THRESHOLD but
+// multiplying together — and compilation gives up partway through rather than after building the
+// whole oversized program.
 let instructionCount = 0;
 
 function newInst<T extends Inst>(inst: T): T {
@@ -363,17 +373,55 @@ function optionalFrag(atom: AtomNode): Frag {
   return { start: split, out: [...body.out, { inst: split, slot: "next2" }] };
 }
 
+// compileCountedRepeat's counter is a single (count, countFor) pair per thread, not a stack, so it
+// can't tell two active repeats apart — a quantified atom that itself contains a quantifier (e.g.
+// (a{5}){500}) can't safely go through it. Every atom below UNROLL_THRESHOLD is quantified with
+// its default {1,1} (see parseQuant), so this is only true when something was genuinely repeated.
+function hasNestedQuantifier(atom: AtomNode): boolean {
+  if (atom.kind !== "group") return false;
+  return atom.alt.options.some((seq) =>
+    seq.atoms.some((q) => q.min !== 1 || q.max !== 1 || hasNestedQuantifier(q.atom)),
+  );
+}
+
+let nextRepeatId = 0;
+
+// Compiles atom{min,max} (max possibly Infinity) as one `repeat` instruction plus one copy of the
+// atom's body, instead of unrolling — see the `repeat`/`increment` handling in addThread for how a
+// thread's counter takes the place of the copies compileQuant's other branch would otherwise make.
+function compileCountedRepeat(atom: AtomNode, min: number, max: number): Frag {
+  if (hasNestedQuantifier(atom)) {
+    throw new RegexTooLargeError("a quantifier this large can't wrap another quantifier");
+  }
+  const repeat: RepeatInst = newInst({
+    op: "repeat",
+    id: nextRepeatId++,
+    min,
+    max,
+    bodyStart: undefined as unknown as Inst,
+  });
+  const body = compileAtom(atom);
+  const increment: IncrementInst = newInst({ op: "increment", repeat });
+  patch(body.out, increment);
+  repeat.bodyStart = body.start;
+  return { start: repeat, out: [{ inst: repeat, slot: "next" }] };
+}
+
 // Whether a quantifier is greedy or lazy only affects which substring a capturing group would
 // record — irrelevant here, since buildProfileMatcher only ever asks "does the whole field match"
 // (see matchFull). So greedy and lazy compile identically; `q.greedy` is parsed but never consulted.
 function compileQuant(q: QuantNode): Frag {
   if (q.max === Infinity) {
     if (q.min === 0) return starFrag(q.atom);
-    return concat(repeatFrag(q.atom, q.min - 1), plusFrag(q.atom));
+    if (q.min <= UNROLL_THRESHOLD) return concat(repeatFrag(q.atom, q.min - 1), plusFrag(q.atom));
+    return compileCountedRepeat(q.atom, q.min, Infinity);
   }
-  const optionals: Frag[] = [];
-  for (let copy = q.min; copy < q.max; copy++) optionals.push(optionalFrag(q.atom));
-  return concat(repeatFrag(q.atom, q.min), concatAll(optionals));
+  if (q.min <= UNROLL_THRESHOLD && q.max - q.min <= UNROLL_THRESHOLD) {
+    const optionals: Frag[] = [];
+    for (let copy = q.min; copy < q.max; copy++) optionals.push(optionalFrag(q.atom));
+    return concat(repeatFrag(q.atom, q.min), concatAll(optionals));
+  }
+  return compileCountedRepeat(q.atom, q.min, q.max);
 }
 
 function compileSeq(seq: SeqNode): Frag {
@@ -391,22 +439,27 @@ function compileAlt(alt: AltNode): Frag {
 
 function compileProgram(alt: AltNode): Inst {
   instructionCount = 0;
+  nextRepeatId = 0;
   const frag = compileAlt(alt);
   const matchInst: MatchInst = newInst({ op: "match" });
   patch(frag.out, matchInst);
   return frag.start;
 }
 
-// A safety net behind MAX_QUANT_REPEAT, not the primary defense against slow matching — that's
-// now the quantifier bound above, which keeps realistic patterns fast in the first place. This
-// budget exists for constructs MAX_QUANT_REPEAT doesn't cover: a long value matched against a
-// small program (e.g. ".*"), or several moderate quantifiers/alternations compounding within one
-// pattern. It's set with headroom above the worst case MAX_QUANT_REPEAT actually allows (a 5-way
-// alternation at the bound measured ~390,000 steps) so a legitimately matching pattern within that
-// bound always finishes rather than being silently cut off — MAX_QUANT_REPEAT is what keeps this
-// budget from ever being the thing standing between a valid pattern and a correct answer.
+// A backstop, not the primary defense against slow matching — compileCountedRepeat is, since it
+// keeps a large bound's matching cost independent of the bound itself. What's left for this budget
+// to catch: several moderate constructs compounding within one pattern, or anything unforeseen.
+// It's generous — matching a large bound against a value that size measures in the tens of
+// thousands of steps (see new-tab-menu.test.ts), so this is headroom, not a tight fit.
 const MAX_MATCH_STEPS = 1000000;
 type StepBudget = { remaining: number };
+
+// A live NFA thread: which instruction it's at, plus the counter compileCountedRepeat's `repeat`/
+// `increment` instructions read and write. `countFor` names which `repeat` instruction `count`
+// belongs to — a thread not currently inside a counted repeat carries a `countFor` that matches no
+// real instruction, so `repeat` treats it as a fresh entry (see the "repeat" case in addThread).
+type Thread = { inst: Inst; count: number; countFor: number };
+const NO_REPEAT = -1;
 
 // \b sits between a word character and a non-word one, counting the space off either end of the
 // value as non-word — so it holds at both ends of "PowerShell" but not inside it.
@@ -425,25 +478,50 @@ function isWordBoundary(str: string, pos: number): boolean {
 // Walked with an explicit stack, not recursion — a flat run of thousands of optional atoms
 // (a?a?a?...) chains that many `split`s in a row, and recursing that chain would grow the JS call
 // stack with the pattern's size, independent of how long the string being matched is.
-function addThread(list: Inst[], visited: Set<Inst>, start: Inst, pos: number, str: string, budget: StepBudget): void {
-  const stack: Inst[] = [start];
+function addThread(
+  list: Thread[],
+  visited: Set<Inst>,
+  start: Thread,
+  pos: number,
+  str: string,
+  budget: StepBudget,
+): void {
+  const stack: Thread[] = [start];
   while (stack.length > 0) {
     if (budget.remaining-- <= 0) return;
-    const inst = stack.pop()!;
+    const thread = stack.pop()!;
+    const inst = thread.inst;
     if (visited.has(inst)) continue;
     visited.add(inst);
+    const { count, countFor } = thread;
     if (inst.op === "split") {
-      stack.push(inst.next2!, inst.next!);
+      stack.push({ inst: inst.next2!, count, countFor }, { inst: inst.next!, count, countFor });
     } else if (inst.op === "nop") {
-      stack.push(inst.next!);
+      stack.push({ inst: inst.next!, count, countFor });
     } else if (inst.op === "start") {
-      if (pos === 0) stack.push(inst.next!);
+      if (pos === 0) stack.push({ inst: inst.next!, count, countFor });
     } else if (inst.op === "end") {
-      if (pos === str.length) stack.push(inst.next!);
+      if (pos === str.length) stack.push({ inst: inst.next!, count, countFor });
     } else if (inst.op === "boundary") {
-      if (isWordBoundary(str, pos) !== inst.negate) stack.push(inst.next!);
+      if (isWordBoundary(str, pos) !== inst.negate) stack.push({ inst: inst.next!, count, countFor });
+    } else if (inst.op === "repeat") {
+      // A thread not already inside this repeat (countFor doesn't match) is entering fresh, at 0.
+      const reps = countFor === inst.id ? count : 0;
+      if (reps < inst.min) {
+        // Below the minimum: another rep is mandatory, no option to stop yet.
+        stack.push({ inst: inst.bodyStart, count: reps, countFor: inst.id });
+      } else if (inst.max === Infinity || reps < inst.max) {
+        // Within range: try one more rep, but stopping here is also valid (mirrors optionalFrag).
+        stack.push({ inst: inst.next!, count, countFor });
+        stack.push({ inst: inst.bodyStart, count: reps, countFor: inst.id });
+      } else {
+        // At the maximum: no more reps allowed.
+        stack.push({ inst: inst.next!, count, countFor });
+      }
+    } else if (inst.op === "increment") {
+      stack.push({ inst: inst.repeat, count: count + 1, countFor: inst.repeat.id });
     } else {
-      list.push(inst);
+      list.push(thread);
     }
   }
 }
@@ -452,28 +530,31 @@ function addThread(list: Inst[], visited: Set<Inst>, start: Inst, pos: number, s
 // of recursing per character the way a backtracking engine would. Every thread advances together, so
 // the call stack never grows with the length of `str` or with the pattern's backtracking search
 // space — a 2,000-character value and a pathological pattern like (a+)+ cost the same handful of
-// stack frames as a one-character match. Total work is bounded by str.length × the pattern's
-// compiled size, so nothing can blow up exponentially, but that product can still be large for a
-// big program and a long value — MAX_MATCH_STEPS caps it.
+// stack frames as a one-character match. Work per position is bounded by the pattern's compiled
+// size — kept independent of any quantifier's bound by compileCountedRepeat — so nothing can blow
+// up exponentially or scale with a large bound; MAX_MATCH_STEPS is a backstop for what's left.
 function matchFull(prog: Inst, str: string): boolean {
   const budget: StepBudget = { remaining: MAX_MATCH_STEPS };
-  let current: Inst[] = [];
-  addThread(current, new Set(), prog, 0, str, budget);
+  let current: Thread[] = [];
+  addThread(current, new Set(), { inst: prog, count: 0, countFor: NO_REPEAT }, 0, str, budget);
 
   for (let pos = 0; pos < str.length; pos++) {
     if (current.length === 0) return false;
-    const next: Inst[] = [];
+    const next: Thread[] = [];
     const visited = new Set<Inst>();
     const ch = str[pos];
-    for (const inst of current) {
+    for (const thread of current) {
       if (budget.remaining-- <= 0) return false;
-      if (inst.op === "char" && inst.test(ch)) addThread(next, visited, inst.next!, pos + 1, str, budget);
-      else if (inst.op === "any") addThread(next, visited, inst.next!, pos + 1, str, budget);
+      const inst = thread.inst;
+      const { count, countFor } = thread;
+      if (inst.op === "char" && inst.test(ch))
+        addThread(next, visited, { inst: inst.next!, count, countFor }, pos + 1, str, budget);
+      else if (inst.op === "any") addThread(next, visited, { inst: inst.next!, count, countFor }, pos + 1, str, budget);
     }
     current = next;
   }
 
-  return current.some((inst) => inst.op === "match");
+  return current.some((thread) => thread.inst.op === "match");
 }
 
 // A matchProfiles entry matches a profile when ANY provided field (name/commandline/source)

--- a/extensions/windows-terminal/src/new-tab-menu.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.ts
@@ -385,6 +385,9 @@ function hasNestedQuantifier(atom: AtomNode): boolean {
 }
 
 let nextRepeatId = 0;
+// Indexed by RepeatInst.id, so addThread's dedup key can look up a repeat's `min` from just the
+// `countFor` a thread carries, without every instruction needing its own back-pointer to it.
+let repeatsById: RepeatInst[] = [];
 
 // Compiles atom{min,max} (max possibly Infinity) as one `repeat` instruction plus one copy of the
 // atom's body, instead of unrolling — see the `repeat`/`increment` handling in addThread for how a
@@ -400,6 +403,7 @@ function compileCountedRepeat(atom: AtomNode, min: number, max: number): Frag {
     max,
     bodyStart: undefined as unknown as Inst,
   });
+  repeatsById[repeat.id] = repeat;
   const body = compileAtom(atom);
   const increment: IncrementInst = newInst({ op: "increment", repeat });
   patch(body.out, increment);
@@ -440,6 +444,7 @@ function compileAlt(alt: AltNode): Frag {
 function compileProgram(alt: AltNode): Inst {
   instructionCount = 0;
   nextRepeatId = 0;
+  repeatsById = [];
   const frag = compileAlt(alt);
   const matchInst: MatchInst = newInst({ op: "match" });
   patch(frag.out, matchInst);
@@ -469,6 +474,48 @@ function isWordBoundary(str: string, pos: number): boolean {
   return isWordChar(str[pos - 1]) !== isWordChar(str[pos]);
 }
 
+// Instructions outside any counted repeat dedupe by identity alone (`plain`), same as before a
+// large quantifier could compile without unrolling. Instructions reached *inside* one (`countFor`
+// names which `repeat`) need `count` in the key too — see capForDedup for why capping it at that
+// repeat's `min` is safe rather than just using it raw.
+type VisitedState = { plain: Set<Inst>; scoped: Map<Inst, Set<number>> };
+
+function newVisited(): VisitedState {
+  return { plain: new Set(), scoped: new Map() };
+}
+
+// Once a thread has reached `min` reps of a counted repeat, every rep beyond that is behaviorally
+// identical for reachability: `repeat` offers the exact same exit target and the exact same
+// continue-into-body target regardless of the exact count, right up to (and including) `max` —
+// forced exit at `max` reaches nothing that optional exit at `min` didn't already reach. So capping
+// the count at `min` for dedup purposes loses no reachable state, while bounding how many times a
+// nullable body (one that can match empty, e.g. (|a)) can loop back within a single position —
+// without the cap, each loop reaches `repeat` at a new, never-before-seen count and dedup never
+// kicks in, so a large `max` risks growing that unboundedly before a real character is consumed.
+// Only called when thread.countFor !== NO_REPEAT (see hasVisited/markVisited), so there's always a
+// real repeat to look up.
+function capForDedup(thread: Thread): number {
+  return Math.min(thread.count, repeatsById[thread.countFor].min);
+}
+
+function hasVisited(visited: VisitedState, thread: Thread): boolean {
+  if (thread.countFor === NO_REPEAT) return visited.plain.has(thread.inst);
+  return visited.scoped.get(thread.inst)?.has(capForDedup(thread)) ?? false;
+}
+
+function markVisited(visited: VisitedState, thread: Thread): void {
+  if (thread.countFor === NO_REPEAT) {
+    visited.plain.add(thread.inst);
+    return;
+  }
+  let seen = visited.scoped.get(thread.inst);
+  if (!seen) {
+    seen = new Set();
+    visited.scoped.set(thread.inst, seen);
+  }
+  seen.add(capForDedup(thread));
+}
+
 // Epsilon-closure: follows the zero-width instructions (`split`, `nop`, and the anchors when their
 // condition holds) until it reaches a `char`/`any`/`match` instruction, adding those to `list`.
 // `visited` dedupes instructions already queued at this string position — that's what stops a
@@ -480,7 +527,7 @@ function isWordBoundary(str: string, pos: number): boolean {
 // stack with the pattern's size, independent of how long the string being matched is.
 function addThread(
   list: Thread[],
-  visited: Set<Inst>,
+  visited: VisitedState,
   start: Thread,
   pos: number,
   str: string,
@@ -491,8 +538,8 @@ function addThread(
     if (budget.remaining-- <= 0) return;
     const thread = stack.pop()!;
     const inst = thread.inst;
-    if (visited.has(inst)) continue;
-    visited.add(inst);
+    if (hasVisited(visited, thread)) continue;
+    markVisited(visited, thread);
     const { count, countFor } = thread;
     if (inst.op === "split") {
       stack.push({ inst: inst.next2!, count, countFor }, { inst: inst.next!, count, countFor });
@@ -536,12 +583,12 @@ function addThread(
 function matchFull(prog: Inst, str: string): boolean {
   const budget: StepBudget = { remaining: MAX_MATCH_STEPS };
   let current: Thread[] = [];
-  addThread(current, new Set(), { inst: prog, count: 0, countFor: NO_REPEAT }, 0, str, budget);
+  addThread(current, newVisited(), { inst: prog, count: 0, countFor: NO_REPEAT }, 0, str, budget);
 
   for (let pos = 0; pos < str.length; pos++) {
     if (current.length === 0) return false;
     const next: Thread[] = [];
-    const visited = new Set<Inst>();
+    const visited = newVisited();
     const ch = str[pos];
     for (const thread of current) {
       if (budget.remaining-- <= 0) return false;

--- a/extensions/windows-terminal/src/new-tab-menu.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.ts
@@ -15,12 +15,14 @@ export interface NewTabMenuEntry {
   entries?: NewTabMenuEntry[];
 }
 
-// A minimal backtracking regex engine, used instead of JavaScript's native RegExp. Native regex
-// matching can't be interrupted once it starts, so a pathological pattern — (a+)+, (a?a?)+,
-// ((ab)+)+ — would freeze the profile list while it renders. This engine bounds itself with a
-// step counter instead: every recursive attempt costs one step, and once the budget is spent the
-// match fails rather than exploring further. That makes ALL patterns safe to run, including ones
-// that look risky, so nothing needs to be rejected up front — a repeated group with safe
+// A minimal regex engine, used instead of JavaScript's native RegExp. Native regex matching can't
+// be interrupted once it starts, so a pathological pattern — (a+)+, (a?a?)+, ((ab)+)+ — would
+// freeze the profile list while it renders, and a backtracking engine's own recursion can overflow
+// the call stack on a long value even for a safe pattern like ".*". This engine avoids both: it
+// compiles the pattern into a Thompson NFA (compileProgram) and matches by advancing every
+// reachable state together, one input character at a time (matchFull) — the technique RE2 and
+// Rust's regex crate use for guaranteed linear-time matching with no backtracking. So nothing needs
+// to be rejected up front and nothing needs a step budget — a repeated group with safe
 // alternatives, like (dev|prod)+, still matches normally.
 type AtomNode =
   | { kind: "char"; test: (ch: string) => boolean }
@@ -33,6 +35,11 @@ type SeqNode = { atoms: QuantNode[] };
 type AltNode = { options: SeqNode[] };
 
 class RegexSyntaxError extends Error {}
+
+// compileQuant below unrolls an explicit {n,m} into n or m literal copies of the atom, so a bound
+// this large would blow up the compiled instruction count regardless of the input being matched.
+// matchProfiles patterns never legitimately need more than this.
+const MAX_QUANT_BOUND = 1000;
 
 // Parses the subset of ECMAScript regex syntax matchProfiles patterns actually use: literals,
 // `.`, escapes (`\d\w\s` and their negations, `\.` etc.), `[...]` classes, `(...)`/`(?:...)`
@@ -88,6 +95,9 @@ function parsePattern(pattern: string): AltNode {
       if (braces) {
         min = parseInt(braces[1], 10);
         max = braces[2] === undefined ? min : braces[3] === "" ? Infinity : parseInt(braces[3], 10);
+        if (max < min || min > MAX_QUANT_BOUND || (max !== Infinity && max > MAX_QUANT_BOUND)) {
+          return fail("quantifier bound out of range");
+        }
         quantified = true;
         i += braces[0].length;
       }
@@ -169,8 +179,11 @@ function parsePattern(pattern: string): AltNode {
         const esc = pattern[i];
         i++;
         if (esc === "d") tests.push((ch) => ch >= "0" && ch <= "9");
+        else if (esc === "D") tests.push((ch) => !(ch >= "0" && ch <= "9"));
         else if (esc === "w") tests.push((ch) => /\w/.test(ch));
+        else if (esc === "W") tests.push((ch) => !/\w/.test(ch));
         else if (esc === "s") tests.push((ch) => /\s/.test(ch));
+        else if (esc === "S") tests.push((ch) => !/\s/.test(ch));
         else tests.push((ch) => ch === esc);
         continue;
       }
@@ -194,55 +207,169 @@ function parsePattern(pattern: string): AltNode {
   return result;
 }
 
-// Every recursive attempt below — descending into a group, trying one more quantifier repeat,
-// trying an alternation branch — spends one step, and a simple linear pattern like ".*" already
-// spends a small constant number of steps per character. A fixed budget would then cut off a
-// legitimate match against a long value (e.g. a ~1000-character commandline) before it finishes.
-// Scaling the budget with the value's length avoids that while still cutting off exponential
-// blowups almost immediately — those exceed even a scaled budget within a few dozen characters.
-const MIN_STEP_BUDGET = 2000;
-const STEP_BUDGET_PER_CHAR = 50;
+// Compiles the parsed AST into a Thompson NFA instead of interpreting it recursively. Each
+// instruction is one node of that NFA; `split` is the only branch point, and `next`/`next2` link
+// the graph together. A `Frag` under construction tracks its entry instruction plus the dangling
+// successor slots ("patch list", in Thompson's original terms) still waiting to be pointed at
+// whatever comes next.
+type CharInst = { op: "char"; test: (ch: string) => boolean; next?: Inst };
+type AnyInst = { op: "any"; next?: Inst };
+type StartInst = { op: "start"; next?: Inst };
+type EndInst = { op: "end"; next?: Inst };
+type SplitInst = { op: "split"; next?: Inst; next2?: Inst };
+type NopInst = { op: "nop"; next?: Inst };
+type MatchInst = { op: "match" };
+type Inst = CharInst | AnyInst | StartInst | EndInst | SplitInst | NopInst | MatchInst;
 
-// Continuation-passing backtracking matcher, fully anchored (matches only if it consumes the
-// whole string). `k` is "what to try once this piece has matched"; quantifiers try repeating
-// (greedy) or stopping (lazy) first, per their `greedy` flag, and fall back to the other on
-// failure — same shape as a native regex engine, just with a hard step ceiling.
-function matchFull(alt: AltNode, str: string): boolean {
-  let steps = 0;
-  const budget = Math.max(MIN_STEP_BUDGET, str.length * STEP_BUDGET_PER_CHAR);
-  const withinBudget = () => ++steps <= budget;
+type PatchSlot =
+  | { inst: CharInst | AnyInst | StartInst | EndInst | NopInst | SplitInst; slot: "next" }
+  | { inst: SplitInst; slot: "next2" };
+type Frag = { start: Inst; out: PatchSlot[] };
 
-  function matchAtomOnce(atom: AtomNode, pos: number, k: (pos: number) => boolean): boolean {
-    if (!withinBudget()) return false;
-    if (atom.kind === "char") return pos < str.length && atom.test(str[pos]) && k(pos + 1);
-    if (atom.kind === "any") return pos < str.length && k(pos + 1);
-    if (atom.kind === "start") return pos === 0 && k(pos);
-    if (atom.kind === "end") return pos === str.length && k(pos);
-    return matchAlt(atom.alt, pos, k);
+function patch(out: PatchSlot[], target: Inst): void {
+  for (const p of out) {
+    if (p.slot === "next2") p.inst.next2 = target;
+    else p.inst.next = target;
   }
+}
 
-  function matchQuant(q: QuantNode, pos: number, k: (pos: number) => boolean): boolean {
-    function attempt(count: number, p: number): boolean {
-      if (!withinBudget()) return false;
-      const tryMore = () => count < q.max && matchAtomOnce(q.atom, p, (np) => attempt(count + 1, np));
-      const tryStop = () => count >= q.min && k(p);
-      return q.greedy ? tryMore() || tryStop() : tryStop() || tryMore();
+function emptyFrag(): Frag {
+  const inst: NopInst = { op: "nop" };
+  return { start: inst, out: [{ inst, slot: "next" }] };
+}
+
+function concat(a: Frag, b: Frag): Frag {
+  patch(a.out, b.start);
+  return { start: a.start, out: b.out };
+}
+
+function concatAll(frags: Frag[]): Frag {
+  return frags.reduce(concat, emptyFrag());
+}
+
+function compileAtom(atom: AtomNode): Frag {
+  if (atom.kind === "group") return compileAlt(atom.alt);
+  if (atom.kind === "char") {
+    const inst: CharInst = { op: "char", test: atom.test };
+    return { start: inst, out: [{ inst, slot: "next" }] };
+  }
+  if (atom.kind === "any") {
+    const inst: AnyInst = { op: "any" };
+    return { start: inst, out: [{ inst, slot: "next" }] };
+  }
+  if (atom.kind === "start") {
+    const inst: StartInst = { op: "start" };
+    return { start: inst, out: [{ inst, slot: "next" }] };
+  }
+  const inst: EndInst = { op: "end" };
+  return { start: inst, out: [{ inst, slot: "next" }] };
+}
+
+function repeatFrag(atom: AtomNode, count: number): Frag {
+  return concatAll(Array.from({ length: count }, () => compileAtom(atom)));
+}
+
+function starFrag(atom: AtomNode): Frag {
+  const split: SplitInst = { op: "split" };
+  const body = compileAtom(atom);
+  patch(body.out, split);
+  split.next = body.start;
+  return { start: split, out: [{ inst: split, slot: "next2" }] };
+}
+
+function plusFrag(atom: AtomNode): Frag {
+  const split: SplitInst = { op: "split" };
+  const body = compileAtom(atom);
+  patch(body.out, split);
+  split.next = body.start;
+  return { start: body.start, out: [{ inst: split, slot: "next2" }] };
+}
+
+function optionalFrag(atom: AtomNode): Frag {
+  const split: SplitInst = { op: "split" };
+  const body = compileAtom(atom);
+  split.next = body.start;
+  return { start: split, out: [...body.out, { inst: split, slot: "next2" }] };
+}
+
+// Whether a quantifier is greedy or lazy only affects which substring a capturing group would
+// record — irrelevant here, since buildProfileMatcher only ever asks "does the whole field match"
+// (see matchFull). So greedy and lazy compile identically; `q.greedy` is parsed but never consulted.
+function compileQuant(q: QuantNode): Frag {
+  if (q.max === Infinity) {
+    if (q.min === 0) return starFrag(q.atom);
+    return concat(repeatFrag(q.atom, q.min - 1), plusFrag(q.atom));
+  }
+  const optionals = concatAll(Array.from({ length: q.max - q.min }, () => optionalFrag(q.atom)));
+  return concat(repeatFrag(q.atom, q.min), optionals);
+}
+
+function compileSeq(seq: SeqNode): Frag {
+  return concatAll(seq.atoms.map(compileQuant));
+}
+
+function compileAlt(alt: AltNode): Frag {
+  return alt.options.map(compileSeq).reduceRight((rest, option) => {
+    const split: SplitInst = { op: "split" };
+    split.next = option.start;
+    split.next2 = rest.start;
+    return { start: split, out: [...option.out, ...rest.out] };
+  });
+}
+
+function compileProgram(alt: AltNode): Inst {
+  const frag = compileAlt(alt);
+  const matchInst: MatchInst = { op: "match" };
+  patch(frag.out, matchInst);
+  return frag.start;
+}
+
+// Epsilon-closure: follows the zero-width instructions (`split`, `nop`, and the anchors when their
+// condition holds) until it reaches a `char`/`any`/`match` instruction, adding those to `list`.
+// `visited` dedupes instructions already queued at this string position — that's what stops a
+// zero-width loop like (a?)* from spinning forever: once its `split` has been visited at a given
+// position, revisiting it adds nothing new, so the closure always terminates after at most one
+// visit per instruction, and the pattern's remainder (matching past the loop) still gets explored.
+function addThread(list: Inst[], visited: Set<Inst>, inst: Inst, pos: number, str: string): void {
+  if (visited.has(inst)) return;
+  visited.add(inst);
+  if (inst.op === "split") {
+    addThread(list, visited, inst.next!, pos, str);
+    addThread(list, visited, inst.next2!, pos, str);
+  } else if (inst.op === "nop") {
+    addThread(list, visited, inst.next!, pos, str);
+  } else if (inst.op === "start") {
+    if (pos === 0) addThread(list, visited, inst.next!, pos, str);
+  } else if (inst.op === "end") {
+    if (pos === str.length) addThread(list, visited, inst.next!, pos, str);
+  } else {
+    list.push(inst);
+  }
+}
+
+// Runs the compiled NFA over `str` breadth-first, one input position at a time (Pike's VM) instead
+// of recursing per character the way a backtracking engine would. Every thread advances together, so
+// the call stack never grows with the length of `str` or with the pattern's backtracking search
+// space — a 2,000-character value and a pathological pattern like (a+)+ cost the same handful of
+// stack frames as a one-character match, and total work is bounded by str.length × the pattern's
+// compiled size, so nothing can blow up exponentially and no step budget is needed.
+function matchFull(prog: Inst, str: string): boolean {
+  let current: Inst[] = [];
+  addThread(current, new Set(), prog, 0, str);
+
+  for (let pos = 0; pos < str.length; pos++) {
+    if (current.length === 0) return false;
+    const next: Inst[] = [];
+    const visited = new Set<Inst>();
+    const ch = str[pos];
+    for (const inst of current) {
+      if (inst.op === "char" && inst.test(ch)) addThread(next, visited, inst.next!, pos + 1, str);
+      else if (inst.op === "any") addThread(next, visited, inst.next!, pos + 1, str);
     }
-    return attempt(0, pos);
+    current = next;
   }
 
-  function matchSeq(atoms: QuantNode[], idx: number, pos: number, k: (pos: number) => boolean): boolean {
-    if (!withinBudget()) return false;
-    if (idx === atoms.length) return k(pos);
-    return matchQuant(atoms[idx], pos, (np) => matchSeq(atoms, idx + 1, np, k));
-  }
-
-  function matchAlt(alt: AltNode, pos: number, k: (pos: number) => boolean): boolean {
-    if (!withinBudget()) return false;
-    return alt.options.some((seq) => matchSeq(seq.atoms, 0, pos, k));
-  }
-
-  return matchAlt(alt, 0, (pos) => pos === str.length);
+  return current.some((inst) => inst.op === "match");
 }
 
 // A matchProfiles entry matches a profile when ANY provided field (name/commandline/source)
@@ -257,17 +384,17 @@ export function buildProfileMatcher(entry: NewTabMenuEntry): ((profile: Profile)
   if (entry.source !== undefined) specs.push({ pattern: entry.source, get: (p) => p.source ?? "" });
   if (specs.length === 0) return null;
 
-  let matchers: { alt: AltNode; get: (profile: Profile) => string }[];
+  let matchers: { prog: Inst; get: (profile: Profile) => string }[];
   try {
-    matchers = specs.map(({ pattern, get }) => ({ alt: parsePattern(pattern), get }));
+    matchers = specs.map(({ pattern, get }) => ({ prog: compileProgram(parsePattern(pattern)), get }));
   } catch {
     return null;
   }
 
   return (profile: Profile) =>
-    matchers.some(({ alt, get }) => {
+    matchers.some(({ prog, get }) => {
       const value = get(profile);
-      return value.length > 0 && matchFull(alt, value);
+      return value.length > 0 && matchFull(prog, value);
     });
 }
 

--- a/extensions/windows-terminal/src/new-tab-menu.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.ts
@@ -385,6 +385,16 @@ function compileProgram(alt: AltNode): Inst {
   return frag.start;
 }
 
+// matchFull's total work is O(program size × value length): the NFA can't backtrack exponentially,
+// but a program well within MAX_PROGRAM_SIZE run against a long field value is still a lot of
+// arithmetic — e.g. (a|b){0,4000} compiles to a modest program but keeps thousands of live threads,
+// and matching it against a long commandline could take tens of millions of steps, run
+// synchronously during rendering, once per profile per resolution pass. This budget bounds that
+// total, independent of both factors, the same "give up and report no match" fallback
+// MAX_PROGRAM_SIZE already uses for a pattern that's too large to compile at all.
+const MAX_MATCH_STEPS = 200000;
+type StepBudget = { remaining: number };
+
 // \b sits between a word character and a non-word one, counting the space off either end of the
 // value as non-word — so it holds at both ends of "PowerShell" but not inside it.
 const isWordChar = (ch: string | undefined) => ch !== undefined && /\w/.test(ch);
@@ -402,9 +412,10 @@ function isWordBoundary(str: string, pos: number): boolean {
 // Walked with an explicit stack, not recursion — a flat run of thousands of optional atoms
 // (a?a?a?...) chains that many `split`s in a row, and recursing that chain would grow the JS call
 // stack with the pattern's size, independent of how long the string being matched is.
-function addThread(list: Inst[], visited: Set<Inst>, start: Inst, pos: number, str: string): void {
+function addThread(list: Inst[], visited: Set<Inst>, start: Inst, pos: number, str: string, budget: StepBudget): void {
   const stack: Inst[] = [start];
   while (stack.length > 0) {
+    if (budget.remaining-- <= 0) return;
     const inst = stack.pop()!;
     if (visited.has(inst)) continue;
     visited.add(inst);
@@ -428,11 +439,13 @@ function addThread(list: Inst[], visited: Set<Inst>, start: Inst, pos: number, s
 // of recursing per character the way a backtracking engine would. Every thread advances together, so
 // the call stack never grows with the length of `str` or with the pattern's backtracking search
 // space — a 2,000-character value and a pathological pattern like (a+)+ cost the same handful of
-// stack frames as a one-character match, and total work is bounded by str.length × the pattern's
-// compiled size, so nothing can blow up exponentially and no step budget is needed.
+// stack frames as a one-character match. Total work is bounded by str.length × the pattern's
+// compiled size, so nothing can blow up exponentially, but that product can still be large for a
+// big program and a long value — MAX_MATCH_STEPS caps it.
 function matchFull(prog: Inst, str: string): boolean {
+  const budget: StepBudget = { remaining: MAX_MATCH_STEPS };
   let current: Inst[] = [];
-  addThread(current, new Set(), prog, 0, str);
+  addThread(current, new Set(), prog, 0, str, budget);
 
   for (let pos = 0; pos < str.length; pos++) {
     if (current.length === 0) return false;
@@ -440,8 +453,9 @@ function matchFull(prog: Inst, str: string): boolean {
     const visited = new Set<Inst>();
     const ch = str[pos];
     for (const inst of current) {
-      if (inst.op === "char" && inst.test(ch)) addThread(next, visited, inst.next!, pos + 1, str);
-      else if (inst.op === "any") addThread(next, visited, inst.next!, pos + 1, str);
+      if (budget.remaining-- <= 0) return false;
+      if (inst.op === "char" && inst.test(ch)) addThread(next, visited, inst.next!, pos + 1, str, budget);
+      else if (inst.op === "any") addThread(next, visited, inst.next!, pos + 1, str, budget);
     }
     current = next;
   }
@@ -452,9 +466,10 @@ function matchFull(prog: Inst, str: string): boolean {
 // A matchProfiles entry matches a profile when ANY provided field (name/commandline/source)
 // fully matches that field's regex — mirrors Windows Terminal's MatchProfilesEntry. Empty profile
 // fields never match, so "source": ".*" skips local profiles and "commandline": ".*" skips
-// profiles without a command line. An entry with no patterns, or a regex that is malformed,
-// unsupported, or too large to compile, matches nothing rather than crashing or matching all —
-// compilation happens here, once per entry, so a refused pattern can't throw during rendering.
+// profiles without a command line. An entry with no patterns, a regex that is malformed or
+// unsupported, one too large to compile, or one whose match against a particular value runs past
+// MAX_MATCH_STEPS, all resolve the same way: that value doesn't match, rather than crashing or
+// matching everything.
 export function buildProfileMatcher(entry: NewTabMenuEntry): ((profile: Profile) => boolean) | null {
   const specs: { pattern: string; get: (profile: Profile) => string }[] = [];
   if (entry.name !== undefined) specs.push({ pattern: entry.name, get: (p) => p.name });

--- a/extensions/windows-terminal/src/new-tab-menu.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.ts
@@ -26,6 +26,11 @@ export interface NewTabMenuEntry {
 // (dev|prod)+, still matches normally, and so does (a+)+. A large bounded quantifier, like
 // (a|b){0,4000} or (|a){2,4000}, is unbounded in practice too — compileCountedRepeat gives it a
 // counter instead of unrolling it, so the compiled size doesn't grow with the bound.
+//
+// What the engine can't do, it says so: a construct it doesn't implement, a pattern too large to
+// compile, or a match that runs past MAX_MATCH_STEPS all throw UnsupportedPatternError out of
+// buildProfileMatcher, so the caller can tell "this profile doesn't match" from "this pattern
+// couldn't be evaluated" and say so instead of quietly dropping profiles from the menu.
 type AtomNode =
   | { kind: "char"; test: (ch: string) => boolean }
   | { kind: "any" }
@@ -37,8 +42,12 @@ type QuantNode = { atom: AtomNode; min: number; max: number; greedy: boolean };
 type SeqNode = { atoms: QuantNode[] };
 type AltNode = { options: SeqNode[] };
 
+// A malformed pattern — one Windows Terminal's own regex engine would reject too, so the entry
+// matches nothing there as well.
 class RegexSyntaxError extends Error {}
-class RegexTooLargeError extends Error {}
+// A pattern that's valid for Windows Terminal but that this engine can't evaluate: a construct it
+// doesn't implement, one too large to compile, or a match that runs past MAX_MATCH_STEPS.
+export class UnsupportedPatternError extends Error {}
 
 // compileQuant unrolls a *small* {n,m} into that many copies of the atom — cheap, and it's what
 // lets a bounded quantifier nest freely inside another (e.g. (a?)*). A *large* bound instead
@@ -48,9 +57,10 @@ class RegexTooLargeError extends Error {}
 // quantifier size — e.g. an alternation with an implausible number of branches.
 const MAX_PROGRAM_SIZE = 50000;
 
-// Below this, compileQuant unrolls a {n,m} into that many literal copies (cheap, and lets it nest
-// inside another large quantifier); at or above it, compileCountedRepeat is used instead — it can't
-// nest inside another counted repeat, but the compiled size no longer scales with the bound.
+// Below this, compileQuant unrolls a {n,m} into that many literal copies (cheap); at or above it,
+// compileCountedRepeat is used instead, and the compiled size no longer scales with the bound. A
+// counted repeat can't nest inside another one, so inside its body every quantifier unrolls
+// regardless of size (see insideCountedRepeat).
 const UNROLL_THRESHOLD = 20;
 
 // Parses the subset of ICU regex syntax (the flavor Windows Terminal itself matches with) that
@@ -58,13 +68,16 @@ const UNROLL_THRESHOLD = 20;
 // etc.), the `\b`/`\B` word-boundary assertions, `[...]` classes, `(...)`/`(?:...)` groups, the
 // `(?i)`/`(?i:...)` case-insensitivity flag, `|` alternation, and `* + ? {n,m}` quantifiers (with
 // lazy `?` variants). Anything else — lookaround, backreferences, unicode property escapes — is
-// unsupported and throws, which buildProfileMatcher treats the same as a malformed pattern.
+// unsupported and throws UnsupportedPatternError; a malformed pattern throws RegexSyntaxError.
 function parsePattern(pattern: string): AltNode {
   let i = 0;
   const n = pattern.length;
   const peek = () => pattern[i];
   const fail = (msg: string): never => {
     throw new RegexSyntaxError(msg);
+  };
+  const unsupported = (msg: string): never => {
+    throw new UnsupportedPatternError(msg);
   };
 
   // Set by (?i) and restored when the enclosing group closes, mirroring ICU: the flag runs from
@@ -73,8 +86,9 @@ function parsePattern(pattern: string): AltNode {
   let ignoreCase = false;
   // parseAtom recurses into parseAlt for every "(" — this bounds that recursion, since the parser
   // (unlike matchFull's explicit-stack VM) has no other stack-safety guard. Nothing near this depth
-  // is a realistic matchProfiles pattern; it exists so a pathologically deep one fails cleanly as
-  // "malformed" like any other unsupported pattern, instead of overflowing the call stack.
+  // is a realistic matchProfiles pattern; it exists so a pathologically deep one is reported as
+  // unsupported, like any other construct past this engine's limits, instead of overflowing the
+  // call stack.
   let groupDepth = 0;
   const MAX_GROUP_DEPTH = 100;
   const foldCase = (test: (ch: string) => boolean) => {
@@ -129,7 +143,7 @@ function parsePattern(pattern: string): AltNode {
         // unbounded {n,}. Checked on the parsed value, not the digit-string length, so a
         // zero-padded bound like {0000000005,10} isn't wrongly rejected as "too large" — no real
         // matchProfiles pattern needs a bound anywhere near this size either way.
-        if (min > 1e9 || (max !== Infinity && max > 1e9)) return fail("quantifier bound too large");
+        if (min > 1e9 || (max !== Infinity && max > 1e9)) return unsupported("quantifier bound too large");
         if (max < min) return fail("quantifier bounds out of order");
         quantified = true;
         i += braces[0].length;
@@ -160,7 +174,7 @@ function parsePattern(pattern: string): AltNode {
       if (peek() === "?") {
         // "?:" plain group, "?i)" / "?-i)" a flag switch, "?i:" a flag scoped to this group.
         const modifier = /^\?(-?)(i*)([:)])/.exec(pattern.slice(i));
-        if (!modifier) return fail("unsupported group modifier");
+        if (!modifier) return unsupported("group modifier not implemented");
         const [consumed, disable, flags, delimiter] = modifier;
         if (flags === "" && delimiter === ")") return fail("empty inline flags");
         if (flags !== "") ignoreCase = disable !== "-";
@@ -169,7 +183,7 @@ function parsePattern(pattern: string): AltNode {
         // ignoreCase set for whatever follows it in the enclosing group.
         if (delimiter === ")") return { kind: "group", alt: { options: [{ atoms: [] }] } };
       }
-      if (++groupDepth > MAX_GROUP_DEPTH) return fail("pattern nested too deeply");
+      if (++groupDepth > MAX_GROUP_DEPTH) return unsupported("pattern nested too deeply");
       const alt = parseAlt();
       groupDepth--;
       if (peek() !== ")") return fail("unbalanced parenthesis");
@@ -221,7 +235,7 @@ function parsePattern(pattern: string): AltNode {
     // An escaped letter or digit that isn't one of the above is a construct this engine doesn't
     // implement (\A, \p{...}, a backreference). Reject the pattern rather than matching it as a
     // literal, which would silently match the wrong profiles.
-    if (/[A-Za-z0-9]/.test(c)) return fail(`unsupported escape "\\${c}"`);
+    if (/[A-Za-z0-9]/.test(c)) return unsupported(`escape "\\${c}" not implemented`);
     return charAtom((ch) => ch === c);
   }
 
@@ -241,7 +255,7 @@ function parsePattern(pattern: string): AltNode {
     if (esc === undefined) return fail("trailing backslash");
     const predicate = escapePredicates[esc];
     if (predicate !== undefined) return { predicate };
-    if (/[A-Za-z0-9]/.test(esc)) return fail(`unsupported escape "\\${esc}"`);
+    if (/[A-Za-z0-9]/.test(esc)) return unsupported(`escape "\\${esc}" not implemented`);
     return { literal: esc };
   }
 
@@ -254,6 +268,11 @@ function parsePattern(pattern: string): AltNode {
     }
     const tests: ((ch: string) => boolean)[] = [];
     while (i < n && peek() !== "]") {
+      // ICU reads an unescaped "[" inside a set as a nested set ([[:alpha:]], [a-z[0-9]]) and "&&"
+      // as set intersection ([a-z&&[^m]]). Neither is implemented; reading them as literals would
+      // quietly match the wrong profiles, so report them instead.
+      if (peek() === "[") return unsupported("nested character set not implemented");
+      if (pattern.startsWith("&&", i)) return unsupported("character set intersection not implemented");
       const startAtom = parseClassAtom();
       if ("predicate" in startAtom) {
         tests.push(startAtom.predicate);
@@ -300,8 +319,8 @@ type SplitInst = { op: "split"; next?: Inst; next2?: Inst };
 type NopInst = { op: "nop"; next?: Inst };
 type MatchInst = { op: "match" };
 // A counted repeat: one shared instruction, however large `max` is. `bodyStart` is entered again
-// each rep instead of being duplicated per rep — see compileCountedRepeat and the `count`/`countFor`
-// fields threads carry through addThread/matchFull.
+// each rep instead of being duplicated per rep — see compileCountedRepeat and the `lo`/`hi`/
+// `countFor` fields threads carry through addThread/matchFull.
 type RepeatInst = { op: "repeat"; min: number; max: number; bodyStart: Inst; next?: Inst };
 // The body's own exit, patched to loop back through here rather than straight to `repeat`, so the
 // matcher can tell "just finished one more rep of this repeat" apart from "entering it fresh".
@@ -331,9 +350,16 @@ type Frag = { start: Inst; out: PatchSlot[] };
 let instructionCount = 0;
 
 function newInst<T extends Inst>(inst: T): T {
-  if (++instructionCount > MAX_PROGRAM_SIZE) throw new RegexTooLargeError("pattern is too large to compile");
+  if (++instructionCount > MAX_PROGRAM_SIZE) throw new UnsupportedPatternError("pattern is too large to compile");
   return inst;
 }
+
+// True while compileCountedRepeat compiles its body. A thread carries a single counter (see
+// Thread), so it can't track two counted repeats at once — every quantifier inside the body
+// unrolls instead, whatever its size, and stays plain instructions the outer count passes through
+// untouched. That's how (a{21}){21} or ((a|b){200}){200} compile; MAX_PROGRAM_SIZE still bounds
+// how large the unrolled body can get.
+let insideCountedRepeat = false;
 
 function patch(out: PatchSlot[], target: Inst): void {
   for (const p of out) {
@@ -417,17 +443,6 @@ function usesCounter(q: QuantNode): boolean {
   return q.min > UNROLL_THRESHOLD || q.max - q.min > UNROLL_THRESHOLD;
 }
 
-// compileCountedRepeat's counter is a single (count, countFor) pair per thread, not a stack, so it
-// can't tell two active counted repeats apart — exiting the inner one resets countFor (see the
-// "repeat" case in addThread) and loses the outer count. So a large quantifier whose body contains
-// another *large* quantifier, e.g. ((a|b){200}){200}, can't go through it. A small quantifier inside
-// the body is fine: it unrolls into plain instructions that carry the thread's count through
-// untouched, so (a?){2,4000} or (a{2}){2,4000} compile and match normally.
-function hasNestedCountedRepeat(atom: AtomNode): boolean {
-  if (atom.kind !== "group") return false;
-  return atom.alt.options.some((seq) => seq.atoms.some((q) => usesCounter(q) || hasNestedCountedRepeat(q.atom)));
-}
-
 // Whether `atom` matches the empty string unconditionally — an empty alternative, or one made only
 // of optional atoms. Anchors and \b don't count: they're zero-width but conditional on position.
 function isNullable(atom: AtomNode): boolean {
@@ -438,21 +453,24 @@ function isNullable(atom: AtomNode): boolean {
 // Compiles atom{min,max} (max possibly Infinity) as one `repeat` instruction plus one copy of the
 // atom's body, instead of unrolling — see the `repeat`/`increment` handling in addThread for how a
 // thread's counter takes the place of the copies compileQuant's other branch would otherwise make.
-// The body can be anything a small quantifier could wrap — nullable alternatives like (|a),
-// differently-sized ones like (a|aa), an unrolled quantifier — because the matcher dedupes threads
-// inside a counted repeat by their exact count (see hasVisited), never by assuming reps line up
-// with string positions.
+// The body can be anything — nullable alternatives like (|a), differently-sized ones like (a|aa),
+// another quantifier (unrolled, see insideCountedRepeat) — because the matcher tracks exactly
+// which counts have reached each instruction (see Thread and VisitedState), never assuming reps
+// line up with string positions.
 function compileCountedRepeat(atom: AtomNode, min: number, max: number): Frag {
-  if (hasNestedCountedRepeat(atom)) {
-    throw new RegexTooLargeError("a quantifier this large can't wrap another quantifier this large");
-  }
   // A body that can always match empty makes `min` meaningless — any shortfall is made up with
   // empty reps at no cost — so (|a){3000,4000} accepts exactly what (|a){0,4000} does. Compiling
-  // it as the latter matters for cost, not just tidiness: below `min` every count is a distinct
-  // state (see VisitedState), and a nullable body reaches all of them at every single position.
+  // it as the latter matters for cost, not just tidiness: a nullable body climbs through every
+  // count below `min` at every single position, one closure step each.
   if (isNullable(atom)) min = 0;
   const repeat: RepeatInst = newInst({ op: "repeat", min, max, bodyStart: undefined as unknown as Inst });
-  const body = compileAtom(atom);
+  insideCountedRepeat = true;
+  let body: Frag;
+  try {
+    body = compileAtom(atom);
+  } finally {
+    insideCountedRepeat = false;
+  }
   const increment: IncrementInst = newInst({ op: "increment", repeat });
   patch(body.out, increment);
   repeat.bodyStart = body.start;
@@ -463,7 +481,7 @@ function compileCountedRepeat(atom: AtomNode, min: number, max: number): Frag {
 // record — irrelevant here, since buildProfileMatcher only ever asks "does the whole field match"
 // (see matchFull). So greedy and lazy compile identically; `q.greedy` is parsed but never consulted.
 function compileQuant(q: QuantNode): Frag {
-  if (usesCounter(q)) return compileCountedRepeat(q.atom, q.min, q.max);
+  if (!insideCountedRepeat && usesCounter(q)) return compileCountedRepeat(q.atom, q.min, q.max);
   if (q.max === Infinity) {
     if (q.min === 0) return starFrag(q.atom);
     return concat(repeatFrag(q.atom, q.min - 1), plusFrag(q.atom));
@@ -488,77 +506,124 @@ function compileAlt(alt: AltNode): Frag {
 
 function compileProgram(alt: AltNode): Inst {
   instructionCount = 0;
+  insideCountedRepeat = false;
   const frag = compileAlt(alt);
   const matchInst: MatchInst = newInst({ op: "match" });
   patch(frag.out, matchInst);
   return frag.start;
 }
 
-// A backstop, not the primary defense against slow matching — compileCountedRepeat is, since it
-// keeps a large bound's matching cost independent of the bound itself. What's left for this budget
-// to catch: several moderate constructs compounding within one pattern, or anything unforeseen.
-// It's generous — matching a large bound against a value that size measures in the tens of
+// A backstop, not the primary defense against slow matching — compileCountedRepeat and the count
+// ranges threads carry (see Thread) are, since together they keep a large bound's matching cost
+// independent of the bound itself. What's left for this budget to catch: several moderate
+// constructs compounding within one pattern, or anything unforeseen. Running out of it throws
+// UnsupportedPatternError rather than reporting "no match" — the two mean different things to the
+// menu. It's generous: matching a large bound against a value that size measures in the tens of
 // thousands of steps (see new-tab-menu.test.ts), so this is headroom, not a tight fit.
 const MAX_MATCH_STEPS = 1000000;
 type StepBudget = { remaining: number };
 
+function spend(budget: StepBudget): void {
+  if (budget.remaining-- <= 0) throw new UnsupportedPatternError("matching it takes too many steps");
+}
+
 // A live NFA thread: which instruction it's at, plus the counter compileCountedRepeat's `repeat`/
-// `increment` instructions read and write. `countFor` names which `repeat` instruction `count`
+// `increment` instructions read and write. `countFor` names which `repeat` instruction the counter
 // belongs to, as a direct reference (not an id looked up in shared state — a `matchProfiles` entry
 // compiles one program per field, and a lookup table reset by each compile would leave an earlier
 // field's threads reading another field's repeat metadata once all fields are later matched). A
 // thread not currently inside a counted repeat carries a `countFor` of null, so `repeat` treats it
 // as a fresh entry (see the "repeat" case in addThread).
-type Thread = { inst: Inst; count: number; countFor: RepeatInst | null };
+//
+// The counter is a range, `lo`..`hi` inclusive, not one number: every count in it has reached this
+// instruction at this position, and one thread stands in for all of them (see enqueue). Nothing
+// less keeps ".*a{1000,4000}" linear — the `.*` enters the repeat at every position, so at
+// position p the body is live with every count from 0 to p, and counts below `min` can't be pruned
+// against each other: a lower one still has more mandatory reps ahead, a higher one has less room
+// before `max`, so neither can stand in for the other. Kept as one range, they cost one thread —
+// when they're contiguous. A body whose alternatives differ in width by 2 or more, like (a|aaa),
+// reaches counts with gaps between them that no merge can close, so below `min` those stay
+// separate threads and the cost is back to O(length × min). That shape is what MAX_MATCH_STEPS is
+// still there to catch, and it fails visibly (see spend) rather than as a non-match.
+type Thread = { inst: Inst; lo: number; hi: number; countFor: RepeatInst | null };
 const NO_REPEAT = null;
 
-// Instructions outside any counted repeat dedupe by identity alone (`plain`) — same as before this
-// engine had a counted-repeat mechanism at all. Instructions reached *while inside* one are keyed
-// by their exact `count` too (`scoped`): the same instruction at the same position with a
-// different count is a genuinely different state, because the count decides how many more reps
-// are still mandatory (below `min`) or still allowed (up to `max`). Nothing about the body is
-// assumed — a prefix like (?:x|xa) can enter the repeat at two different positions, so two threads
-// with different counts legitimately share an instruction at every later position, and merging
-// them (as an earlier "cap the count at min" key did) silently drops the one that could still reach
-// `max`.
+// What's already been queued at the current string position. Instructions outside any counted
+// repeat dedupe by identity alone (`plain`). Instructions reached *while inside* one are keyed by
+// their exact count range too (`scoped`): the same instruction at the same position with different
+// counts is a genuinely different state, because the count decides how many more reps are still
+// mandatory (below `min`) or still allowed (up to `max`). Nothing about the body is assumed — a
+// prefix like (?:x|xa) can enter the repeat at two different positions, so two threads with
+// different counts legitimately share an instruction at every later position, and collapsing
+// them onto one key (as an earlier "cap the count at min" key did) silently drops the one that
+// could still reach `max`.
 //
-// `lowestSettled` is the one pruning that IS sound: once a thread's count is at or above `min`, a
-// lower count can do everything a higher one can (exit now, or keep going — for longer), so a
-// thread whose count is ≥ min is redundant whenever a thread at the same instruction with a count
-// in [min, count] has already been queued at this position. That's what keeps something like
-// ".*a{0,12000}" linear instead of carrying every possible count along at every position.
-type VisitedState = { plain: Set<Inst>; scoped: Map<Inst, Set<number>>; lowestSettled: Map<Inst, number> };
+// Two prunings ARE sound on top of that. `lowestSettled`: once a count is at or above `min`, a
+// lower such count can do everything a higher one can (exit now, or keep going — for longer), so
+// it records the lowest count ≥ min queued at each instruction and any count above it is dropped.
+// That's what keeps ".*a{0,12000}" from carrying every possible count along at every position.
+// `queued`: the threads already waiting at each consuming instruction, so a range that touches or
+// overlaps one of them merges into it (see enqueue) instead of queuing separately — the ranges
+// that make ".*a{1000,4000}" linear are built here, one merge per position.
+type VisitedState = {
+  plain: Set<Inst>;
+  scoped: Map<Inst, Set<string>>;
+  lowestSettled: Map<Inst, number>;
+  queued: Map<Inst, Thread[]>;
+};
 
 function newVisited(): VisitedState {
-  return { plain: new Set(), scoped: new Map(), lowestSettled: new Map() };
+  return { plain: new Set(), scoped: new Map(), lowestSettled: new Map(), queued: new Map() };
 }
 
-function hasVisited(visited: VisitedState, thread: Thread): boolean {
-  const { inst, count, countFor } = thread;
-  if (countFor === NO_REPEAT) return visited.plain.has(inst);
-  if (count >= countFor.min) {
-    const lowest = visited.lowestSettled.get(inst);
-    if (lowest !== undefined && lowest <= count) return true;
-  }
-  return visited.scoped.get(inst)?.has(count) ?? false;
-}
-
-function markVisited(visited: VisitedState, thread: Thread): void {
-  const { inst, count, countFor } = thread;
+// Records the thread at this position and returns what's left of it to explore — its range trimmed
+// of counts `lowestSettled` makes redundant — or null if it adds nothing new.
+function visit(visited: VisitedState, thread: Thread): Thread | null {
+  const { inst, countFor } = thread;
   if (countFor === NO_REPEAT) {
+    if (visited.plain.has(inst)) return null;
     visited.plain.add(inst);
-    return;
+    return thread;
+  }
+  const { lo } = thread;
+  let { hi } = thread;
+  const lowest = visited.lowestSettled.get(inst);
+  if (lowest !== undefined && lowest <= hi) {
+    if (lowest <= lo) return null;
+    hi = lowest - 1;
   }
   let seen = visited.scoped.get(inst);
   if (!seen) {
     seen = new Set();
     visited.scoped.set(inst, seen);
   }
-  seen.add(count);
-  if (count >= countFor.min) {
-    const lowest = visited.lowestSettled.get(inst);
-    if (lowest === undefined || count < lowest) visited.lowestSettled.set(inst, count);
+  const key = `${lo},${hi}`;
+  if (seen.has(key)) return null;
+  seen.add(key);
+  // Anything ≥ min in this range is at most `lowest` - 1 (trimmed above), so this only ever lowers it.
+  if (hi >= countFor.min) visited.lowestSettled.set(inst, Math.max(lo, countFor.min));
+  return { inst, lo, hi, countFor };
+}
+
+// Queues a thread at a consuming instruction for the next position, merging its count range into a
+// thread already queued there when the two touch or overlap (see VisitedState.queued). Threads
+// outside a counted repeat have nothing to merge — `plain` already dedupes them by instruction.
+function enqueue(list: Thread[], visited: VisitedState, thread: Thread): void {
+  if (thread.countFor !== NO_REPEAT) {
+    let queued = visited.queued.get(thread.inst);
+    if (!queued) {
+      queued = [];
+      visited.queued.set(thread.inst, queued);
+    }
+    const neighbor = queued.find((other) => thread.lo <= other.hi + 1 && other.lo <= thread.hi + 1);
+    if (neighbor) {
+      neighbor.lo = Math.min(neighbor.lo, thread.lo);
+      neighbor.hi = Math.max(neighbor.hi, thread.hi);
+      return;
+    }
+    queued.push(thread);
   }
+  list.push(thread);
 }
 
 // \b sits between a word character and a non-word one, counting the space off either end of the
@@ -588,43 +653,36 @@ function addThread(
 ): void {
   const stack: Thread[] = [start];
   while (stack.length > 0) {
-    if (budget.remaining-- <= 0) return;
-    const thread = stack.pop()!;
-    const inst = thread.inst;
-    if (hasVisited(visited, thread)) continue;
-    markVisited(visited, thread);
-    const { count, countFor } = thread;
+    spend(budget);
+    const thread = visit(visited, stack.pop()!);
+    if (!thread) continue;
+    const { inst, lo, hi, countFor } = thread;
     if (inst.op === "split") {
-      stack.push({ inst: inst.next2!, count, countFor }, { inst: inst.next!, count, countFor });
+      stack.push({ inst: inst.next2!, lo, hi, countFor }, { inst: inst.next!, lo, hi, countFor });
     } else if (inst.op === "nop") {
-      stack.push({ inst: inst.next!, count, countFor });
+      stack.push({ inst: inst.next!, lo, hi, countFor });
     } else if (inst.op === "start") {
-      if (pos === 0) stack.push({ inst: inst.next!, count, countFor });
+      if (pos === 0) stack.push({ inst: inst.next!, lo, hi, countFor });
     } else if (inst.op === "end") {
-      if (pos === str.length) stack.push({ inst: inst.next!, count, countFor });
+      if (pos === str.length) stack.push({ inst: inst.next!, lo, hi, countFor });
     } else if (inst.op === "boundary") {
-      if (isWordBoundary(str, pos) !== inst.negate) stack.push({ inst: inst.next!, count, countFor });
+      if (isWordBoundary(str, pos) !== inst.negate) stack.push({ inst: inst.next!, lo, hi, countFor });
     } else if (inst.op === "repeat") {
       // A thread not already inside this repeat (countFor doesn't match) is entering fresh, at 0.
-      const reps = countFor === inst ? count : 0;
-      if (reps < inst.min) {
-        // Below the minimum: another rep is mandatory, no option to stop yet.
-        stack.push({ inst: inst.bodyStart, count: reps, countFor: inst });
-      } else if (inst.max === Infinity || reps < inst.max) {
-        // Within range: try one more rep, but stopping here is also valid (mirrors optionalFrag).
-        // Exiting resets countFor to NO_REPEAT — carrying this repeat's count/countFor past
-        // `next` would let it reach a later, unrelated `repeat` instruction still tagged as
-        // "inside" this one, corrupting that instruction's own dedup key and reps count.
-        stack.push({ inst: inst.next!, count: 0, countFor: NO_REPEAT });
-        stack.push({ inst: inst.bodyStart, count: reps, countFor: inst });
-      } else {
-        // At the maximum: no more reps allowed.
-        stack.push({ inst: inst.next!, count: 0, countFor: NO_REPEAT });
-      }
+      const [from, to] = countFor === inst ? [lo, hi] : [0, 0];
+      // Any count at or above the minimum may stop here (mirrors optionalFrag). Exiting resets the
+      // counter to NO_REPEAT — carrying this repeat's counter past `next` would let it reach a
+      // later, unrelated `repeat` instruction still tagged as "inside" this one, corrupting that
+      // instruction's own dedup key and reps count.
+      if (to >= inst.min) stack.push({ inst: inst.next!, lo: 0, hi: 0, countFor: NO_REPEAT });
+      // Any count below the maximum may run the body again — and of those at or above the
+      // minimum, only the lowest is worth keeping (see VisitedState.lowestSettled).
+      const again = Math.min(to, inst.max - 1, Math.max(from, inst.min));
+      if (from <= again) stack.push({ inst: inst.bodyStart, lo: from, hi: again, countFor: inst });
     } else if (inst.op === "increment") {
-      stack.push({ inst: inst.repeat, count: count + 1, countFor: inst.repeat });
+      stack.push({ inst: inst.repeat, lo: lo + 1, hi: hi + 1, countFor: inst.repeat });
     } else {
-      list.push(thread);
+      enqueue(list, visited, thread);
     }
   }
 }
@@ -635,13 +693,13 @@ function addThread(
 // the call stack never grows with the length of `str` or with the pattern's backtracking search
 // space — a 2,000-character value and a pathological pattern like (a+)+ cost the same handful of
 // stack frames as a one-character match. Work per position is bounded by the pattern's compiled
-// size times the distinct repeat counts still alive there (see VisitedState) — for any realistic
-// pattern that's a handful — so nothing can blow up exponentially; MAX_MATCH_STEPS is a backstop
-// for what's left.
+// size times the distinct repeat count ranges still alive there (see VisitedState) — for any
+// realistic pattern that's a handful — so nothing can blow up exponentially; MAX_MATCH_STEPS is a
+// backstop for what's left, and running out of it throws rather than answering "no match".
 function matchFull(prog: Inst, str: string): boolean {
   const budget: StepBudget = { remaining: MAX_MATCH_STEPS };
   let current: Thread[] = [];
-  addThread(current, newVisited(), { inst: prog, count: 0, countFor: NO_REPEAT }, 0, str, budget);
+  addThread(current, newVisited(), { inst: prog, lo: 0, hi: 0, countFor: NO_REPEAT }, 0, str, budget);
 
   for (let pos = 0; pos < str.length; pos++) {
     if (current.length === 0) return false;
@@ -654,14 +712,14 @@ function matchFull(prog: Inst, str: string): boolean {
     // order, every count would survive at every position and the budget would run out on a
     // perfectly ordinary long value. Counts only ever grow by one per `increment` or reset to
     // zero on exit, so sorting here keeps that dominance order through the whole step.
-    current.sort((a, b) => a.count - b.count);
+    current.sort((a, b) => a.lo - b.lo);
     for (const thread of current) {
-      if (budget.remaining-- <= 0) return false;
-      const inst = thread.inst;
-      const { count, countFor } = thread;
+      spend(budget);
+      const { inst, lo, hi, countFor } = thread;
       if (inst.op === "char" && inst.test(ch))
-        addThread(next, visited, { inst: inst.next!, count, countFor }, pos + 1, str, budget);
-      else if (inst.op === "any") addThread(next, visited, { inst: inst.next!, count, countFor }, pos + 1, str, budget);
+        addThread(next, visited, { inst: inst.next!, lo, hi, countFor }, pos + 1, str, budget);
+      else if (inst.op === "any")
+        addThread(next, visited, { inst: inst.next!, lo, hi, countFor }, pos + 1, str, budget);
     }
     current = next;
   }
@@ -673,10 +731,12 @@ function matchFull(prog: Inst, str: string): boolean {
 // A matchProfiles entry matches a profile when ANY provided field (name/commandline/source)
 // fully matches that field's regex — mirrors Windows Terminal's MatchProfilesEntry. Empty profile
 // fields never match, so "source": ".*" skips local profiles and "commandline": ".*" skips
-// profiles without a command line. An entry with no patterns, a regex that is malformed or
-// unsupported, one too large to compile, or one whose match against a particular value runs past
-// MAX_MATCH_STEPS, all resolve the same way: that value doesn't match, rather than crashing or
-// matching everything.
+// profiles without a command line. An entry with no patterns, or with a malformed regex, matches
+// nothing (returns null) — Windows Terminal rejects those too. A pattern that's valid there but
+// that this engine can't evaluate is different: it throws UnsupportedPatternError, naming the
+// pattern, either here (a construct not implemented, or too large to compile) or from the returned
+// matcher (a match that runs past MAX_MATCH_STEPS), so the caller can say so rather than showing
+// an order that silently leaves profiles out.
 export function buildProfileMatcher(entry: NewTabMenuEntry): ((profile: Profile) => boolean) | null {
   const specs: { pattern: string; get: (profile: Profile) => string }[] = [];
   if (entry.name !== undefined) specs.push({ pattern: entry.name, get: (p) => p.name });
@@ -684,17 +744,36 @@ export function buildProfileMatcher(entry: NewTabMenuEntry): ((profile: Profile)
   if (entry.source !== undefined) specs.push({ pattern: entry.source, get: (p) => p.source ?? "" });
   if (specs.length === 0) return null;
 
-  let matchers: { prog: Inst; get: (profile: Profile) => string }[];
+  const unsupported = (pattern: string, error: unknown): never => {
+    if (error instanceof UnsupportedPatternError) {
+      throw new UnsupportedPatternError(`Can't evaluate the matchProfiles pattern "${pattern}": ${error.message}`);
+    }
+    throw error;
+  };
+
+  let matchers: { pattern: string; prog: Inst; get: (profile: Profile) => string }[];
   try {
-    matchers = specs.map(({ pattern, get }) => ({ prog: compileProgram(parsePattern(pattern)), get }));
-  } catch {
-    return null;
+    matchers = specs.map(({ pattern, get }) => {
+      try {
+        return { pattern, prog: compileProgram(parsePattern(pattern)), get };
+      } catch (error) {
+        return unsupported(pattern, error);
+      }
+    });
+  } catch (error) {
+    if (error instanceof RegexSyntaxError) return null;
+    throw error;
   }
 
   return (profile: Profile) =>
-    matchers.some(({ prog, get }) => {
+    matchers.some(({ pattern, prog, get }) => {
       const value = get(profile);
-      return value.length > 0 && matchFull(prog, value);
+      if (value.length === 0) return false;
+      try {
+        return matchFull(prog, value);
+      } catch (error) {
+        return unsupported(pattern, error);
+      }
     });
 }
 
@@ -703,6 +782,8 @@ export function buildProfileMatcher(entry: NewTabMenuEntry): ((profile: Profile)
 // "matchProfiles" entry anywhere (including inside folders). Pass 2 walks the tree again to
 // build the final order — "remainingProfiles" expands to profiles NOT in that pass-1 set, at
 // the position it appears, so a later explicit reference still lands after the remainder.
+// A matchProfiles pattern this extension can't evaluate throws UnsupportedPatternError out of
+// here (see buildProfileMatcher) — an order computed without it would be wrong, not just partial.
 export function resolveNewTabMenuOrder(profiles: Profile[], newTabMenu: NewTabMenuEntry[]): string[] {
   const referenced = new Set<string>();
 

--- a/extensions/windows-terminal/src/new-tab-menu.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.ts
@@ -63,6 +63,20 @@ const MAX_PROGRAM_SIZE = 50000;
 // regardless of size (see insideCountedRepeat).
 const UNROLL_THRESHOLD = 20;
 
+// ICU's character classes, not JavaScript's ASCII-only ones — Windows Terminal matches with ICU,
+// where \w covers letters, marks, decimal digits, and connector punctuation in any script
+// ("Développement"), \d any script's decimal digits ("١٢٣"), \s is [\t\n\f\r\p{Z}], and \b is
+// defined in terms of that \w ("\bÉquipe\b"). Values and patterns are walked by code point, not
+// UTF-16 code unit, so "." consumes all of "🚀" — and, as in ICU without its DOTALL flag, "."
+// stops at a line terminator.
+const isWordChar = (ch: string) => /[\p{Alphabetic}\p{M}\p{Nd}\p{Pc}\p{Join_Control}]/u.test(ch);
+const isDigit = (ch: string) => /\p{Nd}/u.test(ch);
+const isSpace = (ch: string) => /[\t\n\f\r\p{Z}]/u.test(ch);
+// U+000A-U+000D, U+0085, U+2028, U+2029 — ICU's line terminators (spelled as code points: U+2028/9 are
+// line separators, and a literal one would end the regex line it sits on).
+const LINE_TERMINATORS = new Set([0x0a, 0x0b, 0x0c, 0x0d, 0x85, 0x2028, 0x2029]);
+const isLineTerminator = (ch: string) => LINE_TERMINATORS.has(ch.codePointAt(0)!);
+
 // Parses the subset of ICU regex syntax (the flavor Windows Terminal itself matches with) that
 // matchProfiles patterns actually use: literals, `.`, escapes (`\d\w\s` and their negations, `\.`
 // etc.), the `\b`/`\B` word-boundary assertions, `[...]` classes, `(...)`/`(?:...)` groups, the
@@ -71,8 +85,10 @@ const UNROLL_THRESHOLD = 20;
 // unsupported and throws UnsupportedPatternError; a malformed pattern throws RegexSyntaxError.
 function parsePattern(pattern: string): AltNode {
   let i = 0;
-  const n = pattern.length;
-  const peek = () => pattern[i];
+  const chars = Array.from(pattern);
+  const n = chars.length;
+  const peek = () => chars[i];
+  const rest = () => chars.slice(i).join("");
   const fail = (msg: string): never => {
     throw new RegexSyntaxError(msg);
   };
@@ -134,7 +150,7 @@ function parsePattern(pattern: string): AltNode {
       quantified = true;
       i++;
     } else if (c === "{") {
-      const braces = /^\{(\d+)(,(\d*))?\}/.exec(pattern.slice(i));
+      const braces = /^\{(\d+)(,(\d*))?\}/.exec(rest());
       if (braces) {
         min = parseInt(braces[1], 10);
         max = braces[2] === undefined ? min : braces[3] === "" ? Infinity : parseInt(braces[3], 10);
@@ -156,6 +172,10 @@ function parsePattern(pattern: string): AltNode {
     if (quantified && (atom.kind === "start" || atom.kind === "end" || atom.kind === "boundary")) {
       return fail("quantified anchor");
     }
+    // ICU's possessive quantifiers (a++, a*+, a?+, a{2}+) aren't implemented — and a "+" right
+    // after a quantifier means exactly that there, so it can't be left to read as a stray "+" and
+    // be reported as malformed.
+    if (quantified && peek() === "+") return unsupported("possessive quantifier not implemented");
     let greedy = true;
     if (peek() === "?") {
       greedy = false;
@@ -173,7 +193,7 @@ function parsePattern(pattern: string): AltNode {
       const outerIgnoreCase = ignoreCase;
       if (peek() === "?") {
         // "?:" plain group, "?i)" / "?-i)" a flag switch, "?i:" a flag scoped to this group.
-        const modifier = /^\?(-?)(i*)([:)])/.exec(pattern.slice(i));
+        const modifier = /^\?(-?)(i*)([:)])/.exec(rest());
         if (!modifier) return unsupported("group modifier not implemented");
         const [consumed, disable, flags, delimiter] = modifier;
         if (flags === "" && delimiter === ")") return fail("empty inline flags");
@@ -215,16 +235,16 @@ function parsePattern(pattern: string): AltNode {
   }
 
   const escapePredicates: Record<string, (ch: string) => boolean> = {
-    d: (ch) => ch >= "0" && ch <= "9",
-    D: (ch) => !(ch >= "0" && ch <= "9"),
-    w: (ch) => /\w/.test(ch),
-    W: (ch) => !/\w/.test(ch),
-    s: (ch) => /\s/.test(ch),
-    S: (ch) => !/\s/.test(ch),
+    d: isDigit,
+    D: (ch) => !isDigit(ch),
+    w: isWordChar,
+    W: (ch) => !isWordChar(ch),
+    s: isSpace,
+    S: (ch) => !isSpace(ch),
   };
 
   function parseEscape(): AtomNode {
-    const c = pattern[i];
+    const c = chars[i];
     i++;
     if (c === undefined) return fail("trailing backslash");
     // \b and \B are zero-width assertions about the surrounding characters, not the letters
@@ -244,13 +264,13 @@ function parsePattern(pattern: string): AltNode {
   // \s, or a negation) that can't — \d-9 has no meaningful "range from a whole digit class".
   type ClassAtom = { literal: string } | { predicate: (ch: string) => boolean };
   function parseClassAtom(): ClassAtom {
-    const c = pattern[i];
+    const c = chars[i];
     if (c !== "\\") {
       i++;
       return { literal: c };
     }
     i++;
-    const esc = pattern[i];
+    const esc = chars[i];
     i++;
     if (esc === undefined) return fail("trailing backslash");
     const predicate = escapePredicates[esc];
@@ -272,14 +292,14 @@ function parsePattern(pattern: string): AltNode {
       // as set intersection ([a-z&&[^m]]). Neither is implemented; reading them as literals would
       // quietly match the wrong profiles, so report them instead.
       if (peek() === "[") return unsupported("nested character set not implemented");
-      if (pattern.startsWith("&&", i)) return unsupported("character set intersection not implemented");
+      if (peek() === "&" && chars[i + 1] === "&") return unsupported("character set intersection not implemented");
       const startAtom = parseClassAtom();
       if ("predicate" in startAtom) {
         tests.push(startAtom.predicate);
         continue;
       }
       const start = startAtom.literal;
-      if (peek() === "-" && pattern[i + 1] !== "]" && i + 1 < n) {
+      if (peek() === "-" && chars[i + 1] !== "]" && i + 1 < n) {
         i++; // consume "-"
         const endAtom = parseClassAtom();
         if ("predicate" in endAtom) return fail("a character class can't end a range");
@@ -628,10 +648,10 @@ function enqueue(list: Thread[], visited: VisitedState, thread: Thread): void {
 
 // \b sits between a word character and a non-word one, counting the space off either end of the
 // value as non-word — so it holds at both ends of "PowerShell" but not inside it.
-const isWordChar = (ch: string | undefined) => ch !== undefined && /\w/.test(ch);
-
-function isWordBoundary(str: string, pos: number): boolean {
-  return isWordChar(str[pos - 1]) !== isWordChar(str[pos]);
+function isWordBoundary(chars: string[], pos: number): boolean {
+  const before = pos > 0 && isWordChar(chars[pos - 1]);
+  const after = pos < chars.length && isWordChar(chars[pos]);
+  return before !== after;
 }
 
 // Epsilon-closure: follows the zero-width instructions (`split`, `nop`, and the anchors when their
@@ -648,7 +668,7 @@ function addThread(
   visited: VisitedState,
   start: Thread,
   pos: number,
-  str: string,
+  chars: string[],
   budget: StepBudget,
 ): void {
   const stack: Thread[] = [start];
@@ -664,9 +684,9 @@ function addThread(
     } else if (inst.op === "start") {
       if (pos === 0) stack.push({ inst: inst.next!, lo, hi, countFor });
     } else if (inst.op === "end") {
-      if (pos === str.length) stack.push({ inst: inst.next!, lo, hi, countFor });
+      if (pos === chars.length) stack.push({ inst: inst.next!, lo, hi, countFor });
     } else if (inst.op === "boundary") {
-      if (isWordBoundary(str, pos) !== inst.negate) stack.push({ inst: inst.next!, lo, hi, countFor });
+      if (isWordBoundary(chars, pos) !== inst.negate) stack.push({ inst: inst.next!, lo, hi, countFor });
     } else if (inst.op === "repeat") {
       // A thread not already inside this repeat (countFor doesn't match) is entering fresh, at 0.
       const [from, to] = countFor === inst ? [lo, hi] : [0, 0];
@@ -698,14 +718,16 @@ function addThread(
 // backstop for what's left, and running out of it throws rather than answering "no match".
 function matchFull(prog: Inst, str: string): boolean {
   const budget: StepBudget = { remaining: MAX_MATCH_STEPS };
+  // One element per code point, so a surrogate pair like "🚀" is one character to the matcher.
+  const chars = Array.from(str);
   let current: Thread[] = [];
-  addThread(current, newVisited(), { inst: prog, lo: 0, hi: 0, countFor: NO_REPEAT }, 0, str, budget);
+  addThread(current, newVisited(), { inst: prog, lo: 0, hi: 0, countFor: NO_REPEAT }, 0, chars, budget);
 
-  for (let pos = 0; pos < str.length; pos++) {
+  for (let pos = 0; pos < chars.length; pos++) {
     if (current.length === 0) return false;
     const next: Thread[] = [];
     const visited = newVisited();
-    const ch = str[pos];
+    const ch = chars[pos];
     // Lowest count first, so a thread that dominates (see VisitedState.lowestSettled) is always
     // queued before the ones it makes redundant. The closure explores a body's first alternative
     // first, and for something like (a|aa){21,4000} that's the higher-count path — left in that
@@ -717,9 +739,9 @@ function matchFull(prog: Inst, str: string): boolean {
       spend(budget);
       const { inst, lo, hi, countFor } = thread;
       if (inst.op === "char" && inst.test(ch))
-        addThread(next, visited, { inst: inst.next!, lo, hi, countFor }, pos + 1, str, budget);
-      else if (inst.op === "any")
-        addThread(next, visited, { inst: inst.next!, lo, hi, countFor }, pos + 1, str, budget);
+        addThread(next, visited, { inst: inst.next!, lo, hi, countFor }, pos + 1, chars, budget);
+      else if (inst.op === "any" && !isLineTerminator(ch))
+        addThread(next, visited, { inst: inst.next!, lo, hi, countFor }, pos + 1, chars, budget);
     }
     current = next;
   }

--- a/extensions/windows-terminal/src/new-tab-menu.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.ts
@@ -22,7 +22,12 @@ export interface NewTabMenuEntry {
 // match fails rather than exploring further. That makes ALL patterns safe to run, including ones
 // that look risky, so nothing needs to be rejected up front — a repeated group with safe
 // alternatives, like (dev|prod)+, still matches normally.
-type AtomNode = { kind: "char"; test: (ch: string) => boolean } | { kind: "any" } | { kind: "group"; alt: AltNode };
+type AtomNode =
+  | { kind: "char"; test: (ch: string) => boolean }
+  | { kind: "any" }
+  | { kind: "group"; alt: AltNode }
+  | { kind: "start" }
+  | { kind: "end" };
 type QuantNode = { atom: AtomNode; min: number; max: number; greedy: boolean };
 type SeqNode = { atoms: QuantNode[] };
 type AltNode = { options: SeqNode[] };
@@ -108,6 +113,16 @@ function parsePattern(pattern: string): AltNode {
       i++;
       return { kind: "any" };
     }
+    // matchFull already anchors the whole match, so ^/$ are zero-width assertions here, not
+    // literal characters — a pattern like "^PowerShell$" must still match "PowerShell".
+    if (c === "^") {
+      i++;
+      return { kind: "start" };
+    }
+    if (c === "$") {
+      i++;
+      return { kind: "end" };
+    }
     if (c === "\\") {
       i++;
       return parseEscape();
@@ -172,10 +187,13 @@ function parsePattern(pattern: string): AltNode {
 }
 
 // Every recursive attempt below — descending into a group, trying one more quantifier repeat,
-// trying an alternation branch — spends one step. Legitimate matchProfiles patterns against
-// profile-sized strings need at most a few hundred; this budget leaves headroom for that while
-// still cutting off exponential blowups almost immediately.
-const STEP_BUDGET = 2000;
+// trying an alternation branch — spends one step, and a simple linear pattern like ".*" already
+// spends a small constant number of steps per character. A fixed budget would then cut off a
+// legitimate match against a long value (e.g. a ~1000-character commandline) before it finishes.
+// Scaling the budget with the value's length avoids that while still cutting off exponential
+// blowups almost immediately — those exceed even a scaled budget within a few dozen characters.
+const MIN_STEP_BUDGET = 2000;
+const STEP_BUDGET_PER_CHAR = 50;
 
 // Continuation-passing backtracking matcher, fully anchored (matches only if it consumes the
 // whole string). `k` is "what to try once this piece has matched"; quantifiers try repeating
@@ -183,12 +201,15 @@ const STEP_BUDGET = 2000;
 // failure — same shape as a native regex engine, just with a hard step ceiling.
 function matchFull(alt: AltNode, str: string): boolean {
   let steps = 0;
-  const withinBudget = () => ++steps <= STEP_BUDGET;
+  const budget = Math.max(MIN_STEP_BUDGET, str.length * STEP_BUDGET_PER_CHAR);
+  const withinBudget = () => ++steps <= budget;
 
   function matchAtomOnce(atom: AtomNode, pos: number, k: (pos: number) => boolean): boolean {
     if (!withinBudget()) return false;
     if (atom.kind === "char") return pos < str.length && atom.test(str[pos]) && k(pos + 1);
     if (atom.kind === "any") return pos < str.length && k(pos + 1);
+    if (atom.kind === "start") return pos === 0 && k(pos);
+    if (atom.kind === "end") return pos === str.length && k(pos);
     return matchAlt(atom.alt, pos, k);
   }
 

--- a/extensions/windows-terminal/src/new-tab-menu.ts
+++ b/extensions/windows-terminal/src/new-tab-menu.ts
@@ -267,7 +267,7 @@ type MatchInst = { op: "match" };
 // A counted repeat: one shared instruction, however large `max` is. `bodyStart` is entered again
 // each rep instead of being duplicated per rep — see compileCountedRepeat and the `count`/`countFor`
 // fields threads carry through addThread/matchFull.
-type RepeatInst = { op: "repeat"; id: number; min: number; max: number; bodyStart: Inst; next?: Inst };
+type RepeatInst = { op: "repeat"; min: number; max: number; bodyStart: Inst; next?: Inst };
 // The body's own exit, patched to loop back through here rather than straight to `repeat`, so the
 // matcher can tell "just finished one more rep of this repeat" apart from "entering it fresh".
 type IncrementInst = { op: "increment"; repeat: RepeatInst };
@@ -384,11 +384,6 @@ function hasNestedQuantifier(atom: AtomNode): boolean {
   );
 }
 
-let nextRepeatId = 0;
-// Indexed by RepeatInst.id, so addThread's dedup key can look up a repeat's `min` from just the
-// `countFor` a thread carries, without every instruction needing its own back-pointer to it.
-let repeatsById: RepeatInst[] = [];
-
 // Compiles atom{min,max} (max possibly Infinity) as one `repeat` instruction plus one copy of the
 // atom's body, instead of unrolling — see the `repeat`/`increment` handling in addThread for how a
 // thread's counter takes the place of the copies compileQuant's other branch would otherwise make.
@@ -396,14 +391,7 @@ function compileCountedRepeat(atom: AtomNode, min: number, max: number): Frag {
   if (hasNestedQuantifier(atom)) {
     throw new RegexTooLargeError("a quantifier this large can't wrap another quantifier");
   }
-  const repeat: RepeatInst = newInst({
-    op: "repeat",
-    id: nextRepeatId++,
-    min,
-    max,
-    bodyStart: undefined as unknown as Inst,
-  });
-  repeatsById[repeat.id] = repeat;
+  const repeat: RepeatInst = newInst({ op: "repeat", min, max, bodyStart: undefined as unknown as Inst });
   const body = compileAtom(atom);
   const increment: IncrementInst = newInst({ op: "increment", repeat });
   patch(body.out, increment);
@@ -443,8 +431,6 @@ function compileAlt(alt: AltNode): Frag {
 
 function compileProgram(alt: AltNode): Inst {
   instructionCount = 0;
-  nextRepeatId = 0;
-  repeatsById = [];
   const frag = compileAlt(alt);
   const matchInst: MatchInst = newInst({ op: "match" });
   patch(frag.out, matchInst);
@@ -461,10 +447,13 @@ type StepBudget = { remaining: number };
 
 // A live NFA thread: which instruction it's at, plus the counter compileCountedRepeat's `repeat`/
 // `increment` instructions read and write. `countFor` names which `repeat` instruction `count`
-// belongs to — a thread not currently inside a counted repeat carries a `countFor` that matches no
-// real instruction, so `repeat` treats it as a fresh entry (see the "repeat" case in addThread).
-type Thread = { inst: Inst; count: number; countFor: number };
-const NO_REPEAT = -1;
+// belongs to, as a direct reference (not an id looked up in shared state — a `matchProfiles` entry
+// compiles one program per field, and a lookup table reset by each compile would leave an earlier
+// field's threads reading another field's repeat metadata once all fields are later matched). A
+// thread not currently inside a counted repeat carries a `countFor` of null, so `repeat` treats it
+// as a fresh entry (see the "repeat" case in addThread).
+type Thread = { inst: Inst; count: number; countFor: RepeatInst | null };
+const NO_REPEAT = null;
 
 // \b sits between a word character and a non-word one, counting the space off either end of the
 // value as non-word — so it holds at both ends of "PowerShell" but not inside it.
@@ -493,9 +482,9 @@ function newVisited(): VisitedState {
 // without the cap, each loop reaches `repeat` at a new, never-before-seen count and dedup never
 // kicks in, so a large `max` risks growing that unboundedly before a real character is consumed.
 // Only called when thread.countFor !== NO_REPEAT (see hasVisited/markVisited), so there's always a
-// real repeat to look up.
+// real repeat to read `min` from.
 function capForDedup(thread: Thread): number {
-  return Math.min(thread.count, repeatsById[thread.countFor].min);
+  return Math.min(thread.count, thread.countFor!.min);
 }
 
 function hasVisited(visited: VisitedState, thread: Thread): boolean {
@@ -553,20 +542,20 @@ function addThread(
       if (isWordBoundary(str, pos) !== inst.negate) stack.push({ inst: inst.next!, count, countFor });
     } else if (inst.op === "repeat") {
       // A thread not already inside this repeat (countFor doesn't match) is entering fresh, at 0.
-      const reps = countFor === inst.id ? count : 0;
+      const reps = countFor === inst ? count : 0;
       if (reps < inst.min) {
         // Below the minimum: another rep is mandatory, no option to stop yet.
-        stack.push({ inst: inst.bodyStart, count: reps, countFor: inst.id });
+        stack.push({ inst: inst.bodyStart, count: reps, countFor: inst });
       } else if (inst.max === Infinity || reps < inst.max) {
         // Within range: try one more rep, but stopping here is also valid (mirrors optionalFrag).
         stack.push({ inst: inst.next!, count, countFor });
-        stack.push({ inst: inst.bodyStart, count: reps, countFor: inst.id });
+        stack.push({ inst: inst.bodyStart, count: reps, countFor: inst });
       } else {
         // At the maximum: no more reps allowed.
         stack.push({ inst: inst.next!, count, countFor });
       }
     } else if (inst.op === "increment") {
-      stack.push({ inst: inst.repeat, count: count + 1, countFor: inst.repeat.id });
+      stack.push({ inst: inst.repeat, count: count + 1, countFor: inst.repeat });
     } else {
       list.push(thread);
     }

--- a/extensions/windows-terminal/src/open-profile.tsx
+++ b/extensions/windows-terminal/src/open-profile.tsx
@@ -27,51 +27,74 @@ interface WindowsTerminalSettings {
   newTabMenu?: NewTabMenuEntry[];
 }
 
-// Mirrors Windows Terminal's own newTabMenu resolution: walk the tree (folders recurse),
-// resolve "profile" entries by guid or name, "matchProfiles" by regex, and expand
-// "remainingProfiles" to every profile not already referenced. Order of first reference wins.
-function resolveNewTabMenuOrder(profiles: Profile[], newTabMenu: NewTabMenuEntry[]): string[] {
-  const used = new Set<string>();
-  const order: string[] = [];
+// A matchProfiles entry matches a profile when ANY provided field (name/commandline/source)
+// fully matches that field's regex — mirrors Windows Terminal's MatchProfilesEntry. An entry
+// with no patterns, or a malformed regex, matches nothing rather than crashing or matching all.
+function buildProfileMatcher(entry: NewTabMenuEntry): ((profile: Profile) => boolean) | null {
+  const specs: { pattern: string; get: (profile: Profile) => string }[] = [];
+  if (entry.name !== undefined) specs.push({ pattern: entry.name, get: (p) => p.name });
+  if (entry.commandline !== undefined) specs.push({ pattern: entry.commandline, get: (p) => p.commandline ?? "" });
+  if (entry.source !== undefined) specs.push({ pattern: entry.source, get: (p) => p.source ?? "" });
+  if (specs.length === 0) return null;
 
+  let matchers: { regex: RegExp; get: (profile: Profile) => string }[];
+  try {
+    matchers = specs.map(({ pattern, get }) => ({ regex: new RegExp(`^(?:${pattern})$`), get }));
+  } catch {
+    return null;
+  }
+
+  return (profile: Profile) => matchers.some(({ regex, get }) => regex.test(get(profile)));
+}
+
+// Mirrors Windows Terminal's own newTabMenu resolution (CascadiaSettingsSerialization.cpp):
+// two passes over the tree. Pass 1 collects every profile referenced by a "profile" or
+// "matchProfiles" entry anywhere (including inside folders). Pass 2 walks the tree again to
+// build the final order — "remainingProfiles" expands to profiles NOT in that pass-1 set, at
+// the position it appears, so a later explicit reference still lands after the remainder.
+function resolveNewTabMenuOrder(profiles: Profile[], newTabMenu: NewTabMenuEntry[]): string[] {
+  const referenced = new Set<string>();
+
+  function collectReferenced(entries: NewTabMenuEntry[]) {
+    for (const entry of entries) {
+      if (entry.type === "profile" && entry.profile) {
+        const match = profiles.find((p) => p.guid === entry.profile || p.name === entry.profile);
+        if (match) referenced.add(match.guid);
+      } else if (entry.type === "matchProfiles") {
+        const matcher = buildProfileMatcher(entry);
+        if (matcher) profiles.forEach((p) => matcher(p) && referenced.add(p.guid));
+      } else if (entry.type === "folder" && entry.entries) {
+        collectReferenced(entry.entries);
+      }
+    }
+  }
+  collectReferenced(newTabMenu);
+
+  const order: string[] = [];
+  const placed = new Set<string>();
   function addGuid(guid: string) {
-    if (used.has(guid)) return;
-    used.add(guid);
+    if (placed.has(guid)) return;
+    placed.add(guid);
     order.push(guid);
   }
 
-  function walk(entries: NewTabMenuEntry[]) {
+  function build(entries: NewTabMenuEntry[]) {
     for (const entry of entries) {
       if (entry.type === "profile" && entry.profile) {
         const match = profiles.find((p) => p.guid === entry.profile || p.name === entry.profile);
         if (match) addGuid(match.guid);
       } else if (entry.type === "matchProfiles") {
-        // A malformed regex in settings.json shouldn't crash the whole list — skip just this entry.
-        let nameRe: RegExp | null;
-        let cmdRe: RegExp | null;
-        let sourceRe: RegExp | null;
-        try {
-          nameRe = entry.name ? new RegExp(entry.name) : null;
-          cmdRe = entry.commandline ? new RegExp(entry.commandline) : null;
-          sourceRe = entry.source ? new RegExp(entry.source) : null;
-        } catch {
-          continue;
-        }
-        profiles.forEach((p) => {
-          if (nameRe && !nameRe.test(p.name)) return;
-          if (cmdRe && !cmdRe.test(p.commandline ?? "")) return;
-          if (sourceRe && !sourceRe.test(p.source ?? "")) return;
-          addGuid(p.guid);
-        });
+        const matcher = buildProfileMatcher(entry);
+        if (matcher) profiles.forEach((p) => matcher(p) && addGuid(p.guid));
       } else if (entry.type === "folder" && entry.entries) {
-        walk(entry.entries);
+        build(entry.entries);
       } else if (entry.type === "remainingProfiles") {
-        profiles.forEach((p) => addGuid(p.guid));
+        profiles.forEach((p) => !referenced.has(p.guid) && addGuid(p.guid));
       }
     }
   }
+  build(newTabMenu);
 
-  walk(newTabMenu);
   return order;
 }
 

--- a/extensions/windows-terminal/src/open-profile.tsx
+++ b/extensions/windows-terminal/src/open-profile.tsx
@@ -2,100 +2,13 @@ import { Action, ActionPanel, Icon, Keyboard, List, closeMainWindow, getPreferen
 import { execFile } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
-
-interface Profile {
-  guid: string;
-  name: string;
-  hidden?: boolean;
-  source?: string;
-  commandline?: string;
-}
-
-interface NewTabMenuEntry {
-  type: string;
-  profile?: string;
-  name?: string;
-  commandline?: string;
-  source?: string;
-  entries?: NewTabMenuEntry[];
-}
+import { NewTabMenuEntry, Profile, resolveNewTabMenuOrder } from "./new-tab-menu";
 
 interface WindowsTerminalSettings {
   profiles: {
     list: Profile[];
   };
   newTabMenu?: NewTabMenuEntry[];
-}
-
-// A matchProfiles entry matches a profile when ANY provided field (name/commandline/source)
-// fully matches that field's regex — mirrors Windows Terminal's MatchProfilesEntry. An entry
-// with no patterns, or a malformed regex, matches nothing rather than crashing or matching all.
-function buildProfileMatcher(entry: NewTabMenuEntry): ((profile: Profile) => boolean) | null {
-  const specs: { pattern: string; get: (profile: Profile) => string }[] = [];
-  if (entry.name !== undefined) specs.push({ pattern: entry.name, get: (p) => p.name });
-  if (entry.commandline !== undefined) specs.push({ pattern: entry.commandline, get: (p) => p.commandline ?? "" });
-  if (entry.source !== undefined) specs.push({ pattern: entry.source, get: (p) => p.source ?? "" });
-  if (specs.length === 0) return null;
-
-  let matchers: { regex: RegExp; get: (profile: Profile) => string }[];
-  try {
-    matchers = specs.map(({ pattern, get }) => ({ regex: new RegExp(`^(?:${pattern})$`), get }));
-  } catch {
-    return null;
-  }
-
-  return (profile: Profile) => matchers.some(({ regex, get }) => regex.test(get(profile)));
-}
-
-// Mirrors Windows Terminal's own newTabMenu resolution (CascadiaSettingsSerialization.cpp):
-// two passes over the tree. Pass 1 collects every profile referenced by a "profile" or
-// "matchProfiles" entry anywhere (including inside folders). Pass 2 walks the tree again to
-// build the final order — "remainingProfiles" expands to profiles NOT in that pass-1 set, at
-// the position it appears, so a later explicit reference still lands after the remainder.
-function resolveNewTabMenuOrder(profiles: Profile[], newTabMenu: NewTabMenuEntry[]): string[] {
-  const referenced = new Set<string>();
-
-  function collectReferenced(entries: NewTabMenuEntry[]) {
-    for (const entry of entries) {
-      if (entry.type === "profile" && entry.profile) {
-        const match = profiles.find((p) => p.guid === entry.profile || p.name === entry.profile);
-        if (match) referenced.add(match.guid);
-      } else if (entry.type === "matchProfiles") {
-        const matcher = buildProfileMatcher(entry);
-        if (matcher) profiles.forEach((p) => matcher(p) && referenced.add(p.guid));
-      } else if (entry.type === "folder" && entry.entries) {
-        collectReferenced(entry.entries);
-      }
-    }
-  }
-  collectReferenced(newTabMenu);
-
-  const order: string[] = [];
-  const placed = new Set<string>();
-  function addGuid(guid: string) {
-    if (placed.has(guid)) return;
-    placed.add(guid);
-    order.push(guid);
-  }
-
-  function build(entries: NewTabMenuEntry[]) {
-    for (const entry of entries) {
-      if (entry.type === "profile" && entry.profile) {
-        const match = profiles.find((p) => p.guid === entry.profile || p.name === entry.profile);
-        if (match) addGuid(match.guid);
-      } else if (entry.type === "matchProfiles") {
-        const matcher = buildProfileMatcher(entry);
-        if (matcher) profiles.forEach((p) => matcher(p) && addGuid(p.guid));
-      } else if (entry.type === "folder" && entry.entries) {
-        build(entry.entries);
-      } else if (entry.type === "remainingProfiles") {
-        profiles.forEach((p) => !referenced.has(p.guid) && addGuid(p.guid));
-      }
-    }
-  }
-  build(newTabMenu);
-
-  return order;
 }
 
 const PROFILES = JSON.parse(

--- a/extensions/windows-terminal/src/open-profile.tsx
+++ b/extensions/windows-terminal/src/open-profile.tsx
@@ -8,12 +8,63 @@ interface Profile {
   name: string;
   hidden?: boolean;
   source?: string;
+  commandline?: string;
+}
+
+interface NewTabMenuEntry {
+  type: string;
+  profile?: string;
+  name?: string;
+  commandline?: string;
+  source?: string;
+  entries?: NewTabMenuEntry[];
 }
 
 interface WindowsTerminalSettings {
   profiles: {
     list: Profile[];
   };
+  newTabMenu?: NewTabMenuEntry[];
+}
+
+// Mirrors Windows Terminal's own newTabMenu resolution: walk the tree (folders recurse),
+// resolve "profile" entries by guid or name, "matchProfiles" by regex, and expand
+// "remainingProfiles" to every profile not already referenced. Order of first reference wins.
+function resolveNewTabMenuOrder(profiles: Profile[], newTabMenu: NewTabMenuEntry[]): string[] {
+  const used = new Set<string>();
+  const order: string[] = [];
+
+  function addGuid(guid: string) {
+    if (used.has(guid)) return;
+    used.add(guid);
+    order.push(guid);
+  }
+
+  function walk(entries: NewTabMenuEntry[]) {
+    for (const entry of entries) {
+      if (entry.type === "profile" && entry.profile) {
+        const match = profiles.find((p) => p.guid === entry.profile || p.name === entry.profile);
+        if (match) addGuid(match.guid);
+      } else if (entry.type === "matchProfiles") {
+        const nameRe = entry.name ? new RegExp(entry.name) : null;
+        const cmdRe = entry.commandline ? new RegExp(entry.commandline) : null;
+        const sourceRe = entry.source ? new RegExp(entry.source) : null;
+        profiles.forEach((p) => {
+          if (nameRe && !nameRe.test(p.name)) return;
+          if (cmdRe && !cmdRe.test(p.commandline ?? "")) return;
+          if (sourceRe && !sourceRe.test(p.source ?? "")) return;
+          addGuid(p.guid);
+        });
+      } else if (entry.type === "folder" && entry.entries) {
+        walk(entry.entries);
+      } else if (entry.type === "remainingProfiles") {
+        profiles.forEach((p) => addGuid(p.guid));
+      }
+    }
+  }
+
+  walk(newTabMenu);
+  return order;
 }
 
 const PROFILES = JSON.parse(
@@ -118,45 +169,61 @@ function Actions(props: { name: string; quake: boolean }) {
 }
 
 export default function Command() {
-  const { openProfilesInQuakeWindow: quake } = getPreferenceValues<Preferences>();
+  const { openProfilesInQuakeWindow: quake, useNewTabMenu } = getPreferenceValues<Preferences>();
+
+  const newTabMenuOrder =
+    useNewTabMenu && PROFILES.newTabMenu ? resolveNewTabMenuOrder(PROFILES.profiles.list, PROFILES.newTabMenu) : null;
+  const orderIndex = newTabMenuOrder ? new Map(newTabMenuOrder.map((guid, index) => [guid, index])) : null;
+
+  // When ordering by the New Tab Menu, drop profiles it doesn't reference and sort by
+  // first-reference order; otherwise keep the existing settings.json list order.
+  function applyOrder(items: Profile[]): Profile[] {
+    if (!orderIndex) return items;
+    return items
+      .filter((item) => orderIndex.has(item.guid))
+      .sort((a, b) => orderIndex.get(a.guid)! - orderIndex.get(b.guid)!);
+  }
+
   return (
     <List searchBarPlaceholder="Search all profiles...">
       <List.Section title="Profiles">
-        {PROFILES.profiles.list
-          .filter(
+        {applyOrder(
+          PROFILES.profiles.list.filter(
             (item) =>
               item.hidden !== true &&
               item.source !== "Microsoft.WSL" &&
               item.source !== "Windows.Terminal.Wsl" &&
               item.source !== "Windows.Terminal.SSH",
-          )
-          .map((item) => (
-            <List.Item
-              key={item.guid}
-              icon={
-                item.guid === "{b453ae62-4e3d-5e58-b989-0a998ec441b8}" // Azure Cloud Shell
-                  ? Icon.Cloud
-                  : Icon.Terminal
-              }
-              title={item.name}
-              keywords={
-                item.guid === "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}" || // Windows PowerShell 1.0 (comes with Windows)
-                item.guid === "{574e775e-4f2a-5b96-ac1e-a2962a402336}" // Windows Powershell 7.0+
-                  ? ["pwsh"]
-                  : item.guid === "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}"
-                    ? ["cmd"]
-                    : []
-              }
-              actions={<Actions name={item.name} quake={quake} />}
-            />
-          ))}
+          ),
+        ).map((item) => (
+          <List.Item
+            key={item.guid}
+            icon={
+              item.guid === "{b453ae62-4e3d-5e58-b989-0a998ec441b8}" // Azure Cloud Shell
+                ? Icon.Cloud
+                : Icon.Terminal
+            }
+            title={item.name}
+            keywords={
+              item.guid === "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}" || // Windows PowerShell 1.0 (comes with Windows)
+              item.guid === "{574e775e-4f2a-5b96-ac1e-a2962a402336}" // Windows Powershell 7.0+
+                ? ["pwsh"]
+                : item.guid === "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}"
+                  ? ["cmd"]
+                  : []
+            }
+            actions={<Actions name={item.name} quake={quake} />}
+          />
+        ))}
       </List.Section>
 
-      {PROFILES.profiles.list.some((item) => item.source === "Windows.Terminal.SSH") ? (
-        <List.Section title="Remote Servers">
-          {PROFILES.profiles.list
-            .filter((item) => item.hidden !== true && item.source === "Windows.Terminal.SSH")
-            .map((item) => (
+      {(() => {
+        const remoteServers = applyOrder(
+          PROFILES.profiles.list.filter((item) => item.hidden !== true && item.source === "Windows.Terminal.SSH"),
+        );
+        return remoteServers.length > 0 ? (
+          <List.Section title="Remote Servers">
+            {remoteServers.map((item) => (
               <List.Item
                 key={item.guid}
                 icon={Icon.Network}
@@ -164,19 +231,20 @@ export default function Command() {
                 actions={<Actions name={item.name} quake={quake} />}
               />
             ))}
-        </List.Section>
-      ) : null}
+          </List.Section>
+        ) : null;
+      })()}
 
-      {PROFILES.profiles.list.some(
-        (item) => item.source === "Microsoft.WSL" || item.source === "Windows.Terminal.Wsl",
-      ) ? (
-        <List.Section title="Windows Subsystem for Linux">
-          {PROFILES.profiles.list
-            .filter(
-              (item) =>
-                item.hidden !== true && (item.source === "Microsoft.WSL" || item.source === "Windows.Terminal.Wsl"),
-            )
-            .map((item) => (
+      {(() => {
+        const wslProfiles = applyOrder(
+          PROFILES.profiles.list.filter(
+            (item) =>
+              item.hidden !== true && (item.source === "Microsoft.WSL" || item.source === "Windows.Terminal.Wsl"),
+          ),
+        );
+        return wslProfiles.length > 0 ? (
+          <List.Section title="Windows Subsystem for Linux">
+            {wslProfiles.map((item) => (
               <List.Item
                 key={item.guid}
                 icon={Icon.HardDrive}
@@ -184,8 +252,9 @@ export default function Command() {
                 actions={<Actions name={item.name} quake={quake} />}
               />
             ))}
-        </List.Section>
-      ) : null}
+          </List.Section>
+        ) : null;
+      })()}
     </List>
   );
 }

--- a/extensions/windows-terminal/src/open-profile.tsx
+++ b/extensions/windows-terminal/src/open-profile.tsx
@@ -1,8 +1,19 @@
-import { Action, ActionPanel, Icon, Keyboard, List, closeMainWindow, getPreferenceValues } from "@raycast/api";
+import {
+  Action,
+  ActionPanel,
+  Icon,
+  Keyboard,
+  List,
+  Toast,
+  closeMainWindow,
+  getPreferenceValues,
+  showToast,
+} from "@raycast/api";
 import { execFile } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
-import { NewTabMenuEntry, Profile, resolveNewTabMenuOrder } from "./new-tab-menu";
+import { useEffect, useMemo } from "react";
+import { NewTabMenuEntry, Profile, UnsupportedPatternError, resolveNewTabMenuOrder } from "./new-tab-menu";
 
 interface WindowsTerminalSettings {
   profiles: {
@@ -153,8 +164,31 @@ function ProfileItem(props: { item: Profile; quake: boolean }) {
 export default function Command() {
   const { openProfilesInQuakeWindow: quake, useNewTabMenu } = getPreferenceValues<Preferences>();
 
-  const newTabMenuOrder =
-    useNewTabMenu && PROFILES.newTabMenu ? resolveNewTabMenuOrder(PROFILES.profiles.list, PROFILES.newTabMenu) : null;
+  // A matchProfiles pattern this extension can't evaluate (valid for Windows Terminal, but past
+  // what the matcher implements or affords) means the resolved order can't be trusted — so fall
+  // back to the default sections below and say which pattern, instead of quietly dropping or
+  // misplacing the profiles it would have matched.
+  const { newTabMenuOrder, unsupported } = useMemo(() => {
+    if (!useNewTabMenu || !PROFILES.newTabMenu) return { newTabMenuOrder: null, unsupported: null };
+    try {
+      return {
+        newTabMenuOrder: resolveNewTabMenuOrder(PROFILES.profiles.list, PROFILES.newTabMenu),
+        unsupported: null,
+      };
+    } catch (error) {
+      if (error instanceof UnsupportedPatternError) return { newTabMenuOrder: null, unsupported: error };
+      throw error;
+    }
+  }, [useNewTabMenu]);
+
+  useEffect(() => {
+    if (!unsupported) return;
+    showToast({
+      style: Toast.Style.Failure,
+      title: "New Tab Menu order not applied",
+      message: unsupported.message,
+    });
+  }, [unsupported]);
 
   // The New Tab Menu can interleave regular, SSH, and WSL profiles, so honoring its order means
   // one flat list instead of the three fixed, independently-ordered sections below.

--- a/extensions/windows-terminal/src/open-profile.tsx
+++ b/extensions/windows-terminal/src/open-profile.tsx
@@ -46,9 +46,17 @@ function resolveNewTabMenuOrder(profiles: Profile[], newTabMenu: NewTabMenuEntry
         const match = profiles.find((p) => p.guid === entry.profile || p.name === entry.profile);
         if (match) addGuid(match.guid);
       } else if (entry.type === "matchProfiles") {
-        const nameRe = entry.name ? new RegExp(entry.name) : null;
-        const cmdRe = entry.commandline ? new RegExp(entry.commandline) : null;
-        const sourceRe = entry.source ? new RegExp(entry.source) : null;
+        // A malformed regex in settings.json shouldn't crash the whole list — skip just this entry.
+        let nameRe: RegExp | null;
+        let cmdRe: RegExp | null;
+        let sourceRe: RegExp | null;
+        try {
+          nameRe = entry.name ? new RegExp(entry.name) : null;
+          cmdRe = entry.commandline ? new RegExp(entry.commandline) : null;
+          sourceRe = entry.source ? new RegExp(entry.source) : null;
+        } catch {
+          continue;
+        }
         profiles.forEach((p) => {
           if (nameRe && !nameRe.test(p.name)) return;
           if (cmdRe && !cmdRe.test(p.commandline ?? "")) return;
@@ -168,93 +176,98 @@ function Actions(props: { name: string; quake: boolean }) {
   );
 }
 
+function isSsh(item: Profile) {
+  return item.source === "Windows.Terminal.SSH";
+}
+
+function isWsl(item: Profile) {
+  return item.source === "Microsoft.WSL" || item.source === "Windows.Terminal.Wsl";
+}
+
+function getIcon(item: Profile) {
+  if (item.guid === "{b453ae62-4e3d-5e58-b989-0a998ec441b8}") return Icon.Cloud; // Azure Cloud Shell
+  if (isSsh(item)) return Icon.Network;
+  if (isWsl(item)) return Icon.HardDrive;
+  return Icon.Terminal;
+}
+
+function getKeywords(item: Profile) {
+  if (
+    item.guid === "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}" || // Windows PowerShell 1.0 (comes with Windows)
+    item.guid === "{574e775e-4f2a-5b96-ac1e-a2962a402336}" // Windows Powershell 7.0+
+  ) {
+    return ["pwsh"];
+  }
+  if (item.guid === "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}") return ["cmd"];
+  return [];
+}
+
+function ProfileItem(props: { item: Profile; quake: boolean }) {
+  return (
+    <List.Item
+      key={props.item.guid}
+      icon={getIcon(props.item)}
+      title={props.item.name}
+      keywords={getKeywords(props.item)}
+      actions={<Actions name={props.item.name} quake={props.quake} />}
+    />
+  );
+}
+
 export default function Command() {
   const { openProfilesInQuakeWindow: quake, useNewTabMenu } = getPreferenceValues<Preferences>();
 
   const newTabMenuOrder =
     useNewTabMenu && PROFILES.newTabMenu ? resolveNewTabMenuOrder(PROFILES.profiles.list, PROFILES.newTabMenu) : null;
-  const orderIndex = newTabMenuOrder ? new Map(newTabMenuOrder.map((guid, index) => [guid, index])) : null;
 
-  // When ordering by the New Tab Menu, drop profiles it doesn't reference and sort by
-  // first-reference order; otherwise keep the existing settings.json list order.
-  function applyOrder(items: Profile[]): Profile[] {
-    if (!orderIndex) return items;
-    return items
-      .filter((item) => orderIndex.has(item.guid))
+  // The New Tab Menu can interleave regular, SSH, and WSL profiles, so honoring its order means
+  // one flat list instead of the three fixed, independently-ordered sections below.
+  if (newTabMenuOrder) {
+    const orderIndex = new Map(newTabMenuOrder.map((guid, index) => [guid, index]));
+    const items = PROFILES.profiles.list
+      .filter((item) => item.hidden !== true && orderIndex.has(item.guid))
       .sort((a, b) => orderIndex.get(a.guid)! - orderIndex.get(b.guid)!);
+
+    return (
+      <List searchBarPlaceholder="Search all profiles...">
+        <List.Section title="Profiles">
+          {items.map((item) => (
+            <ProfileItem key={item.guid} item={item} quake={quake} />
+          ))}
+        </List.Section>
+      </List>
+    );
   }
 
   return (
     <List searchBarPlaceholder="Search all profiles...">
       <List.Section title="Profiles">
-        {applyOrder(
-          PROFILES.profiles.list.filter(
-            (item) =>
-              item.hidden !== true &&
-              item.source !== "Microsoft.WSL" &&
-              item.source !== "Windows.Terminal.Wsl" &&
-              item.source !== "Windows.Terminal.SSH",
-          ),
-        ).map((item) => (
-          <List.Item
-            key={item.guid}
-            icon={
-              item.guid === "{b453ae62-4e3d-5e58-b989-0a998ec441b8}" // Azure Cloud Shell
-                ? Icon.Cloud
-                : Icon.Terminal
-            }
-            title={item.name}
-            keywords={
-              item.guid === "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}" || // Windows PowerShell 1.0 (comes with Windows)
-              item.guid === "{574e775e-4f2a-5b96-ac1e-a2962a402336}" // Windows Powershell 7.0+
-                ? ["pwsh"]
-                : item.guid === "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}"
-                  ? ["cmd"]
-                  : []
-            }
-            actions={<Actions name={item.name} quake={quake} />}
-          />
-        ))}
+        {PROFILES.profiles.list
+          .filter((item) => item.hidden !== true && !isSsh(item) && !isWsl(item))
+          .map((item) => (
+            <ProfileItem key={item.guid} item={item} quake={quake} />
+          ))}
       </List.Section>
 
-      {(() => {
-        const remoteServers = applyOrder(
-          PROFILES.profiles.list.filter((item) => item.hidden !== true && item.source === "Windows.Terminal.SSH"),
-        );
-        return remoteServers.length > 0 ? (
-          <List.Section title="Remote Servers">
-            {remoteServers.map((item) => (
-              <List.Item
-                key={item.guid}
-                icon={Icon.Network}
-                title={item.name}
-                actions={<Actions name={item.name} quake={quake} />}
-              />
+      {PROFILES.profiles.list.some((item) => isSsh(item)) ? (
+        <List.Section title="Remote Servers">
+          {PROFILES.profiles.list
+            .filter((item) => item.hidden !== true && isSsh(item))
+            .map((item) => (
+              <ProfileItem key={item.guid} item={item} quake={quake} />
             ))}
-          </List.Section>
-        ) : null;
-      })()}
+        </List.Section>
+      ) : null}
 
-      {(() => {
-        const wslProfiles = applyOrder(
-          PROFILES.profiles.list.filter(
-            (item) =>
-              item.hidden !== true && (item.source === "Microsoft.WSL" || item.source === "Windows.Terminal.Wsl"),
-          ),
-        );
-        return wslProfiles.length > 0 ? (
-          <List.Section title="Windows Subsystem for Linux">
-            {wslProfiles.map((item) => (
-              <List.Item
-                key={item.guid}
-                icon={Icon.HardDrive}
-                title={item.name}
-                actions={<Actions name={item.name} quake={quake} />}
-              />
+      {PROFILES.profiles.list.some((item) => isWsl(item)) ? (
+        <List.Section title="Windows Subsystem for Linux">
+          {PROFILES.profiles.list
+            .filter((item) => item.hidden !== true && isWsl(item))
+            .map((item) => (
+              <ProfileItem key={item.guid} item={item} quake={quake} />
             ))}
-          </List.Section>
-        ) : null;
-      })()}
+        </List.Section>
+      ) : null}
     </List>
   );
 }

--- a/extensions/windows-terminal/tsconfig.json
+++ b/extensions/windows-terminal/tsconfig.json
@@ -7,6 +7,7 @@
     "target": "ES2023",
     "strict": true,
     "isolatedModules": true,
+    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Description

Adds a "Use New Tab Menu order" checkbox preference. When enabled, profiles are filtered and ordered to match Windows Terminal'"'"'s `newTabMenu` setting (`profile`, `matchProfiles`, `folder`, and `remainingProfiles` entries) instead of the raw `settings.json` list order. Off by default, so existing behavior is unchanged.

## Checklist

- [x] I read the extension guidelines
- [x] I read the documentation about publishing
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our metadata tool

https://claude.ai/code/session_017qumXMNaDoczpLwhm54iPc