### PR TITLE
[UpNote] Fix special characters breaking note, notebook and tag actions

### DIFF
--- a/extensions/upnote/CHANGELOG.md
+++ b/extensions/upnote/CHANGELOG.md
@@ -1,6 +1,6 @@
 # UpNote Changelog
 
-## [Fix Special Characters Breaking Note, Notebook and Tag Actions] - {PR_MERGE_DATE}
+## [Fix Special Characters Breaking Note, Notebook and Tag Actions] - 2026-09-09
 
 - Fixed Create Note, Create Notebook and View Tag failing silently when the entered title, text or tag contained an apostrophe or other special characters; x-callback-url parameters are now properly percent-encoded and the URL is opened without going through a shell.
 

--- a/extensions/upnote/CHANGELOG.md
+++ b/extensions/upnote/CHANGELOG.md
@@ -1,5 +1,9 @@
 # UpNote Changelog
 
+## [Fix Special Characters Breaking Note, Notebook and Tag Actions] - 2026-09-09
+
+- Fixed Create Note, Create Notebook and View Tag failing silently when the entered title, text or tag contained an apostrophe or other special characters; x-callback-url parameters are now properly percent-encoded and the URL is opened without going through a shell.
+
 ## [Security Maintenance] - 2026-05-21
 
 - Updated the extension to address security advisories.

--- a/extensions/upnote/CHANGELOG.md
+++ b/extensions/upnote/CHANGELOG.md
@@ -1,6 +1,6 @@
 # UpNote Changelog
 
-## [Fix Special Characters Breaking Note, Notebook and Tag Actions] - 2026-09-09
+## [Fix Special Characters Breaking Note, Notebook and Tag Actions] - {PR_MERGE_DATE}
 
 - Fixed Create Note, Create Notebook and View Tag failing silently when the entered title, text or tag contained an apostrophe or other special characters; x-callback-url parameters are now properly percent-encoded and the URL is opened without going through a shell.
 

--- a/extensions/upnote/package.json
+++ b/extensions/upnote/package.json
@@ -54,5 +54,8 @@
     "brace-expansion@1": "1.1.16",
     "brace-expansion@2": "2.1.2",
     "brace-expansion@5": "5.0.9"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/upnote/src/create-note.tsx
+++ b/extensions/upnote/src/create-note.tsx
@@ -1,5 +1,5 @@
-import { Form, ActionPanel, Action } from "@raycast/api";
-import { exec } from "child_process";
+import { Form, ActionPanel, Action, open } from "@raycast/api";
+import { buildUpnoteUrl } from "./upnote-url";
 
 type Values = {
   title: string;
@@ -10,9 +10,16 @@ type Values = {
 };
 
 export default function Command() {
-  function handleSubmit(values: Values) {
-    const cmd = `open 'upnote://x-callback-url/note/new?title=${values.title}&text=${values.textarea}&notebook=${values.notebook}&new_window=${values.new_window}&markdown=${values.markdown}'`;
-    exec(cmd);
+  async function handleSubmit(values: Values) {
+    await open(
+      buildUpnoteUrl("note/new", {
+        title: values.title,
+        text: values.textarea,
+        notebook: values.notebook,
+        new_window: values.new_window,
+        markdown: values.markdown,
+      }),
+    );
   }
 
   return (

--- a/extensions/upnote/src/create-notebook.tsx
+++ b/extensions/upnote/src/create-notebook.tsx
@@ -1,14 +1,13 @@
-import { Form, ActionPanel, Action } from "@raycast/api";
-import { exec } from "child_process";
+import { Form, ActionPanel, Action, open } from "@raycast/api";
+import { buildUpnoteUrl } from "./upnote-url";
 
 type Values = {
   notebook: string;
 };
 
 export default function Command() {
-  function handleSubmit(values: Values) {
-    const cmd = `open 'upnote://x-callback-url/notebook/new?title=${values.notebook}'`;
-    exec(cmd);
+  async function handleSubmit(values: Values) {
+    await open(buildUpnoteUrl("notebook/new", { title: values.notebook }));
   }
 
   return (

--- a/extensions/upnote/src/upnote-url.ts
+++ b/extensions/upnote/src/upnote-url.ts
@@ -1,0 +1,8 @@
+/** Builds a percent-encoded UpNote x-callback-url. */
+export function buildUpnoteUrl(action: string, params: Record<string, string | boolean | undefined>): string {
+  const query = Object.entries(params)
+    .filter((entry): entry is [string, string | boolean] => entry[1] !== undefined)
+    .map(([key, value]) => `${key}=${encodeURIComponent(String(value))}`)
+    .join("&");
+  return `upnote://x-callback-url/${action}?${query}`;
+}

--- a/extensions/upnote/src/view-tag.tsx
+++ b/extensions/upnote/src/view-tag.tsx
@@ -1,15 +1,15 @@
-import { Form, ActionPanel, Action } from "@raycast/api";
+import { Form, ActionPanel, Action, open } from "@raycast/api";
 import { useForm, FormValidation } from "@raycast/utils";
-import { exec } from "child_process";
+import { buildUpnoteUrl } from "./upnote-url";
+
 type Values = {
   tag: string;
 };
 
 export default function Command() {
   const { handleSubmit, itemProps } = useForm<Values>({
-    onSubmit: (values) => {
-      const cmd = `open 'upnote://x-callback-url/tag/view?tag=${values.tag}'`;
-      exec(cmd);
+    onSubmit: async (values) => {
+      await open(buildUpnoteUrl("tag/view", { tag: values.tag }));
     },
     validation: {
       tag: FormValidation.Required,


### PR DESCRIPTION
## Description

Fixes #30895 — notes containing an apostrophe (e.g. `Bob's note`) were silently never created.

### Root cause

All three commands (`create-note`, `create-notebook`, `view-tag`) built the x-callback-url as a shell string and ran it through `child_process.exec`:

```ts
const cmd = `open 'upnote://x-callback-url/note/new?title=${values.title}&text=${values.textarea}&...'`;
exec(cmd);
```

User input was interpolated raw inside single quotes:

- An apostrophe (`'`) terminates the shell quote — bash fails with a syntax error before `open` ever runs, so nothing happens (exactly the reported symptom). Verified locally: running the old command with `Bob's note` exits `syntax error: unexpected EOF while looking for matching '`.
- Characters with URL meaning (`&`, `#`, `=`, spaces, newlines, non-ASCII) were not percent-encoded, so they truncated or garbled the parameters UpNote received.
- Passing user text through a shell string also left a command-injection surface.

### Changes

- Added a small shared `buildUpnoteUrl(action, params)` helper that percent-encodes every parameter value (`encodeURIComponent`) and omits undefined ones.
- All three commands now build the URL with it and open it via Raycast's `open()` (no shell involved — argv is passed directly).
- CHANGELOG entry added.

### Validation

- RED: reproduced the old failure — a stub `open` on PATH never runs because the shell rejects the command containing `Bob's note`.
- GREEN: asserts that titles/text/tags with apostrophes, spaces, `&`, `%`, newlines and unicode (`’`, `—`, `é`) encode correctly and round-trip through `URLSearchParams` exactly for all three commands.
- `tsc --noEmit` clean, `ray lint` clean (only a pre-existing title-casing warning), `ray build` succeeds.