### PR TITLE
[ado-search] Add optional assigned-to-me filter to My Work Items

### DIFF
--- a/extensions/ado-search/CHANGELOG.md
+++ b/extensions/ado-search/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Azure DevOps Repository Search
 
+## [Optional assigned-to-me filter for My Work Items] - {PR_MERGE_DATE}
+Added a setting to My Work Items to browse work items assigned to anyone, not just yourself. It is on by default (assigned-to-me only); when turned off, a project, state, or type filter is required to keep the result set bounded, and each item's assignee is shown in the list.
+
 ## [Fix My Work Items settings not saving] - 2026-06-24
 Fixed the My Work Items setup form silently discarding selections (project, states, types, default repository, default base branch) that were made while option lists were still loading, which caused Save to persist the defaults.
 

--- a/extensions/ado-search/CHANGELOG.md
+++ b/extensions/ado-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Azure DevOps Repository Search
 
-## [Optional assigned-to-me filter for My Work Items] - {PR_MERGE_DATE}
+## [Optional assigned-to-me filter for My Work Items] - 2026-09-10
 Added a setting to My Work Items to browse work items assigned to anyone, not just yourself. It is on by default (assigned-to-me only); when turned off, a project, state, or type filter is required to keep the result set bounded, and each item's assignee is shown in the list.
 
 ## [Fix My Work Items settings not saving] - 2026-06-24

--- a/extensions/ado-search/README.md
+++ b/extensions/ado-search/README.md
@@ -14,6 +14,6 @@ Find and open your own PBIs (Product Backlog Items) quickly.
 Find and open pipelines based on your Azure DevOps organization and project.
 
 ## Manage your work items
-Browse work items assigned to you across projects, filter and group them by state, type or project, and change state on a single item or many at once. View descriptions with inline images plus acceptance criteria, repro steps, comments and attachments, create new work items, and create branches linked to a work item.
+Browse work items assigned to you across projects, filter and group them by state, type or project, and change state on a single item or many at once. By default the list shows only items assigned to you; you can turn that off in settings to browse everyone's items (a project, state, or type filter is required to keep the result set bounded), with each item's assignee shown in the list. View descriptions with inline images plus acceptance criteria, repro steps, comments and attachments, create new work items, and create branches linked to a work item.
 
 > The "My Work Items" command needs a Personal Access Token with **Work Items (Read & Write)** and **Code (Read & Write)** scopes (the latter for branch creation).

--- a/extensions/ado-search/src/lib/azure-devops.ts
+++ b/extensions/ado-search/src/lib/azure-devops.ts
@@ -1,15 +1,12 @@
 import { getPreferenceValues } from "@raycast/api";
 import { readFile } from "fs/promises";
