### PR TITLE
proxmox: fix VM and storage lists stuck loading when the server is slower than the refresh interval

### DIFF
--- a/extensions/proxmox/CHANGELOG.md
+++ b/extensions/proxmox/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Proxmox Changelog
 
+## [Fix Slow Server Loading] - 2026-09-10
+
+- Fixed the VM and storage lists staying empty and loading forever when a server responds slower than the refresh interval
+
 ## [Multiple Servers] - 2026-09-07
 
 - Added support for multiple Proxmox servers ([#27260](https://github.com/raycast/extensions/issues/27260))

--- a/extensions/proxmox/CHANGELOG.md
+++ b/extensions/proxmox/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Proxmox Changelog
 
-## [Fix Slow Server Loading] - 2026-09-10
+## [Fix Slow Server Loading] - {PR_MERGE_DATE}
 
 - Fixed the VM and storage lists staying empty and loading forever when a server responds slower than the refresh interval
+- Fixed an unresponsive server blocking the refresh of the lists, requests are now cancelled after 10 seconds and the failure is shown for that server
 
 ## [Multiple Servers] - 2026-09-07
 

--- a/extensions/proxmox/CHANGELOG.md
+++ b/extensions/proxmox/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Proxmox Changelog
 
-## [Fix Slow Server Loading] - {PR_MERGE_DATE}
+## [Fix Slow Server Loading] - 2026-09-10
 
 - Fixed the VM and storage lists staying empty and loading forever when a server responds slower than the refresh interval
 - Fixed an unresponsive server blocking the refresh of the lists, requests are now cancelled after 10 seconds and the failure is shown for that server

--- a/extensions/proxmox/src/api/index.ts
+++ b/extensions/proxmox/src/api/index.ts
@@ -1,11 +1,32 @@
 import type { ApiResponse, PveServer, PveVm, WithServer } from "@/types";
 import { buildHeaders } from "@/utils/headers";
 
+/** Upper bound for a single request, a server that stops answering must not stay pending forever */
+const REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * Bound a request in time, keeping the abort signal a caller already passed.
+ *
+ * This must run per request rather than once per render: a signal created at
+ * render time is still the one a later manual refresh reuses, and by then its
+ * deadline has expired, which would fail the request before it is even sent.
+ *
+ * The deadline rejects with a `TimeoutError` rather than an `AbortError`, so
+ * callers can tell a hung server apart from a request they cancelled
+ * themselves and report it instead of silently discarding it.
+ */
+function withTimeout(signal?: AbortSignal | null): AbortSignal {
+  const timeout = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+  return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
 export async function pveFetch<T = unknown>(server: PveServer, url: string, options?: RequestInit) {
   const fetchUrl = new URL(url, server.url).toString();
-  const fetchOptions = Object.assign({}, options, {
+  const fetchOptions: RequestInit = {
+    ...options,
     headers: buildHeaders(server),
-  });
+    signal: withTimeout(options?.signal),
+  };
 
   const response = await fetch(fetchUrl, fetchOptions);
   if (!response.ok) {

--- a/extensions/proxmox/src/api/index.ts
+++ b/extensions/proxmox/src/api/index.ts
@@ -4,28 +4,23 @@ import { buildHeaders } from "@/utils/headers";
 /** Upper bound for a single request, a server that stops answering must not stay pending forever */
 const REQUEST_TIMEOUT_MS = 10_000;
 
-/**
- * Bound a request in time, keeping the abort signal a caller already passed.
- *
- * This must run per request rather than once per render: a signal created at
- * render time is still the one a later manual refresh reuses, and by then its
- * deadline has expired, which would fail the request before it is even sent.
- *
- * The deadline rejects with a `TimeoutError` rather than an `AbortError`, so
- * callers can tell a hung server apart from a request they cancelled
- * themselves and report it instead of silently discarding it.
- */
-function withTimeout(signal?: AbortSignal | null): AbortSignal {
-  const timeout = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
-  return signal ? AbortSignal.any([signal, timeout]) : timeout;
-}
-
 export async function pveFetch<T = unknown>(server: PveServer, url: string, options?: RequestInit) {
   const fetchUrl = new URL(url, server.url).toString();
+
+  // Bound each request in time, so a server that accepts the connection but
+  // never answers cannot keep its caller pending forever. This has to happen
+  // per request rather than once per render: a signal created during a render
+  // is still the one a later manual refresh reuses, and by then its deadline
+  // has expired, which would fail the request before it is even sent.
+  //
+  // The deadline rejects with a `TimeoutError` rather than an `AbortError`, so
+  // callers can tell a hung server apart from a request they cancelled
+  // themselves and report it instead of silently discarding it.
+  const deadline = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
   const fetchOptions: RequestInit = {
     ...options,
     headers: buildHeaders(server),
-    signal: withTimeout(options?.signal),
+    signal: options?.signal ? AbortSignal.any([options.signal, deadline]) : deadline,
   };
 
   const response = await fetch(fetchUrl, fetchOptions);

--- a/extensions/proxmox/src/components/VmActionPanel.tsx
+++ b/extensions/proxmox/src/components/VmActionPanel.tsx
@@ -4,6 +4,7 @@ import type { PveVm, VmAction, WithServer } from "@/types";
 import { PveVmStatus, PveVmTypes } from "@/types";
 import type { useVmList } from "@/hooks/use-vm-list";
 import { ALL_ACTIONS } from "@/utils/const";
+import { describeFetchError } from "@/utils/errors";
 import { formatBrowserUrl } from "@/utils/format";
 
 type VmActionPanelProps = {
@@ -36,6 +37,7 @@ export const VmActionPanel = ({ vm, revalidate, mutate }: VmActionPanelProps) =>
     } catch (e) {
       await showFailureToast(e, {
         title: `Failed to ${title} ${vm.name}`,
+        message: describeFetchError(e),
       });
       return;
     }

--- a/extensions/proxmox/src/hooks/use-multi-pve-fetch.ts
+++ b/extensions/proxmox/src/hooks/use-multi-pve-fetch.ts
@@ -18,8 +18,9 @@ type MultiPveFetchOptions = {
  *
  * Every tick fetches all servers as one batch, so while a server hangs the
  * healthy ones refresh at that server's request timeout instead of at
- * `timerInterval`. Splitting the batch per server would keep them on their own
- * cadence, but also cost one re-render and one cache write per server per tick.
+ * `timerInterval`. Keeping them on their own cadence would mean one hook per
+ * server, which needs a child component per server since the server count
+ * changes at runtime.
  */
 export const useMultiPveFetch = <T>(url: string, options?: MultiPveFetchOptions) => {
   const { timerInterval = 1000, execute = true } = options ?? {};

--- a/extensions/proxmox/src/hooks/use-multi-pve-fetch.ts
+++ b/extensions/proxmox/src/hooks/use-multi-pve-fetch.ts
@@ -52,11 +52,16 @@ export const useMultiPveFetch = <T>(url: string, options?: MultiPveFetchOptions)
     }
 
     const handle = setInterval(() => {
-      result.revalidate();
+      // revalidate() aborts the request that is still in flight, so ticking
+      // while a server is slower than the interval would abort every request
+      // before it can resolve and the list would never leave the loading state.
+      if (!result.isLoading) {
+        result.revalidate();
+      }
     }, timerInterval);
 
     return () => clearInterval(handle);
-  }, [result.revalidate, timerInterval, execute]);
+  }, [result.revalidate, result.isLoading, timerInterval, execute]);
 
   return {
     ...result,

--- a/extensions/proxmox/src/hooks/use-multi-pve-fetch.ts
+++ b/extensions/proxmox/src/hooks/use-multi-pve-fetch.ts
@@ -15,6 +15,11 @@ type MultiPveFetchOptions = {
  *
  * Failures are captured per server, so one unreachable server
  * doesn't prevent showing the results of the others.
+ *
+ * Every tick fetches all servers as one batch, so while a server hangs the
+ * healthy ones refresh at that server's request timeout instead of at
+ * `timerInterval`. Splitting the batch per server would keep them on their own
+ * cadence, but also cost one re-render and one cache write per server per tick.
  */
 export const useMultiPveFetch = <T>(url: string, options?: MultiPveFetchOptions) => {
   const { timerInterval = 1000, execute = true } = options ?? {};

--- a/extensions/proxmox/src/hooks/use-pve-fetch.ts
+++ b/extensions/proxmox/src/hooks/use-pve-fetch.ts
@@ -28,11 +28,16 @@ export const usePveFetch = <T>(server: PveServer, url: string, options?: PveFetc
     }
 
     const handle = setInterval(() => {
-      result.revalidate();
+      // revalidate() aborts the request that is still in flight, so ticking
+      // while the server is slower than the interval would abort every request
+      // before it can resolve and the data would never refresh.
+      if (!result.isLoading) {
+        result.revalidate();
+      }
     }, timerInterval);
 
     return () => clearInterval(handle);
-  }, [result.revalidate, timerInterval, execute]);
+  }, [result.revalidate, result.isLoading, timerInterval, execute]);
 
   return result;
 };

--- a/extensions/proxmox/src/hooks/use-pve-fetch.ts
+++ b/extensions/proxmox/src/hooks/use-pve-fetch.ts
@@ -1,25 +1,31 @@
-import { useEffect } from "react";
-import { useFetch } from "@raycast/utils";
-import type { ApiResponse, FetchOptions, PveServer } from "@/types";
+import { useEffect, useRef } from "react";
+import { useCachedPromise } from "@raycast/utils";
+import type { PveServer } from "@/types";
 import type { OmitData, WithData } from "@/types";
-import { buildHeaders } from "@/utils/headers";
+import { pveFetch } from "@/api";
 
-type PveFetchOptions<T> = FetchOptions<T> & {
+type PveFetchOptions<T> = {
+  /** Set to false to skip fetching, e.g. while the data isn't needed yet */
+  execute?: boolean;
+  /** Called when a request fails, e.g. to show a toast and an error screen */
+  onError?: (error: Error) => void | Promise<void>;
+  onData?: (data: T) => void | Promise<void>;
+  /** How often to revalidate in milliseconds, `null` to never poll */
   timerInterval?: number | null;
 };
 
 export const usePveFetch = <T>(server: PveServer, url: string, options?: PveFetchOptions<T>) => {
   const { timerInterval = 1000, ...rest } = options ?? {};
-  const fetchUrl = new URL(url, server.url).toString();
-  const fetchOptions: FetchOptions<T> = {
-    ...rest,
-    headers: buildHeaders(server),
-    mapResult(result) {
-      return { data: (result as ApiResponse<T>).data };
-    },
-  };
+  const abortable = useRef<AbortController>(null);
 
-  const result = useFetch<T>(fetchUrl, fetchOptions);
+  // Fetching through pveFetch() bounds every request in time and stays
+  // cache-backed, so the last successful data renders again on a cold start.
+  const result = useCachedPromise(
+    async (server: PveServer, url: string): Promise<T> =>
+      (await pveFetch<T>(server, url, { signal: abortable.current?.signal })).data,
+    [server, url],
+    { ...rest, abortable },
+  );
 
   const execute = rest.execute !== false;
   useEffect(() => {

--- a/extensions/proxmox/src/hooks/use-storage-content.ts
+++ b/extensions/proxmox/src/hooks/use-storage-content.ts
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { showFailureToast } from "@raycast/utils";
 import type { PveServer, PveStorageContent, WithShowErrorScreen } from "@/types";
 import { type PveFetchWithDataResult, usePveFetch } from "@/hooks/use-pve-fetch";
+import { describeFetchError } from "@/utils/errors";
 
 export const useStorageContent = (
   server: PveServer,
@@ -12,7 +13,7 @@ export const useStorageContent = (
 
   const { data, ...rest } = usePveFetch<PveStorageContent[]>(server, `api2/json/nodes/${node}/storage/${id}/content`, {
     onError: (error) => {
-      showFailureToast(error);
+      showFailureToast(error, { message: describeFetchError(error) });
       setShowErrorScreen(true);
     },
     timerInterval: null,

--- a/extensions/proxmox/src/hooks/use-storage-status.ts
+++ b/extensions/proxmox/src/hooks/use-storage-status.ts
@@ -17,6 +17,9 @@ export const useStorageStatus = (
       showFailureToast(error);
       setShowErrorScreen(true);
     },
+    // A timed-out or failed poll latches the error screen, clear it again once
+    // the server answers so the recovered status shows instead of a stale error.
+    onData: () => setShowErrorScreen(false),
     timerInterval: 5000,
   });
 

--- a/extensions/proxmox/src/hooks/use-storage-status.ts
+++ b/extensions/proxmox/src/hooks/use-storage-status.ts
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { showFailureToast } from "@raycast/utils";
 import type { PveServer, PveStorageStatus, WithShowErrorScreen } from "@/types";
 import { type PveFetchResult, usePveFetch } from "@/hooks/use-pve-fetch";
+import { describeFetchError } from "@/utils/errors";
 
 export const useStorageStatus = (
   server: PveServer,
@@ -14,7 +15,7 @@ export const useStorageStatus = (
   const result = usePveFetch<PveStorageStatus>(server, `api2/json/nodes/${node}/storage/${id}/status`, {
     execute: options?.execute,
     onError: (error) => {
-      showFailureToast(error);
+      showFailureToast(error, { message: describeFetchError(error) });
       setShowErrorScreen(true);
     },
     // A timed-out or failed poll latches the error screen, clear it again once

--- a/extensions/proxmox/src/types/index.ts
+++ b/extensions/proxmox/src/types/index.ts
@@ -1,7 +1,3 @@
-import type { useFetch } from "@raycast/utils";
-
-export type FetchOptions<T> = Parameters<typeof useFetch<T>>[1];
-
 export type PveServer = {
   id: string;
   name: string;

--- a/extensions/proxmox/src/utils/errors.ts
+++ b/extensions/proxmox/src/utils/errors.ts
@@ -16,10 +16,18 @@ function describeCause(cause: Error): string {
 /**
  * Node's fetch wraps the interesting part (DNS, TLS, connection errors)
  * in `error.cause` and only reports "fetch failed" itself.
+ *
+ * A deadline from `AbortSignal.timeout()` reaches us directly as a
+ * `TimeoutError` without a cause, and its own wording ("The operation was
+ * aborted due to timeout") reads like a cancellation rather than a slow server.
  */
 export function describeFetchError(error: unknown): string {
   if (!(error instanceof Error)) {
     return String(error);
+  }
+
+  if (error.name === "TimeoutError") {
+    return "The server did not respond in time";
   }
 
   if (error.cause instanceof Error) {


### PR DESCRIPTION
## Description

Fixes the `Manage VMs` and `Manage Storage` commands rendering an empty screen that spins forever when a Proxmox server responds slower than the refresh interval, and fixes an unresponsive server blocking the refresh of both lists.

### Problem

Since the multiple-servers update (#30125), both list commands show no items and stay in the loading state when the server takes longer than ~1 s to answer (slow WAN/VPN link, busy host, or a hanging unreachable server). `Manage Servers` keeps working, because it only reads LocalStorage and the extension preferences.

### Cause

Both list hooks poll with `setInterval(() => result.revalidate(), timerInterval)`, and `timerInterval` defaults to `1000` ms. `revalidate()` from `usePromise` aborts the in-flight request before starting the next one and re-enters `isLoading: true`. When a fetch is slower than the interval, every response is aborted before it can resolve:

- the abort surfaces as `AbortError`, which `usePromise` deliberately ignores **without clearing `isLoading`**
- one second later the tick aborts the next request → the hook can never reach a settled state, so `data` stays `undefined` and the list is permanently loading
- in `useMultiPveFetch` the abort is rethrown so the whole `Promise.all` rejects, meaning one slow or hanging server also wipes the results of every other configured server

The race is not new: the pre-multiple-servers `usePveFetch` had the identical 1 s revalidate timer. It was masked because the old `useFetch` is cache-backed (`useCachedPromise` → Raycast `Cache`) and rendered the last successful data on mount. #30125 switched the two list hooks to the raw, uncached `usePromise`, which removed the mask.

### Fix

**1. Gate the polling tick on `!result.isLoading`** in both hooks, so the timer never aborts a request that is still in flight and simply polls again once it settles:

```ts
const handle = setInterval(() => {
  if (!result.isLoading) {
    result.revalidate();
  }
}, timerInterval);
```

This removes the race itself rather than hiding it again — a cache shim would only mask it like before, and a longer interval would just move the latency threshold at which the white screen returns.

**2. Bound every request in time** (`src/api/index.ts`), because the gate alone turns a hung connection into permanently disabled polling — nothing would ever abort a request that never finishes, so `isLoading` stays true forever and no server ever refreshes again:

```ts
const deadline = AbortSignal.timeout(REQUEST_TIMEOUT_MS); // 10 s
const fetchOptions: RequestInit = {
  ...options,
  headers: buildHeaders(server),
  signal: options?.signal ? AbortSignal.any([options.signal, deadline]) : deadline,
};
```

- the deadline is built **per request**, not per render: a signal created during a render is still the one a later manual refresh reuses, and by then its deadline has expired, which would fail the request before it is even sent
- it rejects with `TimeoutError`, not `AbortError`, so `useMultiPveFetch` captures it per server and keeps rendering the healthy servers' results
- a caller's own deadline still wins — `AbortSignal.any` takes whichever fires first, so the 5 s connection check in `ServerForm` is unchanged

`usePveFetch` moved from `useFetch` to `useCachedPromise` + `pveFetch`, so the timeout applies per request while the cache-backed behaviour it relied on is kept. `useStorageStatus` now clears its error screen when a later poll succeeds, otherwise the new deadline turns a transient hang into a permanent "check your preferences" screen.

**3. Describe the new failure.** `AbortSignal.timeout()` rejects with a `DOMException` whose message is "The operation was aborted due to timeout", which reads like a cancellation rather than a slow server. `describeFetchError()` now maps `TimeoutError` to "The server did not respond in time", and the storage status/content toasts plus the VM action failure toast pass that description instead of the raw message — they showed the raw one before. Every other error keeps its existing wording, including the `cause` unwrapping for DNS/TLS/connection failures.

**Known tradeoff:** a tick fetches all servers as one batch, so while one server hangs the healthy ones refresh at that server's 10 s timeout instead of at `timerInterval`. Keeping them on their own cadence would mean one hook per server, and since the server count changes at runtime that needs a child component per server plus a different aggregate shape. Noted in the hook's doc comment.

### Verification

Compiled the real entries (`src/index.tsx`, `src/storage.tsx`, `StorageDetail`, `StorageContentList`, `VmActionPanel`) with a mocked Raycast API and rendered them via `react-test-renderer` against `@raycast/utils@2.3.1`. The mock only rejects a hung socket when the caller's own signal fires, like a real connection to a host that goes quiet. Waits flush React in small `act` chunks, since one long `act` defers the re-render that recreates the interval and fakes "polling stopped".

| scenario | before | after |
| --- | --- | --- |
| VM list, 1500 ms latency > 1000 ms interval | `isLoading=true`, 0 sections / 0 items, 6 fetches, 5 aborted | 1 item, 3 fetches in 6 s, **0** timer aborts |
| one hung + one healthy server | `isLoading=true`, **0 items** — the healthy server's data is lost too, forever | hung server shows a `Connection Failed` row, healthy server renders, 4 fetches |
| the hung server starts answering again | still nothing, ever | failure row disappears, both servers' VMs render |
| storage status, hung then recovered | stuck loading forever | settles at the deadline, error shows, then clears and the status renders again |
| manual refresh after >10 s idle | n/a | request is sent and resolves (no stale expired signal) |
| cold start with a warm `Cache`, hung server | n/a | cached values render immediately, no spinner |
| timeout wording, list error item | n/a | "The server did not respond in time", no raw `DOMException` message |
| timeout wording, storage + VM action toasts | raw "The operation was aborted due to timeout" | same friendly wording |
| `describeFetchError` regression, 9 cases | — | `ECONNREFUSED` / DNS / TLS / `AggregateError` / HTTP status / non-`Error` all unchanged |

As a counterfactual, removing only the deadline reproduces the reported P1 exactly: with one hung server the list stays `isLoading=true` with **zero items** — including the healthy server's — and polling never resumes even after the server recovers. Removing only the `onData` clear leaves the storage detail stuck on the error screen after the server recovers. `Manage Servers` is unaffected and still lists the server from the preferences.

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
