### PR TITLE
[Statamic Docs] Fix crash on launch in newer Raycast versions

### DIFF
--- a/extensions/statamic-docs/CHANGELOG.md
+++ b/extensions/statamic-docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Statamic Docs Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-09-09
 
 - Fixed a crash on launch in newer Raycast versions, caused by the version dropdown firing before the available versions had loaded
 

--- a/extensions/statamic-docs/CHANGELOG.md
+++ b/extensions/statamic-docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Statamic Docs Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Fixed a crash on launch in newer Raycast versions, caused by the version dropdown firing before the available versions had loaded
+
 ## [Update] - 2026-02-12
 
 - Added `-beta` flag for beta releases in the version switcher

--- a/extensions/statamic-docs/src/statamic.tsx
+++ b/extensions/statamic-docs/src/statamic.tsx
@@ -107,6 +107,8 @@ export default function main() {
 
   const versionChanged = async (value: string) => {
     const version = availableVersions.find((v) => v.version === value);
+    if (!version) return;
+
     setSelectedVersion(version);
     await LocalStorage.setItem("version", JSON.stringify(version));
   };


### PR DESCRIPTION
This pull request fixes an issue where the Statamic Docs extension crashes on launch in newer versions of Raycast, with an "Invalid parameters for method setLocalStorageItem" error.

This was happening because the version dropdown uses `storeValue`, so on mount it restores the previously selected version and fires `onChange` before the available versions have been fetched. The lookup returned `undefined`, which ended up being passed to `LocalStorage.setItem`. Older versions of Raycast silently accepted this, but newer versions validate the value and throw.

This PR fixes it by returning early from the change handler when the version can't be found. The selected version is still restored from `LocalStorage` once the available versions have loaded, so behaviour is otherwise unchanged.
