### PR TITLE
Update google-maps-search extension

### DIFF
--- a/extensions/google-maps-search/CHANGELOG.md
+++ b/extensions/google-maps-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Google Maps Search Changelog
 
-## [Prefill Home Origin Address] - {PR_MERGE_DATE}
+## [Prefill Home Origin Address] - 2026-09-10
 
 ### Fixed
 

--- a/extensions/google-maps-search/CHANGELOG.md
+++ b/extensions/google-maps-search/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Google Maps Search Changelog
 
+## [Prefill Home Origin Address] - {PR_MERGE_DATE}
+
+### Fixed
+
+- Prefill the origin address with the home address when Home is set as the preferred starting location.
+
 ## [Chore: Fixed throttle issue] - 2025-03-10
 
 ## [Added preferred starting location] - 2024-11-20

--- a/extensions/google-maps-search/src/travelTo.tsx
+++ b/extensions/google-maps-search/src/travelTo.tsx
@@ -10,7 +10,9 @@ export default function Command() {
 
   // State variables
   const [origin, setOrigin] = useState<OriginOption>(preferences.preferredOrigin); // Controls which origin option is selected
-  const [originAddress, setOriginAddress] = useState<string>(""); // Stores the origin address
+  const [originAddress, setOriginAddress] = useState<string>(
+    preferences.preferredOrigin === OriginOption.Home ? preferences.homeAddress : ""
+  ); // Stores the origin address
   const [destination, setDestination] = useState<string>(""); // Stores the destination address
   const [mode, setMode] = useState<string>(preferences.preferredMode); // Stores the selected transport mode
   const [isLoading, setIsLoading] = useState<boolean>(preferences.useSelected); // Controls loading state


### PR DESCRIPTION
## Description

Setting **Preferred Starting Location** to `Home` (with a Home Address filled in) had no effect on the **Get Me Somewhere** command. The "Starting from" dropdown correctly displayed `Home`, but the generated directions always started from the user's current location.

## Root cause

In `src/travelTo.tsx`, the dropdown selection and the address used to build the URL are two separate pieces of state:

- `origin` was initialized from `preferences.preferredOrigin`, so the dropdown rendered `Home` as expected.
- `originAddress` was hardcoded to `""` on mount, and was only ever populated inside `handleOriginChange`, which fires exclusively on a *manual* dropdown change.

So on first open the two disagreed, and `makeDirectionsURL` was called with an empty origin. Google Maps interprets an empty `&origin=` as the current location, which is why the preference appeared to be ignored, selecting `Home` by hand in the dropdown worked, which masked the bug.

## Fix

Seed `originAddress` from the preference on mount so it matches the initial dropdown value:

```ts
const [originAddress, setOriginAddress] = useState<string>(
  preferences.preferredOrigin === OriginOption.Home ? preferences.homeAddress : ""
);
```

handleOriginChange is untouched; the Current Location and Custom defaults are unchanged (both correctly start empty).

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
