### PR TITLE
Clockify: fix requests being sent to an undefined workspace

### DIFF
--- a/extensions/clockify/CHANGELOG.md
+++ b/extensions/clockify/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Clockify Changelog
 
-## [Fix requests being sent to an undefined workspace] - {PR_MERGE_DATE}
+## [Fix requests being sent to an undefined workspace] - 2026-09-09
 
 - Fixed commands failing with "User doesn't belong to Workspace" and "Timer could not be started" when the stored workspace id was missing. The id is now resolved and repaired on demand rather than read straight from `LocalStorage`, which can drop a key when several values are written concurrently.
 - Fixed the menu bar command being unable to recover from that state on its own, as it never bootstrapped the workspace id itself.

--- a/extensions/clockify/CHANGELOG.md
+++ b/extensions/clockify/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Clockify Changelog
 
+## [Fix requests being sent to an undefined workspace] - {PR_MERGE_DATE}
+
+- Fixed commands failing with "User doesn't belong to Workspace" and "Timer could not be started" when the stored workspace id was missing. The id is now resolved and repaired on demand rather than read straight from `LocalStorage`, which can drop a key when several values are written concurrently.
+- Fixed the menu bar command being unable to recover from that state on its own, as it never bootstrapped the workspace id itself.
+- Added a fallback to the active workspace, and then to the first available workspace, for accounts where Clockify returns no default workspace.
+- Hardened API key validation so an unset key shows the invalid-key screen instead of failing to render.
+- The "Timer could not be started" toast now reports the reason returned by Clockify.
+
 ## [Fix project selection resetting and timer failing to start] - 2026-09-08
 
 - Fixed the project dropdown resetting to the first project on every selection in both "Start New Timer" and "Add Time Entry".

--- a/extensions/clockify/src/index.tsx
+++ b/extensions/clockify/src/index.tsx
@@ -22,6 +22,7 @@ import {
   getAllTimeEntriesFromLocalStorage,
   fetcher,
   dateDiffToString,
+  resolveConfig,
 } from "./utils";
 import { TimeEntry, Project, Task, Tag } from "./types";
 import { FormValidation, useCachedState, useForm } from "@raycast/utils";
