### PR TITLE
Update attio extension

### DIFF
--- a/extensions/attio/CHANGELOG.md
+++ b/extensions/attio/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Attio Changelog
 
-## [Create Records + AI Tools] - {PR_MERGE_DATE}
+## [Create Records + AI Tools] - 2026-09-12
 
 ### Create People, Companies, and Deals
 

--- a/extensions/attio/CHANGELOG.md
+++ b/extensions/attio/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Attio Changelog
 
+## [Create Records + AI Tools] - {PR_MERGE_DATE}
+
+### Create People, Companies, and Deals
+
+- Dedicated Create Person / Create Company / Create Deal commands with Raycast draft support — dismiss mid-entry and pick the form back up later
+- New Record (`⌘N`) from every record list — the standard objects open their Create command; custom objects get the same schema-driven form inline
+- Schema-driven form: writable attributes from your workspace schema, inline required/invalid validation, tag-style entry for multi-value fields (domains validated for well-formed TLDs), person names parsed into Attio's name format, deal owners picked from workspace members
+- Success toast offers Open in Attio for the record you just created
+- Record action panels reordered: open/pin/new up top, edit and copy together, view controls, then export with delete always last
+
+### Editing
+
+- The Edit form now covers names (split First/Last, like Attio), owners, and single record links — associate a person with a company via live record search, right from Raycast
+- Fields follow your workspace's schema order, required fields validate inline, and everything saves in one request
+
+### AI Extension
+
+- Talk to Attio from Raycast AI (`@attio`): Search Records, Create Person, Create Company, and Create Deal tools, with confirmation before any write
+- Create Deal resolves stage names case-insensitively against your pipeline and matches owners by member name or email
+
 ## [Task Edit Fix] - 2026-09-09
 
 - Fixed a React state-update warning when returning from the task edit or new-task form

--- a/extensions/attio/CHANGELOG.md
+++ b/extensions/attio/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Dedicated Create Person / Create Company / Create Deal commands with Raycast draft support — dismiss mid-entry and pick the form back up later
 - New Record (`⌘N`) from every record list — the standard objects open their Create command; custom objects get the same schema-driven form inline
-- Schema-driven form: writable attributes from your workspace schema, inline required/invalid validation, tag-style entry for multi-value fields (domains validated for well-formed TLDs), person names parsed into Attio's name format, deal owners picked from workspace members
+- Schema-driven form: writable attributes from your workspace schema (multi-value record links, locations, and interactions stay Attio-only), inline required/invalid validation, tag-style entry for multi-value fields with TLD-validated domains, split first/last name fields, record links with live search, deal owners picked from workspace members, and untouched checkboxes leaving workspace defaults intact
 - Success toast offers Open in Attio for the record you just created
 - Record action panels reordered: open/pin/new up top, edit and copy together, view controls, then export with delete always last
 

--- a/extensions/attio/README.md
+++ b/extensions/attio/README.md
@@ -68,7 +68,7 @@ If you grant only the "required to read" scopes above, the extension is fully re
 - **Members and Teams** — browse workspace members
 - **Manage Webhooks** — configure webhooks and webhook events (create, edit, delete; event-type picker)
 
-New records are created with the dedicated Create commands or from any record list (`⌘N`): every writable attribute your workspace defines is rendered, required fields are validated inline, and deal owners are picked from your workspace members. The Create commands support Raycast drafts — a half-filled form survives dismissing Raycast.
+New records are created with the dedicated Create commands or from any record list (`⌘N`): writable attributes from your workspace schema are rendered — including person names, owners, and record links like a person's Company — with inline validation for required fields. Multi-value record links, locations, and interactions can only be set in Attio. The Create commands support Raycast drafts — a half-filled form survives dismissing Raycast.
 
 ## AI Extension
 

--- a/extensions/attio/README.md
+++ b/extensions/attio/README.md
@@ -41,7 +41,7 @@ Two dependencies are easy to miss because the command name doesn't suggest them:
 
 | Scope                             | Unlocks                                  |
 | --------------------------------- | ---------------------------------------- |
-| `record_permission:read-write`    | Editing and deleting records             |
+| `record_permission:read-write`    | Creating, editing, and deleting records  |
 | `note:read-write`                 | Editing notes                            |
 | `task:read-write`                 | Creating, completing, and deleting tasks |
 | `object_configuration:read-write` | Creating custom objects                  |
@@ -58,7 +58,8 @@ If you grant only the "required to read" scopes above, the extension is fully re
 
 ## Commands
 
-- **Search People / Search Companies / Search Deals** — browse, search, sort, filter, pin, edit, and export the standard objects; related records open in their home command
+- **Search People / Search Companies / Search Deals** — browse, search, sort, filter, pin, create, edit, and export the standard objects; related records open in their home command
+- **Create Person / Create Company / Create Deal** — schema-driven forms with draft support: dismiss Raycast mid-entry and your in-progress record is waiting when you come back
 - **Search Tasks** — browse, filter, sort, group by due date, create, edit, complete, and delete tasks
 - **My Tasks** — tasks assigned to you
 - **Search Notes** — browse and edit notes with markdown rendering and parent-record context
@@ -66,3 +67,16 @@ If you grant only the "required to read" scopes above, the extension is fully re
 - **Objects** — browse every object (including custom objects) and their records
 - **Members and Teams** — browse workspace members
 - **Manage Webhooks** — configure webhooks and webhook events (create, edit, delete; event-type picker)
+
+New records are created with the dedicated Create commands or from any record list (`⌘N`): every writable attribute your workspace defines is rendered, required fields are validated inline, and deal owners are picked from your workspace members. The Create commands support Raycast drafts — a half-filled form survives dismissing Raycast.
+
+## AI Extension
+
+Ask Raycast AI to work with your Attio data — type `@attio` in AI Chat or Quick AI:
+
+- **Search Records** — "find the company Acme", "look up ada@example.com"
+- **Create Person** — "add Ada Lovelace (ada@example.com) as a contact"
+- **Create Company** — "create a company called Acme with domain acme.com"
+- **Create Deal** — "start a deal named Acme Enterprise worth 5000, owned by Chris"
+
+Create tools ask for confirmation before writing, and respect the same token scopes as the commands — a read-only token can search but not create.

--- a/extensions/attio/ai.yaml
+++ b/extensions/attio/ai.yaml
@@ -1,0 +1,166 @@
+instructions: |
+  - Format created records as markdown links using the `url` the create tools return. `search-records` results carry NO URLs — refer to those records by plain title and never invent a link.
+  - Resolve referenced records with `search-records`. Never invent record IDs and never silently pick an unrelated fuzzy match. If multiple plausible matches remain, ask the user to clarify.
+  - Before creating a person or company, call `search-records` with the name (and email or domain when given). If a likely match already exists, tell the user and ask whether to create anyway — never create a duplicate silently.
+  - `search-records` searches people, companies, and deals. Scope with `objects` when the user names a record type ("find the company acme" → `objects: ["companies"]`); omit it to search all three. Email addresses, domains, and deal titles are all valid queries.
+  - `create-person`: pass the full name as spoken ("Ada Lovelace") in `name`. Put an email in `email_address` and a role in `job_title` — never fold them into the name. Use `description` for free-text context the user gives about the person.
+  - `create-company`: `domain` is a bare hostname ("acme.com"). Strip any protocol, path, or "www." the user pastes ("https://www.acme.com/about" → "acme.com").
+  - `create-deal`: `value` is a plain number — convert "$5k" or "5,000" to 5000. `stage` must match a stage title configured in the workspace; pass the user's words and the tool resolves them case-insensitively. If the tool errors listing several matching stages, relay those choices and ask the user to pick one.
+  - `create-deal` `owner` accepts a workspace member's full name or email. If the tool reports multiple members share the name, ask the user for the owner's email. Attio usually requires a deal owner — ask for one if the user didn't specify it.
+  - If a tool fails with a scope or permission error, tell the user which scope their Attio access token is missing (e.g. `record_permission:read-write` for creating records) instead of retrying.
+  - These tools cover searching records and creating people, companies, and deals. For tasks, notes, lists, webhooks, editing, or deleting, direct the user to the extension's commands (Search Tasks, Search Notes, Manage Webhooks, and the object search commands).
+
+evals:
+  # Routing: plain search, scoped search, email lookup
+  - input: "@attio find the company acme"
+    mocks:
+      search-records:
+        - record_id: "6d3e1f70-0000-4000-8000-000000000001"
+          object: "companies"
+          title: "Acme Corp"
+    expected:
+      - callsTool:
+          name: "search-records"
+          arguments:
+            query:
+              includes: "acme"
+            objects:
+              includes: "companies"
+
+  - input: "@attio who is ada@example.com?"
+    mocks:
+      search-records:
+        - record_id: "6d3e1f70-0000-4000-8000-000000000002"
+          object: "people"
+          title: "Ada Lovelace"
+    expected:
+      - callsTool:
+          name: "search-records"
+          arguments:
+            query:
+              includes: "ada@example.com"
+      - includes: "Ada Lovelace"
+
+  - input: "@attio search my deals for renewal"
+    mocks:
+      search-records:
+        - record_id: "6d3e1f70-0000-4000-8000-000000000003"
+          object: "deals"
+          title: "Globex — Renewal 2027"
+    expected:
+      - callsTool:
+          name: "search-records"
+          arguments:
+            query:
+              includes: "renewal"
+            objects:
+              includes: "deals"
+
+  # Create person: dupe-check first, email goes in email_address
+  - input: "@attio add Ada Lovelace (ada@example.com) as a new contact"
+    mocks:
+      search-records: []
+      create-person:
+        record_id: "6d3e1f70-0000-4000-8000-000000000004"
+        url: "https://app.attio.com/example/person/6d3e1f70-0000-4000-8000-000000000004"
+    expected:
+      - callsTool:
+          name: "create-person"
+          arguments:
+            name: "Ada Lovelace"
+            email_address: "ada@example.com"
+
+  - input: "@attio create a contact for Grace Hopper, she's the CTO at Navy Systems"
+    usedAsExample: false
+    mocks:
+      search-records: []
+      create-person:
+        record_id: "6d3e1f70-0000-4000-8000-000000000005"
+        url: "https://app.attio.com/example/person/6d3e1f70-0000-4000-8000-000000000005"
+    expected:
+      - callsTool:
+          name: "create-person"
+          arguments:
+            name: "Grace Hopper"
+            job_title:
+              includes: "CTO"
+
+  # A likely-duplicate person: surface the match, don't create silently
+  - input: "@attio add Ada Lovelace as a contact"
+    usedAsExample: false
+    mocks:
+      search-records:
+        - record_id: "6d3e1f70-0000-4000-8000-000000000002"
+          object: "people"
+          title: "Ada Lovelace"
+    expected:
+      - callsTool: "search-records"
+      - not:
+          callsTool: "create-person"
+
+  # Create company: pasted URL is stripped to a bare domain
+  - input: "@attio create a company called Acme with the website https://www.acme.com/about"
+    mocks:
+      search-records: []
+      create-company:
+        record_id: "6d3e1f70-0000-4000-8000-000000000006"
+        url: "https://app.attio.com/example/company/6d3e1f70-0000-4000-8000-000000000006"
+    expected:
+      - callsTool:
+          name: "create-company"
+          arguments:
+            name: "Acme"
+            domain: "acme.com"
+
+  # Create deal: shorthand value converts to a plain number; owner passes through
+  - input: "@attio start a deal named Acme Enterprise worth $5k, owned by chris@example.com"
+    mocks:
+      create-deal:
+        record_id: "6d3e1f70-0000-4000-8000-000000000007"
+        url: "https://app.attio.com/example/deal/6d3e1f70-0000-4000-8000-000000000007"
+    expected:
+      - callsTool:
+          name: "create-deal"
+          arguments:
+            name: "Acme Enterprise"
+            value: 5000
+            owner:
+              includes: "chris@example.com"
+
+  - input: "@attio create a deal called Globex Renewal in the won stage"
+    usedAsExample: false
+    mocks:
+      create-deal:
+        record_id: "6d3e1f70-0000-4000-8000-000000000008"
+        url: "https://app.attio.com/example/deal/6d3e1f70-0000-4000-8000-000000000008"
+    expected:
+      - callsTool:
+          name: "create-deal"
+          arguments:
+            name:
+              includes: "Globex Renewal"
+            stage:
+              includes: "won"
+
+  # Routing boundary: reading data must not create anything
+  - input: "@attio do we have anyone from Initech in the CRM?"
+    usedAsExample: false
+    mocks:
+      search-records: []
+    expected:
+      - callsTool: "search-records"
+      - not:
+          callsTool: "create-person"
+
+  # Out of tool scope: point at the extension's commands
+  - input: "@attio create a task to follow up with Ada next week"
+    usedAsExample: false
+    mocks:
+      search-records: []
+    expected:
+      - not:
+          callsTool: "create-person"
+      - not:
+          callsTool: "create-company"
+      - not:
+          callsTool: "create-deal"

