### PR TITLE
Downloads Manager: align shortcuts with Search Screenshots

### DIFF
--- a/extensions/downloads-manager/CHANGELOG.md
+++ b/extensions/downloads-manager/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Downloads Manager Changelog
 
-## [Align shortcuts with Search Screenshots] - {PR_MERGE_DATE}
+## [Align shortcuts with Search Screenshots] - 2026-09-09
 
 Bring Downloads Manager closer to Raycast's native Screenshots extension's "Search Screenshots" command, making common file actions and keyboard shortcuts more consistent across Raycast.
 

--- a/extensions/downloads-manager/CHANGELOG.md
+++ b/extensions/downloads-manager/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Downloads Manager Changelog
 
-## [Align Manage Downloads keyboard shortcuts] - {PR_MERGE_DATE}
+## [Align shortcuts with Search Screenshots] - {PR_MERGE_DATE}
+
+Bring Downloads Manager closer to Raycast's native Screenshots extension's "Search Screenshots" command, making common file actions and keyboard shortcuts more consistent across Raycast.
 
 - Added a Primary Action preference to copy downloads with Enter, while keeping Open as the default.
 - Added pasting the selected download to the focused app with Command+Enter on macOS or Ctrl+Enter on Windows.

--- a/extensions/downloads-manager/CHANGELOG.md
+++ b/extensions/downloads-manager/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Downloads Manager Changelog
 
+## [Align Manage Downloads keyboard shortcuts] - {PR_MERGE_DATE}
+
+- Added a Primary Action preference to copy downloads with Enter, while keeping Open as the default.
+- Added pasting the selected download to the focused app with Command+Enter on macOS or Ctrl+Enter on Windows.
+- Added Open and Reveal shortcuts and switched Copy Path to Raycast's standard platform-specific shortcut.
+- Organized the action menu consistently across list and grid layouts.
+
 ## [Add toggle to show filename being deleted permanently] - 2026-08-30
 
 - Added a toggle to the preference to show/hide the latest downloaded file being permanently deleted.

--- a/extensions/downloads-manager/README.md
+++ b/extensions/downloads-manager/README.md
@@ -2,6 +2,26 @@
 
 Search and organize your downloads
 
+## Manage Downloads Shortcuts
+
+Set **Primary Action** to **Copy to Clipboard** in the Manage Downloads command preferences to copy the selected download with Enter, like Raycast's Search Screenshots. The default remains **Open**, which opens files and browses directories.
+
+These shortcuts work in both list and grid layouts, including inside directories:
+
+| Action                                     | macOS             | Windows      |
+| ------------------------------------------ | ----------------- | ------------ |
+| Primary action (Open or Copy)              | Enter             | Enter        |
+| Paste selected download to the focused app | Command+Enter     | Ctrl+Enter   |
+| Copy to Clipboard                          | Command+Shift+C   | Ctrl+Shift+C |
+| Open file / browse directory               | Command+O         | Ctrl+O       |
+| Open With                                  | Command+Shift+O   | Ctrl+Shift+O |
+| Quick Look                                 | Command+Y         | Ctrl+Y       |
+| Reveal in Finder / File Explorer           | Command+Option+O  | Ctrl+Alt+O   |
+| Copy Path                                  | Command+Control+C | Alt+Shift+C  |
+| Delete Download (move to Trash)            | Control+X         | Ctrl+D       |
+
+Paste uses the app focused before opening Raycast; its action label includes that app's name when available. The destination app must support pasting files. Copy Path replaces the previous Command+Shift+. / Ctrl+Shift+. shortcut.
+
 ## Delete Latest Download via Deeplink
 
 Use a background deeplink to delete the latest download without focusing Raycast:

--- a/extensions/downloads-manager/README.md
+++ b/extensions/downloads-manager/README.md
@@ -2,26 +2,6 @@
 
 Search and organize your downloads
 
-## Manage Downloads Shortcuts
-
-Set **Primary Action** to **Copy to Clipboard** in the Manage Downloads command preferences to copy the selected download with Enter, like Raycast's Search Screenshots. The default remains **Open**, which opens files and browses directories.
-
-These shortcuts work in both list and grid layouts, including inside directories:
-
-| Action                                     | macOS             | Windows      |
-| ------------------------------------------ | ----------------- | ------------ |
-| Primary action (Open or Copy)              | Enter             | Enter        |
-| Paste selected download to the focused app | Command+Enter     | Ctrl+Enter   |
-| Copy to Clipboard                          | Command+Shift+C   | Ctrl+Shift+C |
-| Open file / browse directory               | Command+O         | Ctrl+O       |
-| Open With                                  | Command+Shift+O   | Ctrl+Shift+O |
-| Quick Look                                 | Command+Y         | Ctrl+Y       |
-| Reveal in Finder / File Explorer           | Command+Option+O  | Ctrl+Alt+O   |
-| Copy Path                                  | Command+Control+C | Alt+Shift+C  |
-| Delete Download (move to Trash)            | Control+X         | Ctrl+D       |
-
-Paste uses the app focused before opening Raycast; its action label includes that app's name when available. The destination app must support pasting files. Copy Path replaces the previous Command+Shift+. / Ctrl+Shift+. shortcut.
-
 ## Delete Latest Download via Deeplink
 
 Use a background deeplink to delete the latest download without focusing Raycast:

