### PR TITLE
Update Sunsama extension

### DIFF
--- a/extensions/sunsama/CHANGELOG.md
+++ b/extensions/sunsama/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Sunsama Changelog
 
-## [Default Channel for Linked Tasks] - {PR_MERGE_DATE}
+## [Default Channel for Linked Tasks] - 2026-09-09
 
 - A pasted link now keeps whichever channel Sunsama's own automation assigns to
   it, and falls back to your default channel when no automation fires. Picking a

--- a/extensions/sunsama/CHANGELOG.md
+++ b/extensions/sunsama/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Sunsama Changelog
 
+## [Default Channel for Linked Tasks] - {PR_MERGE_DATE}
+
+- A pasted link now keeps whichever channel Sunsama's own automation assigns to
+  it, and falls back to your default channel when no automation fires. Picking a
+  channel yourself still wins.
+- Add Task opens its connection to Sunsama while you type, so submitting no
+  longer waits for it.
+
 ## [Initial Version] - 2026-09-05
 
 Manage your Sunsama tasks from Raycast, over Sunsama's official MCP server.

--- a/extensions/sunsama/src/add-task.tsx
+++ b/extensions/sunsama/src/add-task.tsx
@@ -16,7 +16,9 @@ import {
   getDefaultChannel,
   getRecentChannel,
   rememberLastChannel,
+  setChannel,
 } from "./lib/sunsama-client";
+import { warmUp } from "./lib/mcp";
 import { toDayString } from "./lib/date";
 import { reportError } from "./lib/errors";
 import { parseDuration, parseSubtasks } from "./lib/time";
@@ -46,6 +48,11 @@ export default function AddTask() {
     getPreferenceValues<Preferences.AddTask>();
   const rememberFor = Number(rememberChannelMinutes) || 0;
   const channels = useChannels();
+
+  // Nothing else in this form touches the server — the stored channel list is
+  // read from disk — so without this the MCP handshake happens on submit, in
+  // front of the user. Opening it on mount overlaps it with the typing.
+  useEffect(warmUp, []);
 
   // The channel to start on: the one just used, while it's still recent, and
   // otherwise the saved default. Resolved together so the field is only set
@@ -117,28 +124,54 @@ export default function AddTask() {
       style: Toast.Style.Animated,
       title: "Creating task…",
     });
