### PR TITLE
Font Search: fix font preview in dark mode

### DIFF
--- a/extensions/font-search/CHANGELOG.md
+++ b/extensions/font-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Search Installed Fonts Changelog
 
-## [Fix Font Preview in Dark Mode] - {PR_MERGE_DATE}
+## [Fix Font Preview in Dark Mode] - 2026-09-09
 
 - The font preview was rendered with black text regardless of the theme, making it invisible in dark mode. It is now tinted with Raycast's primary text color, so it follows the active theme, including custom ones.
 - Fixed the preview failing to render when the preview text or a font name contains `&`, `<` or `>`, which produced invalid SVG markup.

--- a/extensions/font-search/CHANGELOG.md
+++ b/extensions/font-search/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Search Installed Fonts Changelog
 
+## [Fix Font Preview in Dark Mode] - {PR_MERGE_DATE}
+
+- The font preview was rendered with black text regardless of the theme, making it invisible in dark mode. It is now tinted with Raycast's primary text color, so it follows the active theme, including custom ones.
+- Fixed the preview failing to render when the preview text or a font name contains `&`, `<` or `>`, which produced invalid SVG markup.
+
 ## [Updates] - 2025-05-08
 
 - Added a sub menu for each font's postscript names. Opened with Cmd + N.

--- a/extensions/font-search/package.json
+++ b/extensions/font-search/package.json
@@ -50,5 +50,8 @@
     "lint": "ray lint",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/font-search/package.json
+++ b/extensions/font-search/package.json
@@ -5,6 +5,9 @@
   "description": "Search locally installed fonts, as displayed in font book.",
   "icon": "extension-icon.png",
   "author": "tnixc",
+  "contributors": [
+    "mindprint"
+  ],
   "preferences": [
     {
       "name": "previewText",

--- a/extensions/font-search/src/fontPreview.ts
+++ b/extensions/font-search/src/fontPreview.ts
@@ -1,20 +1,42 @@
 import { Color } from "@raycast/api";
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
 export function createFontPreviewSVG(fontName: string, text: string): string {
+  // Both values end up inside the SVG markup, so they have to be escaped: an
+  // ampersand in the preview text preference (or in a font name) would otherwise
+  // produce invalid XML and the preview would not render at all.
+  const family = escapeXml(fontName);
+  const previewText = escapeXml(text);
+
+  // The fill below is only a placeholder: `raycast-tint-color` recolors every
+  // non-transparent pixel of a markdown image, so the preview picks up Raycast's
+  // primary text color and follows the active theme. The token cannot be used as
+  // the SVG `fill` directly, because Raycast does not resolve `raycast-*` colors
+  // inside an embedded data URI.
   const svgContent = `
     <svg xmlns="http://www.w3.org/2000/svg" width="600" height="300">
       <style>
         text {
           font-size: 24px;
-          fill: ${Color.PrimaryText};
+          fill: #000000;
           filter: saturate(0);
         }
       </style>
-      <text font-family="${fontName}" x="10" y="70">${text}</text>
-      <text font-family="${fontName}" x="10" y="120">ABCDEFGHIJKLMNOPQRSTUVWXYZ</text>
-      <text font-family="${fontName}" x="10" y="170">abcdefghijklmnopqrstuvwxyz</text>
-      <text font-family="${fontName}" x="10" y="220">0123456789!@#$%^()_+-={}[]:;</text>
+      <text font-family="${family}" x="10" y="70">${previewText}</text>
+      <text font-family="${family}" x="10" y="120">ABCDEFGHIJKLMNOPQRSTUVWXYZ</text>
+      <text font-family="${family}" x="10" y="170">abcdefghijklmnopqrstuvwxyz</text>
+      <text font-family="${family}" x="10" y="220">0123456789!@#$%^()_+-={}[]:;</text>
     </svg>
   `;
 
-  return `![Font preview](data:image/svg+xml;base64,${Buffer.from(svgContent).toString("base64")})`;
+  const uri = `data:image/svg+xml;base64,${Buffer.from(svgContent).toString("base64")}`;
+  return `![Font preview](${uri}?raycast-tint-color=${Color.PrimaryText})`;
 }


### PR DESCRIPTION
## Description

The font preview is invisible in dark mode. `src/fontPreview.ts` sets the SVG `fill` to `Color.PrimaryText`, but Raycast only resolves `raycast-*` color tokens for `Image.ImageLike` props. Inside a base64 data URI in a markdown `Detail` it is invalid CSS, so the fill falls back to black and the preview disappears against a dark background.

This tints the markdown image with `?raycast-tint-color=${Color.PrimaryText}` instead, which is the approach used by `nerd-font-picker`. Verified against the stock light and dark themes, and against custom themes with pink and blue text colors — the preview now matches the metadata labels beside it in every case.

Also escaped the preview text and font name before interpolating them into the SVG. An `&` in the Preview Text preference (for example `Fish & Chips`) produced invalid XML and the preview did not render at all.

## Screencast

Dark mode, after the fix:

![Font Search in dark mode with a readable preview](https://raw.githubusercontent.com/mindprint/raycast-extensions/pr-assets/font-search-dark-mode-fixed-opt.png)

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