+import { buildWorkItemsWiql } from "./wiql";
 
 export function parseList(s: string | undefined): string[] {
   return (s ?? "")
     .split(",")
     .map((x) => x.trim())
     .filter(Boolean);
-}
-
-function quoteList(values: string[]): string {
-  return values.map((v) => `'${v.replace(/'/g, "''")}'`).join(", ");
 }
 
 export interface WorkItem {
@@ -76,6 +73,11 @@ export interface WorkItemFilters {
   states?: string[];
   /** When set, filter to specific work item types. Empty/undefined = all types. */
   types?: string[];
+  /**
+   * Restrict to items assigned to the current user. Defaults to true.
+   * When false, a bounding filter (project/states/types) is required.
+   */
+  assignedToMe?: boolean;
 }
 
 /**
@@ -88,26 +90,14 @@ export interface WorkItemFilters {
 export async function getMyWorkItems(filters: WorkItemFilters = {}): Promise<WorkItem[]> {
   const { headers, org } = getAuth();
   const project = filters.project?.trim() || undefined;
-  const states = filters.states ?? [];
-  const types = filters.types ?? [];
-
-  // WIQL is scoped per-project if @project clause is included; otherwise org-wide
-  const projectClause = project ? `AND [System.TeamProject] = '${project.replace(/'/g, "''")}'` : "";
-  const stateClause = states.length
-    ? `AND [System.State] IN (${quoteList(states)})`
-    : `AND [System.State] NOT IN ('Closed', 'Removed', 'Done')`;
-  const typeClause = types.length ? `AND [System.WorkItemType] IN (${quoteList(types)})` : "";
 
   const wiql = {
-    query: `
-      SELECT [System.Id]
-      FROM WorkItems
-      WHERE [System.AssignedTo] = @Me
-        ${stateClause}
-        ${typeClause}
-        ${projectClause}
-      ORDER BY [System.ChangedDate] DESC
-    `,
+    query: buildWorkItemsWiql({
+      project,
+      states: filters.states,
+      types: filters.types,
+      assignedToMe: filters.assignedToMe,
+    }),
   };
 
   const wiqlUrl = project

--- a/extensions/ado-search/src/lib/wiql.ts
+++ b/extensions/ado-search/src/lib/wiql.ts
@@ -1,0 +1,52 @@
+/**
+ * Pure WIQL (Work Item Query Language) builder for the "My Work Items" command.
+ * No I/O, no Raycast deps — kept separate so it is unit-testable via
+ * `npx tsx src/lib/wiql.test.ts` (see wiql.test.ts).
+ */
+
+export interface WorkItemsWiqlOptions {
+  /** Filter to a single project. Empty/undefined = org-wide. */
+  project?: string;
+  /** Filter to specific states. Empty/undefined = all except Closed/Removed/Done. */
+  states?: string[];
+  /** Filter to specific work item types. Empty/undefined = all types. */
+  types?: string[];
+  /**
+   * Restrict to items assigned to the current user. Defaults to true.
+   * When false, a bounding filter (project/states/types) is required to avoid
+   * pulling the entire organization's backlog.
+   */
+  assignedToMe?: boolean;
+}
+
+function quoteList(values: string[]): string {
+  return values.map((v) => `'${v.replace(/'/g, "''")}'`).join(", ");
+}
+
+/** Build the WIQL query string that selects work item IDs. */
+export function buildWorkItemsWiql(options: WorkItemsWiqlOptions): string {
+  const project = options.project?.trim() || undefined;
+  const states = options.states ?? [];
+  const types = options.types ?? [];
+  const assignedToMe = options.assignedToMe !== false; // default true
+
+  // Volume guard: an unassigned, unfiltered query could return the whole org.
+  if (!assignedToMe && !project && states.length === 0 && types.length === 0) {
+    throw new Error("When not filtering by assigned-to-me, set a bounding filter (project, state, or type).");
+  }
+
+  const predicates: string[] = [];
+  if (assignedToMe) predicates.push("[System.AssignedTo] = @Me");
+  predicates.push(
+    states.length ? `[System.State] IN (${quoteList(states)})` : `[System.State] NOT IN ('Closed', 'Removed', 'Done')`,
+  );
+  if (types.length) predicates.push(`[System.WorkItemType] IN (${quoteList(types)})`);
+  if (project) predicates.push(`[System.TeamProject] = '${project.replace(/'/g, "''")}'`);
+
+  return `
+      SELECT [System.Id]
+      FROM WorkItems
+      WHERE ${predicates.join(" AND ")}
+      ORDER BY [System.ChangedDate] DESC
+    `;
+}

--- a/extensions/ado-search/src/lib/wiql.ts
+++ b/extensions/ado-search/src/lib/wiql.ts
@@ -1,7 +1,7 @@
 /**
  * Pure WIQL (Work Item Query Language) builder for the "My Work Items" command.
- * No I/O, no Raycast deps — kept separate so it is unit-testable via
- * `npx tsx src/lib/wiql.test.ts` (see wiql.test.ts).
+ * No I/O, no Raycast deps — kept side-effect free so the query shape can be
+ * reasoned about (and typechecked via `npm run build`) in isolation.
  */
 
 export interface WorkItemsWiqlOptions {

--- a/extensions/ado-search/src/my-work-items.tsx
+++ b/extensions/ado-search/src/my-work-items.tsx
@@ -1061,6 +1061,17 @@ function SetupView({ firstRun = false, onSaved }: { firstRun?: boolean; onSaved?
   const branchList = branches ?? [];
 
   const handleSubmit = async () => {
+    // Mirror the query-layer guard in buildWorkItemsWiql: browsing everyone's
+    // items needs a bounding filter, otherwise the next query would throw and
+    // leave the list empty/stale despite a "saved" toast.
+    if (!assignedToMe && !project.trim() && states.length === 0 && types.length === 0) {
+      showToast({
+        style: Toast.Style.Failure,
+        title: "Add a bounding filter",
+        message: "To show items not assigned to you, pick a project, state, or type first.",
+      });
+      return;
+    }
     setSubmitting(true);
     const next: AppSettings = {
       project: project.trim(),

--- a/extensions/ado-search/src/my-work-items.tsx
+++ b/extensions/ado-search/src/my-work-items.tsx
@@ -135,6 +135,8 @@ interface AppSettings {
   stateOrder: string;
   defaultRepo: string;
   defaultBaseBranch: string;
+  /** When true, only show items assigned to me. Default true. */
+  assignedToMe: boolean;
 }
 
 const EMPTY_SETTINGS: AppSettings = {
@@ -144,6 +146,7 @@ const EMPTY_SETTINGS: AppSettings = {
   stateOrder: "",
   defaultRepo: "",
   defaultBaseBranch: "",
+  assignedToMe: true,
 };
 
 const STORAGE_KEYS = {
@@ -153,6 +156,7 @@ const STORAGE_KEYS = {
   stateOrder: "app.stateOrder",
   defaultRepo: "app.defaultRepo",
   defaultBaseBranch: "app.defaultBaseBranch",
+  assignedToMe: "app.assignedToMe",
   onboarded: "app.onboarded",
 };
 
@@ -160,13 +164,14 @@ async function readAppSettings(): Promise<{
   settings: AppSettings;
   onboarded: boolean;
 }> {
-  const [p, s, t, so, r, b, o] = await Promise.all([
+  const [p, s, t, so, r, b, am, o] = await Promise.all([
     LocalStorage.getItem<string>(STORAGE_KEYS.project),
     LocalStorage.getItem<string>(STORAGE_KEYS.states),
     LocalStorage.getItem<string>(STORAGE_KEYS.types),
     LocalStorage.getItem<string>(STORAGE_KEYS.stateOrder),
     LocalStorage.getItem<string>(STORAGE_KEYS.defaultRepo),
     LocalStorage.getItem<string>(STORAGE_KEYS.defaultBaseBranch),
+    LocalStorage.getItem<string>(STORAGE_KEYS.assignedToMe),
     LocalStorage.getItem<string>(STORAGE_KEYS.onboarded),
   ]);
   const tryParse = <T,>(v: string | undefined, fallback: T): T => {
@@ -185,6 +190,7 @@ async function readAppSettings(): Promise<{
       stateOrder: tryParse<string>(so, ""),
       defaultRepo: tryParse<string>(r, ""),
       defaultBaseBranch: tryParse<string>(b, ""),
+      assignedToMe: tryParse<boolean>(am, true),
     },
     onboarded: tryParse<boolean>(o, false),
   };
@@ -198,6 +204,7 @@ async function writeAppSettings(settings: AppSettings): Promise<void> {
     LocalStorage.setItem(STORAGE_KEYS.stateOrder, JSON.stringify(settings.stateOrder)),
     LocalStorage.setItem(STORAGE_KEYS.defaultRepo, JSON.stringify(settings.defaultRepo)),
     LocalStorage.setItem(STORAGE_KEYS.defaultBaseBranch, JSON.stringify(settings.defaultBaseBranch)),
+    LocalStorage.setItem(STORAGE_KEYS.assignedToMe, JSON.stringify(settings.assignedToMe)),
     LocalStorage.setItem(STORAGE_KEYS.onboarded, JSON.stringify(true)),
   ]);
 }
@@ -249,15 +256,17 @@ export default function Command() {
   const appStates = settings.states;
   const appTypes = settings.types;
   const appStateOrder = settings.stateOrder;
+  const appAssignedToMe = settings.assignedToMe;
 
   const { data, isLoading, revalidate, mutate } = useCachedPromise(
-    async (projectArg: string, statesArg: string, typesArg: string) =>
+    async (projectArg: string, statesArg: string, typesArg: string, assignedToMeArg: boolean) =>
       getMyWorkItems({
         project: projectArg || undefined,
         states: statesArg ? statesArg.split("|") : undefined,
         types: typesArg ? typesArg.split("|") : undefined,
+        assignedToMe: assignedToMeArg,
       }),
-    [appProject, appStates.join("|"), appTypes.join("|")],
+    [appProject, appStates.join("|"), appTypes.join("|"), appAssignedToMe],
     {
       initialData: [],
       keepPreviousData: true,
@@ -388,6 +397,19 @@ export default function Command() {
                 shortcut={{ modifiers: ["cmd"], key: "n" }}
                 target={<CreateWorkItemForm knownProjects={projects} onCreated={() => revalidate()} />}
               />
+              <Action.Push
+                title="Settings"
+                icon={Icon.Gear}
+                shortcut={{ modifiers: ["cmd", "opt"], key: "," }}
+                target={
+                  <SetupView
+                    onSaved={(next) => {
+                      handleSettingsSaved(next);
+                      revalidate();
+                    }}
+                  />
+                }
+              />
             </ActionPanel>
           }
         />
@@ -408,6 +430,7 @@ export default function Command() {
               <WorkItemRow
                 key={item.id}
                 item={item}
+                showAssignee={!appAssignedToMe}
                 onChange={() => revalidate()}
                 onItemUpdated={onItemUpdated}
                 showDetail={showDetail}
@@ -446,6 +469,7 @@ function WorkItemRow({
   onSelectAllVisible,
   onClearSelection,
   onSettingsSaved,
+  showAssignee,
 }: {
   item: WorkItem;
   onChange: () => void;
@@ -460,6 +484,7 @@ function WorkItemRow({
   onSelectAllVisible: () => void;
   onClearSelection: () => void;
   onSettingsSaved: (s: AppSettings) => void;
+  showAssignee: boolean;
 }) {
   const typeAcc = getTypeAccessory(item.workItemType);
   const selectedCount = selectedItems.length;
@@ -480,6 +505,9 @@ function WorkItemRow({
             ]
           : []),
         ...(item.priority ? [{ text: `P${item.priority}` }] : []),
+        ...(showAssignee && item.assignedTo
+          ? [{ icon: Icon.Person, text: item.assignedTo, tooltip: `Assigned to ${item.assignedTo}` }]
+          : []),
         {
           tag: { value: item.state, color: getStateColor(item.state) },
         },
@@ -974,6 +1002,7 @@ function SetupView({ firstRun = false, onSaved }: { firstRun?: boolean; onSaved?
   const [types, setTypes] = useState<string[]>([]);
   const [defaultRepo, setDefaultRepo] = useState("");
   const [defaultBaseBranch, setDefaultBaseBranch] = useState("");
+  const [assignedToMe, setAssignedToMe] = useState(true);
   const [formInitialized, setFormInitialized] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
@@ -987,6 +1016,7 @@ function SetupView({ firstRun = false, onSaved }: { firstRun?: boolean; onSaved?
       setTypes(settings.types);
       setDefaultRepo(settings.defaultRepo);
       setDefaultBaseBranch(settings.defaultBaseBranch);
+      setAssignedToMe(settings.assignedToMe);
       setFormInitialized(true);
     });
     return () => {
@@ -1039,6 +1069,7 @@ function SetupView({ firstRun = false, onSaved }: { firstRun?: boolean; onSaved?
       stateOrder: stateOrder.trim(),
       defaultRepo: defaultRepo.trim(),
       defaultBaseBranch: defaultBaseBranch.trim(),
+      assignedToMe,
     };
     try {
       await writeAppSettings(next);
@@ -1131,6 +1162,14 @@ function SetupView({ firstRun = false, onSaved }: { firstRun?: boolean; onSaved?
           <Form.Dropdown.Item key={p} value={p} title={p} />
         ))}
       </Form.Dropdown>
+      <Form.Checkbox
+        id="assignedToMe"
+        title="Assignment"
+        label="Only show items assigned to me"
+        info="When on, the list is scoped to items assigned to you. Turn off to see everyone's items — a project, state, or type filter is required to keep the result set bounded."
+        value={assignedToMe}
+        onChange={setAssignedToMe}
+      />
       <Form.TagPicker
         id="states"
         title="States to Show"


### PR DESCRIPTION
## Demo

<details>
<summary>Example, with sensitive info redacted</summary>

<img width="760" height="489" alt="image" src="https://github.com/user-attachments/assets/8895292c-e720-4b4a-b602-4f63947361fa" />
<img width="746" height="473" alt="image" src="https://github.com/user-attachments/assets/b53499fa-0ec8-4562-8e8d-cfbcff897011" />


</details>

## Description
Adds an "Only show items assigned to me" setting to the My Work Items command (on by default, so existing behavior is unchanged). When turned off, the WIQL query drops `[System.AssignedTo] = @Me` so the list shows everyone's items. A project/state/type filter is required in that mode to keep the result set bounded, and each item's assignee is shown in the list.

Also exposes the Settings action from the empty-state view so it remains reachable when the list is empty.

## Testing
- `ray build` and `ray lint` pass.
- Ran locally via `ray develop`: toggling the setting refetches; with the filter off a bounding filter is enforced (clear error toast otherwise) and assignees render as a list accessory.

## Checklist
- [x] Updated `CHANGELOG.md` using the `{PR_MERGE_DATE}` placeholder
- [x] I am already listed in the extension's `contributors`
