### PR TITLE
[Color Picker] Fix grey color swatches for some color formats

### DIFF
--- a/extensions/color-picker/CHANGELOG.md
+++ b/extensions/color-picker/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Fix] - {PR_MERGE_DATE}
 
 - Fix color swatches rendering as a grey square when the color format preference is set to a format that is not a valid CSS color, such as `HEX No Prefix`
+- Fix the `OKLCH` format dropping the alpha channel and producing a `NaN` hue for black, white and gray
 
 ## [Favorite Colors & AI Tools] - 2026-08-29
 

--- a/extensions/color-picker/CHANGELOG.md
+++ b/extensions/color-picker/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Color Picker Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-09-10
 
 - Fix color swatches rendering as a grey square when the color format preference is set to a format that is not a valid CSS color, such as `HEX No Prefix`
 - Fix the `OKLCH` format dropping the alpha channel and producing a `NaN` hue for black, white and gray

--- a/extensions/color-picker/CHANGELOG.md
+++ b/extensions/color-picker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Color Picker Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- Fix color swatches rendering as a grey square when the color format preference is set to a format that is not a valid CSS color, such as `HEX No Prefix`
+
 ## [Favorite Colors & AI Tools] - 2026-08-29
 
 - Add a `Favorite Colors` command to view and use saved favorites

--- a/extensions/color-picker/src/lib/color-format.ts
+++ b/extensions/color-picker/src/lib/color-format.ts
@@ -1,0 +1,55 @@
+import ColorJS from "colorjs.io";
+import type { ColorFormatType, HistoryColor } from "./types";
+
+export function formatColor(_color: HistoryColor, format?: ColorFormatType) {
+  let color;
+  if (typeof _color === "string") {
+    color = new ColorJS(_color);
+  } else if ("colorSpace" in _color) {
+    color = new ColorJS(_color.colorSpace, [_color.red, _color.green, _color.blue], _color.alpha);
+  } else {
+    color = new ColorJS("srgb", [_color.red / 255, _color.green / 255, _color.blue / 255], _color.alpha);
+  }
+
+  switch (format) {
+    default:
+    case "hex": {
+      return color.to("srgb").toString({ format: "hex" }).toUpperCase();
+    }
+    case "hex-lower-case": {
+      return color.to("srgb").toString({ format: "hex" }).toLowerCase();
+    }
+    case "hex-no-prefix": {
+      return color.to("srgb").toString({ format: "hex" }).replace("#", "");
+    }
+    case "rgb": {
+      return color.to("srgb").toString({ format: "rgb_number" });
+    }
+    case "rgb-percentage": {
+      return color.to("srgb").toString({ format: "rgb" });
+    }
+    case "rgba": {
+      return color.to("srgb").toString({ format: "rgba_number" });
+    }
+    case "rgba-percentage": {
+      return color.to("srgb").toString({ format: "rgba" });
+    }
+    case "hsla": {
+      return color.to("hsl").toString({ format: "hsla" });
+    }
+    case "hsva": {
+      return color.to("hsv").toString({ format: "color" });
+    }
+    case "oklch": {
+      return color.to("oklch").toString();
+    }
+    case "lch": {
+      const lchColor = color.to("lch");
+      const [l, c, h] = lchColor.coords;
+      return `lch(${l.toFixed(2)}% ${c} ${h})`;
+    }
+    case "p3": {
+      return color.to("p3").toString({ format: "p3" });
+    }
+  }
+}

--- a/extensions/color-picker/src/lib/utils.ts
+++ b/extensions/color-picker/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import { getPreferenceValues, Icon, Image, Keyboard, List } from "@raycast/api";
-import ColorJS from "colorjs.io";
 import { Colors, Palette } from "color-namer";
+import { formatColor } from "./color-format";
 import uniqBy from "lodash/uniqBy";
 import { CopyColorsFormat, HistoryColor, HistoryItem } from "./types";
 import { ColorFormatType } from "./types";
