### PR TITLE
[Clockify] Honor the project's billable default when creating time entries

### DIFF
--- a/extensions/clockify/CHANGELOG.md
+++ b/extensions/clockify/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Clockify Changelog
 
+## [Fix time entries always being created as non-billable] - {PR_MERGE_DATE}
+
+- Time entries now follow the project's "billable by default" setting instead of always being created as non-billable. Clockify treats an absent `billable` field as `false` rather than inheriting it from the project, so the value is now sent explicitly.
+- Applies to starting a new timer, restarting a recent entry, and adding a completed entry with "Add Time Entry".
+
 ## [Fix requests being sent to an undefined workspace] - 2026-09-09
 
 - Fixed commands failing with "User doesn't belong to Workspace" and "Timer could not be started" when the stored workspace id was missing. The id is now resolved and repaired on demand rather than read straight from `LocalStorage`, which can drop a key when several values are written concurrently.

--- a/extensions/clockify/CHANGELOG.md
+++ b/extensions/clockify/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Clockify Changelog
 
-## [Fix time entries always being created as non-billable] - {PR_MERGE_DATE}
+## [Fix time entries always being created as non-billable] - 2026-09-09
 
 - Time entries now follow the project's "billable by default" setting instead of always being created as non-billable. Clockify treats an absent `billable` field as `false` rather than inheriting it from the project, so the value is now sent explicitly.
 - Applies to starting a new timer, restarting a recent entry, and adding a completed entry with "Add Time Entry".

--- a/extensions/clockify/src/index.tsx
+++ b/extensions/clockify/src/index.tsx
@@ -23,6 +23,7 @@ import {
   fetcher,
   dateDiffToString,
   resolveConfig,
+  isProjectBillable,
 } from "./utils";
 import { TimeEntry, Project, Task, Tag } from "./types";
 import { FormValidation, useCachedState, useForm } from "@raycast/utils";
@@ -469,6 +470,9 @@ function AddTimeEntry({ updateTimeEntries }: { updateTimeEntries: () => void }) 
 
       const { workspaceId } = await resolveConfig();
 
+      // See addNewTimeEntry: an absent billable field means false, not the project's default.
+      const billable = await isProjectBillable(projectId);
+
       const { data, error } = await fetcher(`/workspaces/${workspaceId}/time-entries`, {
         method: "POST",
         body: {
@@ -478,6 +482,7 @@ function AddTimeEntry({ updateTimeEntries }: { updateTimeEntries: () => void }) 
           taskId: taskId === "-1" ? null : taskId || null,
           projectId,
           tagIds: tagIds || [],
+          billable,
           customFieldValues: [],
         },
       });