--- a/extensions/attio/package.json
+++ b/extensions/attio/package.json
@@ -106,6 +106,39 @@
       ]
     },
     {
+      "name": "create-person",
+      "title": "Create Person",
+      "description": "Add a new person to your workspace",
+      "mode": "view",
+      "keywords": [
+        "crm",
+        "new",
+        "contact"
+      ]
+    },
+    {
+      "name": "create-company",
+      "title": "Create Company",
+      "description": "Add a new company to your workspace",
+      "mode": "view",
+      "keywords": [
+        "crm",
+        "new",
+        "org"
+      ]
+    },
+    {
+      "name": "create-deal",
+      "title": "Create Deal",
+      "description": "Add a new deal to your pipeline",
+      "mode": "view",
+      "keywords": [
+        "crm",
+        "new",
+        "pipeline"
+      ]
+    },
+    {
       "name": "tasks",
       "title": "Search Tasks",
       "description": "List Workspace Tasks",
@@ -134,6 +167,28 @@
       "keywords": [
         "integrations"
       ]
+    }
+  ],
+  "tools": [
+    {
+      "name": "search-records",
+      "title": "Search Records",
+      "description": "Search people, companies, and deals in the Attio workspace by name, email, domain, or deal title."
+    },
+    {
+      "name": "create-person",
+      "title": "Create Person",
+      "description": "Create a new person record in Attio with a name and optionally an email address, job title, and description."
+    },
+    {
+      "name": "create-company",
+      "title": "Create Company",
+      "description": "Create a new company record in Attio with a name and optionally a website domain and description."
+    },
+    {
+      "name": "create-deal",
+      "title": "Create Deal",
+      "description": "Create a new deal record in Attio with a name and optionally a stage, value, and owner (a workspace member)."
     }
   ],
   "dependencies": {

--- a/extensions/attio/src/api/endpoints.ts
+++ b/extensions/attio/src/api/endpoints.ts
@@ -53,6 +53,8 @@ export const searchRecords = (query: string, objects: string[]) =>
   });
 export const getRecord = (object: string, recordId: string) =>
   request<Envelope<AttioRecord>>(`/v2/objects/${object}/records/${recordId}`);