@@ -11,59 +11,7 @@ export const isWindows = process.platform === "win32";
 const preferences = getPreferenceValues<ExtensionPreferences>();
 
 export function getFormattedColor(_color: HistoryColor, format?: ColorFormatType) {
-  let color;
-  if (typeof _color === "string") {
-    color = new ColorJS(_color);
-  } else if ("colorSpace" in _color) {
-    color = new ColorJS(_color.colorSpace, [_color.red, _color.green, _color.blue], _color.alpha);
-  } else {
-    color = new ColorJS("srgb", [_color.red / 255, _color.green / 255, _color.blue / 255], _color.alpha);
-  }
-
-  switch (format || preferences.colorFormat) {
-    default:
-    case "hex": {
-      return color.to("srgb").toString({ format: "hex" }).toUpperCase();
-    }
-    case "hex-lower-case": {
-      return color.to("srgb").toString({ format: "hex" }).toLowerCase();
-    }
-    case "hex-no-prefix": {
-      return color.to("srgb").toString({ format: "hex" }).replace("#", "");
-    }
-    case "rgb": {
-      return color.to("srgb").toString({ format: "rgb_number" });
-    }
-    case "rgb-percentage": {
-      return color.to("srgb").toString({ format: "rgb" });
-    }
-    case "rgba": {
-      return color.to("srgb").toString({ format: "rgba_number" });
-    }
-    case "rgba-percentage": {
-      return color.to("srgb").toString({ format: "rgba" });
-    }
-    case "hsla": {
-      return color.to("hsl").toString({ format: "hsla" });
-    }
-    case "hsva": {
-      return color.to("hsv").toString({ format: "color" });
-    }
-    case "oklch": {
-      const oklchColor = color.to("oklch");
-      const [l, c, h] = oklchColor.coords;
-      const lPercentage = (l * 100).toFixed(2);
-      return `oklch(${lPercentage}% ${c} ${h})`;
-    }
-    case "lch": {
-      const lchColor = color.to("lch");
-      const [l, c, h] = lchColor.coords;
-      return `lch(${l.toFixed(2)}% ${c} ${h})`;
-    }
-    case "p3": {
-      return color.to("p3").toString({ format: "p3" });
-    }
-  }
+  return formatColor(_color, format || preferences.colorFormat);
 }
 
 export function getPreviewColor(color: HistoryColor) {

--- a/extensions/color-picker/src/lib/utils.ts
+++ b/extensions/color-picker/src/lib/utils.ts
@@ -66,13 +66,8 @@ export function getFormattedColor(_color: HistoryColor, format?: ColorFormatType
   }
 }
 
-const unsupportedPreviewFormats = ["p3", "rgb", "rgb-percentage"];
 export function getPreviewColor(color: HistoryColor) {
-  const formattedColor = getFormattedColor(
-    color,
-    unsupportedPreviewFormats.includes(preferences.colorFormat) ? "oklch" : undefined,
-  );
-  return formattedColor;
+  return getFormattedColor(color, "oklch");
 }
 
 export function getShortcut(index: number) {

--- a/extensions/color-picker/test/color-tools.test.mjs
+++ b/extensions/color-picker/test/color-tools.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import analyzeContrast from "../src/tools/analyze-contrast.ts";
 import generateColorScale from "../src/tools/generate-color-scale.ts";
+import { formatColor } from "../src/lib/color-format.ts";
 
 test("color calculations", () => {
   assert.deepEqual(analyzeContrast({ foreground: "#000", background: "#fff" }).ratio, 21);
@@ -9,4 +10,16 @@ test("color calculations", () => {
   const result = generateColorScale({ color: "#FF6363" });
   assert.equal(result.scale.length, 11);
   assert.deepEqual(result.scale[5], { label: 500, color: "#FF6363" });
+});
+
+test("oklch previews keep alpha", () => {
+  assert.equal(formatColor("rgba(87, 99, 237, 0.5)", "oklch"), "oklch(56.943% 0.20528 274.1 / 0.5)");
+  assert.equal(formatColor("hsla(235, 80%, 63%, 0.25)", "oklch"), "oklch(56.544% 0.2061 273.83 / 0.25)");
+});
+
+test("oklch previews of grayscale colors have no NaN hue", () => {
+  for (const color of ["#000000", "#808080", "#ffffff"]) {
+    const result = formatColor(color, "oklch");
+    assert.ok(!result.includes("NaN"), `${color} produced ${result}`);
+  }
 });


### PR DESCRIPTION
## Description

Closes #30929.

Pick a colour, open `Organize Colors`, and the swatch is a plain grey square. The hex text and the timestamp under it are correct, only the swatch is wrong.

The swatch comes from `getPreviewColor`, which formatted the colour using the `Color Format` preference. That preference is for copying and pasting, as its own description in the manifest says, so it can produce strings that are not CSS colours at all. On `HEX No Prefix` the swatch is handed `5763ed` with no `#`, Raycast cannot read that as a colour, and you get grey.

Three formats were already known to have this problem:

```ts
const unsupportedPreviewFormats = ["p3", "rgb", "rgb-percentage"];
```

`hex-no-prefix` and `hsva` were missing from the list. I would rather not add two more names to a list that has now been incomplete twice, so the swatch stops asking the preference and always uses oklch, which is what that list already fell back to. Every piece of text and every copy action still uses the preference exactly as before.

This reaches further than the report suggests. `getPreviewColor` feeds every swatch in the extension, and `getIcon` passes a string through untouched, so the same grey appears in the `Organize Colors` list view, `Favorite Colors`, `Generate Colors` and the menu bar icon.

## Screencast

The before is the screenshot in #30929.

On how I tested this: `ray develop` builds fine on my machine but never hands anything to Raycast, so I could not put a patched build on screen. Instead I tested the released build directly, since the preference lets you feed it any of these strings. On Windows 11 with Raycast 2.2.0, `#5763ED` and `oklch(38.16% 0.19 273)` both render correctly and `5763ed` renders grey, which is the whole bug and the reason oklch is a safe target. I also could not produce a `dist` build, because that step needs the Swift package and I am on Windows. `ray build -e dev` and `ray lint` both pass.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