+    // A link may carry its own channel automation server-side (e.g. a Trello
+    // board mapped to a channel). Only worth deferring to it when the channel
+    // field is still whatever it auto-filled to — an explicit pick always wins.
+    const channelUntouched = values.channel === (startingChannel ?? "");
+    const deferToAutomation = !!url && channelUntouched;
+
     try {
-      const createdTitle = await createTask({
+      const created = await createTask({
         title,
         day: toDayString(values.day ?? new Date()),
         url,
         notes: values.notes.trim() || undefined,
-        channel: values.channel || undefined,
+        channel: deferToAutomation ? undefined : values.channel || undefined,
         position: values.position === "bottom" ? "bottom" : "top",
         timeEstimate,
         subtasks: parseSubtasks(values.subtasks),
       });
+
+      // No automation fired — fall back to the default/recent channel so a
+      // link without one still lands where every other task would.
+      let fellBackToDefault = false;
+      if (
+        deferToAutomation &&
+        !created.channel &&
+        created.id &&
+        values.channel
+      ) {
+        await setChannel(created.id, values.channel);
+        fellBackToDefault = true;
+      }
+
       // Recorded after the task lands, so the next one can start here while
-      // it's still recent.
-      await rememberLastChannel(values.channel);
+      // it's still recent — the picked channel, whichever channel automation
+      // assigned, or the default just applied as a fallback.
+      await rememberLastChannel(created.channel || values.channel || "");
       await toast.hide();
       // Close and go back to root. Without an explicit type this follows the
       // user's "Pop to Root Search" preference, which can leave the filled-in
       // form on the stack for the next launch.
-      await showHUD(`Added task: ${createdTitle}`, {
-        popToRootType: PopToRootType.Immediate,
-        clearRootSearch: true,
-      });
+      await showHUD(
+        created.channel && !fellBackToDefault
+          ? `Added task: ${created.title} → ${created.channel}`
+          : `Added task: ${created.title}`,
+        {
+          popToRootType: PopToRootType.Immediate,
+          clearRootSearch: true,
+        },
+      );
     } catch (error) {
       toast.hide();
       await reportError(error, "Failed to create task");

--- a/extensions/sunsama/src/add-task.tsx
+++ b/extensions/sunsama/src/add-task.tsx
@@ -19,6 +19,7 @@ import {
   setChannel,
 } from "./lib/sunsama-client";
 import { warmUp } from "./lib/mcp";
+import { ChannelPickState, nextChannelPickState } from "./lib/channels";
 import { toDayString } from "./lib/date";
 import { reportError } from "./lib/errors";
 import { parseDuration, parseSubtasks } from "./lib/time";
@@ -90,10 +91,21 @@ export default function AddTask() {
     },
   });
 
-  // On the very first run (no cache yet), apply it once it resolves.
+  // Whether the channel was picked by the user or filled in for them. Recorded
+  // as it happens rather than compared at submit, so switching away and back
+  // still counts as a deliberate choice.
+  const [channelPick, setChannelPick] = useState<ChannelPickState>({
+    autoFilled: null,
+    touched: false,
+  });
+
+  // On the very first run (no cache yet), apply it once it resolves — but never
+  // over a channel the user picked while it was still resolving.
   useEffect(() => {
-    if (startingChannel) setValue("channel", startingChannel);
-  }, [startingChannel, setValue]);
+    if (!startingChannel || channelPick.touched) return;
+    setChannelPick((pick) => ({ ...pick, autoFilled: startingChannel }));
+    setValue("channel", startingChannel);
+  }, [startingChannel, channelPick.touched, setValue]);
 
   async function submit(values: FormValues) {
     const entry = values.task.trim();
@@ -127,8 +139,7 @@ export default function AddTask() {
     // A link may carry its own channel automation server-side (e.g. a Trello
     // board mapped to a channel). Only worth deferring to it when the channel
     // field is still whatever it auto-filled to — an explicit pick always wins.
-    const channelUntouched = values.channel === (startingChannel ?? "");
-    const deferToAutomation = !!url && channelUntouched;
+    const deferToAutomation = !!url && !channelPick.touched;
 
     try {
       const created = await createTask({
@@ -224,7 +235,14 @@ export default function AddTask() {
         type={Form.DatePicker.Type.Date}
       />
       <Form.Separator />
-      <ChannelDropdown {...itemProps.channel} channels={channels} />
+      <ChannelDropdown
+        {...itemProps.channel}
+        channels={channels}
+        onChange={(value) => {
+          setChannelPick((pick) => nextChannelPickState(pick, value));
+          itemProps.channel.onChange?.(value);
+        }}
+      />
       <Form.Dropdown {...itemProps.position} title="Position">
         <Form.Dropdown.Item
           value="top"

--- a/extensions/sunsama/src/add-task.tsx
+++ b/extensions/sunsama/src/add-task.tsx
@@ -144,29 +144,41 @@ export default function AddTask() {
 
       // No automation fired — fall back to the default/recent channel so a
       // link without one still lands where every other task would.
-      let fellBackToDefault = false;
+      let channelFailed = false;
       if (
         deferToAutomation &&
         !created.channel &&
         created.id &&
         values.channel
       ) {
-        await setChannel(created.id, values.channel);
-        fellBackToDefault = true;
+        // The task exists by now, so a failure here is not a failed creation.
+        // Reporting it as one would send the user back to a filled-in form and
+        // invite a retry that creates a duplicate — say what actually went
+        // wrong instead and leave the task standing without a channel.
+        try {
+          await setChannel(created.id, values.channel);
+        } catch {
+          channelFailed = true;
+        }
       }
 
       // Recorded after the task lands, so the next one can start here while
       // it's still recent — the picked channel, whichever channel automation
-      // assigned, or the default just applied as a fallback.
-      await rememberLastChannel(created.channel || values.channel || "");
+      // assigned, or the default just applied as a fallback. Nothing to record
+      // when the fallback didn't take.
+      await rememberLastChannel(
+        channelFailed ? "" : created.channel || values.channel || "",
+      );
       await toast.hide();
       // Close and go back to root. Without an explicit type this follows the
       // user's "Pop to Root Search" preference, which can leave the filled-in
       // form on the stack for the next launch.
       await showHUD(
-        created.channel && !fellBackToDefault
-          ? `Added task: ${created.title} → ${created.channel}`
-          : `Added task: ${created.title}`,
+        channelFailed
+          ? `Added task: ${created.title} — couldn't set the channel`
+          : created.channel
+            ? `Added task: ${created.title} → ${created.channel}`
+            : `Added task: ${created.title}`,
         {
           popToRootType: PopToRootType.Immediate,
           clearRootSearch: true,

--- a/extensions/sunsama/src/lib/channels.test.ts
+++ b/extensions/sunsama/src/lib/channels.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { matchesChannel, matchesNoChannel } from "./channels";
+import {
+  matchesChannel,
+  matchesNoChannel,
+  nextChannelPickState,
+} from "./channels";
 import { Channel } from "./types";
 
 const channel = (name: string, categoryName?: string): Channel => ({
@@ -59,5 +63,33 @@ describe("matchesNoChannel", () => {
 
   it("stops matching once the query names something else", () => {
     expect(matchesNoChannel("bark")).toBe(false);
+  });
+});
+
+describe("nextChannelPickState", () => {
+  // The picks the field reports, in order, starting from the channel the form
+  // filled in for the user.
+  const pick = (autoFilled: string | null, ...picks: string[]) =>
+    picks.reduce(nextChannelPickState, { autoFilled, touched: false });
+
+  it("doesn't count the channel the form filled in", () => {
+    expect(pick("Work", "Work").touched).toBe(false);
+  });
+
+  it("counts a channel the user picked", () => {
+    expect(pick("Work", "Work", "The Lab").touched).toBe(true);
+    expect(pick(null, "The Lab").touched).toBe(true);
+  });
+
+  it("counts switching away and back to the channel filled in", () => {
+    expect(pick("Work", "Work", "The Lab", "Work").touched).toBe(true);
+  });
+
+  it("counts a pick made before the channel was filled in", () => {
+    expect(pick(null, "The Lab", "Work").touched).toBe(true);
+  });
+
+  it("counts clearing the channel", () => {
+    expect(pick("Work", "Work", "").touched).toBe(true);
   });
 });

--- a/extensions/sunsama/src/lib/channels.ts
+++ b/extensions/sunsama/src/lib/channels.ts
@@ -25,3 +25,41 @@ export function matchesNoChannel(query: string): boolean {
   const parts = query.toLowerCase().split(/\s+/).filter(Boolean);
   return parts.every((part) => "no channel".includes(part));
 }
+
+/**
+ * How a channel field stands relative to what the form filled in for the user.
+ *
+ * `autoFilled` is the channel that was applied programmatically — the recent or
+ * default one — and is still waiting to be seen come back through `onChange`,
+ * which Raycast also fires for a value set in code. `touched` is whether the
+ * user has picked a channel themselves.
+ */
+export interface ChannelPickState {
+  autoFilled: string | null;
+  touched: boolean;
+}
+
+/**
+ * Fold one channel selection into the pick state.
+ *
+ * A linked task can have its channel chosen server-side by an automation, and
+ * that should only happen while the user has left the field alone. Deciding
+ * that by comparing the field to the auto-filled channel at submit time gets it
+ * wrong when the user switches away and back: the values match again, but the
+ * choice was still deliberate. So the pick is recorded as it happens and never
+ * unrecorded.
+ *
+ * The one selection that doesn't count is the echo of the channel just applied
+ * in code, which is consumed the first time it arrives.
+ *
+ * @param  state The state so far.
+ * @param  pick  The channel name now selected ("" for no channel).
+ * @return The updated state.
+ */
+export function nextChannelPickState(
+  state: ChannelPickState,
+  pick: string,
+): ChannelPickState {
+  if (pick === state.autoFilled) return { ...state, autoFilled: null };
+  return { ...state, touched: true };
+}

--- a/extensions/sunsama/src/lib/mcp.ts
+++ b/extensions/sunsama/src/lib/mcp.ts
@@ -208,6 +208,19 @@ async function getClient(): Promise<Client> {
   return clientPromise;
 }
 
+/**
+ * Open the connection ahead of the first tool call.
+ *
+ * Connecting means an MCP initialize round trip, plus a token refresh when the
+ * stored one has expired — paid by whichever call goes first. A command that
+ * sits idle while the user fills in a form pays it on submit, where it's felt;
+ * calling this on mount moves it to where it isn't. Failures are swallowed:
+ * `getClient` drops the cached promise, so the real call retries and reports.
+ */
+export function warmUp(): void {
+  void getClient().catch(() => undefined);
+}
+
 function mapError(error: unknown): never {
   const text = error instanceof Error ? error.message : String(error);
   if (error instanceof UnauthorizedError || /401|unauthorized/i.test(text)) {

--- a/extensions/sunsama/src/lib/sunsama-client.ts
+++ b/extensions/sunsama/src/lib/sunsama-client.ts
@@ -408,9 +408,18 @@ export async function getTask(taskId: string): Promise<Task | null> {
   return t ? projectTask(t) : null;
 }
 
-/** Creates the task and returns its final title, which the server sets from a
- * linked item when no title was given. */
-export async function createTask(input: CreateTaskInput): Promise<string> {
+export interface CreatedTask {
+  id?: string;
+  title: string;
+  /** Set when the server assigned a channel we didn't pass — the linked
+   * item's board already maps to one, and channel prediction filled it in. */
+  channel?: string;
+}
+
+/** Creates the task and returns its final title (the server sets one from a
+ * linked item when no title was given) and, for a linked task created with no
+ * channel, whichever channel Sunsama's own prediction assigned. */
+export async function createTask(input: CreateTaskInput): Promise<CreatedTask> {
   const args: Record<string, unknown> = {
     day: input.day,
     position: input.position ?? "top",
@@ -426,18 +435,23 @@ export async function createTask(input: CreateTaskInput): Promise<string> {
     args.subtasks = input.subtasks.map((s) => ({ title: s.title }));
 
   const text = await callTool("create_task", args);
-  // Best-effort: pull the created title out of the JSON reply for the HUD.
+  // Best-effort: pull the created title/channel out of the JSON reply.
   try {
     const parsed = JSON.parse(text) as {
-      task?: { title?: string };
+      task?: { _id?: string; title?: string; channel?: string };
+      _id?: string;
       title?: string;
+      channel?: string;
     };
+    const id = parsed.task?._id ?? parsed._id;
     const title = parsed.task?.title ?? parsed.title;
-    if (title) return title;
+    const channel = parsed.task?.channel ?? parsed.channel;
+    if (title)
+      return { id, title, channel: input.channel ? undefined : channel };
   } catch {
     // non-JSON reply — fall through
   }
-  return input.title?.trim() || input.url || "New task";
+  return { title: input.title?.trim() || input.url || "New task" };
 }
 
 export async function completeTask(taskId: string): Promise<void> {


### PR DESCRIPTION
## Description

Update to the Sunsama extension.

A pasted link can carry a channel automation on Sunsama's side — a Trello board mapped to a channel, for example. Add Task was always passing the default channel to `create_task`, which suppressed that automation, so a linked task never landed where the automation intended.

The channel is now left off when a link is being attached and the user hasn't picked one, and the default is applied afterwards only if the server picked nothing. An explicit pick is passed straight through and still wins.

Add Task also opens its connection to the MCP server when the form mounts. Nothing else in that form touches the server — the channel list is read from disk — so the handshake used to land on submit, where the user waits on it.

Verified against the live server: a plain task comes back with no `channel` field, while a Trello card on a mapped board comes back with the channel already filled in.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder

https://claude.ai/code/session_01KAYqb4ZRrrq7ukUszDQQXW
