### PR TITLE
[Day One] Support renamed CLI command

### DIFF
--- a/extensions/day-one/CHANGELOG.md
+++ b/extensions/day-one/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Day One Changelog
 
-## [Support the renamed dayone CLI] - {PR_MERGE_DATE}
+## [Support the renamed dayone CLI] - 2026-09-09
 
 - Fixed the "Day One CLI Missing" error on Day One for Mac 2025.19+, which renamed the CLI from `dayone2` to `dayone`. The extension now detects and uses whichever CLI is installed.
 

--- a/extensions/day-one/CHANGELOG.md
+++ b/extensions/day-one/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Day One Changelog
 
+## [Support the renamed dayone CLI] - {PR_MERGE_DATE}
+
+- Fixed the "Day One CLI Missing" error on Day One for Mac 2025.19+, which renamed the CLI from `dayone2` to `dayone`. The extension now detects and uses whichever CLI is installed.
+
 ## [Bug fix] - 2026-05-19
 
 - Fixed CLI detection when Raycast does not inherit the terminal PATH.

--- a/extensions/day-one/package.json
+++ b/extensions/day-one/package.json
@@ -6,9 +6,13 @@
   "icon": "day-one.png",
   "author": "AntonNiklasson",
   "contributors": [
-    "bestemic"
+    "bestemic",
+    "Fizzbow"
   ],
   "license": "MIT",
+  "categories": [
+    "Productivity"
+  ],
   "commands": [
     {
       "name": "add-entry",

--- a/extensions/day-one/src/day-one.ts
+++ b/extensions/day-one/src/day-one.ts
@@ -13,22 +13,49 @@ type Entry = {
   journal?: string;
 };
 
-export async function isDayOneInstalled(): Promise<CLIState> {
-  try {
-    await exec("dayone2 --version");
-    return "ready";
-  } catch (error) {
-    if (error instanceof Error && error.message.includes(`addPersistentStoreWithType`)) {
-      return "out-of-sync";
-    }
+// Day One renamed its CLI from `dayone2` to `dayone` starting with Mac 2025.19.
+// Newer installs only ship `dayone`, older ones only ship `dayone2`, so we probe both.
+const CLI_CANDIDATES = ["dayone", "dayone2"] as const;
 
-    return "missing";
+let resolvedCommand: string | null = null;
+
+async function resolveCLI(): Promise<{ command: string | null; state: CLIState }> {
+  let outOfSyncCommand: string | null = null;
+
+  for (const candidate of CLI_CANDIDATES) {
+    try {
+      await exec(`${candidate} --version`);
+      resolvedCommand = candidate;
+      return { command: candidate, state: "ready" };
+    } catch (error) {
+      if (error instanceof Error && error.message.includes(`addPersistentStoreWithType`)) {
+        // The CLI exists but is out of sync with the desktop app.
+        outOfSyncCommand = outOfSyncCommand ?? candidate;
+      }
+    }
   }
+
+  if (outOfSyncCommand) {
+    resolvedCommand = outOfSyncCommand;
+    return { command: outOfSyncCommand, state: "out-of-sync" };
+  }
+
+  resolvedCommand = null;
+  return { command: null, state: "missing" };
+}
+
+export async function isDayOneInstalled(): Promise<CLIState> {
+  const { state } = await resolveCLI();
+  return state;
 }
 
 async function addEntry(entry: Entry) {
+  const cli = resolvedCommand ?? (await resolveCLI()).command;
+
+  if (!cli) throw Error("Day One CLI not found");
+
   const date = entry.date.toISOString().split(".")[0] + "Z";
-  let command = `dayone2 new "${entry.body}" --isoDate "${date}"`;
+  let command = `${cli} new "${entry.body}" --isoDate "${date}"`;
 
   if (entry.journal) {
     command = `${command} --journal "${entry.journal}"`;


### PR DESCRIPTION
## Description

Fixes #26051.

Day One for Mac 2025.19 renamed its CLI command from `dayone2` to `dayone`. New installations only expose `dayone`, while the extension still invoked `dayone2`, causing it to incorrectly show "Day One CLI Missing".

This change:

- detects `dayone` first and falls back to `dayone2` for older installations
- reuses the resolved command when creating entries
- preserves the common macOS PATH handling added in #28116
- preserves the existing out-of-sync error handling

## Screencast

N/A — small CLI compatibility fix. The distribution build was manually tested in Raycast with Day One 2026.18.1779 and only the `dayone` command installed; Add Entry successfully opened the entry form.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)