--- a/extensions/clockify/src/types.d.ts
+++ b/extensions/clockify/src/types.d.ts
@@ -19,6 +19,9 @@ export interface Project {
   description?: string;
   name: string;
   color: string;
+  // The project's "billable by default" setting. Optional so that an absent value stays
+  // distinguishable from false: callers omit the field entirely rather than sending a guess.
+  billable?: boolean;
 }
 
 export interface Task {

--- a/extensions/clockify/src/utils.ts
+++ b/extensions/clockify/src/utils.ts
@@ -366,6 +366,35 @@ export async function getProjects({ onError }: { onError?: (state: boolean) => v
   }
 }
 
+/**
+ * Whether a project is billable by default.
+ *
+ * Prefers the project list the forms already cache in LocalStorage and only falls back to a
+ * request, because a timer can be restarted from a recent entry before any form has loaded
+ * projects. Returns undefined when the setting cannot be determined, which callers pass straight
+ * into the request body: JSON.stringify drops undefined, so the field is omitted and behaviour is
+ * unchanged rather than guessed at.
+ *
+ * Cache-first means a setting changed in Clockify web can be stale here until the cache is
+ * rewritten, which either form does on mount. Restarting a recent entry does not open a form, so
+ * that path can use an older value. Accepted deliberately: billability changes rarely, and always
+ * refetching would add a request to every timer start.
+ */
+export async function isProjectBillable(projectId: string): Promise<boolean | undefined> {
+  try {
+    const stored = await LocalStorage.getItem<string>("projects");
+    if (stored) {
+      const project = (JSON.parse(stored) as Project[]).find((project) => project.id === projectId);
+      if (project) return project.billable;
+    }
+  } catch (e) {
+    console.error("Error reading cached projects:", e);
+  }
+
+  const projects = await getProjects();
+  return projects.find((project) => project.id === projectId)?.billable;
+}
+
 export async function getTasksForProject(projectId: string): Promise<Task[]> {
   const { workspaceId } = await resolveConfig();
   const cacheKey = `project[${projectId}]`;
@@ -395,6 +424,12 @@ export async function addNewTimeEntry(
   showToast(Toast.Style.Animated, "Starting…");
 
   const { workspaceId } = await resolveConfig();
+
+  // Clockify defaults billable to false when the field is absent; it does not fall back to the
+  // project's "billable by default" setting, so that has to be sent explicitly or every entry
+  // lands as non-billable.
+  const billable = await isProjectBillable(projectId);
+
   const { data, error } = await fetcher(`/workspaces/${workspaceId}/time-entries`, {
     method: "POST",
     body: {
@@ -403,6 +438,7 @@ export async function addNewTimeEntry(
       taskId,
       projectId,
       tagIds,
+      billable,
       customFieldValues: [],
     },
   });

--- a/extensions/clockify/src/utils.ts
+++ b/extensions/clockify/src/utils.ts
@@ -367,29 +367,54 @@ export async function getProjects({ onError }: { onError?: (state: boolean) => v
 }
 
 /**
+ * Looks a project up in whichever cache holds it.
+ *
+ * There are two, written by independent code paths: the forms in index.tsx cache the project list
+ * in LocalStorage under "projects", and getProjects() caches it in Cache under clockify/projects.
+ * Both are checked so that a list fetched by either path is reused. LocalStorage comes first only
+ * because the forms rewrite it on every mount, making it the more recently refreshed of the two.
+ */
+async function findCachedProject(projectId: string): Promise<Project | undefined> {
+  let stored: string | undefined;
+
+  try {
+    stored = await LocalStorage.getItem<string>("projects");
+  } catch (e) {
+    console.error("Error reading cached projects:", e);
+  }
+
+  for (const source of [stored, cache.get(PROJECTS_CACHE_KEY)]) {
+    if (!source) continue;
+
+    try {
+      const project = (JSON.parse(source) as Project[]).find((project) => project.id === projectId);
+      if (project) return project;
+    } catch (e) {
+      console.error("Error reading cached projects:", e);
+    }
+  }
+
+  return undefined;
+}
+
+/**
  * Whether a project is billable by default.
  *
- * Prefers the project list the forms already cache in LocalStorage and only falls back to a
- * request, because a timer can be restarted from a recent entry before any form has loaded
- * projects. Returns undefined when the setting cannot be determined, which callers pass straight
- * into the request body: JSON.stringify drops undefined, so the field is omitted and behaviour is
- * unchanged rather than guessed at.
+ * Reads the cached project list and only falls back to a request, because a timer can be restarted
+ * from a recent entry before any form has loaded projects. getProjects() populates one of the
+ * caches findCachedProject() reads, so that fallback primes itself and costs one request rather
+ * than one per timer start. Returns undefined when the setting cannot be determined, which callers
+ * pass straight into the request body: JSON.stringify drops undefined, so the field is omitted and
+ * behaviour is unchanged rather than guessed at.
  *
- * Cache-first means a setting changed in Clockify web can be stale here until the cache is
+ * Cache-first means a setting changed in Clockify web can be stale here until a cache is
  * rewritten, which either form does on mount. Restarting a recent entry does not open a form, so
  * that path can use an older value. Accepted deliberately: billability changes rarely, and always
  * refetching would add a request to every timer start.
  */
 export async function isProjectBillable(projectId: string): Promise<boolean | undefined> {
-  try {
-    const stored = await LocalStorage.getItem<string>("projects");
-    if (stored) {
-      const project = (JSON.parse(stored) as Project[]).find((project) => project.id === projectId);
-      if (project) return project.billable;
-    }
-  } catch (e) {
-    console.error("Error reading cached projects:", e);
-  }
+  const cached = await findCachedProject(projectId);
+  if (cached) return cached.billable;
 
   const projects = await getProjects();
   return projects.find((project) => project.id === projectId)?.billable;


### PR DESCRIPTION
## Description

Time entries created from the extension were always non-billable, ignoring the project's "billable by default" setting.

Fixes #29680

### Root cause

`POST /workspaces/{workspaceId}/time-entries` treats an absent `billable` field as `false`. It does **not** inherit the value from the project.

This is a regression from #4705, which removed a hardcoded `billable: true` in order to "use the project's default", citing the API docs line *"'start' is the only mandatory field in this request"*. That line makes the field optional, but it does not say Clockify falls back to the project setting when it is omitted — so the extension went from always billable to never billable.

Verified against the API, on a project with "billable by default" enabled:

| request body | resulting entry |
| --- | --- |
| `{start, end, projectId}` — what the extension sent | `billable: false` |
| `{start, end, projectId, billable: true}` | `billable: true` |

### Fix

Added `isProjectBillable(projectId)` in `utils.ts` and send the result explicitly from both places that create an entry:

- `addNewTimeEntry()` — covers "Start New Timer" and restarting an entry from "Latest entries"
- the inline `POST` in `AddTimeEntry` — covers adding a completed entry, which the issue author noted was affected too

Two details worth flagging for review:

- **`undefined` is meaningful.** When the project's setting cannot be determined, `isProjectBillable()` returns `undefined`; `JSON.stringify` drops it, so the field is omitted and behaviour matches today rather than guessing `false`.
- **It reads the cached project list first**, falling back to a request only when the project is not cached, because a recent entry can be restarted before any form has loaded projects. A setting changed in Clockify web can therefore be stale until the cache is rewritten, which either form does on mount. This is deliberate — billability changes rarely, and always refetching would add a request to every timer start — and it is documented in the function's docblock.

Task-level billability is out of scope; this only addresses the project default the issue asked about.

### Testing

Ran through `npm run dev` against a real workspace:

- Start New Timer on a billable project → entry is billable
- Restart a recent entry on a billable project → entry is billable
- Add Time Entry (backdated) on a billable project → entry is billable
- Same four paths on a project with "billable by default" off → entry stays non-billable

`npm run lint` and `npx tsc --noEmit` are clean.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` (succeeds); the behaviour above was exercised via `npm run dev` in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
