### PR TITLE
fix(browser-tabs): keep maximized windows maximized on Windows

### DIFF
--- a/extensions/browser-tabs/CHANGELOG.md
+++ b/extensions/browser-tabs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Browser Tabs Changelog
 
-## [Fix Maximized Windows on Windows] - {PR_MERGE_DATE}
+## [Fix Maximized Windows on Windows] - 2026-09-09
 
 - Fix switching to or closing a tab shrinking a maximized browser window on Windows: a window that is already on screen is no longer shown again, only brought to the front
 

--- a/extensions/browser-tabs/CHANGELOG.md
+++ b/extensions/browser-tabs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Browser Tabs Changelog
 
+## [Fix Maximized Windows on Windows] - {PR_MERGE_DATE}
+
+- Fix switching to or closing a tab shrinking a maximized browser window on Windows: a window that is already on screen is no longer shown again, only brought to the front
+
 ## [Windows Support] - 2026-08-12
 
 - Add Windows support: tabs are read from running browsers with UI Automation through a native helper, so no browser extension is needed

--- a/extensions/browser-tabs/rust/src/main.rs
+++ b/extensions/browser-tabs/rust/src/main.rs
@@ -35,7 +35,7 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
 };
 use windows::Win32::UI::WindowsAndMessaging::{
     EnumWindows, GetForegroundWindow, GetWindowThreadProcessId, IsIconic, IsWindowVisible,
-    SetForegroundWindow, ShowWindow, SW_RESTORE, SW_SHOW,
+    SetForegroundWindow, ShowWindow, SW_RESTORE,
 };
 
 /// Browsers whose tab strips UI Automation can read. The Gecko based ones are included even
@@ -494,10 +494,12 @@ fn is_selected(tab: &IUIAutomationElement) -> bool {
 
 fn bring_window_to_front(hwnd: HWND) {
     unsafe {
+        // Only a minimised window needs showing again, and SW_RESTORE puts one that was
+        // maximised before it was minimised back to maximised. A window that is already on
+        // screen is left alone: ShowWindow on it drops a maximised window back to its
+        // restored size, and foregrounding is all that is needed anyway.
         if IsIconic(hwnd).as_bool() {
             let _ = ShowWindow(hwnd, SW_RESTORE);
-        } else {
-            let _ = ShowWindow(hwnd, SW_SHOW);
         }
         let _ = SetForegroundWindow(hwnd);
     }


### PR DESCRIPTION
## Description

On Windows, switching to a tab shrank a maximized browser window back to its restored size.

`bring_window_to_front` called `ShowWindow(hwnd, SW_SHOW)` on every window that was not minimized. A window that is already on screen does not need showing again, and that call drops a maximized window out of its maximized state. `SetForegroundWindow` on its own is all the focusing that is needed.

`ShowWindow` now runs only when the window is minimized, where `SW_RESTORE` already puts a window that was maximized before it was minimized back to maximized. Both `activate_tab` and `close_tab` go through this function, so both are fixed.

Ref https://github.com/raycast/extensions/issues/30903 — that report also covers Raycast's own window switching, which is outside this extension, so the issue is left open.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] `cargo check` passes on the native helper
- [x] The change is confined to the Windows helper and does not touch the macOS code path
- [x] I updated the `CHANGELOG.md`
