### PR TITLE
Update launchdarkly extension

### DIFF
--- a/extensions/launchdarkly/CHANGELOG.md
+++ b/extensions/launchdarkly/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Launchdarkly Changelog
 
-## [Windows support] - {PR_MERGE_DATE}
+## [Windows support] - 2026-09-10
 
 - 🪟 The extension is now available on Raycast for Windows
 - ⌨️ Switch Project, Toggle Name, Recent Changes and Flag History shortcuts use `Ctrl` instead of `⌘` on Windows

--- a/extensions/launchdarkly/CHANGELOG.md
+++ b/extensions/launchdarkly/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Launchdarkly Changelog
 
+## [Windows support] - {PR_MERGE_DATE}
+
+- 🪟 The extension is now available on Raycast for Windows
+
 ## [Projects, history, favorites and richer targeting] - 2026-09-08
 
 ### New

--- a/extensions/launchdarkly/CHANGELOG.md
+++ b/extensions/launchdarkly/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Windows support] - {PR_MERGE_DATE}
 
 - 🪟 The extension is now available on Raycast for Windows
+- ⌨️ Switch Project, Toggle Name, Recent Changes and Flag History shortcuts use `Ctrl` instead of `⌘` on Windows
 
 ## [Projects, history, favorites and richer targeting] - 2026-09-08
 

--- a/extensions/launchdarkly/README.md
+++ b/extensions/launchdarkly/README.md
@@ -29,6 +29,8 @@ Browse your LaunchDarkly feature flags, targeting rules, environments and recent
 
 ## Commands
 
+Shortcuts below are shown for macOS; on Windows, use `Ctrl` instead of `⌘` and `Alt` instead of `⌥`.
+
 ### List Feature Flags
 
 Search flags in the current project. The dropdown filters by **state** (live, deprecated, archived), **type** (temporary, permanent), **My Flags** (flags you maintain) and **tags**. Favorites and recently viewed flags appear above the results when the search is empty.

--- a/extensions/launchdarkly/README.md
+++ b/extensions/launchdarkly/README.md
@@ -29,7 +29,7 @@ Browse your LaunchDarkly feature flags, targeting rules, environments and recent
 
 ## Commands
 
-Shortcuts below are shown for macOS; on Windows, use `Ctrl` instead of `⌘` and `Alt` instead of `⌥`.
+Shortcuts below are shown for macOS; on Windows, use `Ctrl` instead of `⌘` and `Alt` instead of `⌥`, except the favorites shortcut is `Ctrl+.`.
 
 ### List Feature Flags
 

--- a/extensions/launchdarkly/package.json
+++ b/extensions/launchdarkly/package.json
@@ -43,7 +43,7 @@
       "name": "projectKey",
       "type": "textfield",
       "title": "Default Project Key",
-      "description": "Project used until you pick another one with the Switch Project action (⌘⇧S). If left blank, defaults to 'default'.",
+      "description": "Project used until you pick another one with the Switch Project action (⌘⇧S on macOS, Ctrl+Shift+S on Windows). If left blank, defaults to 'default'.",
       "required": false
     },
     {

--- a/extensions/launchdarkly/package.json
+++ b/extensions/launchdarkly/package.json
@@ -82,6 +82,7 @@
     "mock-server": "ts-node ./mock/mock-ld-server.ts"
   },
   "platforms": [
-    "macOS"
+    "macOS",
+    "Windows"
   ]
 }

--- a/extensions/launchdarkly/src/utils/shortcuts.ts
+++ b/extensions/launchdarkly/src/utils/shortcuts.ts
@@ -1,7 +1,18 @@
 import { Keyboard } from "@raycast/api";
 
-/** Shortcuts shared across views so the same key does the same thing everywhere. */
-export const SWITCH_PROJECT_SHORTCUT: Keyboard.Shortcut = { modifiers: ["cmd", "shift"], key: "s" };
-export const TOGGLE_NAME_SHORTCUT: Keyboard.Shortcut = { modifiers: ["cmd", "shift"], key: "t" };
-export const RECENT_CHANGES_SHORTCUT: Keyboard.Shortcut = { modifiers: ["cmd", "shift"], key: "l" };
-export const FLAG_HISTORY_SHORTCUT: Keyboard.Shortcut = { modifiers: ["cmd", "shift"], key: "h" };
+/**
+ * Shortcuts shared across views so the same key does the same thing everywhere.
+ * `cmd` is ambiguous across platforms, so each shortcut declares both variants;
+ * Raycast would otherwise ignore it on Windows.
+ */
+function crossPlatform(key: Keyboard.KeyEquivalent): Keyboard.Shortcut {
+  return {
+    macOS: { modifiers: ["cmd", "shift"], key },
+    Windows: { modifiers: ["ctrl", "shift"], key },
+  };
+}
+
+export const SWITCH_PROJECT_SHORTCUT = crossPlatform("s");
+export const TOGGLE_NAME_SHORTCUT = crossPlatform("t");
+export const RECENT_CHANGES_SHORTCUT = crossPlatform("l");
+export const FLAG_HISTORY_SHORTCUT = crossPlatform("h");


### PR DESCRIPTION
## Description

I was able to test it on Windows, and it works fine, so I’m just adding Windows to the list.


## Screencast
<img width="799" height="498" alt="Screenshot 2026-09-09 at 11 31 13 PM" src="https://github.com/user-attachments/assets/836a3602-1ad4-4bf2-8f62-bae0c516ec1d" />


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