@@ -380,8 +381,7 @@ function StopTimerAtForm({ entry, updateTimeEntries }: { entry: TimeEntry; updat
       if (!endDate) return;
       showToast(Toast.Style.Animated, "Stopping timer...");
 
-      const workspaceId = await LocalStorage.getItem("workspaceId");
-      const userId = await LocalStorage.getItem("userId");
+      const { workspaceId, userId } = await resolveConfig();
 
       const { data, error } = await fetcher(`/workspaces/${workspaceId}/user/${userId}/time-entries`, {
         method: "PATCH",
@@ -467,7 +467,7 @@ function AddTimeEntry({ updateTimeEntries }: { updateTimeEntries: () => void }) 
 
       showToast(Toast.Style.Animated, "Adding time entry...");
 
-      const workspaceId = await LocalStorage.getItem("workspaceId");
+      const { workspaceId } = await resolveConfig();
 
       const { data, error } = await fetcher(`/workspaces/${workspaceId}/time-entries`, {
         method: "POST",

--- a/extensions/clockify/src/types.d.ts
+++ b/extensions/clockify/src/types.d.ts
@@ -43,7 +43,14 @@ export interface FetcherArgs {
 export interface User {
   id: string;
   name: string;
-  defaultWorkspace: string;
+  // Not guaranteed to be present: Clockify omits/empties these for some accounts.
+  defaultWorkspace?: string;
+  activeWorkspace?: string;
+}
+
+export interface Workspace {
+  id: string;
+  name: string;
 }
 
 export interface FetcherResponse {

--- a/extensions/clockify/src/useConfig.ts
+++ b/extensions/clockify/src/useConfig.ts
@@ -40,10 +40,15 @@ export default function useConfig(): ConfigProps {
           // setItem cannot store undefined, so an unresolved workspace means workspaceId never
           // lands in LocalStorage, the guard above fails on every mount, and every request goes to
           // /workspaces/undefined/...
-          const workspaceId = await resolveWorkspaceId(user);
+          const { workspaceId, error: workspaceError } = await resolveWorkspaceId(user);
+
+          if (!workspaceError && !workspaceId) {
+            showToast(Toast.Style.Failure, "No Clockify workspace found for this API key");
+            return;
+          }
 
           if (!workspaceId) {
-            showToast(Toast.Style.Failure, "No Clockify workspace found for this API key");
+            showToast(Toast.Style.Failure, "Could not load Clockify workspaces", workspaceError?.toString());
             return;
           }
 

--- a/extensions/clockify/src/useConfig.ts
+++ b/extensions/clockify/src/useConfig.ts
@@ -1,7 +1,7 @@
 import { LocalStorage, showToast, Toast } from "@raycast/api";
 import { useState, useEffect } from "react";
 import { fetcher, validateToken } from "./utils";
-import { DataValues, User } from "./types";
+import { DataValues, User, Workspace } from "./types";
 
 interface ConfigProps {
   config: DataValues;
@@ -36,10 +36,31 @@ export default function useConfig(): ConfigProps {
 
         if (data) {
           const user = data as User;
-          LocalStorage.setItem("userId", user.id);
-          LocalStorage.setItem("workspaceId", user.defaultWorkspace);
-          LocalStorage.setItem("name", user.name);
-          setData({ userId: user.id, workspaceId: user.defaultWorkspace, name: user.name });
+
+          // defaultWorkspace is not guaranteed. setItem cannot store undefined, so a missing value
+          // means workspaceId never lands in LocalStorage, the guard above fails on every mount,
+          // and every request goes to /workspaces/undefined/... Fall back to the active workspace,
+          // then to the first workspace this token can see.
+          let workspaceId = user.defaultWorkspace || user.activeWorkspace;
+
+          if (!workspaceId) {
+            const { data: workspaces } = await fetcher(`/workspaces`);
+            workspaceId = (workspaces as Workspace[] | undefined)?.[0]?.id;
+          }
+
+          if (!workspaceId) {
+            showToast(Toast.Style.Failure, "No Clockify workspace found for this API key");
+            return;
+          }
+
+          // Await these, and write them one at a time rather than with Promise.all: consumers read
+          // the ids back out of LocalStorage as soon as config is published, and concurrent writes
+          // can be lost — leaving workspaceId absent while userId and name land.
+          await LocalStorage.setItem("userId", user.id);
+          await LocalStorage.setItem("workspaceId", workspaceId);
+          await LocalStorage.setItem("name", user.name);
+
+          setData({ userId: user.id, workspaceId, name: user.name });
           showToast(Toast.Style.Success, "Clockify is ready");
         } else if (error === "Unauthorized") {
           showToast(Toast.Style.Failure, "Invalid API Key detected");

--- a/extensions/clockify/src/useConfig.ts
+++ b/extensions/clockify/src/useConfig.ts
@@ -1,7 +1,7 @@
 import { LocalStorage, showToast, Toast } from "@raycast/api";
 import { useState, useEffect } from "react";
-import { fetcher, validateToken } from "./utils";
-import { DataValues, User, Workspace } from "./types";
+import { fetcher, resolveWorkspaceId, validateToken } from "./utils";
+import { DataValues, User } from "./types";
 
 interface ConfigProps {
   config: DataValues;
@@ -37,16 +37,10 @@ export default function useConfig(): ConfigProps {
         if (data) {
           const user = data as User;
 
-          // defaultWorkspace is not guaranteed. setItem cannot store undefined, so a missing value
-          // means workspaceId never lands in LocalStorage, the guard above fails on every mount,
-          // and every request goes to /workspaces/undefined/... Fall back to the active workspace,
-          // then to the first workspace this token can see.
-          let workspaceId = user.defaultWorkspace || user.activeWorkspace;
-
-          if (!workspaceId) {
-            const { data: workspaces } = await fetcher(`/workspaces`);
-            workspaceId = (workspaces as Workspace[] | undefined)?.[0]?.id;
-          }
+          // setItem cannot store undefined, so an unresolved workspace means workspaceId never
+          // lands in LocalStorage, the guard above fails on every mount, and every request goes to
+          // /workspaces/undefined/...
+          const workspaceId = await resolveWorkspaceId(user);
 
           if (!workspaceId) {
             showToast(Toast.Style.Failure, "No Clockify workspace found for this API key");

--- a/extensions/clockify/src/utils.ts
+++ b/extensions/clockify/src/utils.ts
@@ -65,13 +65,20 @@ export async function fetcher(
  *
  * Single implementation on purpose: both useConfig and resolveConfig need this chain, and two
  * copies would be free to drift apart.
+ *
+ * Returns the error separately so callers can tell "this account has no workspace" apart from
+ * "the request failed"; the two need different messages.
  */
-export async function resolveWorkspaceId(user: User | undefined): Promise<string | undefined> {
+export async function resolveWorkspaceId(
+  user: User | undefined,
+): Promise<{ workspaceId?: string; error?: string | Error }> {
   const fromUser = user?.defaultWorkspace || user?.activeWorkspace;
-  if (fromUser) return fromUser;
+  if (fromUser) return { workspaceId: fromUser };
 
-  const { data } = await fetcher(`/workspaces`);
-  return (data as Workspace[] | undefined)?.[0]?.id;
+  const { data, error } = await fetcher(`/workspaces`);
+  if (error) return { error };
+
+  return { workspaceId: (data as Workspace[] | undefined)?.[0]?.id };
 }
 
 /**
@@ -98,7 +105,7 @@ export async function resolveConfig(): Promise<{ workspaceId?: string; userId?: 
   const { data } = await fetcher(`/user`);
   const user = data as User | undefined;
 
-  const workspaceId = storedWorkspaceId || (await resolveWorkspaceId(user));
+  const workspaceId = storedWorkspaceId || (await resolveWorkspaceId(user)).workspaceId;
   const userId = storedUserId || user?.id;
 
   if (workspaceId) await LocalStorage.setItem("workspaceId", workspaceId);

--- a/extensions/clockify/src/utils.ts
+++ b/extensions/clockify/src/utils.ts
@@ -1,6 +1,6 @@
 import { Cache, LocalStorage, Toast, getPreferenceValues, showToast } from "@raycast/api";
 import uniqWith from "lodash.uniqwith";
-import { FetcherArgs, FetcherResponse, TimeEntry, Project, Task } from "./types";
+import { FetcherArgs, FetcherResponse, TimeEntry, Project, Task, User } from "./types";
 import { showFailureToast } from "@raycast/utils";
 
 const cache = new Cache();
@@ -59,11 +59,47 @@ export async function fetcher(
   }
 }
 
+/**
+ * Resolves the workspace and user ids that every request needs.
+ *
+ * These are written by useConfig, but a resolved `LocalStorage.setItem` does not guarantee the key
+ * is readable yet: when several writes are issued concurrently — useConfig can bootstrap from more
+ * than one mounted component at once — a key can be lost, and callers then request
+ * /workspaces/undefined/... which Clockify rejects with "User doesn't belong to Workspace".
+ *
+ * So treat LocalStorage as a cache rather than the source of truth: if either id is missing,
+ * re-derive it from /user and repair the stored copy with sequential writes.
+ */
+export async function resolveConfig(): Promise<{ workspaceId?: string; userId?: string }> {
+  const [storedWorkspaceId, storedUserId] = await Promise.all([
+    LocalStorage.getItem<string>("workspaceId"),
+    LocalStorage.getItem<string>("userId"),
+  ]);
+
+  if (storedWorkspaceId && storedUserId) {
+    return { workspaceId: storedWorkspaceId, userId: storedUserId };
+  }
+
+  const { data } = await fetcher(`/user`);
+  const user = data as User | undefined;
+
+  const workspaceId = storedWorkspaceId || user?.defaultWorkspace || user?.activeWorkspace;
+  const userId = storedUserId || user?.id;
+
+  if (workspaceId) await LocalStorage.setItem("workspaceId", workspaceId);
+  if (userId) await LocalStorage.setItem("userId", userId);
+
+  return { workspaceId, userId };
+}
+
 export function validateToken(): boolean {
   const preferences = getPreferenceValues<Preferences>();
   const token = preferences.token;
 
-  if (token.length !== 48) {
+  // Guard before reading .length: this runs inside a useState initializer, so if the preference is
+  // ever absent the throw happens during render and takes the whole command down rather than
+  // showing the recoverable invalid-key state.
+  if (!token || token.length !== 48) {
     showToast(Toast.Style.Failure, "Invalid API Key detected");
     return false;
   }
@@ -129,8 +165,7 @@ export function toMonospaceFont(text: string | null): string {
 }
 
 export async function getTimeEntries({ onError }: { onError?: (state: boolean) => void }): Promise<TimeEntry[]> {
-  const workspaceId = await LocalStorage.getItem("workspaceId");
-  const userId = await LocalStorage.getItem("userId");
+  const { workspaceId, userId } = await resolveConfig();
 
   const { data, error } = await fetcher(
     `/workspaces/${workspaceId}/user/${userId}/time-entries?hydrated=true&page-size=500`,
@@ -158,8 +193,7 @@ export async function getTimeEntries({ onError }: { onError?: (state: boolean) =
 export async function stopCurrentTimer(callback?: () => void): Promise<void> {
   showToast(Toast.Style.Animated, "Stopping…");
 
-  const workspaceId = await LocalStorage.getItem("workspaceId");
-  const userId = await LocalStorage.getItem("userId");
+  const { workspaceId, userId } = await resolveConfig();
 
   const { data, error } = await fetcher(`/workspaces/${workspaceId}/user/${userId}/time-entries`, {
     method: "PATCH",
@@ -235,8 +269,7 @@ export function getAllTimeEntriesFromLocalStorage(): TimeEntry[] {
 
 export async function getTodayTotalTimeForProject(projectId: string): Promise<number> {
   try {
-    const workspaceId = await LocalStorage.getItem("workspaceId");
-    const userId = await LocalStorage.getItem("userId");
+    const { workspaceId, userId } = await resolveConfig();
 
     // Get today's date range in ISO format
     const today = new Date();
@@ -295,7 +328,7 @@ export function millisecondsToDurationString(ms: number): string {
 }
 
 export async function getProjects({ onError }: { onError?: (state: boolean) => void } = {}): Promise<Project[]> {
-  const workspaceId = await LocalStorage.getItem("workspaceId");
+  const { workspaceId } = await resolveConfig();
 
   const { data, error } = await fetcher(`/workspaces/${workspaceId}/projects?page-size=1000&archived=false`);
   if (error === "Unauthorized") {
@@ -312,7 +345,7 @@ export async function getProjects({ onError }: { onError?: (state: boolean) => v
 }
 
 export async function getTasksForProject(projectId: string): Promise<Task[]> {
-  const workspaceId = await LocalStorage.getItem("workspaceId");
+  const { workspaceId } = await resolveConfig();
   const cacheKey = `project[${projectId}]`;
 
   const { data, error } = await fetcher(`/workspaces/${workspaceId}/projects/${projectId}/tasks?page-size=1000`);
@@ -339,7 +372,7 @@ export async function addNewTimeEntry(
 ): Promise<TimeEntry | null> {
   showToast(Toast.Style.Animated, "Starting…");
 
-  const workspaceId = await LocalStorage.getItem("workspaceId");
+  const { workspaceId } = await resolveConfig();
   const { data, error } = await fetcher(`/workspaces/${workspaceId}/time-entries`, {
     method: "POST",
     body: {
@@ -370,7 +403,9 @@ export async function addNewTimeEntry(
 
     return data as TimeEntry;
   } else {
-    showToast(Toast.Style.Failure, "Timer could not be started");
+    // Surface the reason: this toast used to be the extension's only symptom for several distinct
+    // failures, which made them very hard to tell apart.
+    showToast(Toast.Style.Failure, "Timer could not be started", error?.toString());
     return null;
   }
 }

--- a/extensions/clockify/src/utils.ts
+++ b/extensions/clockify/src/utils.ts
@@ -1,6 +1,6 @@
 import { Cache, LocalStorage, Toast, getPreferenceValues, showToast } from "@raycast/api";
 import uniqWith from "lodash.uniqwith";
-import { FetcherArgs, FetcherResponse, TimeEntry, Project, Task, User } from "./types";
+import { FetcherArgs, FetcherResponse, TimeEntry, Project, Task, User, Workspace } from "./types";
 import { showFailureToast } from "@raycast/utils";
 
 const cache = new Cache();
@@ -60,6 +60,21 @@ export async function fetcher(
 }
 
 /**
+ * Picks the workspace to operate on. `defaultWorkspace` is not guaranteed to be present, so fall
+ * back to the active workspace and then to the first workspace this token can see.
+ *
+ * Single implementation on purpose: both useConfig and resolveConfig need this chain, and two
+ * copies would be free to drift apart.
+ */
+export async function resolveWorkspaceId(user: User | undefined): Promise<string | undefined> {
+  const fromUser = user?.defaultWorkspace || user?.activeWorkspace;
+  if (fromUser) return fromUser;
+
+  const { data } = await fetcher(`/workspaces`);
+  return (data as Workspace[] | undefined)?.[0]?.id;
+}
+
+/**
  * Resolves the workspace and user ids that every request needs.
  *
  * These are written by useConfig, but a resolved `LocalStorage.setItem` does not guarantee the key
@@ -83,7 +98,7 @@ export async function resolveConfig(): Promise<{ workspaceId?: string; userId?: 
   const { data } = await fetcher(`/user`);
   const user = data as User | undefined;
 
-  const workspaceId = storedWorkspaceId || user?.defaultWorkspace || user?.activeWorkspace;
+  const workspaceId = storedWorkspaceId || (await resolveWorkspaceId(user));
   const userId = storedUserId || user?.id;
 
   if (workspaceId) await LocalStorage.setItem("workspaceId", workspaceId);


### PR DESCRIPTION
## Description

Fixes commands failing with `"User doesn't belong to Workspace"` (HTTP 400) and `"WorkspaceId is missing in feature check"` (HTTP 403), which surface in the UI as a permanently empty time-entry list and a bare **"Timer could not be started"** toast.

### Root cause

`useConfig` bootstraps `userId`, `workspaceId` and `name` into `LocalStorage`, then every API helper in `utils.ts` reads those ids back out of `LocalStorage` independently. Two problems compound there:

**1. A resolved `LocalStorage.setItem` does not guarantee the key is readable.** `useConfig` issued its three writes without awaiting them, and `useConfig` can bootstrap from more than one mounted component at once. Under that concurrency a write is lost. Captured from a dev build, with logging added around the write and the read:

```
wrote workspaceId="63c59a0a…c9"
getTimeEntries read workspaceId=undefined userId="63c59a0a…c8"
  | allItems keys=["name","userId"] allItems.workspaceId=undefined
GET /workspaces/undefined/user/63c59a0a…c8/time-entries?hydrated=true&page-size=500 -> 400
  {"message":"User doesn't belong to Workspace","code":501}
```

`name` and `userId` — written in the same batch — both landed; `workspaceId` did not. Because `useConfig`'s guard is `if (userId && workspaceId && name)`, the missing key makes it refetch `/user` on every mount and re-race, so the extension can stay stuck in this state rather than recovering. It is intermittent, which is consistent with users reporting this on some installs and not others.

**2. `defaultWorkspace` was typed as required.** `User.defaultWorkspace: string` is non-optional in `types.d.ts`, so nothing warned that it can be absent — and `setItem` cannot store `undefined`, which produces the same missing-key state by a second route.

### Fix

- New `resolveConfig()` in `utils.ts` treats `LocalStorage` as a cache rather than the source of truth: if either id is missing it re-derives from `/user` and repairs the stored copy. All 8 read sites (6 in `utils.ts`, 2 in `index.tsx`) go through it, so a lost write now self-heals instead of producing `/workspaces/undefined/...`.
- `useConfig` writes the three keys sequentially rather than via `Promise.all`, so it stops provoking the loss in the first place.
- Workspace resolution falls back `defaultWorkspace` → `activeWorkspace` → first entry from `GET /workspaces`, and shows an explicit error if none resolves instead of continuing with `undefined`.
- `types.d.ts`: `defaultWorkspace` is now optional, `activeWorkspace` added, plus a `Workspace` interface.

Two smaller items, both of which cost time while diagnosing this:

- `validateToken()` read `token.length` without guarding, inside a `useState` initializer — an absent preference throws during render and takes the command down with no log output. Now guarded.
- The "Timer could not be started" toast includes the reason Clockify returned, matching the existing pattern in `AddTimeEntry`.

### Side effect worth noting for review

`resolveConfig()` issues a `GET /user` when an id is missing, and several callers can hit that concurrently on a cold start — a few extra requests, once, against a limit I measured at roughly 10 req/s per API key. The alternative is threading the ids down from `useConfig` as parameters, which is cleaner but touches many more signatures and would not help `clockifymenu.tsx`, which never calls `useConfig` and therefore could not previously recover from the missing key at all.

This may be the underlying cause of #28716; I have not been able to confirm that from the reports, so I am not claiming it as a fix.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
