### PR TITLE
[Deepcast] Respect View in Raycast preference

### DIFF
--- a/extensions/deepcast/CHANGELOG.md
+++ b/extensions/deepcast/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Deepcast Changelog
 
-## [Respect Translation Action Preference] - {PR_MERGE_DATE}
+## [Respect Translation Action Preference] - 2026-09-10
 
 - Fix the main Translate form ignoring `On Translation Action` and always copying the translated text to the clipboard ([#30932](https://github.com/raycast/extensions/issues/30932))
 

--- a/extensions/deepcast/CHANGELOG.md
+++ b/extensions/deepcast/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Deepcast Changelog
 
+## [Respect Translation Action Preference] - {PR_MERGE_DATE}
+
+- Fix the main Translate form ignoring `On Translation Action` and always copying the translated text to the clipboard ([#30932](https://github.com/raycast/extensions/issues/30932))
+
 ## [Fix Close Window Preference] - 2026-09-03
 
 - Fix `Close Raycast After Translation` preference being ignored when `On Translation Action` is not set: the `default` case in `sendTranslateRequest` was not calling `delayedCloseWindow`, so the window would close even when the preference was off ([#30609](https://github.com/raycast/extensions/issues/30609))

--- a/extensions/deepcast/package.json
+++ b/extensions/deepcast/package.json
@@ -22,7 +22,8 @@
     "shashank_rm",
     "heyflorentin",
     "ridemountainpig",
-    "12ian34"
+    "12ian34",
+    "lambegraham"
   ],
   "platforms": [
     "macOS",
@@ -794,6 +795,6 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish",
-    "test": "node --test tests/hyperlinks.test.ts"
+    "test": "node --experimental-test-module-mocks --test tests/*.test.ts"
   }
 }

--- a/extensions/deepcast/src/index.tsx
+++ b/extensions/deepcast/src/index.tsx
@@ -281,9 +281,7 @@ const Command = (props: LaunchProps<{ launchContext?: LaunchContext }>) => {
         </>
       )}
       <Form.TextArea id="translation" title="Translation" value={translation} />
-      {translation.length > 0 && (
-        <Form.Description title="Copied" text="Rich text is on the clipboard. Paste with ⌘V." />
-      )}
+      {translation.length > 0 && <Form.Description title="Status" text="Translation complete." />}
       {(showTransliteration == "always" || (showTransliteration == "whenProvided" && transliteration.length > 0)) && (
         <Form.Description title="Transliteration" text={transliteration} />
       )}

--- a/extensions/deepcast/src/index.tsx
+++ b/extensions/deepcast/src/index.tsx
@@ -97,7 +97,7 @@ const Command = (props: LaunchProps<{ launchContext?: LaunchContext }>) => {
       text: values.text,
       targetLanguage: values.to,
       sourceLanguage: values.from && values.from.length > 0 ? values.from : undefined,
-      onTranslateAction: "none",
+      viewInCurrentCommand: true,
       formality: values.formality ?? "default",
     });
 

--- a/extensions/deepcast/src/utils.ts
+++ b/extensions/deepcast/src/utils.ts
@@ -130,12 +130,14 @@ export async function sendTranslateRequest({
   sourceLanguage,
   targetLanguage,
   onTranslateAction,
+  viewInCurrentCommand,
   formality,
 }: {
   text?: string;
   sourceLanguage?: SourceLanguage;
   targetLanguage: TargetLanguage;
   onTranslateAction?: Preferences["onTranslateAction"] | "none";
+  viewInCurrentCommand?: boolean;
   formality: Formality;
 }) {
   try {
@@ -146,7 +148,7 @@ export async function sendTranslateRequest({
     const source: { text: string; html?: string } = initialText ? { text: initialText } : await readContent();
     const { text, isHtml } = prepareTranslationPayload(source.text, source.html);
 
-    await showToast(Toast.Style.Animated, "Fetching translation...");
+    const loadingToast = await showToast(Toast.Style.Animated, "Fetching translation...");
     try {
       const {
         translations: [{ text: translation, detected_source_language: detectedSourceLanguage }],
@@ -164,6 +166,7 @@ export async function sendTranslateRequest({
           },
         })
         .json<{ translations: { text: string; detected_source_language: SourceLanguage }[] }>();
+      await loadingToast.hide();
       switch (onTranslateAction) {
         case "clipboard":
           await copyTranslatedText(translation, isHtml);
@@ -171,6 +174,10 @@ export async function sendTranslateRequest({
           await delayedCloseWindow(closeRaycastAfterTranslation);
           break;
         case "view":
+          if (viewInCurrentCommand) {
+            await delayedCloseWindow(closeRaycastAfterTranslation);
+            break;
+          }
           try {
             await launchCommand({
               name: "index",
@@ -204,6 +211,7 @@ export async function sendTranslateRequest({
       }
       return { translation, detectedSourceLanguage, isHtml };
     } catch (error) {
+      await loadingToast.hide();
       await showToast(Toast.Style.Failure, "Something went wrong", gotErrorToString(error));
     }
   } catch {

--- a/extensions/deepcast/tests/raycast-api.mock.ts
+++ b/extensions/deepcast/tests/raycast-api.mock.ts
@@ -1,0 +1,26 @@
+import { mock } from "node:test";
+
+export const clipboardCopy = mock.fn(async () => undefined);
+export const closeMainWindow = mock.fn(async () => undefined);
+export const launchCommand = mock.fn(async () => undefined);
+export const toastHide = mock.fn(async () => undefined);
+
+export const Clipboard = {
+  copy: clipboardCopy,
+  paste: mock.fn(async () => undefined),
+  read: mock.fn(async () => ({ text: "" })),
+  readText: mock.fn(async () => ""),
+};
+
+export const LaunchType = { UserInitiated: "userInitiated" };
+export const Toast = { Style: { Animated: "animated", Failure: "failure", Success: "success" } };
+export const getPreferenceValues = () => ({
+  closeRaycastAfterTranslation: false,
+  key: "test-key:fx",
+  onTranslateAction: "view",
+  returnToRootState: false,
+  source: "selected",
+});
+export const getSelectedText = mock.fn(async () => "");
+export const popToRoot = mock.fn(async () => undefined);
+export const showToast = mock.fn(async () => ({ hide: toastHide }));

--- a/extensions/deepcast/tests/translation-action.test.ts
+++ b/extensions/deepcast/tests/translation-action.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { registerHooks } from "node:module";
+import { describe, it, mock } from "node:test";
+import { clipboardCopy, closeMainWindow, launchCommand, toastHide } from "./raycast-api.mock.ts";
+
+const raycastApiMockUrl = new URL("./raycast-api.mock.ts", import.meta.url).href;
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier === "@raycast/api") {
+      return { shortCircuit: true, url: raycastApiMockUrl };
+    }
+    if (specifier === "./hyperlinks" && context.parentURL?.endsWith("/src/utils.ts")) {
+      return { shortCircuit: true, url: new URL("../src/hyperlinks.ts", import.meta.url).href };
+    }
+    return nextResolve(specifier, context);
+  },
+});
+
+mock.module("got", {
+  defaultExport: {
+    post: () => ({
+      json: async () => ({
+        translations: [{ detected_source_language: "EN", text: "Hallo" }],
+      }),
+    }),
+  },
+  namedExports: {
+    HTTPError: class HTTPError extends Error {},
+    RequestError: class RequestError extends Error {},
+  },
+});
+
+const { sendTranslateRequest } = await import("../src/utils.ts");
+
+describe("main Translate form action", () => {
+  it("returns the saved View in Raycast translation for local display", async () => {
+    const response = await sendTranslateRequest({
+      formality: "default",
+      targetLanguage: "DE",
+      text: "Hello",
+      viewInCurrentCommand: true,
+    });
+
+    assert.equal(response?.translation, "Hallo");
+    assert.equal(launchCommand.mock.callCount(), 0);
+    assert.equal(clipboardCopy.mock.callCount(), 0);
+    assert.equal(closeMainWindow.mock.callCount(), 0);
+    assert.equal(toastHide.mock.callCount(), 1);
+  });
+
+  it("still launches the main command when View is requested elsewhere", async () => {
+    await sendTranslateRequest({
+      formality: "default",
+      targetLanguage: "DE",
+      text: "Hello",
+    });
+
+    assert.equal(launchCommand.mock.callCount(), 1);
+    assert.equal(clipboardCopy.mock.callCount(), 0);
+    assert.equal(closeMainWindow.mock.callCount(), 0);
+  });
+});


### PR DESCRIPTION
## Description

- Respect the saved `On Translation Action` preference in the main Translate command.
- Render `View in Raycast` results in the active command instead of attempting to relaunch that same command.
- Dismiss the loading toast as soon as DeepL returns the translation.
- Keep language-specific commands opening the main Translate view as before.

This is a follow-up to #30622, which fixed the unset/default action path. The explicit `View in Raycast` path remained broken and was reported separately in #30932.

Fixes #30932

## Screencast

Screenshot attached below shows the translated result rendered in Raycast with the window remaining open and the loading toast dismissed.

## Test Plan

- `npm test` — 17 tests passed
- `npm run lint`
- `npm run build`
- Manually tested the development extension with:
  - `On Translation Action: View in Raycast`
  - `Close Raycast After Translation: Off`
  - `Return to Root State: Off`
  - Confirmed the translation renders in the current window without copying to the clipboard or closing Raycast

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
