### PR TITLE
Agent Usage: apply saved provider order in the menu bar

### DIFF
--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Agent Usage Changelog
 
+## [Unreleased]
+
+### Bug Fixes
+
+- Apply the provider order from Move Up/Down in the list to the menu bar (use Refresh All after reordering)
+
 ## [Add OpenRouter credit balance] - 2026-09-08
 
 ### New Features

--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Agent Usage Changelog
 
-## [Unreleased]
+## [Apply Saved Provider Order] - {PR_MERGE_DATE}
 
 ### Bug Fixes
 

--- a/extensions/agent-usage/CHANGELOG.md
+++ b/extensions/agent-usage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Agent Usage Changelog
 
-## [Apply Saved Provider Order] - {PR_MERGE_DATE}
+## [Apply Saved Provider Order] - 2026-09-09
 
 ### Bug Fixes
 

--- a/extensions/agent-usage/src/agent-usage-menubar.tsx
+++ b/extensions/agent-usage/src/agent-usage-menubar.tsx
@@ -2,6 +2,7 @@ import {
   getPreferenceValues,
   Icon,
   LaunchType,
+  LocalStorage,
   MenuBarExtra,
   launchCommand,
   openCommandPreferences,
@@ -9,10 +10,16 @@ import {
   Keyboard,
 } from "@raycast/api";
 import type { Image } from "@raycast/api";
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { formatClock, latestTimestamp } from "./agents/format.ts";
-import { sortByDefaultAgentOrder } from "./agents/order.ts";
+import {
+  AGENT_ORDER_KEY,
+  DEFAULT_AGENT_ORDER,
+  isDefaultAgentId,
+  parseStoredAgentOrder,
+  sortByAgentOrder,
+} from "./agents/order.ts";
 import {
   useAihubmixUsage,
   useAmpUsage,
@@ -84,6 +91,17 @@ function getMenuItemTooltip(usageTooltip?: string): string {
 
 export default function MenuBarCommand() {
   const prefs = getPreferenceValues<AgentVisibilityPreferences>();
+  const [agentOrder, setAgentOrder] = useState<readonly AgentId[]>(DEFAULT_AGENT_ORDER);
+
+  const loadAgentOrder = useCallback(async () => {
+    const stored = await LocalStorage.getItem<string>(AGENT_ORDER_KEY);
+    const parsed = parseStoredAgentOrder(stored, isDefaultAgentId, DEFAULT_AGENT_ORDER);
+    setAgentOrder(parsed ?? DEFAULT_AGENT_ORDER);
+  }, []);
+
+  useEffect(() => {
+    void loadAgentOrder();
+  }, [loadAgentOrder]);
 
   const isAihubmixVisible = Boolean(prefs.showAihubmix);
   const isAmpVisible = Boolean(prefs.showAmp);
@@ -506,7 +524,7 @@ export default function MenuBarCommand() {
 
   const visibleAgents = useMemo(
     () =>
-      sortByDefaultAgentOrder(
+      sortByAgentOrder(
         [
           ...singleAgents,
           ...clinePassAgents,
@@ -516,12 +534,14 @@ export default function MenuBarCommand() {
           ...syntheticAgents,
           ...zaiAgents,
         ].filter((a) => a.visible),
+        agentOrder,
       ),
-    [singleAgents, clinePassAgents, codexAgents, copilotAgents, kimiAgents, syntheticAgents, zaiAgents],
+    [singleAgents, clinePassAgents, codexAgents, copilotAgents, kimiAgents, syntheticAgents, zaiAgents, agentOrder],
   );
   const isLoading = visibleAgents.some((agent) => agent.isLoading);
 
   const handleRefresh = async () => {
+    await loadAgentOrder();
     await Promise.all(visibleAgents.map((a) => a.revalidate()));
     await showHUD("Agent Usage Refreshed");
   };

--- a/extensions/agent-usage/src/agent-usage.tsx
+++ b/extensions/agent-usage/src/agent-usage.tsx
@@ -18,7 +18,13 @@ import { ManageAccountsForm } from "./accounts/ManageAccountsForm.tsx";
 import type { AccountUsageState } from "./accounts/types.ts";
 import { formatErrorMarkdown } from "./agents/detail-format.ts";
 import { formatClock, latestTimestamp } from "./agents/format.ts";
-import { DEFAULT_AGENT_ORDER, getInitialSelectedRowId, getRequestedSelectedRowId } from "./agents/order.ts";
+import {
+  AGENT_ORDER_KEY,
+  DEFAULT_AGENT_ORDER,
+  getInitialSelectedRowId,
+  getRequestedSelectedRowId,
+  parseStoredAgentOrder,
+} from "./agents/order.ts";
 import {
   useAihubmixUsage,
   useAmpUsage,
@@ -85,8 +91,6 @@ import { formatSyntheticUsageText, getSyntheticAccessory, renderSyntheticDetail 
 import type { SyntheticError, SyntheticUsage } from "./synthetic/types.ts";
 import { formatZaiUsageText, getZaiAccessory, renderZaiDetail } from "./zai/renderer.tsx";
 import type { ZaiError, ZaiUsage } from "./zai/types.ts";
-
-const AGENT_ORDER_KEY = "agent-order";
 
 type ErrorLike = { type: string; message: string };
 type CommandLaunchContext = { selectedAgentId?: string };
@@ -623,20 +627,10 @@ export default function Command(props: LaunchProps<{ launchContext: CommandLaunc
 
   useEffect(() => {
     LocalStorage.getItem<string>(AGENT_ORDER_KEY).then((stored) => {
-      if (stored) {
-        try {
-          const parsed = JSON.parse(stored);
-          if (Array.isArray(parsed)) {
-            const validOrder = parsed.filter((id): id is AgentId => typeof id === "string" && isAgentId(id));
-            if (validOrder.length > 0) {
-              const missingIds = AGENT_IDS.filter((id) => !validOrder.includes(id));
-              setAgentOrder([...validOrder, ...missingIds]);
-              setHasStoredAgentOrder(true);
-            }
-          }
-        } catch {
-          // keep default order
-        }
+      const parsed = parseStoredAgentOrder(stored, isAgentId, AGENT_IDS);
+      if (parsed) {
+        setAgentOrder(parsed);
+        setHasStoredAgentOrder(true);
       }
       setOrderLoaded(true);
     });

--- a/extensions/agent-usage/src/agents/order.test.ts
+++ b/extensions/agent-usage/src/agents/order.test.ts
@@ -1,7 +1,16 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { getInitialSelectedRowId, getRequestedSelectedRowId, sortByDefaultAgentOrder } from "./order.ts";
+import {
+  DEFAULT_AGENT_ORDER,
+  getInitialSelectedRowId,
+  getRequestedSelectedRowId,
+  isDefaultAgentId,
+  parseStoredAgentOrder,
+  resolveProviderId,
+  sortByAgentOrder,
+  sortByDefaultAgentOrder,
+} from "./order.ts";
 import type { AgentId } from "./types.ts";
 
 test("sortByDefaultAgentOrder uses the canonical provider order and keeps provider accounts together", () => {
@@ -51,6 +60,37 @@ test("sortByDefaultAgentOrder uses the canonical provider order and keeps provid
       "zai-1",
     ],
   );
+});
+
+test("sortByAgentOrder respects a saved user order and composite account row ids", () => {
+  const agents = [
+    { id: "amp" },
+    { id: "codex-account-1" },
+    { id: "zai-account-1" },
+    { id: "claude" },
+    { id: "minimaxcn-1" },
+    { id: "minimax" },
+  ];
+
+  assert.deepEqual(
+    sortByAgentOrder(agents, ["zai", "minimaxcn", "claude", "codex", "amp", "minimax"]).map((agent) => agent.id),
+    ["zai-account-1", "minimaxcn-1", "claude", "codex-account-1", "amp", "minimax"],
+  );
+});
+
+test("resolveProviderId prefers the longest matching provider prefix", () => {
+  assert.equal(resolveProviderId("minimaxcn-account-1"), "minimaxcn");
+  assert.equal(resolveProviderId("minimax"), "minimax");
+  assert.equal(resolveProviderId("unknown-row"), undefined);
+});
+
+test("parseStoredAgentOrder merges missing providers after the saved order", () => {
+  assert.deepEqual(
+    parseStoredAgentOrder(JSON.stringify(["zai", "amp"]), isDefaultAgentId, DEFAULT_AGENT_ORDER)?.slice(0, 2),
+    ["zai", "amp"],
+  );
+  assert.equal(parseStoredAgentOrder(undefined, isDefaultAgentId, DEFAULT_AGENT_ORDER), null);
+  assert.equal(parseStoredAgentOrder("not-json", isDefaultAgentId, DEFAULT_AGENT_ORDER), null);
 });
 
 test("getInitialSelectedRowId selects the first visible provider in the saved user order", () => {

--- a/extensions/agent-usage/src/agents/order.ts
+++ b/extensions/agent-usage/src/agents/order.ts
@@ -1,5 +1,7 @@
 import type { AgentId } from "./types.ts";
 
+export const AGENT_ORDER_KEY = "agent-order";
+
 export const DEFAULT_AGENT_ORDER = [
   "aihubmix",
   "amp",
@@ -24,16 +26,74 @@ export const DEFAULT_AGENT_ORDER = [
 
 const defaultOrderIndex = new Map<AgentId, number>(DEFAULT_AGENT_ORDER.map((agentId, index) => [agentId, index]));
 
-export function sortByDefaultAgentOrder<T extends { id: AgentId }>(agents: readonly T[]): T[] {
+/** Longest-first so `minimaxcn-…` resolves before `minimax-…`. */
+const providerIdsByLength = [...DEFAULT_AGENT_ORDER].sort((left, right) => right.length - left.length);
+
+export function isDefaultAgentId(value: string): value is AgentId {
+  return defaultOrderIndex.has(value as AgentId);
+}
+
+/**
+ * Map a menu-bar / list row id (`codex`, `codex-account-1`) to its provider id.
+ */
+export function resolveProviderId(rowId: string): AgentId | undefined {
+  if (isDefaultAgentId(rowId)) {
+    return rowId;
+  }
+
+  for (const agentId of providerIdsByLength) {
+    if (rowId.startsWith(`${agentId}-`)) {
+      return agentId;
+    }
+  }
+
+  return undefined;
+}
+
+export function sortByAgentOrder<T extends { id: string }>(agents: readonly T[], order: readonly AgentId[]): T[] {
+  const orderIndex = new Map(order.map((agentId, index) => [agentId, index]));
+
   return agents
     .map((agent, originalIndex) => ({ agent, originalIndex }))
-    .sort(
-      (left, right) =>
-        (defaultOrderIndex.get(left.agent.id) ?? Number.MAX_SAFE_INTEGER) -
-          (defaultOrderIndex.get(right.agent.id) ?? Number.MAX_SAFE_INTEGER) ||
-        left.originalIndex - right.originalIndex,
-    )
+    .sort((left, right) => {
+      const leftProviderId = resolveProviderId(left.agent.id);
+      const rightProviderId = resolveProviderId(right.agent.id);
+      const leftOrder =
+        leftProviderId !== undefined
+          ? (orderIndex.get(leftProviderId) ?? Number.MAX_SAFE_INTEGER)
+          : Number.MAX_SAFE_INTEGER;
+      const rightOrder =
+        rightProviderId !== undefined
+          ? (orderIndex.get(rightProviderId) ?? Number.MAX_SAFE_INTEGER)
+          : Number.MAX_SAFE_INTEGER;
+      return leftOrder - rightOrder || left.originalIndex - right.originalIndex;
+    })
     .map(({ agent }) => agent);
+}
+
+export function sortByDefaultAgentOrder<T extends { id: string }>(agents: readonly T[]): T[] {
+  return sortByAgentOrder(agents, DEFAULT_AGENT_ORDER);
+}
+
+export function parseStoredAgentOrder(
+  stored: string | undefined,
+  isValidId: (value: string) => value is AgentId,
+  knownIds: readonly AgentId[],
+): AgentId[] | null {
+  if (!stored) return null;
+
+  try {
+    const parsed = JSON.parse(stored);
+    if (!Array.isArray(parsed)) return null;
+
+    const validOrder = parsed.filter((id): id is AgentId => typeof id === "string" && isValidId(id));
+    if (validOrder.length === 0) return null;
+
+    const missingIds = knownIds.filter((id) => !validOrder.includes(id));
+    return [...validOrder, ...missingIds];
+  } catch {
+    return null;
+  }
 }
 
 export function getInitialSelectedRowId(


### PR DESCRIPTION
## Summary
- The list command already saved Move Up/Down order to LocalStorage (`agent-order`), but the menu bar always sorted with the default provider order.
- Menu bar now loads that shared order on mount and again on Refresh All, and sorts items (including multi-account row ids) with it.
- Shared parse/sort helpers live in `order.ts` so list and menu bar stay in sync.

## Testing
- Ran `npm test` (including order helpers), `npm run build`, typecheck, and lint — all passed.
- Simulated the menu bar path locally: stored order JSON → `parseStoredAgentOrder` → `sortByAgentOrder` (with multi-account row ids); confirmed custom order differed from default and reset restored default.
- Started `npx ray develop`, reordered providers in Agent Usage with Move Up/Down, then used Refresh All in the menu bar — order matched the list.