+export const createRecord = (object: string, body: RecordUpdateBody) =>
+  request<Envelope<AttioRecord>>(`/v2/objects/${object}/records`, { method: "POST", body: JSON.stringify(body) });
 /** PUT, not PATCH: PATCH appends to multiselects; PUT overwrites (types.ts). */
 export const updateRecord = (object: string, recordId: string, body: RecordUpdateBody) =>
   request<Envelope<AttioRecord>>(`/v2/objects/${object}/records/${recordId}`, {

--- a/extensions/attio/src/api/operations.ts
+++ b/extensions/attio/src/api/operations.ts
@@ -32,6 +32,10 @@ export const OPERATIONS = {
     path: "/v2/objects/{object}/records/{record}",
     scopes: ["record_permission:read", "object_configuration:read"],
   },
+  createRecord: {
+    path: "/v2/objects/{object}/records",
+    scopes: ["record_permission:read-write", "object_configuration:read"],
+  },
   updateRecord: {
     path: "/v2/objects/{object}/records/{record}",
     scopes: ["record_permission:read-write", "object_configuration:read"],

--- a/extensions/attio/src/components/CreateRecordCommand.tsx
+++ b/extensions/attio/src/components/CreateRecordCommand.tsx
@@ -1,0 +1,67 @@
+import { getErrorMessage } from "@chrismessina/raycast-kit/errors";
+import { Form, Icon, List, popToRoot } from "@raycast/api";
+import { missingScopes } from "../api/operations";
+import { useSchema } from "../hooks/useSchema";
+import { useSelf } from "../hooks/useSelf";
+import { guard } from "./Guard";
+import RecordCreateForm from "./RecordCreateForm";
+
+/**
+ * Top-level Create command (drafts only work on a command-root form, so these
+ * can't be pushed views). Same guard chain as StandardObjectCommand.
+ */
+export default function CreateRecordCommand({
+  slug,
+  draftValues,
+}: {
+  slug: "people" | "companies" | "deals";
+  draftValues?: Record<string, unknown>;
+}) {
+  const self = useSelf();
+  const schema = useSchema();
+
+  const g = guard({
+    selfIsActive: self.isActive,
+    selfIsLoading: self.isLoading,
+    selfError: self.error,
+    missing: [
+      ...new Set([...missingScopes(self.granted, "listObjects"), ...missingScopes(self.granted, "createRecord")]),
+    ],
+    error: schema.error,
+    hasLiveData: schema.objects.length > 0,
+    onRetry: () => {
+      self.revalidate();
+      schema.revalidate();
+    },
+    errorDetail: (self.error ?? schema.error) ? getErrorMessage(self.error ?? schema.error) : undefined,
+  });
+  if (g) return g;
+
+  if (schema.isLoading) return <Form isLoading />;
+
+  const object = schema.objects.find((o) => o.api_slug === slug);
+  const attributes = schema.attributesFor(slug);
+  if (!object || !attributes) {
+    return (
+      <List>
+        <List.EmptyView
+          icon={Icon.Box}
+          title={`${slug.charAt(0).toUpperCase() + slug.slice(1)} isn't enabled in this workspace`}
+          description="An admin can enable it in Attio's settings."
+        />
+      </List>
+    );
+  }
+
+  return (
+    <RecordCreateForm
+      objectSlug={slug}
+      singularNoun={object.singular_noun ?? "Record"}
+      attributes={attributes}
+      enableDrafts
+      draftValues={draftValues}
+      onCreated={() => {}}
+      afterCreate={popToRoot}
+    />
+  );
+}

--- a/extensions/attio/src/components/RecordActions.tsx
+++ b/extensions/attio/src/components/RecordActions.tsx
@@ -34,6 +34,10 @@ export default function RecordActions(props: {
   pins?: { pinned: boolean; toggle: () => void };
   pushFallback: (objectSlug: string, recordId: string) => void;
   extraViewActions?: ReactNode;
+  /** "New <Object>" action — last row of the primary section. */
+  newAction?: ReactNode;
+  /** Export submenu — untitled tail section, above Delete. */
+  exportAction?: ReactNode;
 }) {
   const {
     record,
@@ -46,6 +50,8 @@ export default function RecordActions(props: {
     pins,
     pushFallback,
     extraViewActions,
+    newAction,
+    exportAction,
   } = props;
   const self = useSelf();
   const canEdit = satisfied(self.granted, "record_permission:read-write");
@@ -96,6 +102,9 @@ export default function RecordActions(props: {
   const title = recordTitle(record, objectSlug);
   const hasResolvableTitle = title !== shortId(record.id.record_id);
 
+  // Panel order per Chris's 2026-09-09 sort: Primary (open/pin/new), Edit
+  // (edit + copies), View (relations + list controls), then an untitled tail
+  // for Export and Delete — Delete always bottommost.
   return (
     <>
       <ActionPanel.Section>
@@ -107,6 +116,46 @@ export default function RecordActions(props: {
             onAction={() => openRelated("companies", companyRef!.target_record_id)}
           />
         )}
+        {pins && (
+          <Action
+            icon={pins.pinned ? Icon.TackDisabled : Icon.Tack}
+            title={pins.pinned ? "Unpin Record" : "Pin Record"}
+            shortcut={{
+              macOS: { modifiers: ["cmd", "shift"], key: "p" },
+              Windows: { modifiers: ["ctrl", "shift"], key: "p" },
+            }}
+            onAction={pins.toggle}
+          />
+        )}
+        {newAction}
+      </ActionPanel.Section>
+      <ActionPanel.Section title="Edit">
+        {canEdit && attributes && (
+          <Action.Push
+            icon={Icon.Pencil}
+            title={`Edit ${singularNoun}`}
+            target={
+              <RecordEditForm
+                objectSlug={objectSlug}
+                singularNoun={singularNoun}
+                record={record}
+                attributes={attributes}
+                titleFor={titleFor}
+                onSaved={onMutated}
+              />
+            }
+            shortcut={Keyboard.Shortcut.Common.Edit}
+          />
+        )}
+        {hasResolvableTitle && <Action.CopyToClipboard title="Copy Name" content={title} />}
+        {emailValue && <Action.CopyToClipboard title="Copy Email Address" content={emailValue.email_address} />}
+        <Action.CopyToClipboard
+          title="Copy Record URL"
+          content={record.web_url}
+          shortcut={Keyboard.Shortcut.Common.CopyPath}
+        />
+      </ActionPanel.Section>
+      <ActionPanel.Section title="View">
         {peopleRefs.length > 0 && (
           <ActionPanel.Submenu title="View Related People" icon={Icon.TwoPeople}>
             {peopleRefs.map((v) => (
@@ -131,35 +180,10 @@ export default function RecordActions(props: {
             ))}
           </ActionPanel.Submenu>
         )}
-        {pins && (
-          <Action
-            icon={pins.pinned ? Icon.TackDisabled : Icon.Tack}
-            title={pins.pinned ? "Unpin Record" : "Pin Record"}
-            shortcut={{
-              macOS: { modifiers: ["cmd", "shift"], key: "p" },
-              Windows: { modifiers: ["ctrl", "shift"], key: "p" },
-            }}
-            onAction={pins.toggle}
-          />
-        )}
+        {extraViewActions}
       </ActionPanel.Section>
-      <ActionPanel.Section title="Edit">
-        {canEdit && attributes && (
-          <Action.Push
-            icon={Icon.Pencil}
-            title={`Edit ${singularNoun}`}
-            target={
-              <RecordEditForm
-                objectSlug={objectSlug}
-                singularNoun={singularNoun}
-                record={record}
-                attributes={attributes}
-                onSaved={onMutated}
-              />
-            }
-            shortcut={Keyboard.Shortcut.Common.Edit}
-          />
-        )}
+      <ActionPanel.Section>
+        {exportAction}
         {canEdit && (
           <Action
             icon={Icon.Trash}
@@ -170,16 +194,6 @@ export default function RecordActions(props: {
           />
         )}
       </ActionPanel.Section>
-      <ActionPanel.Section title="Copy">
-        <Action.CopyToClipboard
-          title="Copy Record URL"
-          content={record.web_url}
-          shortcut={Keyboard.Shortcut.Common.CopyPath}
-        />
-        {emailValue && <Action.CopyToClipboard title="Copy Email Address" content={emailValue.email_address} />}
-        {hasResolvableTitle && <Action.CopyToClipboard title="Copy Name" content={title} />}
-      </ActionPanel.Section>
-      {extraViewActions && <ActionPanel.Section title="View">{extraViewActions}</ActionPanel.Section>}
     </>
   );
 }

--- a/extensions/attio/src/components/RecordCreateForm.tsx
+++ b/extensions/attio/src/components/RecordCreateForm.tsx
@@ -1,0 +1,400 @@
+import { failToast } from "@chrismessina/raycast-kit";
+import { Fragment, useMemo, useRef, useState } from "react";
+import { Action, ActionPanel, Form, Icon, open, showToast, Toast, useNavigation } from "@raycast/api";
+import { showFailureToast, useCachedPromise } from "@raycast/utils";
+import { createRecord, listAttributeOptions, listAttributeStatuses } from "../api/endpoints";
+import { missingScopes } from "../api/operations";
+import type { Attribute } from "../api/types";
+import { useMembers } from "../hooks/useMembers";
+import { cacheNs, useSelf } from "../hooks/useSelf";
+import { creatableAttributes, toWireValue } from "../lib/edit-mapping";
+import { openRecordInHomeCommand } from "../lib/open-record";
+
+/**
+ * Tag-input companion-field id suffix. ":" can't appear in an Attio api_slug,
+ * so a real attribute named e.g. "approval_pending" can never collide.
+ */
+const PENDING_SUFFIX = ":pending";
+
+/** Placeholder nouns per attribute type — "Type an email address followed by a comma to add". */
+const TAG_NOUNS: Record<string, string> = {
+  "email-address": "an email address",
+  domain: "a domain",
+  "phone-number": "a phone number",
+};
+
+/**
+ * Multiselect free-text entry (Karakeep's Create Bookmark tag pattern): a
+ * TagPicker holds committed values; a companion TextField commits on comma or
+ * blur. No option lookup — values are whatever the user types.
+ */
+function TagInput(props: {
+  attr: Attribute;
+  values: string[];
+  onChange: (v: string[]) => void;
+  /** Mirrors uncommitted text up so submit can fold it in (⌘↵ skips blur). */
+  onPendingChange: (t: string) => void;
+  info?: string;
+  error?: string;
+  initialPending?: string;
+}) {
+  const [pending, setPendingState] = useState(props.initialPending ?? "");
+  const setPending = (t: string) => {
+    setPendingState(t);
+    props.onPendingChange(t);
+  };
+  const commit = (raw: string) => {
+    const adds = raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const next = [...props.values];
+    for (const x of adds) if (!next.includes(x)) next.push(x);
+    if (next.length !== props.values.length) props.onChange(next);
+  };
+  return (
+    <>
+      <Form.TextField
+        id={props.attr.api_slug + PENDING_SUFFIX}
+        title={`Add ${props.attr.title}`}
+        placeholder={`Type ${TAG_NOUNS[props.attr.type] ?? "a value"} followed by a comma to add`}
+        info={props.info}
+        error={props.error}
+        value={pending}
+        onChange={(t) => {
+          if (t.includes(",")) {
+            const parts = t.split(",");
+            commit(parts.slice(0, -1).join(","));
+            setPending(parts[parts.length - 1]);
+          } else setPending(t);
+        }}
+        onBlur={() => {
+          commit(pending);
+          setPending("");
+        }}
+      />
+      <Form.TagPicker id={props.attr.api_slug} title={props.attr.title} value={props.values} onChange={props.onChange}>
+        {props.values.map((v) => (
+          <Form.TagPicker.Item key={v} value={v} title={v} />
+        ))}
+      </Form.TagPicker>
+    </>
+  );
+}
+
+/**
+ * Schema-driven create form: same field mapping as RecordEditForm, including
+ * personal-name (split First/Last) and actor-reference (deal Owner) as a
+ * workspace-member dropdown.
+ * Empty fields are simply omitted from the POST.
+ */
+export default function RecordCreateForm(props: {
+  objectSlug: string;
+  singularNoun: string;
+  attributes: Attribute[];
+  onCreated: () => void;
+  /** Top-level Create commands enable drafts; pushed forms can't (Raycast limitation). */
+  enableDrafts?: boolean;
+  draftValues?: Record<string, unknown>;
+  /** What to do after a successful create — defaults to pop (no-op at a command root). */
+  afterCreate?: () => void;
+}) {
+  const { pop } = useNavigation();
+  const self = useSelf();
+  const members = useMembers();
+  const canListMembers = missingScopes(self.granted, "listMembers").length === 0;
+  const creatable = useMemo(() => creatableAttributes(props.attributes), [props.attributes]);
+  // Restored draft values seed the form: "<slug>_pending" keys are tag-input
+  // text that never got committed; everything else is field state.
+  const fromDraft = useMemo(() => {
+    const fields: Record<string, unknown> = {};
+    const pending: Record<string, string> = {};
+    for (const [k, v] of Object.entries(props.draftValues ?? {})) {
+      if (v == null || v === "" || (Array.isArray(v) && v.length === 0)) continue;
+      if (k.endsWith(PENDING_SUFFIX)) pending[k.slice(0, -PENDING_SUFFIX.length)] = String(v);
+      else fields[k] = v;
+    }
+    return { fields, pending };
+  }, []);
+  const [current, setCurrent] = useState<Record<string, unknown>>(fromDraft.fields);
+  // Inline field errors (Raycast-standard validation) — set on submit, cleared on edit.
+  const [errors, setErrors] = useState<Record<string, string | undefined>>({});
+  const set = (slug: string) => (value: unknown) => {
+    setCurrent((c) => ({ ...c, [slug]: value }));
+    // Clear the field's error — a ":first"/":last" sub-key clears its base
+    // attribute's error, which is where submit records it.
+    const base = slug.replace(/:(first|last)$/, "");
+    setErrors((e) => (e[slug] || e[base] ? { ...e, [slug]: undefined, [base]: undefined } : e));
+  };
+  // "Required" only when Attio will actually reject an omission — a required
+  // field with a workspace default is satisfied by the default.
+  const requiredInfo = (a: Attribute) => (a.is_required && !a.is_default_value_enabled ? "Required" : undefined);
+  const submitting = useRef(false);
+  // Uncommitted tag-input text per slug — ⌘↵ can submit before blur commits it.
+  const pendingTags = useRef<Record<string, string>>(fromDraft.pending);
+
+  const { data: choices } = useCachedPromise(
+    // _ns is cache-key-only: it scopes cached choices to the token fingerprint
+    // so another workspace's option titles never surface. It must NOT be
+    // folded into objectSlug — that string becomes the request URL.
+    async (_ns: string, objectSlug: string, slugs: string) => {
+      const out: Record<string, string[]> = {};
+      for (const slug of slugs.split(",").filter(Boolean)) {
+        const a = creatable.find((x) => x.api_slug === slug);
+        if (!a) continue;
+        if (a.type === "select")
+          out[slug] = (await listAttributeOptions(objectSlug, slug)).data
+            .filter((o) => !o.is_archived)
+            .map((o) => o.title);
+        if (a.type === "status")
+          out[slug] = (await listAttributeStatuses(objectSlug, slug)).data
+            .filter((s) => !s.is_archived)
+            .map((s) => s.title);
+      }
+      return out;
+    },
+    [
+      cacheNs,
+      props.objectSlug,
+      creatable
+        .filter((a) => a.type === "select" || a.type === "status")
+        .map((a) => a.api_slug)
+        .join(","),
+    ],
+  );
+
+  async function submit() {
+    if (submitting.current) return;
+    const anyPending = Object.values(pendingTags.current).some((t) => t.trim() !== "");
+    if (Object.keys(current).length === 0 && !anyPending) {
+      showFailureToast(new Error("Fill in at least one field"), { title: "Nothing to create" });
+      return;
+    }
+    const values: Record<string, unknown[]> = {};
+    const nextErrors: Record<string, string> = {};
+    for (const a of creatable) {
+      let val = current[a.api_slug];
+      // Fold in text typed into a tag input but not yet committed by comma/blur.
+      const pend = pendingTags.current[a.api_slug]?.trim();
+      if (pend) {
+        const arr = Array.isArray(val) ? [...(val as string[])] : [];
+        for (const x of pend
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean))
+          if (!arr.includes(x)) arr.push(x);
+        val = arr;
+      }
+      let wire: unknown[];
+      try {
+        if (a.type === "personal-name") {
+          const first = String(current[a.api_slug + ":first"] ?? "").trim();
+          const last = String(current[a.api_slug + ":last"] ?? "").trim();
+          wire =
+            first || last
+              ? [{ first_name: first, last_name: last, full_name: [first, last].filter(Boolean).join(" ") }]
+              : [];
+        } else if (a.type === "actor-reference")
+          wire = val ? [{ referenced_actor_type: "workspace-member", referenced_actor_id: val }] : [];
+        // Checkboxes always send what the form shows (an untouched box shows
+        // unchecked); everything else empty is omitted so Attio can apply a
+        // configured default — which also covers required-with-default fields.
+        else wire = toWireValue(a, val ?? (a.type === "checkbox" ? false : ""));
+      } catch (error) {
+        nextErrors[a.api_slug] = error instanceof Error ? error.message : "Invalid value";
+        continue;
+      }
+      if (a.is_required && !a.is_default_value_enabled && wire.length === 0) {
+        nextErrors[a.api_slug] = "Required";
+        continue;
+      }
+      if (wire.length > 0) values[a.api_slug] = wire;
+    }
+    if (Object.keys(nextErrors).length > 0) {
+      setErrors(nextErrors);
+      return;
+    }
+    submitting.current = true;
+    const toast = await showToast(Toast.Style.Animated, `Creating ${props.singularNoun.toLowerCase()}`);
+    try {
+      const { data } = await createRecord(props.objectSlug, { data: { values } });
+      toast.style = Toast.Style.Success;
+      toast.title = `${props.singularNoun} created`;
+      // Primary opens the record in its home command (standard objects);
+      // custom objects have no home command, so Attio is the only target.
+      toast.primaryAction = {
+        title: `Open ${props.singularNoun}`,
+        onAction: async () => {
+          if (!(await openRecordInHomeCommand(props.objectSlug, data.id.record_id))) await open(data.web_url);
+        },
+      };
+      toast.secondaryAction = { title: "Open in Attio", onAction: () => open(data.web_url) };
+      props.onCreated();
+      (props.afterCreate ?? pop)();
+    } catch (error) {
+      failToast(toast, error, { title: "Create failed" });
+    } finally {
+      submitting.current = false;
+    }
+  }
+
+  return (
+    <Form
+      enableDrafts={props.enableDrafts}
+      navigationTitle={`New ${props.singularNoun}`}
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm icon={Icon.Plus} title={`Create ${props.singularNoun}`} onSubmit={submit} />
+        </ActionPanel>
+      }
+    >
+      {creatable.map((a) => {
+        const val = current[a.api_slug];
+        const info = requiredInfo(a);
+        const error = errors[a.api_slug];
+        switch (a.type) {
+          case "personal-name":
+            // Split fields, matching Attio's own editor.
+            return (
+              <Fragment key={a.api_slug}>
+                <Form.TextField
+                  id={a.api_slug + ":first"}
+                  title="First Name"
+                  info={info}
+                  error={error}
+                  value={String(current[a.api_slug + ":first"] ?? "")}
+                  onChange={set(a.api_slug + ":first")}
+                />
+                <Form.TextField
+                  id={a.api_slug + ":last"}
+                  title="Last Name"
+                  value={String(current[a.api_slug + ":last"] ?? "")}
+                  onChange={set(a.api_slug + ":last")}
+                />
+              </Fragment>
+            );
+          case "actor-reference":
+            if (!canListMembers)
+              return (
+                <Form.Description
+                  key={a.api_slug}
+                  title={a.title}
+                  text={`Picking a member needs the user_management:read scope on your token${a.is_required ? " — required to create" : ""}.`}
+                />
+              );
+            // ponytail: single-value dropdown even for multiselect actor
+            // attributes; upgrade to a member TagPicker if one ever needs it.
+            return (
+              <Form.Dropdown
+                key={a.api_slug}
+                id={a.api_slug}
+                title={a.title}
+                info={info}
+                error={error}
+                value={String(val ?? "")}
+                onChange={set(a.api_slug)}
+              >
+                {!a.is_required && <Form.Dropdown.Item value="" title="—" />}
+                {members.all.map((m) => (
+                  <Form.Dropdown.Item key={m.id} value={m.id} title={m.name} icon={Icon.Person} />
+                ))}
+              </Form.Dropdown>
+            );
+          case "checkbox":
+            return (
+              <Form.Checkbox
+                key={a.api_slug}
+                id={a.api_slug}
+                label={a.title}
+                value={Boolean(val)}
+                onChange={set(a.api_slug)}
+              />
+            );
+          case "date":
+          case "timestamp":
+            return (
+              <Form.DatePicker
+                key={a.api_slug}
+                id={a.api_slug}
+                title={a.title}
+                info={info}
+                error={error}
+                type={a.type === "date" ? Form.DatePicker.Type.Date : Form.DatePicker.Type.DateTime}
+                value={(val as Date) ?? null}
+                onChange={set(a.api_slug)}
+              />
+            );
+          case "select":
+          case "status": {
+            const opts = choices?.[a.api_slug];
+            if (!opts) return <Form.Description key={a.api_slug} title={a.title} text="Loading choices…" />;
+            if (a.is_multiselect) {
+              const selected = Array.isArray(val) ? (val as string[]) : [];
+              return (
+                <Form.TagPicker
+                  key={a.api_slug}
+                  id={a.api_slug}
+                  title={a.title}
+                  info={info}
+                  error={error}
+                  value={selected}
+                  onChange={set(a.api_slug)}
+                >
+                  {[...new Set([...opts, ...selected])].map((o) => (
+                    <Form.TagPicker.Item key={o} value={o} title={o} />
+                  ))}
+                </Form.TagPicker>
+              );
+            }
+            return (
+              <Form.Dropdown
+                key={a.api_slug}
+                id={a.api_slug}
+                title={a.title}
+                info={info}
+                error={error}
+                value={String(val ?? "")}
+                onChange={set(a.api_slug)}
+              >
+                {!a.is_required && <Form.Dropdown.Item value="" title="—" />}
+                {/* Union in a restored draft value whose option was renamed/archived
+                    since — it stays visible instead of silently showing empty. */}
+                {[...new Set([...opts, ...(typeof val === "string" && val !== "" ? [val] : [])])].map((o) => (
+                  <Form.Dropdown.Item key={o} value={o} title={o} />
+                ))}
+              </Form.Dropdown>
+            );
+          }
+          default:
+            if (a.is_multiselect)
+              return (
+                <TagInput
+                  key={a.api_slug}
+                  attr={a}
+                  values={Array.isArray(val) ? (val as string[]) : []}
+                  onChange={set(a.api_slug)}
+                  onPendingChange={(t) => {
+                    pendingTags.current[a.api_slug] = t;
+                    setErrors((e) => (e[a.api_slug] ? { ...e, [a.api_slug]: undefined } : e));
+                  }}
+                  info={info}
+                  error={error}
+                  initialPending={pendingTags.current[a.api_slug]}
+                />
+              );
+            return (
+              <Form.TextField
+                key={a.api_slug}
+                id={a.api_slug}
+                title={a.title}
+                info={info}
+                error={error}
+                value={String(val ?? "")}
+                onChange={set(a.api_slug)}
+              />
+            );
+        }
+      })}
+    </Form>
+  );
+}

--- a/extensions/attio/src/components/RecordCreateForm.tsx
+++ b/extensions/attio/src/components/RecordCreateForm.tsx
@@ -6,9 +6,11 @@ import { createRecord, listAttributeOptions, listAttributeStatuses } from "../ap
 import { missingScopes } from "../api/operations";
 import type { Attribute } from "../api/types";
 import { useMembers } from "../hooks/useMembers";
+import { useSchema } from "../hooks/useSchema";
 import { cacheNs, useSelf } from "../hooks/useSelf";
-import { creatableAttributes, toWireValue } from "../lib/edit-mapping";
+import { creatableAttributes, staticCheckboxDefault, toWireValue } from "../lib/edit-mapping";
 import { openRecordInHomeCommand } from "../lib/open-record";
+import RecordRefPicker, { decodeRef } from "./RecordRefPicker";
 
 /**
  * Tag-input companion-field id suffix. ":" can't appear in an Attio api_slug,
@@ -103,6 +105,12 @@ export default function RecordCreateForm(props: {
   const self = useSelf();
   const members = useMembers();
   const canListMembers = missingScopes(self.granted, "listMembers").length === 0;
+  const schema = useSchema();
+  const slugByObjectId = useMemo(
+    () => Object.fromEntries(schema.objects.map((o) => [o.id.object_id, o.api_slug])),
+    [schema.objects],
+  );
+  const allObjectSlugs = useMemo(() => schema.objects.map((o) => o.api_slug), [schema.objects]);
   const creatable = useMemo(() => creatableAttributes(props.attributes), [props.attributes]);
   // Restored draft values seed the form: "<slug>_pending" keys are tag-input
   // text that never got committed; everything else is field state.
@@ -114,12 +122,25 @@ export default function RecordCreateForm(props: {
       if (k.endsWith(PENDING_SUFFIX)) pending[k.slice(0, -PENDING_SUFFIX.length)] = String(v);
       else fields[k] = v;
     }
-    return { fields, pending };
+    // A restored draft counts as user input; the seeds added below do not.
+    const draftKeys = Object.keys(fields);
+    // Seed checkboxes with their STATIC workspace defaults so the form shows
+    // the value Attio will apply; drafts win over seeds.
+    for (const a of creatableAttributes(props.attributes)) {
+      if (a.type === "checkbox" && !(a.api_slug in fields)) {
+        const d = staticCheckboxDefault(a);
+        if (d !== undefined) fields[a.api_slug] = d;
+      }
+    }
+    return { fields, pending, draftKeys };
   }, []);
   const [current, setCurrent] = useState<Record<string, unknown>>(fromDraft.fields);
+  // Slugs the USER changed (drafts count, default seeds don't) — gates "Nothing to create".
+  const touched = useRef<Set<string>>(new Set(fromDraft.draftKeys));
   // Inline field errors (Raycast-standard validation) — set on submit, cleared on edit.
   const [errors, setErrors] = useState<Record<string, string | undefined>>({});
   const set = (slug: string) => (value: unknown) => {
+    touched.current.add(slug);
     setCurrent((c) => ({ ...c, [slug]: value }));
     // Clear the field's error — a ":first"/":last" sub-key clears its base
     // attribute's error, which is where submit records it.
@@ -166,7 +187,7 @@ export default function RecordCreateForm(props: {
   async function submit() {
     if (submitting.current) return;
     const anyPending = Object.values(pendingTags.current).some((t) => t.trim() !== "");
-    if (Object.keys(current).length === 0 && !anyPending) {
+    if (touched.current.size === 0 && !anyPending) {
       showFailureToast(new Error("Fill in at least one field"), { title: "Nothing to create" });
       return;
     }
@@ -196,6 +217,11 @@ export default function RecordCreateForm(props: {
               : [];
         } else if (a.type === "actor-reference")
           wire = val ? [{ referenced_actor_type: "workspace-member", referenced_actor_id: val }] : [];
+        else if (a.type === "record-reference") wire = val ? [decodeRef(String(val))] : [];
+        // An untouched checkbox with no visible static default is OMITTED so
+        // Attio can apply a dynamic/server default (a seeded one sends what
+        // the form displayed).
+        else if (a.type === "checkbox" && current[a.api_slug] === undefined) continue;
         // Checkboxes always send what the form shows (an untouched box shows
         // unchecked); everything else empty is omitted so Attio can apply a
         // configured default — which also covers required-with-default fields.
@@ -300,6 +326,22 @@ export default function RecordCreateForm(props: {
                 ))}
               </Form.Dropdown>
             );
+          case "record-reference": {
+            const allowedIds = a.config?.record_reference?.allowed_object_ids ?? null;
+            const allowed = (allowedIds?.length ? allowedIds.map((id) => slugByObjectId[id]) : allObjectSlugs).filter(
+              (s): s is string => typeof s === "string" && s !== "",
+            );
+            return (
+              <RecordRefPicker
+                key={a.api_slug}
+                attr={a}
+                allowedSlugs={allowed}
+                value={String(val ?? "")}
+                onChange={set(a.api_slug)}
+                error={error}
+              />
+            );
+          }
           case "checkbox":
             return (
               <Form.Checkbox

--- a/extensions/attio/src/components/RecordEditForm.tsx
+++ b/extensions/attio/src/components/RecordEditForm.tsx
@@ -1,32 +1,54 @@
 import { failToast } from "@chrismessina/raycast-kit";
-import { useMemo, useState } from "react";
+import { Fragment, useMemo, useRef, useState } from "react";
 import { Action, ActionPanel, Alert, confirmAlert, Form, Icon, showToast, Toast, useNavigation } from "@raycast/api";
 import { showFailureToast, useCachedPromise } from "@raycast/utils";
 import { listAttributeOptions, listAttributeStatuses, updateRecord } from "../api/endpoints";
+import { missingScopes } from "../api/operations";
 import type { AttioRecord, Attribute } from "../api/types";
+import { useMembers } from "../hooks/useMembers";
+import { useSchema } from "../hooks/useSchema";
+import { cacheNs, useSelf } from "../hooks/useSelf";
 import { recordTitle } from "../lib/display";
-import { changedValues, editableAttributes, initialFieldValue } from "../lib/edit-mapping";
+import { changedValues, deferredEditableAttributes, editableAttributes, initialFieldValue } from "../lib/edit-mapping";
+import { shortId } from "../lib/format";
+import RecordRefPicker, { decodeRef, encodeRef } from "./RecordRefPicker";
 
 /**
  * Schema-driven edit form (spec §8.6): fields from is_writable + type, values
  * pre-filled, ONLY changed attributes sent, via PUT (PATCH appends multiselects).
  * Clearing a previously non-empty value requires confirmation (fail-closed on
- * live CRM data). record-reference / actor-reference / personal-name /
- * location / interaction are deferred — not rendered.
+ * live CRM data). Covers the standard editable types PLUS names (split
+ * first/last, like Attio's editor), owners (workspace members), and single
+ * record links (async record search). Multiselect record links, location, and
+ * interaction stay Attio-only.
  */
 export default function RecordEditForm(props: {
   objectSlug: string;
   singularNoun: string;
   record: AttioRecord;
   attributes: Attribute[];
+  titleFor?: (id: string) => { title: string; url?: string } | undefined;
   onSaved: () => void;
 }) {
   const { pop } = useNavigation();
+  const self = useSelf();
+  const schema = useSchema();
+  const members = useMembers();
+  const canListMembers = missingScopes(self.granted, "listMembers").length === 0;
   const editable = useMemo(() => editableAttributes(props.attributes), [props.attributes]);
+  const deferred = useMemo(() => deferredEditableAttributes(props.attributes), [props.attributes]);
   const excluded = useMemo(
-    () => props.attributes.filter((a) => !a.is_archived && !editable.includes(a)).map((a) => a.title),
-    [props.attributes, editable],
+    () => props.attributes.filter((a) => !a.is_archived && !editable.includes(a) && !deferred.includes(a)).length > 0,
+    [props.attributes, editable, deferred],
   );
+  const submitting = useRef(false);
+
+  const slugByObjectId = useMemo(
+    () => Object.fromEntries(schema.objects.map((o) => [o.id.object_id, o.api_slug])),
+    [schema.objects],
+  );
+  const allObjectSlugs = useMemo(() => schema.objects.map((o) => o.api_slug), [schema.objects]);
+
   const initial = useMemo(() => {
     const m: Record<string, unknown> = {};
     for (const a of editable) m[a.api_slug] = initialFieldValue(a, props.record.values);
@@ -35,9 +57,29 @@ export default function RecordEditForm(props: {
   const [current, setCurrent] = useState<Record<string, unknown>>(initial);
   const set = (slug: string) => (value: unknown) => setCurrent((c) => ({ ...c, [slug]: value }));
 
+  // Deferred fields track separately as strings: personal-name splits into
+  // ":first"/":last" sub-keys; actor/record references hold encoded ids.
+  const initialD = useMemo(() => {
+    const m: Record<string, string> = {};
+    for (const a of deferred) {
+      const v = props.record.values[a.api_slug]?.[0];
+      if (a.type === "personal-name") {
+        m[a.api_slug + ":first"] = (v?.attribute_type === "personal-name" && v.first_name) || "";
+        m[a.api_slug + ":last"] = (v?.attribute_type === "personal-name" && v.last_name) || "";
+      } else if (v?.attribute_type === "actor-reference") m[a.api_slug] = v.referenced_actor_id ?? "";
+      else if (v?.attribute_type === "record-reference") m[a.api_slug] = encodeRef(v.target_object, v.target_record_id);
+      else m[a.api_slug] = "";
+    }
+    return m;
+  }, [deferred, props.record]);
+  const [currentD, setCurrentD] = useState<Record<string, string>>(initialD);
+  const setD = (slug: string) => (v: string) => setCurrentD((c) => ({ ...c, [slug]: v }));
+
   // Options/statuses for dropdowns, fetched lazily for just this object's select/status attributes.
   const { data: choices } = useCachedPromise(
-    async (objectSlug: string, slugs: string) => {
+    // _ns is cache-key-only (token fingerprint scoping); folding it into
+    // objectSlug would corrupt the request URL.
+    async (_ns: string, objectSlug: string, slugs: string) => {
       const out: Record<string, string[]> = {};
       for (const slug of slugs.split(",").filter(Boolean)) {
         const a = editable.find((x) => x.api_slug === slug);
@@ -54,6 +96,7 @@ export default function RecordEditForm(props: {
       return out;
     },
     [
+      cacheNs,
       props.objectSlug,
       editable
         .filter((a) => a.type === "select" || a.type === "status")
@@ -63,16 +106,23 @@ export default function RecordEditForm(props: {
   );
 
   async function submit() {
+    // Guard BEFORE any await — the clear-confirmation alert leaves a window
+    // where a second ⌘↵ could otherwise start a duplicate submit.
+    if (submitting.current) return;
+    submitting.current = true;
+    try {
+      await doSubmit();
+    } finally {
+      submitting.current = false;
+    }
+  }
+
+  async function doSubmit() {
     let changed: Record<string, unknown[]>;
     try {
       changed = changedValues(initial, current, editable);
     } catch (error) {
       showFailureToast(error, { title: "Invalid value" });
-      return;
-    }
-    if (Object.keys(changed).length === 0) {
-      await showToast(Toast.Style.Success, "No changes");
-      pop();
       return;
     }
     for (const a of editable) {
@@ -81,11 +131,47 @@ export default function RecordEditForm(props: {
         return;
       }
     }
-    const cleared = Object.entries(changed).filter(([slug, v]) => v.length === 0 && String(initial[slug] ?? "") !== "");
+    // Deferred fields: trim-compare so whitespace-only edits never PUT.
+    for (const a of deferred) {
+      let wire: unknown[];
+      if (a.type === "personal-name") {
+        const first = (currentD[a.api_slug + ":first"] ?? "").trim();
+        const last = (currentD[a.api_slug + ":last"] ?? "").trim();
+        if (first === initialD[a.api_slug + ":first"].trim() && last === initialD[a.api_slug + ":last"].trim())
+          continue;
+        wire =
+          first || last
+            ? [{ first_name: first, last_name: last, full_name: [first, last].filter(Boolean).join(" ") }]
+            : [];
+      } else {
+        if ((currentD[a.api_slug] ?? "").trim() === (initialD[a.api_slug] ?? "").trim()) continue;
+        const v = (currentD[a.api_slug] ?? "").trim();
+        if (a.type === "actor-reference")
+          wire = v ? [{ referenced_actor_type: "workspace-member", referenced_actor_id: v }] : [];
+        else wire = v ? [decodeRef(v)] : [];
+      }
+      if (a.is_required && wire.length === 0) {
+        showFailureToast(new Error(`${a.title} is required`), { title: `${a.title} is required` });
+        return;
+      }
+      changed[a.api_slug] = wire;
+    }
+    if (Object.keys(changed).length === 0) {
+      await showToast(Toast.Style.Success, "No changes");
+      pop();
+      return;
+    }
+    const hadValue = (slug: string) =>
+      (Array.isArray(initial[slug]) ? (initial[slug] as unknown[]).length > 0 : String(initial[slug] ?? "") !== "") ||
+      (initialD[slug] ?? "") !== "" ||
+      (initialD[slug + ":first"] ?? "") !== "" ||
+      (initialD[slug + ":last"] ?? "") !== "";
+    const cleared = Object.entries(changed).filter(([slug, v]) => v.length === 0 && hadValue(slug));
     if (cleared.length > 0) {
+      const all = [...editable, ...deferred];
       const ok = await confirmAlert({
         title: `Clear ${cleared.length} value${cleared.length > 1 ? "s" : ""}?`,
-        message: cleared.map(([slug]) => editable.find((a) => a.api_slug === slug)?.title ?? slug).join(", "),
+        message: cleared.map(([slug]) => all.find((a) => a.api_slug === slug)?.title ?? slug).join(", "),
         primaryAction: { title: "Clear", style: Alert.ActionStyle.Destructive },
       });
       if (!ok) return;
@@ -102,6 +188,83 @@ export default function RecordEditForm(props: {
     }
   }
 
+  const renderDeferred = (a: Attribute) => {
+    if (a.type === "personal-name")
+      // Split fields, matching Attio's own editor.
+      return (
+        <Fragment key={a.api_slug}>
+          <Form.TextField
+            id={a.api_slug + ":first"}
+            title="First Name"
+            value={currentD[a.api_slug + ":first"] ?? ""}
+            onChange={setD(a.api_slug + ":first")}
+          />
+          <Form.TextField
+            id={a.api_slug + ":last"}
+            title="Last Name"
+            value={currentD[a.api_slug + ":last"] ?? ""}
+            onChange={setD(a.api_slug + ":last")}
+          />
+        </Fragment>
+      );
+    if (a.type === "actor-reference") {
+      if (!canListMembers)
+        return (
+          <Form.Description
+            key={a.api_slug}
+            title={a.title}
+            text="Picking a member needs the user_management:read scope on your token."
+          />
+        );
+      // Keep the current owner selectable even while the member list is
+      // loading/empty — otherwise a required field shows a blank dropdown.
+      const currentId = initialD[a.api_slug];
+      const memberItems = new Map<string, string>(
+        currentId ? [[currentId, members.nameFor(currentId) ?? shortId(currentId)]] : [],
+      );
+      for (const m of members.all) memberItems.set(m.id, m.name);
+      return (
+        <Form.Dropdown
+          key={a.api_slug}
+          id={a.api_slug}
+          title={a.title}
+          value={currentD[a.api_slug] ?? ""}
+          onChange={setD(a.api_slug)}
+        >
+          {/* Keep "—" when the field STARTED empty, even if required — the user
+              must be able to revert an exploratory pick without abandoning the form. */}
+          {(!a.is_required || !currentId) && <Form.Dropdown.Item value="" title="—" />}
+          {[...memberItems].map(([id, name]) => (
+            <Form.Dropdown.Item key={id} value={id} title={name} icon={Icon.Person} />
+          ))}
+        </Form.Dropdown>
+      );
+    }
+    // record-reference
+    const allowedIds = a.config?.record_reference?.allowed_object_ids ?? null;
+    const allowed = (allowedIds?.length ? allowedIds.map((id) => slugByObjectId[id]) : allObjectSlugs).filter(
+      (s): s is string => typeof s === "string" && s !== "",
+    );
+    const init = initialD[a.api_slug]
+      ? {
+          value: initialD[a.api_slug],
+          title:
+            props.titleFor?.(decodeRef(initialD[a.api_slug]).target_record_id)?.title ??
+            shortId(decodeRef(initialD[a.api_slug]).target_record_id),
+        }
+      : undefined;
+    return (
+      <RecordRefPicker
+        key={a.api_slug}
+        attr={a}
+        allowedSlugs={allowed}
+        initial={init}
+        value={currentD[a.api_slug] ?? ""}
+        onChange={setD(a.api_slug)}
+      />
+    );
+  };
+
   return (
     <Form
       navigationTitle={`Edit ${props.singularNoun}`}
@@ -111,92 +274,92 @@ export default function RecordEditForm(props: {
         </ActionPanel>
       }
     >
-      {editable.map((a) => {
-        const val = current[a.api_slug];
-        switch (a.type) {
-          case "checkbox":
-            return (
-              <Form.Checkbox
-                key={a.api_slug}
-                id={a.api_slug}
-                label={a.title}
-                value={Boolean(val)}
-                onChange={set(a.api_slug)}
-              />
-            );
-          case "date":
-          case "timestamp":
-            return (
-              <Form.DatePicker
-                key={a.api_slug}
-                id={a.api_slug}
-                title={a.title}
-                type={a.type === "date" ? Form.DatePicker.Type.Date : Form.DatePicker.Type.DateTime}
-                value={(val as Date) ?? null}
-                onChange={set(a.api_slug)}
-              />
-            );
-          case "select":
-          case "status": {
-            const opts = choices?.[a.api_slug];
-            if (!opts) return <Form.Description key={a.api_slug} title={a.title} text="Loading choices…" />;
-            if (a.is_multiselect) {
-              // Array-valued state end to end: a joined "A, B" string is not an
-              // option, and a Dropdown would PUT a single value over the rest.
-              const selected = Array.isArray(val) ? (val as string[]) : [];
-              // Union in the INITIAL selections too: an archived option lives in
-              // neither opts nor (once deselected) the current selection, and it
-              // must stay re-selectable until the form is saved.
-              const initialSel = Array.isArray(initial[a.api_slug]) ? (initial[a.api_slug] as string[]) : [];
+      {/* One pass over the schema keeps Attio's natural field order — name and
+          company sit up top, not appended after everything else. */}
+      {props.attributes
+        .filter((a) => editable.includes(a) || deferred.includes(a))
+        .map((a) => {
+          if (deferred.includes(a)) return renderDeferred(a);
+          const val = current[a.api_slug];
+          switch (a.type) {
+            case "checkbox":
               return (
-                <Form.TagPicker
+                <Form.Checkbox
+                  key={a.api_slug}
+                  id={a.api_slug}
+                  label={a.title}
+                  value={Boolean(val)}
+                  onChange={set(a.api_slug)}
+                />
+              );
+            case "date":
+            case "timestamp":
+              return (
+                <Form.DatePicker
                   key={a.api_slug}
                   id={a.api_slug}
                   title={a.title}
-                  value={selected}
+                  type={a.type === "date" ? Form.DatePicker.Type.Date : Form.DatePicker.Type.DateTime}
+                  value={(val as Date) ?? null}
+                  onChange={set(a.api_slug)}
+                />
+              );
+            case "select":
+            case "status": {
+              const opts = choices?.[a.api_slug];
+              if (!opts) return <Form.Description key={a.api_slug} title={a.title} text="Loading choices…" />;
+              if (a.is_multiselect) {
+                // Array-valued state end to end: a joined "A, B" string is not an
+                // option, and a Dropdown would PUT a single value over the rest.
+                const selected = Array.isArray(val) ? (val as string[]) : [];
+                // Union in the INITIAL selections too: an archived option lives in
+                // neither opts nor (once deselected) the current selection, and it
+                // must stay re-selectable until the form is saved.
+                const initialSel = Array.isArray(initial[a.api_slug]) ? (initial[a.api_slug] as string[]) : [];
+                return (
+                  <Form.TagPicker
+                    key={a.api_slug}
+                    id={a.api_slug}
+                    title={a.title}
+                    value={selected}
+                    onChange={set(a.api_slug)}
+                  >
+                    {[...new Set([...opts, ...initialSel, ...selected])].map((o) => (
+                      <Form.TagPicker.Item key={o} value={o} title={o} />
+                    ))}
+                  </Form.TagPicker>
+                );
+              }
+              return (
+                <Form.Dropdown
+                  key={a.api_slug}
+                  id={a.api_slug}
+                  title={a.title}
+                  value={String(val ?? "")}
                   onChange={set(a.api_slug)}
                 >
-                  {[...new Set([...opts, ...initialSel, ...selected])].map((o) => (
-                    <Form.TagPicker.Item key={o} value={o} title={o} />
+                  {!a.is_required && <Form.Dropdown.Item value="" title="—" />}
+                  {opts.map((o) => (
+                    <Form.Dropdown.Item key={o} value={o} title={o} />
                   ))}
-                </Form.TagPicker>
+                </Form.Dropdown>
               );
             }
-            return (
-              <Form.Dropdown
-                key={a.api_slug}
-                id={a.api_slug}
-                title={a.title}
-                value={String(val ?? "")}
-                onChange={set(a.api_slug)}
-              >
-                {!a.is_required && <Form.Dropdown.Item value="" title="—" />}
-                {opts.map((o) => (
-                  <Form.Dropdown.Item key={o} value={o} title={o} />
-                ))}
-              </Form.Dropdown>
-            );
+            default:
+              return (
+                <Form.TextField
+                  key={a.api_slug}
+                  id={a.api_slug}
+                  title={a.title}
+                  info={a.is_required && !a.is_default_value_enabled ? "Required" : undefined}
+                  placeholder={a.is_multiselect ? "Comma-separated" : undefined}
+                  value={String(val ?? "")}
+                  onChange={set(a.api_slug)}
+                />
+              );
           }
-          default:
-            return (
-              <Form.TextField
-                key={a.api_slug}
-                id={a.api_slug}
-                title={a.title + (a.is_required ? " *" : "")}
-                placeholder={a.is_multiselect ? "Comma-separated" : undefined}
-                value={String(val ?? "")}
-                onChange={set(a.api_slug)}
-              />
-            );
-        }
-      })}
-      {excluded.length > 0 && (
-        <Form.Description
-          text={`Not editable here: ${excluded.slice(0, 8).join(", ")}${
-            excluded.length > 8 ? `, and ${excluded.length - 8} more` : ""
-          } — open in Attio to change ${excluded.length === 1 ? "it" : "these"}.`}
-        />
-      )}
+        })}
+      {excluded && <Form.Description text="Open in Attio to view the complete record." />}
     </Form>
   );
 }

--- a/extensions/attio/src/components/RecordRefPicker.tsx
+++ b/extensions/attio/src/components/RecordRefPicker.tsx
@@ -3,6 +3,7 @@ import { Form } from "@raycast/api";
 import { useCachedPromise } from "@raycast/utils";
 import { searchRecords } from "../api/endpoints";
 import type { Attribute } from "../api/types";
+import { useRecordTitles } from "../hooks/useRecordTitles";
 import { cacheNs } from "../hooks/useSelf";
 
 /** Dropdown values are strings; ":" can't appear in an object slug, so this encoding is unambiguous. */
@@ -34,10 +35,19 @@ export default function RecordRefPicker(props: {
     [cacheNs, text, props.allowedSlugs.join(",")],
     { keepPreviousData: true },
   );
+  // A restored draft arrives as an encoded ref with no matching item (search
+  // hasn't run yet) — resolve its title so the dropdown shows a name instead
+  // of blanking out while still submitting the saved relationship.
+  const orphan =
+    props.value && props.value !== props.initial?.value && props.value !== picked?.value && props.value.includes(":")
+      ? props.value
+      : "";
+  const { titleFor } = useRecordTitles(orphan ? [decodeRef(orphan)] : []);
   const items = new Map<string, string>();
   if (props.initial) items.set(props.initial.value, props.initial.title);
   if (picked) items.set(picked.value, picked.title);
   for (const h of hits ?? []) items.set(encodeRef(h.object_slug, h.id.record_id), h.record_text);
+  if (orphan && !items.has(orphan)) items.set(orphan, titleFor(decodeRef(orphan).target_record_id)?.title ?? orphan);
   return (
     <Form.Dropdown
       id={props.attr.api_slug}

--- a/extensions/attio/src/components/RecordRefPicker.tsx
+++ b/extensions/attio/src/components/RecordRefPicker.tsx
@@ -19,6 +19,7 @@ export default function RecordRefPicker(props: {
   initial?: { value: string; title: string };
   value: string;
   onChange: (v: string) => void;
+  error?: string;
 }) {
   const [text, setText] = useState("");
   // The picked item must survive later searches that no longer include it —
@@ -52,6 +53,7 @@ export default function RecordRefPicker(props: {
         props.onChange(v);
       }}
       info="Type to search"
+      error={props.error}
     >
       {/* Keep "—" when the field STARTED empty, even if required — the user
           must be able to revert an exploratory pick without abandoning the form. */}

--- a/extensions/attio/src/components/RecordRefPicker.tsx
+++ b/extensions/attio/src/components/RecordRefPicker.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import { Form } from "@raycast/api";
+import { useCachedPromise } from "@raycast/utils";
+import { searchRecords } from "../api/endpoints";
+import type { Attribute } from "../api/types";
+import { cacheNs } from "../hooks/useSelf";
+
+/** Dropdown values are strings; ":" can't appear in an object slug, so this encoding is unambiguous. */
+export const encodeRef = (object: string, id: string) => `${object}:${id}`;
+export const decodeRef = (v: string) => {
+  const i = v.indexOf(":");
+  return { target_object: v.slice(0, i), target_record_id: v.slice(i + 1) };
+};
+
+/** Async-search picker for a single record-reference (e.g. a person's Company). */
+export default function RecordRefPicker(props: {
+  attr: Attribute;
+  allowedSlugs: string[];
+  initial?: { value: string; title: string };
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const [text, setText] = useState("");
+  // The picked item must survive later searches that no longer include it —
+  // a controlled value whose item vanished would blank the dropdown.
+  const [picked, setPicked] = useState(props.initial);
+  const { data: hits, isLoading } = useCachedPromise(
+    // _ns scopes the cache to the token fingerprint (workspace) — key-only.
+    async (_ns: string, q: string, slugs: string) => {
+      const objects = slugs.split(",").filter(Boolean);
+      return q.trim() && objects.length > 0 ? (await searchRecords(q, objects)).data : [];
+    },
+    [cacheNs, text, props.allowedSlugs.join(",")],
+    { keepPreviousData: true },
+  );
+  const items = new Map<string, string>();
+  if (props.initial) items.set(props.initial.value, props.initial.title);
+  if (picked) items.set(picked.value, picked.title);
+  for (const h of hits ?? []) items.set(encodeRef(h.object_slug, h.id.record_id), h.record_text);
+  return (
+    <Form.Dropdown
+      id={props.attr.api_slug}
+      title={props.attr.title}
+      isLoading={isLoading}
+      throttle
+      filtering={false}
+      onSearchTextChange={setText}
+      value={props.value}
+      onChange={(v) => {
+        const title = items.get(v);
+        if (v && title) setPicked({ value: v, title });
+        props.onChange(v);
+      }}
+      info="Type to search"
+    >
+      {/* Keep "—" when the field STARTED empty, even if required — the user
+          must be able to revert an exploratory pick without abandoning the form. */}
+      {(!props.attr.is_required || !props.initial) && <Form.Dropdown.Item value="" title="—" />}
+      {[...items].map(([v, title]) => (
+        <Form.Dropdown.Item key={v} value={v} title={title} />
+      ))}
+    </Form.Dropdown>
+  );
+}

--- a/extensions/attio/src/create-company.tsx
+++ b/extensions/attio/src/create-company.tsx
@@ -1,0 +1,6 @@
+import type { LaunchProps } from "@raycast/api";
+import CreateRecordCommand from "./components/CreateRecordCommand";
+
+export default function Command(props: LaunchProps<{ draftValues: Record<string, unknown> }>) {
+  return <CreateRecordCommand slug="companies" draftValues={props.draftValues} />;
+}

--- a/extensions/attio/src/create-deal.tsx
+++ b/extensions/attio/src/create-deal.tsx
@@ -1,0 +1,6 @@
+import type { LaunchProps } from "@raycast/api";
+import CreateRecordCommand from "./components/CreateRecordCommand";
+
+export default function Command(props: LaunchProps<{ draftValues: Record<string, unknown> }>) {
+  return <CreateRecordCommand slug="deals" draftValues={props.draftValues} />;
+}

--- a/extensions/attio/src/create-person.tsx
+++ b/extensions/attio/src/create-person.tsx
@@ -1,0 +1,6 @@
+import type { LaunchProps } from "@raycast/api";
+import CreateRecordCommand from "./components/CreateRecordCommand";
+
+export default function Command(props: LaunchProps<{ draftValues: Record<string, unknown> }>) {
+  return <CreateRecordCommand slug="people" draftValues={props.draftValues} />;
+}

--- a/extensions/attio/src/hooks/useMembers.ts
+++ b/extensions/attio/src/hooks/useMembers.ts
@@ -23,5 +23,6 @@ export function useMembers() {
   return {
     nameFor: (actorId: string) => data?.[actorId]?.name,
     avatarFor: (actorId: string) => data?.[actorId]?.avatar,
+    all: Object.entries(data ?? {}).map(([id, m]) => ({ id, name: m.name })),
   };
 }

--- a/extensions/attio/src/lib/edit-mapping.test.ts
+++ b/extensions/attio/src/lib/edit-mapping.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 import type { Attribute, AttributeValue } from "../api/types";
-import { changedValues, editableAttributes, initialFieldValue, toWireValue } from "./edit-mapping";
+import {
+  changedValues,
+  creatableAttributes,
+  deferredEditableAttributes,
+  editableAttributes,
+  initialFieldValue,
+  personalNameToWire,
+  toWireValue,
+} from "./edit-mapping";
 
 const attr = (x: Partial<Attribute>): Attribute =>
   ({
@@ -41,6 +49,59 @@ describe("editableAttributes", () => {
       attr({ api_slug: "ok_status", type: "status" }),
     ];
     expect(editableAttributes(list).map((a) => a.api_slug)).toEqual(["ok_text", "ok_status"]);
+  });
+});
+
+describe("creatableAttributes — create form adds name/owner types the edit form defers", () => {
+  it("includes personal-name and actor-reference on top of the editable set", () => {
+    const list = [
+      attr({ api_slug: "name", type: "personal-name" }),
+      attr({ api_slug: "owner", type: "actor-reference" }),
+      attr({ api_slug: "ok_text", type: "text" }),
+      attr({ api_slug: "not_writable", type: "personal-name", is_writable: false }),
+      attr({ api_slug: "deferred_loc", type: "location" }),
+    ];
+    expect(creatableAttributes(list).map((a) => a.api_slug)).toEqual(["name", "owner", "ok_text"]);
+  });
+});
+
+describe("deferredEditableAttributes — the edit form's name/owner/record-link fields", () => {
+  it("keeps writable personal-name, actor-reference, and single record-reference", () => {
+    const list = [
+      attr({ api_slug: "name", type: "personal-name" }),
+      attr({ api_slug: "owner", type: "actor-reference" }),
+      attr({ api_slug: "company", type: "record-reference" }),
+      attr({ api_slug: "team", type: "record-reference", is_multiselect: true }), // no async multiselect UI
+      attr({ api_slug: "loc", type: "location" }), // stays Attio-only
+      attr({ api_slug: "ro_name", type: "personal-name", is_writable: false }),
+      attr({ api_slug: "plain_text", type: "text" }), // main edit form owns it
+    ];
+    expect(deferredEditableAttributes(list).map((a) => a.api_slug)).toEqual(["name", "owner", "company"]);
+  });
+});
+
+describe("personalNameToWire — Attio object syntax needs all three fields", () => {
+  it("splits First … Last into the object form", () => {
+    expect(personalNameToWire("Ada Lovelace")).toEqual([
+      { first_name: "Ada", last_name: "Lovelace", full_name: "Ada Lovelace" },
+    ]);
+    expect(personalNameToWire("Anne Marie Smith")).toEqual([
+      { first_name: "Anne Marie", last_name: "Smith", full_name: "Anne Marie Smith" },
+    ]);
+  });
+  it("normalizes non-breaking spaces so pasted names still split", () => {
+    expect(personalNameToWire("Ada Lovelace")).toEqual([
+      { first_name: "Ada", last_name: "Lovelace", full_name: "Ada Lovelace" },
+    ]);
+  });
+  it("single token uses Attio's string syntax (no comma = first name)", () => {
+    expect(personalNameToWire("Ada")).toEqual(["Ada"]);
+  });
+  it("'Last, First' input passes through as the string syntax Attio parses", () => {
+    expect(personalNameToWire("Smith, John")).toEqual(["Smith, John"]);
+  });
+  it("empty clears", () => {
+    expect(personalNameToWire("  ")).toEqual([]);
   });
 });
 
@@ -123,6 +184,25 @@ describe("initialFieldValue / toWireValue round-trip", () => {
   it("multiselect email splits comma-separated input", () => {
     const a = attr({ api_slug: "e", type: "email-address", is_multiselect: true });
     expect(toWireValue(a, "a@b.co, c@d.co")).toEqual(["a@b.co", "c@d.co"]);
+  });
+  it("multiselect free-text types accept arrays (tag-input UI); single-value types reject them", () => {
+    const domains = attr({ api_slug: "d", type: "domain", is_multiselect: true });
+    expect(toWireValue(domains, ["attio.com", "example.org"])).toEqual(["attio.com", "example.org"]);
+    expect(toWireValue(attr({ api_slug: "e", type: "email-address", is_multiselect: true }), ["a@b.co"])).toEqual([
+      "a@b.co",
+    ]);
+    expect(() => toWireValue(attr({ api_slug: "t", type: "text" }), ["a", "b"])).toThrow(/single/i);
+  });
+  it("domains must have a well-formed TLD", () => {
+    const a = attr({ api_slug: "d", type: "domain", is_multiselect: true });
+    expect(toWireValue(a, ["sub.attio.com"])).toEqual(["sub.attio.com"]);
+    expect(() => toWireValue(a, ["not a domain"])).toThrow(/domain/i);
+    expect(() => toWireValue(a, ["attio"])).toThrow(/domain/i); // no TLD
+    expect(() => toWireValue(a, ["https://attio.com"])).toThrow(/domain/i); // no protocol
+    expect(() => toWireValue(a, "attio, example.org")).toThrow(/domain/i); // string path validates too
+    expect(toWireValue(a, ["example.xn--p1ai"])).toEqual(["example.xn--p1ai"]); // punycode TLD is legal
+    expect(() => toWireValue(a, ["bad-.com"])).toThrow(/domain/i); // labels can't end in a hyphen
+    expect(() => toWireValue(a, ["-bad.com"])).toThrow(/domain/i); // or start with one
   });
 });
 

--- a/extensions/attio/src/lib/edit-mapping.test.ts
+++ b/extensions/attio/src/lib/edit-mapping.test.ts
@@ -7,6 +7,7 @@ import {
   editableAttributes,
   initialFieldValue,
   personalNameToWire,
+  staticCheckboxDefault,
   toWireValue,
 } from "./edit-mapping";
 
@@ -52,16 +53,43 @@ describe("editableAttributes", () => {
   });
 });
 
-describe("creatableAttributes — create form adds name/owner types the edit form defers", () => {
-  it("includes personal-name and actor-reference on top of the editable set", () => {
+describe("creatableAttributes — create form covers names, owners, and record links", () => {
+  it("includes personal-name, actor-reference, and single record-reference on top of the editable set", () => {
     const list = [
       attr({ api_slug: "name", type: "personal-name" }),
       attr({ api_slug: "owner", type: "actor-reference" }),
+      attr({ api_slug: "company", type: "record-reference" }),
+      attr({ api_slug: "team", type: "record-reference", is_multiselect: true }), // no async multiselect UI
       attr({ api_slug: "ok_text", type: "text" }),
       attr({ api_slug: "not_writable", type: "personal-name", is_writable: false }),
       attr({ api_slug: "deferred_loc", type: "location" }),
     ];
-    expect(creatableAttributes(list).map((a) => a.api_slug)).toEqual(["name", "owner", "ok_text"]);
+    expect(creatableAttributes(list).map((a) => a.api_slug)).toEqual(["name", "owner", "company", "ok_text"]);
+  });
+});
+
+describe("staticCheckboxDefault — seeds the create form so display matches outcome", () => {
+  it("returns the workspace's static default for a checkbox", () => {
+    const a = attr({
+      api_slug: "c",
+      type: "checkbox",
+      is_default_value_enabled: true,
+      default_value: { type: "static", template: [{ attribute_type: "checkbox", value: true }] },
+    });
+    expect(staticCheckboxDefault(a)).toBe(true);
+  });
+  it("returns undefined for dynamic, disabled, or non-checkbox defaults", () => {
+    expect(staticCheckboxDefault(attr({ api_slug: "c", type: "checkbox" }))).toBeUndefined();
+    expect(
+      staticCheckboxDefault(
+        attr({
+          api_slug: "c",
+          type: "checkbox",
+          is_default_value_enabled: true,
+          default_value: { type: "dynamic", template: "current-user" },
+        }),
+      ),
+    ).toBeUndefined();
   });
 });
 

--- a/extensions/attio/src/lib/edit-mapping.ts
+++ b/extensions/attio/src/lib/edit-mapping.ts
@@ -21,13 +21,30 @@ export const editableAttributes = (attributes: Attribute[]): Attribute[] =>
   attributes.filter((a) => a.is_writable && !a.is_archived && EDITABLE_TYPES.has(a.type));
 
 /**
- * The create form additionally renders personal-name (person Name) and
- * actor-reference (deal Owner, required) — a record can't be created without
- * them.
+ * The create form additionally renders personal-name (person Name),
+ * actor-reference (deal Owner, required), and single record links (a person's
+ * Company). Multiselect record links, location, and interaction stay
+ * Attio-only — no async-search multiselect control exists.
  */
 const CREATABLE_TYPES = new Set([...EDITABLE_TYPES, "personal-name", "actor-reference"]);
 export const creatableAttributes = (attributes: Attribute[]): Attribute[] =>
-  attributes.filter((a) => a.is_writable && !a.is_archived && CREATABLE_TYPES.has(a.type));
+  attributes.filter(
+    (a) =>
+      a.is_writable &&
+      !a.is_archived &&
+      (CREATABLE_TYPES.has(a.type) || (a.type === "record-reference" && !a.is_multiselect)),
+  );
+
+/**
+ * A checkbox's static workspace default, so the create form can DISPLAY the
+ * value Attio would apply — an untouched box is omitted from the POST and the
+ * default wins; the form must show that outcome, not an unchecked lie.
+ */
+export function staticCheckboxDefault(a: Attribute): boolean | undefined {
+  if (!a.is_default_value_enabled || a.default_value?.type !== "static") return undefined;
+  const t = a.default_value.template?.[0];
+  return t && t.attribute_type === "checkbox" && typeof t.value === "boolean" ? t.value : undefined;
+}
 
 /**
  * The edit form's additional supported types beyond EDITABLE_TYPES: names,

--- a/extensions/attio/src/lib/edit-mapping.ts
+++ b/extensions/attio/src/lib/edit-mapping.ts
@@ -20,6 +20,39 @@ const EDITABLE_TYPES = new Set([
 export const editableAttributes = (attributes: Attribute[]): Attribute[] =>
   attributes.filter((a) => a.is_writable && !a.is_archived && EDITABLE_TYPES.has(a.type));
 
+/**
+ * The create form additionally renders personal-name (person Name) and
+ * actor-reference (deal Owner, required) — a record can't be created without
+ * them.
+ */
+const CREATABLE_TYPES = new Set([...EDITABLE_TYPES, "personal-name", "actor-reference"]);
+export const creatableAttributes = (attributes: Attribute[]): Attribute[] =>
+  attributes.filter((a) => a.is_writable && !a.is_archived && CREATABLE_TYPES.has(a.type));
+
+/**
+ * The edit form's additional supported types beyond EDITABLE_TYPES: names,
+ * owners, and record links, each with bespoke controls. Single-select only —
+ * there's no async-search multiselect control. Location and interaction stay
+ * Attio-only.
+ */
+const DEFERRED_EDITABLE = new Set(["personal-name", "actor-reference", "record-reference"]);
+export const deferredEditableAttributes = (attributes: Attribute[]): Attribute[] =>
+  attributes.filter((a) => a.is_writable && !a.is_archived && !a.is_multiselect && DEFERRED_EDITABLE.has(a.type));
+
+/**
+ * "First … Last" → Attio's object syntax (all three fields required). A single
+ * token or an explicit "Last, First" uses the string syntax Attio parses.
+ */
+export function personalNameToWire(input: string): unknown[] {
+  // Pasted names often carry NBSP/narrow-NBSP — normalize so splitting works.
+  const s = input.replace(/[\u00A0\u202F]/g, " ").trim();
+  if (s === "") return [];
+  if (s.includes(",") || !s.includes(" ")) return [s];
+  const parts = s.split(/\s+/);
+  const last_name = parts[parts.length - 1];
+  return [{ first_name: parts.slice(0, -1).join(" "), last_name, full_name: s }];
+}
+
 /** Current value → form control value. Multiselects join with ", ". */
 export function initialFieldValue(
   a: Attribute,
@@ -37,6 +70,16 @@ export function initialFieldValue(
   return vs.map((v) => formatValue(v)).join(", ");
 }
 
+/**
+ * Bare hostname with a real TLD — no protocol, path, or spaces. Labels can't
+ * start or end with a hyphen; the TLD is alphabetic or punycode (xn--).
+ */
+const LABEL = "[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?";
+const DOMAIN_RE = new RegExp(`^(?:${LABEL}\\.)+(?:[a-z]{2,63}|xn--[a-z0-9]{2,59})$`, "i");
+const assertDomain = (a: Attribute) => (s: string) => {
+  if (!DOMAIN_RE.test(s)) throw new Error(`"${s}" isn't a valid domain for ${a.title} (e.g. attio.com)`);
+};
+
 /** Form control value → wire array for PUT values. Throws with a user-facing message on invalid input. */
 export function toWireValue(a: Attribute, formValue: unknown): unknown[] {
   const split = (s: string) =>
@@ -44,13 +87,15 @@ export function toWireValue(a: Attribute, formValue: unknown): unknown[] {
       .split(",")
       .map((x) => x.trim())
       .filter(Boolean);
-  // TagPicker values (multiselect select/status) arrive as arrays — pass the
-  // exact strings through: a trim would change the option identifier the API
-  // resolves against. Any other type receiving an array is a caller bug.
+  // TagPicker values (any multiselect: select/status options, or free-text
+  // tag inputs like domains/emails) arrive as arrays — pass the exact strings
+  // through: a trim would change the option identifier the API resolves
+  // against. A single-value type receiving an array is a caller bug.
   if (Array.isArray(formValue)) {
-    if (!(a.is_multiselect && (a.type === "select" || a.type === "status")))
-      throw new Error(`${a.title} must be a single value`);
-    return formValue.filter((x): x is string => typeof x === "string" && x !== "");
+    if (!a.is_multiselect) throw new Error(`${a.title} must be a single value`);
+    const out = formValue.filter((x): x is string => typeof x === "string" && x !== "");
+    if (a.type === "domain") out.forEach(assertDomain(a));
+    return out;
   }
   switch (a.type) {
     case "checkbox":
@@ -99,7 +144,9 @@ export function toWireValue(a: Attribute, formValue: unknown): unknown[] {
     default: {
       const s = String(formValue ?? "").trim();
       if (s === "") return [];
-      return a.is_multiselect ? split(s) : [s];
+      const out = a.is_multiselect ? split(s) : [s];
+      if (a.type === "domain") out.forEach(assertDomain(a));
+      return out;
     }
   }
 }

--- a/extensions/attio/src/records.tsx
+++ b/extensions/attio/src/records.tsx
@@ -1,12 +1,23 @@
 import { useState } from "react";
-import { Action, ActionPanel, Icon, Image, List, useNavigation } from "@raycast/api";
-import { useCachedPromise, useCachedState } from "@raycast/utils";
+import {
+  Action,
+  ActionPanel,
+  Icon,
+  Image,
+  Keyboard,
+  launchCommand,
+  LaunchType,
+  List,
+  useNavigation,
+} from "@raycast/api";
+import { showFailureToast, useCachedPromise, useCachedState } from "@raycast/utils";
 import { deleteRecord, listAttributeStatuses, queryRecords, searchRecords } from "./api/endpoints";
-import { DEFAULT_PAGE_SIZE as PAGE_SIZE } from "./api/operations";
+import { DEFAULT_PAGE_SIZE as PAGE_SIZE, satisfied } from "./api/operations";
 import type { AttioObject, AttioRecord, AttributeValue, SearchHit } from "./api/types";
 import ExportActions from "./components/ExportActions";
 import { guard } from "./components/Guard";
 import RecordActions from "./components/RecordActions";
+import RecordCreateForm from "./components/RecordCreateForm";
 import RecordDetail from "./components/RecordDetail";
 import RecordScreen from "./components/RecordScreen";
 import { useAttio } from "./hooks/useAttio";
@@ -14,13 +25,21 @@ import { useMembers } from "./hooks/useMembers";
 import { usePins } from "./hooks/usePins";
 import { useRecordTitles } from "./hooks/useRecordTitles";
 import { useSchema } from "./hooks/useSchema";
-import { cacheNs } from "./hooks/useSelf";
+import { cacheNs, useSelf } from "./hooks/useSelf";
 import { getObjectTitle, recordSubtitle, recordTitle, SORT_OPTIONS } from "./lib/display";
 import { formatValues, getRecordReferences, shortId } from "./lib/format";
 import { recordIcon, STANDARD_OBJECT_ICONS } from "./lib/record-icon";
 
+/** Standard objects with a dedicated top-level Create command (drafts work there). */
+const CREATE_COMMANDS: Record<string, string> = {
+  people: "create-person",
+  companies: "create-company",
+  deals: "create-deal",
+};
+
 export default function Records({ object }: { object: AttioObject }) {
   const schema = useSchema();
+  const self = useSelf();
   const members = useMembers();
   const pins = usePins(object.api_slug ?? "");
   const { push } = useNavigation();
@@ -90,6 +109,49 @@ export default function Records({ object }: { object: AttioObject }) {
       )}
     />
   );
+  const singular = object.singular_noun ?? "Record";
+  // Standard objects launch their dedicated Create command (top-level form =
+  // draft support); custom objects keep the pushed form, which can't draft.
+  // hasOwn guards against inherited keys — a custom object could be slugged "constructor".
+  const createCommand = Object.hasOwn(CREATE_COMMANDS, object.api_slug ?? "")
+    ? CREATE_COMMANDS[object.api_slug ?? ""]
+    : undefined;
+  const newRecordAction =
+    satisfied(self.granted, "record_permission:read-write") && attributes ? (
+      createCommand ? (
+        <Action
+          icon={Icon.Plus}
+          title={`New ${singular}`}
+          shortcut={Keyboard.Shortcut.Common.New}
+          onAction={async () => {
+            try {
+              await launchCommand({ name: createCommand, type: LaunchType.UserInitiated });
+            } catch (error) {
+              showFailureToast(error, { title: `Couldn't open Create ${singular}` });
+            }
+          }}
+        />
+      ) : (
+        <Action.Push
+          icon={Icon.Plus}
+          title={`New ${singular}`}
+          shortcut={Keyboard.Shortcut.Common.New}
+          target={
+            <RecordCreateForm
+              objectSlug={object.api_slug ?? ""}
+              singularNoun={singular}
+              attributes={attributes}
+              // Refresh BOTH data paths: the browse query and, when the form was
+              // opened from a "no matches" search, the search results behind it.
+              onCreated={() => {
+                revalidate();
+                searchH.revalidate();
+              }}
+            />
+          }
+        />
+      )
+    ) : null;
   const pinnedRecords = records.filter((r) => pins.pinned.has(r.id.record_id));
   const mainRecords = records.filter((r) => !pins.pinned.has(r.id.record_id));
 
@@ -132,6 +194,8 @@ export default function Records({ object }: { object: AttioObject }) {
               onDelete={makeDeleteHandler(record)}
               pins={{ pinned: isPinned, toggle: () => pins.toggle(record.id.record_id) }}
               pushFallback={(slug, id) => push(<RecordScreen objectSlug={slug} recordId={id} />)}
+              newAction={newRecordAction}
+              exportAction={exportAction}
               extraViewActions={
                 <>
                   {isDeals && ownerRef?.referenced_actor_id && !ownerFilter && (
@@ -170,7 +234,6 @@ export default function Records({ object }: { object: AttioObject }) {
                 </>
               }
             />
-            <ActionPanel.Section>{exportAction}</ActionPanel.Section>
           </ActionPanel>
         }
       />
@@ -206,6 +269,7 @@ export default function Records({ object }: { object: AttioObject }) {
                 onAction={() => pins.toggle(hit.id.record_id)}
               />
             </ActionPanel.Section>
+            <ActionPanel.Section>{newRecordAction}</ActionPanel.Section>
           </ActionPanel>
         }
       />
@@ -236,7 +300,11 @@ export default function Records({ object }: { object: AttioObject }) {
     >
       {searching ? (
         searchHits.length === 0 && !searchH.isLoading ? (
-          <List.EmptyView icon={Icon.MagnifyingGlass} title={`No matches in ${object.plural_noun ?? "records"}`} />
+          <List.EmptyView
+            icon={Icon.MagnifyingGlass}
+            title={`No matches in ${object.plural_noun ?? "records"}`}
+            actions={newRecordAction ? <ActionPanel>{newRecordAction}</ActionPanel> : undefined}
+          />
         ) : (
           searchHits.map(renderSearchItem)
         )
@@ -244,6 +312,7 @@ export default function Records({ object }: { object: AttioObject }) {
         <List.EmptyView
           icon={Icon.Document}
           title={`No ${(object.singular_noun ?? object.api_slug ?? "").toLowerCase()} records`}
+          actions={newRecordAction ? <ActionPanel>{newRecordAction}</ActionPanel> : undefined}
         />
       ) : (
         <>

--- a/extensions/attio/src/tools/create-company.ts
+++ b/extensions/attio/src/tools/create-company.ts
@@ -1,0 +1,29 @@
+import type { Tool } from "@raycast/api";
+import { createRecord } from "../api/endpoints";
+
+type Input = {
+  /** The company's name, e.g. "Attio". */
+  name: string;
+  /** The company's website domain, e.g. "attio.com" — no protocol or path. */
+  domain?: string;
+  /** A short free-text description of the company. */
+  description?: string;
+};
+
+export const confirmation: Tool.Confirmation<Input> = async (input) => ({
+  message: "Create this company in Attio?",
+  info: [
+    { name: "Name", value: input.name },
+    ...(input.domain ? [{ name: "Domain", value: input.domain }] : []),
+    ...(input.description ? [{ name: "Description", value: input.description }] : []),
+  ],
+});
+
+/** Create a new company record in Attio. */
+export default async function tool(input: Input) {
+  const values: Record<string, unknown[]> = { name: [input.name] };
+  if (input.domain) values.domains = [input.domain];
+  if (input.description) values.description = [input.description];
+  const { data } = await createRecord("companies", { data: { values } });
+  return { record_id: data.id.record_id, url: data.web_url };
+}

--- a/extensions/attio/src/tools/create-deal.ts
+++ b/extensions/attio/src/tools/create-deal.ts
@@ -1,0 +1,73 @@
+import type { Tool } from "@raycast/api";
+import { createRecord, listAttributeStatuses, listMembers } from "../api/endpoints";
+
+type Input = {
+  /** The deal's name, e.g. "Acme Corp — Enterprise plan". */
+  name: string;
+  /**
+   * The deal stage. Must exactly match a stage title configured in the
+   * workspace (use whatever the user said; common defaults are "Lead",
+   * "In Progress", "Won 🎉", "Lost"). Omit to use the workspace default.
+   */
+  stage?: string;
+  /** The deal value as a plain number, e.g. 5000. */
+  value?: number;
+  /**
+   * Full name or email of the workspace member who owns the deal. Attio
+   * usually requires an owner — ask the user if they didn't specify one.
+   */
+  owner?: string;
+};
+
+export const confirmation: Tool.Confirmation<Input> = async (input) => ({
+  message: "Create this deal in Attio?",
+  info: [
+    { name: "Name", value: input.name },
+    ...(input.stage ? [{ name: "Stage", value: input.stage }] : []),
+    ...(input.value !== undefined ? [{ name: "Value", value: String(input.value) }] : []),
+    ...(input.owner ? [{ name: "Owner", value: input.owner }] : []),
+  ],
+});
+
+/** Create a new deal record in Attio. A deal needs a name; Attio also requires an owner and defaults the stage. */
+export default async function tool(input: Input) {
+  const values: Record<string, unknown[]> = { name: [input.name] };
+  if (input.stage) {
+    // Resolve case-insensitively against real stage titles so "won" matches
+    // "Won 🎉" — but only when the prefix is unambiguous.
+    const q = input.stage.toLowerCase();
+    const stages = (await listAttributeStatuses("deals", "stage")).data.filter((s) => !s.is_archived);
+    const exact = stages.find((s) => s.title.toLowerCase() === q);
+    const prefixed = stages.filter((s) => s.title.toLowerCase().startsWith(q));
+    if (!exact && prefixed.length > 1)
+      throw new Error(
+        `"${input.stage}" matches several stages (${prefixed.map((s) => s.title).join(", ")}) — ask the user which one.`,
+      );
+    values.stage = [exact?.title ?? prefixed[0]?.title ?? input.stage];
+  }
+  if (input.value !== undefined) values.value = [input.value];
+  if (input.owner) {
+    const q = input.owner.toLowerCase();
+    if (q.includes("@")) {
+      // Attio resolves member emails directly — no user_management:read needed.
+      values.owner = [{ workspace_member_email_address: input.owner }];
+    } else {
+      const { data: members } = await listMembers();
+      const matches = members.filter((x) => `${x.first_name} ${x.last_name}`.trim().toLowerCase() === q);
+      if (matches.length === 0)
+        throw new Error(`No workspace member matches "${input.owner}" — ask the user which member owns the deal.`);
+      if (matches.length > 1)
+        throw new Error(
+          `Several workspace members are named "${input.owner}" (${matches
+            .map((x) => x.email_address)
+            .filter(Boolean)
+            .join(", ")}) — ask the user for the owner's email.`,
+        );
+      values.owner = [
+        { referenced_actor_type: "workspace-member", referenced_actor_id: matches[0].id.workspace_member_id },
+      ];
+    }
+  }
+  const { data } = await createRecord("deals", { data: { values } });
+  return { record_id: data.id.record_id, url: data.web_url };
+}

--- a/extensions/attio/src/tools/create-person.ts
+++ b/extensions/attio/src/tools/create-person.ts
@@ -1,0 +1,34 @@
+import type { Tool } from "@raycast/api";
+import { createRecord } from "../api/endpoints";
+import { personalNameToWire } from "../lib/edit-mapping";
+
+type Input = {
+  /** The person's full name, e.g. "Ada Lovelace". */
+  name: string;
+  /** The person's email address. */
+  email_address?: string;
+  /** The person's job title. */
+  job_title?: string;
+  /** A short free-text description of the person. */
+  description?: string;
+};
+
+export const confirmation: Tool.Confirmation<Input> = async (input) => ({
+  message: "Create this person in Attio?",
+  info: [
+    { name: "Name", value: input.name },
+    ...(input.email_address ? [{ name: "Email", value: input.email_address }] : []),
+    ...(input.job_title ? [{ name: "Job title", value: input.job_title }] : []),
+    ...(input.description ? [{ name: "Description", value: input.description }] : []),
+  ],
+});
+
+/** Create a new person record in Attio. */
+export default async function tool(input: Input) {
+  const values: Record<string, unknown[]> = { name: personalNameToWire(input.name) };
+  if (input.email_address) values.email_addresses = [input.email_address];
+  if (input.job_title) values.job_title = [input.job_title];
+  if (input.description) values.description = [input.description];
+  const { data } = await createRecord("people", { data: { values } });
+  return { record_id: data.id.record_id, url: data.web_url };
+}

--- a/extensions/attio/src/tools/search-records.ts
+++ b/extensions/attio/src/tools/search-records.ts
@@ -1,0 +1,24 @@
+import { searchRecords } from "../api/endpoints";
+
+type Input = {
+  /** The text to search for — a person's name, a company name, a deal title, an email address, or a domain. */
+  query: string;
+  /**
+   * Which record types to search. Omit to search all three.
+   * Valid values: "people", "companies", "deals".
+   */
+  objects?: ("people" | "companies" | "deals")[];
+};
+
+/** Search people, companies, and deals in the Attio workspace. */
+export default async function tool(input: Input) {
+  const { data } = await searchRecords(
+    input.query,
+    input.objects?.length ? input.objects : ["people", "companies", "deals"],
+  );
+  return data.map((h) => ({
+    record_id: h.id.record_id,
+    object: h.object_slug,
+    title: h.record_text,
+  }));
+}


### PR DESCRIPTION
## Description

Adds record creation and Raycast AI support to the Attio extension. New `Create Person`, `Create Company`, and `Create Deal` commands open a schema-driven form with draft support, and every record list gets a `New <Object>` action (`⌘N`) — including a create path straight from a "no matches" search. The edit form now also covers person names (split First/Last, matching Attio's editor), owners, and single record links such as a person's Company, via a live record-search picker.

### Changes

- Create Person / Create Company / Create Deal commands with Raycast draft support; `⌘N` from any record list (custom objects included, via an inline form)

<img width="862" height="587" alt="image" src="https://github.com/user-attachments/assets/94940248-9bdf-430c-baa1-b5391976d96d" />

<img width="862" height="587" alt="image" src="https://github.com/user-attachments/assets/258da7b8-c568-4f6d-829e-26502f03a8f4" />

<img width="862" height="587" alt="image" src="https://github.com/user-attachments/assets/d3c85ec2-9c0d-42d6-bb8f-363418d090f3" />

- Create/edit forms render every writable attribute from the workspace schema: split name fields, workspace-member owner dropdown, tag-style multi-value entry (domains validated for well-formed TLDs), inline required/invalid validation
- Editing now supports names, owners, and single record links (async record search scoped to the attribute's allowed objects); one PUT per save, changed values only
- Record action panels reordered for consistency: open/pin/new, edit + copy, view controls, then export with delete always last
- Success toast after creating offers Open <Object> (in Raycast) and Open in Attio

- **AI Extension**: `@attio` tools for Search Records, Create Person, Create Company, and Create Deal — writes behind confirmations, deal stages resolved case-insensitively, owners matched by member name or email; `ai.yaml` ships instructions plus 11 evals (11/11 passing via `ray evals`)

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I ran `npm run lint` and `npx tsc --noEmit` — both clean
- [x] I checked that this change does not break existing commands or remove functionality
- [x] I updated `CHANGELOG.md` per the changelog conventions
