### PR TITLE
Update attio extension

### DIFF
--- a/extensions/attio/CHANGELOG.md
+++ b/extensions/attio/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Attio Changelog
 
-## [Task Edit Fix] - {PR_MERGE_DATE}
+## [Task Edit Fix] - 2026-09-09
 
 - Fixed a React state-update warning when returning from the task edit or new-task form
 

--- a/extensions/attio/CHANGELOG.md
+++ b/extensions/attio/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Attio Changelog
 
+## [Task Edit Fix] - {PR_MERGE_DATE}
+
+- Fixed a React state-update warning when returning from the task edit or new-task form
+
 ## [2.0.0] - 2026-09-08
 
 Full rewrite. Same commands, new engine — plus a set of new commands.

--- a/extensions/attio/src/tasks.tsx
+++ b/extensions/attio/src/tasks.tsx
@@ -93,6 +93,11 @@ export default function Tasks({ initialFilter = "all" }: { initialFilter?: Filte
     [sort],
   );
   const { isLoading, data, pagination, error, revalidate, mutate, self } = h;
+  // Raycast invokes Action.Push's onPop DURING the navigation re-render, so a
+  // bare `revalidate` there setStates Tasks mid-render ("Cannot update a
+  // component (Tasks) while rendering InternalNavigationRoot", live 2026-09-08).
+  // Defer it out of the render pass.
+  const revalidateAfterPop = () => setTimeout(revalidate, 0);
   const members = useMembers();
   const allTasks: Task[] = data ?? [];
   const currentDate = useMemo(() => new Date(), []);
@@ -206,7 +211,7 @@ export default function Tasks({ initialFilter = "all" }: { initialFilter?: Filte
       icon={Icon.Plus}
       title="New Task"
       target={<NewTask />}
-      onPop={revalidate}
+      onPop={revalidateAfterPop}
       shortcut={Keyboard.Shortcut.Common.New}
     />
   ) : null;
@@ -274,7 +279,7 @@ export default function Tasks({ initialFilter = "all" }: { initialFilter?: Filte
                 icon={Icon.Pencil}
                 title="Edit Task"
                 target={<TaskEditForm task={task} />}
-                onPop={revalidate}
+                onPop={revalidateAfterPop}
                 shortcut={Keyboard.Shortcut.Common.Edit}
               />
             )}


### PR DESCRIPTION
## Description

Small follow-up to #30881 (Attio 2.0): fixes a React state-update warning surfaced while testing the released build. Raycast invokes `Action.Push`'s `onPop` during the navigation re-render, so the bare `revalidate` there updated the Tasks component mid-render ("Cannot update a component (`Tasks`) while rendering a different component (`InternalNavigationRoot`)") when returning from the task edit or new-task form. The revalidate is now deferred out of the render pass.

### Changes

- Defer `onPop` revalidation in the Tasks command (both the edit-task and new-task push actions)

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that this change does not break existing commands or remove functionality
- [x] I updated `CHANGELOG.md` with an overview of the changes
