### PR TITLE
docs(zotero): update README for fuzzy search, BibTeX-key search, and group libraries

### DIFF
--- a/extensions/zotero/CHANGELOG.md
+++ b/extensions/zotero/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zotero Changelog
 
+## [Docs] - {PR_MERGE_DATE}
+
+- Updated the README to document fuzzy search, the "Search by BibTeX Citation Key" preference, group libraries, the collection filter, and the 100-result limit
+
 ## [Group libraries, fuzzy search, and BibTeX-key search] - 2026-08-30
 
 - Search now uses a subsequence fuzzy finder (fuzzysort) instead of near-exact matching, so typing `qsim` finds "Quantum Simulation". Results are ranked by how well they match, and the most recent items show for an empty query.

--- a/extensions/zotero/CHANGELOG.md
+++ b/extensions/zotero/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Zotero Changelog
 
-## [Docs] - {PR_MERGE_DATE}
+## [Docs] - 2026-09-10
 
 - Updated the README to document fuzzy search, the "Search by BibTeX Citation Key" preference, group libraries, the collection filter, and the 100-result limit
 

--- a/extensions/zotero/README.md
+++ b/extensions/zotero/README.md
@@ -81,10 +81,11 @@ Please note that the cache will become invalid if you update preferences.
 
 ![Empty View](media/empty_view.png)
 
-Search is fuzzy: each query term matches scattered letters in order, so typing `qsim` finds
-"Quantum Simulation". Results are ranked by how well they match. At most 100 results are shown
-at a time; when a query matches more, the section subtitle says "Top 100 — refine your search
-to see more".
+Search is fuzzy: each query term matches scattered letters in order in the title, tags, authors,
+DOI, and collection names, so typing `qsim` finds "Quantum Simulation". Abstracts and notes are
+matched as contiguous text, so a phrase from them must appear as-is. Results are ranked by how
+well they match. At most 100 results are shown at a time; when a query matches 100 or more, the
+section subtitle says "Top 100 — refine your search to see more".
 
 This extension supports different types of searches. Here are some common examples:
 
@@ -149,5 +150,5 @@ reference. It shows up when your library has at least one group, and opens a lis
 which groups to include. Your personal library is always searched.
 
 References from a group library show the group name after the title, for example
-"Title · Group Name", and a `**Library:**` line in the detail view. Pressing Enter opens them
-in Zotero.
+"Title · Group Name", and a `**Library:**` line in the detail view. The "Open in Zotero"
+action opens them in the Zotero app.

--- a/extensions/zotero/README.md
+++ b/extensions/zotero/README.md
@@ -30,6 +30,7 @@ Preferences related to these features are:
   A default of 10 minutes is Used.
 
 - **Whether to use Better BibTex Citation**: If you use the [Better BibTex zotero extension](https://retorque.re/zotero-better-bibtex/), you can enable this flag to copy Better BibTex citation keys for any reference.
+- **Search by BibTeX Citation Key**: If you use the Better BibTex zotero extension, you can enable this flag to search references by citation key. With it on, typing a citation key like `smith2020quantum` returns that reference. It only needs the Better BibTex plugin, so you can use it without setting up the CSL JSON file for copy and paste.
 - **Better Bibtex CSL JSON File**: Path where you save your auto-updating CSL JSON file. **PLEASE
   NOTE THAT THIS IS MUST IF YOU WANT TO USE THESE FEATURES**. Please see the following screencast
   to setup this properly. You will need to update this entry to the path you chose to save this CSL
@@ -73,12 +74,17 @@ Preferences related to these features are:
 
 ## Features
 
-On launching the application, you will get and empty view. The results will only show up when you
-type any search query. To speedup queries, sqlite query results are cached locally for 10 minutes.
+On launching the application, the most recent references are shown, and results update as you
+type. To speedup queries, sqlite query results are cached locally for 10 minutes.
 Additionally, This cache is valid in those 10 minutes, only if your database has not changed since.
 Please note that the cache will become invalid if you update preferences.
 
 ![Empty View](media/empty_view.png)
+
+Search is fuzzy: each query term matches scattered letters in order, so typing `qsim` finds
+"Quantum Simulation". Results are ranked by how well they match. At most 100 results are shown
+at a time; when a query matches more, the section subtitle says "Top 100 — refine your search
+to see more".
 
 This extension supports different types of searches. Here are some common examples:
 
@@ -114,10 +120,17 @@ search for references with ALL of the queried tags (Examples 7 and 10).
 If you want to search for ANY of the tags, you should not prefix it with "." character. For example
 in queries 9 and 10, AAA will be searched in tags in only OR/ANY sense.
 
+You can also filter the results to a single collection using the dropdown next to the search bar.
+It lists collections from your personal library and the group libraries you have included.
+Collections are matched by library and key, so two collections with the same name stay separate,
+and the dropdown labels them so you can tell them apart. The filter is applied to the whole
+library before the 100-result limit.
+
 This extension support a few sub commands.
 
 - link to the reference in your zotero app (default)
 - link to the PDF of your reference in zotero app or default PDF Reader
+- copy the PDF file path of your reference to the clipboard
 - open original link to open URL in default browser
 - Copy BibTex citation key to the clipboard
 - copy reference using CSA style to the clipboard
@@ -127,3 +140,14 @@ This extension support a few sub commands.
 
 Please note that in case a reference has multiple PDF files associated with it, the primary (oldest)
 PDF file will be opened, matching Zotero's native behavior.
+
+## Group libraries
+
+By default, only your personal library is searched, so a reference shared to a group does not
+show up twice. To include groups, use the "Configure Group Libraries" action (`⌘L`) on any
+reference. It shows up when your library has at least one group, and opens a list where you pick
+which groups to include. Your personal library is always searched.
+
+References from a group library show the group name after the title, for example
+"Title · Group Name", and a `**Library:**` line in the detail view. Pressing Enter opens them
+in Zotero.


### PR DESCRIPTION
## Description

The feature work from #30589 and the earlier memory fixes left `extensions/zotero/README.md` describing the old behavior. This updates it to match what the extension does today.

**Fuzzy search.** Replaces the "results will only show up when you type any search query" description (an empty query now shows the most recent items) and notes that matching is fuzzy and ranked, with a 100-result cap that shows "Top 100 — refine your search to see more".

**Group libraries.** New section: only the personal library is searched by default, the "Configure Group Libraries" action (`⌘L`) picks which groups to include, group items show the group name in the list and a `Library` line in the detail view, and Enter opens them in Zotero.

**BibTeX-key search.** Documents the "Search by BibTeX Citation Key" preference, which works without the Better BibTex copy/paste setup.

**Collection filter.** Documents the collection dropdown next to the search bar: it lists personal and included-group collections, same-name collections stay separate, and the filter is applied before the 100-result limit.

**Sub commands.** Adds the "Copy PDF Path" action to the sub command list, which shipped in April but was never documented.

No new screenshots; the existing images still show a valid search view.

### Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I updated the `CHANGELOG.md` with a new entry using the `{PR_MERGE_DATE}` placeholder