--- a/extensions/downloads-manager/package.json
+++ b/extensions/downloads-manager/package.json
@@ -30,6 +30,24 @@
       "mode": "view",
       "preferences": [
         {
+          "type": "dropdown",
+          "name": "primaryAction",
+          "title": "Primary Action",
+          "description": "The action performed when pressing Enter on a download",
+          "required": false,
+          "default": "open",
+          "data": [
+            {
+              "title": "Open",
+              "value": "open"
+            },
+            {
+              "title": "Copy to Clipboard",
+              "value": "copy"
+            }
+          ]
+        },
+        {
           "type": "checkbox",
           "name": "showHiddenFiles",
           "label": "Show Hidden Files",

--- a/extensions/downloads-manager/src/manage-downloads.tsx
+++ b/extensions/downloads-manager/src/manage-downloads.tsx
@@ -3,6 +3,8 @@ import {
   Action,
   Alert,
   confirmAlert,
+  getFrontmostApplication,
+  getPreferenceValues,
   Grid,
   Icon,
   Keyboard,
@@ -97,6 +99,15 @@ const PAGE_SIZE = 100;
 const MOVE_TO_TRASH_CONFIRMATION_KEY = "manage-downloads-move-to-trash-confirmed";
 
 function Command({ currentFolderPath = downloadsFolder }: { currentFolderPath?: string }) {
+  const { primaryAction = "open" } = getPreferenceValues<Preferences.ManageDownloads>();
+  const { data: frontmostApplication } = usePromise(async () => {
+    try {
+      return await getFrontmostApplication();
+    } catch {
+      // Pasting still works when the focused application's name is unavailable.
+      return undefined;
+    }
+  });
   const [downloads, setDownloads] = useState<Download[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [hasMore, setHasMore] = useState(true);
@@ -208,72 +219,96 @@ function Command({ currentFolderPath = downloadsFolder }: { currentFolderPath?: 
     setIsShowingDetail((prev: boolean) => !prev);
   }, []);
 
-  const actions = (download: Download) => (
-    <ActionPanel>
-      <ActionPanel.Section>
-        {download.isDirectory ? (
-          <Action.Push title="Open Directory" target={<Command currentFolderPath={download.path} />} />
-        ) : (
-          <Action.Open title="Open File" target={download.path} />
-        )}
-        <Action.ShowInFinder path={download.path} />
-        <Action.CopyToClipboard
-          title="Copy File"
-          content={{ file: download.path }}
-          shortcut={Keyboard.Shortcut.Common.Copy}
-        />
-        <Action.CopyToClipboard
-          title="Copy Path"
-          content={download.path}
-          shortcut={{
-            macOS: { modifiers: ["cmd", "shift"], key: "." },
-            Windows: { modifiers: ["ctrl", "shift"], key: "." },
-          }}
-        />
-        <Action
-          title="Reload Downloads"
-          icon={Icon.RotateAntiClockwise}
-          shortcut={Keyboard.Shortcut.Common.Refresh}
-          onAction={handleReload}
-        />
-      </ActionPanel.Section>
-      <ActionPanel.Section>
-        <Action.OpenWith path={download.path} shortcut={Keyboard.Shortcut.Common.OpenWith} />
-        <Action.ToggleQuickLook shortcut={Keyboard.Shortcut.Common.ToggleQuickLook} />
-        <Action
-          title="Toggle Layout"
-          icon={downloadsLayout === "list" ? Icon.AppWindowGrid3x3 : Icon.AppWindowList}
-          shortcut={{ macOS: { modifiers: ["cmd"], key: "l" }, Windows: { modifiers: ["ctrl"], key: "l" } }}
-          onAction={() => setDownloadsLayout(downloadsLayout === "list" ? "grid" : "list")}
-        />
-        <Action
-          title="Toggle Detail View"
-          icon={isShowingDetail ? Icon.EyeDisabled : Icon.Eye}
-          shortcut={{
-            macOS: { modifiers: ["cmd", "shift"], key: "l" },
-            Windows: { modifiers: ["ctrl", "shift"], key: "l" },
-          }}
-          onAction={toggleDetailView}
-        />
-      </ActionPanel.Section>
-      <ActionPanel.Section>
-        <Action
-          title="Delete Download"
-          icon={Icon.Trash}
-          shortcut={Keyboard.Shortcut.Common.Remove}
-          style={Action.Style.Destructive}
-          onAction={() => handleMoveToTrash(download.path)}
-        />
-        <Action
-          title="Delete All Downloads"
-          icon={Icon.Trash}
-          shortcut={Keyboard.Shortcut.Common.RemoveAll}
-          style={Action.Style.Destructive}
-          onAction={() => handleMoveToTrash(downloads.map((d: Download) => d.path))}
-        />
-      </ActionPanel.Section>
-    </ActionPanel>
-  );
+  const actions = (download: Download) => {
+    const openAction = download.isDirectory ? (
+      <Action.Push
+        title="Open Directory"
+        target={<Command currentFolderPath={download.path} />}
+        shortcut={Keyboard.Shortcut.Common.Open}
+      />
+    ) : (
+      <Action.Open title="Open File" target={download.path} shortcut={Keyboard.Shortcut.Common.Open} />
+    );
+    const copyAction = (
+      <Action.CopyToClipboard
+        title="Copy to Clipboard"
+        content={{ file: download.path }}
+        shortcut={Keyboard.Shortcut.Common.Copy}
+      />
+    );
+
+    return (
+      <ActionPanel title={download.file}>
+        <ActionPanel.Section>
+          {primaryAction === "copy" ? copyAction : openAction}
+          <Action.Paste
+            title={frontmostApplication ? `Paste to ${frontmostApplication.name}` : "Paste to Focused App"}
+            content={{ file: download.path }}
+            shortcut={{
+              macOS: { modifiers: ["cmd"], key: "return" },
+              Windows: { modifiers: ["ctrl"], key: "return" },
+            }}
+          />
+        </ActionPanel.Section>
+        <ActionPanel.Section>
+          {primaryAction === "copy" ? openAction : copyAction}
+          <Action.OpenWith path={download.path} shortcut={Keyboard.Shortcut.Common.OpenWith} />
+          <Action.ToggleQuickLook shortcut={Keyboard.Shortcut.Common.ToggleQuickLook} />
+          <Action.ShowInFinder
+            path={download.path}
+            shortcut={{
+              macOS: { modifiers: ["cmd", "opt"], key: "o" },
+              Windows: { modifiers: ["ctrl", "alt"], key: "o" },
+            }}
+          />
+          <Action.CopyToClipboard
+            title="Copy Path"
+            content={download.path}
+            shortcut={Keyboard.Shortcut.Common.CopyPath}
+          />
+        </ActionPanel.Section>
+        <ActionPanel.Section>
+          <Action
+            title="Reload Downloads"
+            icon={Icon.RotateAntiClockwise}
+            shortcut={Keyboard.Shortcut.Common.Refresh}
+            onAction={handleReload}
+          />
+          <Action
+            title="Toggle Layout"
+            icon={downloadsLayout === "list" ? Icon.AppWindowGrid3x3 : Icon.AppWindowList}
+            shortcut={{ macOS: { modifiers: ["cmd"], key: "l" }, Windows: { modifiers: ["ctrl"], key: "l" } }}
+            onAction={() => setDownloadsLayout(downloadsLayout === "list" ? "grid" : "list")}
+          />
+          <Action
+            title="Toggle Detail View"
+            icon={isShowingDetail ? Icon.EyeDisabled : Icon.Eye}
+            shortcut={{
+              macOS: { modifiers: ["cmd", "shift"], key: "l" },
+              Windows: { modifiers: ["ctrl", "shift"], key: "l" },
+            }}
+            onAction={toggleDetailView}
+          />
+        </ActionPanel.Section>
+        <ActionPanel.Section>
+          <Action
+            title="Delete Download"
+            icon={Icon.Trash}
+            shortcut={Keyboard.Shortcut.Common.Remove}
+            style={Action.Style.Destructive}
+            onAction={() => handleMoveToTrash(download.path)}
+          />
+          <Action
+            title="Delete All Downloads"
+            icon={Icon.Trash}
+            shortcut={Keyboard.Shortcut.Common.RemoveAll}
+            style={Action.Style.Destructive}
+            onAction={() => handleMoveToTrash(downloads.map((d: Download) => d.path))}
+          />
+        </ActionPanel.Section>
+      </ActionPanel>
+    );
+  };
 
   const emptyViewProps = {
     icon: { fileIcon: downloadsFolder },


### PR DESCRIPTION
## Description

Bring Downloads Manager closer to Raycast's native Screenshots extension's **Search Screenshots** command. Downloads Manager has been around for a long time; aligning common file actions and shortcuts makes switching between these commands more consistent and lets users reuse the same keyboard habits.

This update adds an optional command-level Primary Action preference for copy-on-Enter (Open stays the default), Paste to the focused app on Command+Enter / Ctrl+Enter, Open and Reveal shortcuts, and Raycast's standard Copy Path shortcut. The action order is shared across list and grid layouts, with platform-appropriate Windows shortcuts.

## Validation

- `npm run build` and `npm run lint` passed.
- Contributor tested the local development build on macOS and confirmed the behavior works.
- Windows runtime testing and a separate manual test of the distribution build remain pending.
