### PR TITLE
Ghostty: Fix new window workspace placement

### DIFF
--- a/extensions/ghostty/CHANGELOG.md
+++ b/extensions/ghostty/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Ghostty Changelog
 
-## [Fix new window opening on the wrong workspace] - 2026-9-10
+## [Fix new window opening on the wrong workspace] - {PR_MERGE_DATE}
 
 - Fixed "New Window" activating an existing window before creating the new one, which caused window managers (OmniWM, yabai, aerospace, etc.) to switch to the workspace of the existing window. The new window now opens on the current workspace.
 

--- a/extensions/ghostty/CHANGELOG.md
+++ b/extensions/ghostty/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Ghostty Changelog
 
+## [Fix new window opening on the wrong workspace] - 2026-9-10
+
+- Fixed "New Window" activating an existing window before creating the new one, which caused window managers (OmniWM, yabai, aerospace, etc.) to switch to the workspace of the existing window. The new window now opens on the current workspace.
+
 ## [Edit Ghostty Config] - 2026-03-25
 
 - Add new command to view and edit the Ghostty configuration file (`~/.config/ghostty/config`)

--- a/extensions/ghostty/CHANGELOG.md
+++ b/extensions/ghostty/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Ghostty Changelog
 
-## [Fix new window opening on the wrong workspace] - {PR_MERGE_DATE}
+## [Fix new window opening on the wrong workspace] - 2026-09-10
 
 - Fixed "New Window" activating an existing window before creating the new one, which caused window managers (OmniWM, yabai, aerospace, etc.) to switch to the workspace of the existing window. The new window now opens on the current workspace.
 

--- a/extensions/ghostty/src/utils/scripts.ts
+++ b/extensions/ghostty/src/utils/scripts.ts
@@ -10,10 +10,11 @@
 export const openGhosttyWindow = `
 set wasRunning to application "Ghostty" is running
 tell application "Ghostty"
-    activate
     if wasRunning then
         set newWin to new window
         activate window newWin
+    else
+        activate
     end if
 end tell`;
 


### PR DESCRIPTION
## Description

- Create a new Ghostty window before activating the application.
- Focus the newly created window without switching to the workspace of an existing Ghostty window.
- Preserve the existing launch behavior when Ghostty is not already running.

Fixes #30944

## Testing

- Ran `npm run build`.
- Tested the development build with OmniWM 0.6.9:
  - Kept an existing Ghostty window on workspace 1.
  - Focused workspace 2 and ran **New Ghostty Window** through Raycast.
  - Confirmed the new window opened and remained focused on workspace 2.
- Verified the previous `activate`-before-`new window` ordering reproduces the issue by switching back to workspace 1.

## Screencast

N/A — verified manually with OmniWM; the action overlay is not reliably captured by macOS screen recording.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
