### PR TITLE
[Safari] Add New Window command

### DIFF
--- a/extensions/safari/CHANGELOG.md
+++ b/extensions/safari/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Safari Changelog
 
-## [New Command] - {PR_MERGE_DATE}
+## [New Command] - 2026-09-09
 
 - Add a `New Window` command that opens a new window of the selected Safari browser.
 

--- a/extensions/safari/CHANGELOG.md
+++ b/extensions/safari/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Safari Changelog
 
+## [New Command] - {PR_MERGE_DATE}
+
+- Add a `New Window` command that opens a new window of the selected Safari browser.
+
 ## [Fix] - 2026-08-12
 
 - Handle large Safari bookmark libraries without parser limit errors.

--- a/extensions/safari/package.json
+++ b/extensions/safari/package.json
@@ -20,7 +20,8 @@
     "xmok",
     "niksite",
     "ojowwalker77",
-    "gumadeiras"
+    "gumadeiras",
+    "jsonMartin"
   ],
   "pastContributors": [
     "axsuul",
@@ -177,6 +178,13 @@
       "title": "Close Other Tabs",
       "subtitle": "Safari",
       "description": "Close all Safari tabs except the current one",
+      "mode": "no-view"
+    },
+    {
+      "name": "new-window",
+      "title": "New Window",
+      "subtitle": "Safari",
+      "description": "Open a new Safari window",
       "mode": "no-view"
     }
   ],

--- a/extensions/safari/src/new-window.ts
+++ b/extensions/safari/src/new-window.ts
@@ -1,0 +1,18 @@
+import { closeMainWindow, showToast, Toast } from "@raycast/api";
+import { newWindow } from "./safari";
+
+export default async function Command() {
+  try {
+    // Dismiss Raycast before Safari activates so it does not reclaim keyboard focus.
+    await closeMainWindow();
+    await newWindow();
+  } catch (error) {
+    console.error(error);
+
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "Could not complete New Window",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/extensions/safari/src/safari.ts
+++ b/extensions/safari/src/safari.ts
@@ -188,3 +188,22 @@ export async function closeOtherTabs() {
     return `Error: ${error}`;
   }
 }
+
+// Create before activating to avoid switching to an existing window's Space.
+// Retry activation because Safari can drop it while finishing a cold launch.
+export async function newWindow() {
+  const activationRetries = 10;
+  const activationDelaySeconds = 0.2;
+
+  await runAppleScript(`
+    tell application "${safariAppIdentifier}"
+      make new document
+      repeat ${activationRetries} times
+        activate
+        if frontmost then exit repeat
+        delay ${activationDelaySeconds}
+      end repeat
+      if not frontmost then error "Window created, but ${safariAppIdentifier} did not take focus"
+    end tell
+  `);
+}


### PR DESCRIPTION
## Description

Adds a standalone **New Window** command for Safari or Safari Technology Preview, using the existing Local Safari Browser preference. It follows the existing bookmark action’s order: dismiss Raycast, create a document, then activate Safari. Safari supplies the default new-window content.

A bounded activation retry handles dropped activation observed during cold launch. Existing commands are unchanged; there are no new dependencies or assets.

### Validation

- `bun run lint` and `bun run build` passed.
- Tested the distribution build through Raycast search with Safari running: a new window opened and its address field received keyboard focus. Closed only the empty test window afterward.
- The extracted AppleScript compiles against Safari.

## Screencast

Screenshot of the standalone command in Raycast:

<img width="825" height="523" alt="new-window-command" src="https://github.com/user-attachments/assets/6e981604-b5fb-4e64-9b99-febc75c3c23c" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `bun run build` (the existing `ray build` script) and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself. The existing `full-disk-access.png` has no local source reference; this PR leaves assets unchanged and reuses `safari-icon.png`.
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it). No README or README assets are added.
