### PR TITLE
Update Sunsama extension

### DIFF
--- a/extensions/sunsama/CHANGELOG.md
+++ b/extensions/sunsama/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Sunsama Changelog
 
+## [AI Extension] - {PR_MERGE_DATE}
+
+- Ask Raycast AI to manage your day: mention `@sunsama` in AI Chat to list a
+  day's tasks and channels, add tasks (with notes, a channel, planned time,
+  subtasks, or a pasted link), edit, complete, reschedule, and delete tasks,
+  add subtasks, and start or stop timers. Changes to an existing task ask you
+  to confirm first.
+
 ## [Default Channel for Linked Tasks] - 2026-09-09
 
 - A pasted link now keeps whichever channel Sunsama's own automation assigns to

--- a/extensions/sunsama/CHANGELOG.md
+++ b/extensions/sunsama/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Sunsama Changelog
 
-## [AI Extension] - {PR_MERGE_DATE}
-
-- Ask Raycast AI to manage your day: mention `@sunsama` in AI Chat to list a
-  day's tasks and channels, add tasks (with notes, a channel, planned time,
-  subtasks, or a pasted link), edit, complete, reschedule, and delete tasks,
-  add subtasks, and start or stop timers. Changes to an existing task ask you
-  to confirm first.
-
 ## [Default Channel for Linked Tasks] - 2026-09-09
 
 - A pasted link now keeps whichever channel Sunsama's own automation assigns to

--- a/extensions/sunsama/CHANGELOG.md
+++ b/extensions/sunsama/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Sunsama Changelog
 
-## [Default Channel for Linked Tasks] - {PR_MERGE_DATE}
+## [Default Channel for Linked Tasks] - 2026-09-09
 
 - A pasted link now keeps whichever channel Sunsama's own automation assigns to
   it, and falls back to your default channel when no automation fires. Picking a

--- a/extensions/sunsama/CHANGELOG.md
+++ b/extensions/sunsama/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Sunsama Changelog
 
+## [Default Channel for Linked Tasks] - {PR_MERGE_DATE}
+
+- A pasted link now keeps whichever channel Sunsama's own automation assigns to
+  it, and falls back to your default channel when no automation fires. Picking a
+  channel yourself still wins.
+- Add Task opens its connection to Sunsama while you type, so submitting no
+  longer waits for it.
+
 ## [Initial Version] - 2026-09-05
 
 Manage your Sunsama tasks from Raycast, over Sunsama's official MCP server.

--- a/extensions/sunsama/README.md
+++ b/extensions/sunsama/README.md
@@ -59,6 +59,22 @@ Picks the channel new tasks default to. Sunsama has no "list all channels"
 endpoint, only search, so this list is search-driven — start typing and it
 narrows.
 
+## Ask Raycast AI
+
+The extension is also an AI Extension. Mention it in Raycast AI Chat with
+`@sunsama` and ask in plain words:
+
+- `@sunsama what's on my plate today?`
+- `@sunsama add a task to call the dentist tomorrow, 15 minutes`
+- `@sunsama mark 'Write release notes' as done`
+- `@sunsama start the timer on Write release notes`
+- `@sunsama push Write release notes to Monday`
+
+The AI can list a day's tasks and channels, add tasks (with notes, a channel,
+planned time, subtasks, or a pasted link), edit, complete, reschedule, and
+delete tasks, add subtasks, and start or stop timers. Anything that changes an
+existing task asks you to confirm first, and deleting is marked as destructive.
+
 ## Time input
 
 Anywhere you type a duration, all of these work:
@@ -96,6 +112,13 @@ npm run lint     # eslint + prettier
 npm run build    # the build Raycast actually publishes
 ```
 
+The AI tools have evals in `package.json` under `ai.evals`. They run on
+Raycast's servers, so sign in once with `npx ray login`, then:
+
+```bash
+npx ray evals
+```
+
 The tests cover the pure logic — duration parsing, day math, and the HTML to
 Markdown conversion for notes. Sunsama sends task notes as HTML but takes
 Markdown back when you save them, so that conversion has to survive a round trip
@@ -110,6 +133,7 @@ src/
   view-today.tsx          View Today's Tasks command
   set-default-channel.tsx Set Default Channel command
   components/             Forms and lists pushed onto the navigation stack
+  tools/                  AI Extension tools (one file per tool)
   lib/
     mcp.ts                OAuth, MCP transport, tool and resource calls
     sunsama-client.ts     Tasks, subtasks, channels, timers

--- a/extensions/sunsama/README.md
+++ b/extensions/sunsama/README.md
@@ -72,8 +72,10 @@ The extension is also an AI Extension. Mention it in Raycast AI Chat with
 
 The AI can list a day's tasks and channels, add tasks (with notes, a channel,
 planned time, subtasks, or a pasted link), edit, complete, reschedule, and
-delete tasks, add subtasks, and start or stop timers. Anything that changes an
-existing task asks you to confirm first, and deleting is marked as destructive.
+delete tasks, add subtasks, and start or stop timers. Editing, completing,
+rescheduling, or deleting a task asks you to confirm first, and deleting is
+marked as destructive. Adding tasks or subtasks and starting or stopping a
+timer run straight away.
 
 ## Time input
 

--- a/extensions/sunsama/package.json
+++ b/extensions/sunsama/package.json
@@ -9,7 +9,6 @@
     "fix-lint": "ray lint --fix",
     "test": "vitest run",
     "build": "ray build",
-    "deploy": "ray build && pwsh -NoProfile -File scripts/deploy.ps1",
     "publish": "npx @raycast/api@latest publish",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1"
   },

--- a/extensions/sunsama/package.json
+++ b/extensions/sunsama/package.json
@@ -9,6 +9,7 @@
     "fix-lint": "ray lint --fix",
     "test": "vitest run",
     "build": "ray build",
+    "deploy": "ray build && pwsh -NoProfile -File scripts/deploy.ps1",
     "publish": "npx @raycast/api@latest publish",
     "prepublishOnly": "echo \"\\n\\nIt seems like you are trying to publish the Raycast extension to npm.\\n\\nIf you did intend to publish it to npm, remove the \\`prepublishOnly\\` script and rerun \\`npm publish\\` again.\\nIf you wanted to publish it to the Raycast Store instead, use \\`npm run publish\\` instead.\\n\\n\" && exit 1"
   },
@@ -105,6 +106,199 @@
       "icon": "extension-icon.png"
     }
   ],
+  "tools": [
+    {
+      "name": "get-tasks",
+      "title": "Get Tasks",
+      "description": "List the tasks on a day (today by default) with their ids, planned and tracked time, channel, notes, and subtasks"
+    },
+    {
+      "name": "get-channels",
+      "title": "Get Channels",
+      "description": "List every channel and category in the workspace, so a task can be filed under the right name"
+    },
+    {
+      "name": "create-task",
+      "title": "Create Task",
+      "description": "Add a task to a day, optionally with notes, a channel, planned time, subtasks, or a link to Trello, GitHub, Todoist, ClickUp, and more"
+    },
+    {
+      "name": "complete-task",
+      "title": "Complete Task",
+      "description": "Mark a task as completed"
+    },
+    {
+      "name": "reschedule-task",
+      "title": "Reschedule Task",
+      "description": "Move a task to another day, or to the backlog"
+    },
+    {
+      "name": "edit-task",
+      "title": "Edit Task",
+      "description": "Change a task's title, notes, planned time, or channel"
+    },
+    {
+      "name": "add-subtasks",
+      "title": "Add Subtasks",
+      "description": "Add subtasks to an existing task"
+    },
+    {
+      "name": "start-timer",
+      "title": "Start Timer",
+      "description": "Start the timer on a task or one of its subtasks"
+    },
+    {
+      "name": "stop-timer",
+      "title": "Stop Timer",
+      "description": "Stop the running timer"
+    },
+    {
+      "name": "delete-task",
+      "title": "Delete Task",
+      "description": "Delete a task permanently"
+    }
+  ],
+  "ai": {
+    "instructions": "Sunsama is a daily planner: every task lives on a day (YYYY-MM-DD, in the user's local timezone) or in the backlog. Tasks belong to at most one channel (a project or area, like 'Work' or 'Client X'); categories group channels. Planned time and tracked time are in minutes. Every tool that changes a task needs its id, so call get-tasks for the right day first and match the task by title. Only call get-channels when the user names a channel and you need its exact spelling. 'Today', 'tomorrow' and weekday names resolve against the current date. A pasted link (Trello card, GitHub issue, Todoist task, ...) should go in create-task's url, not the title — Sunsama titles the task from the item.",
+    "evals": [
+      {
+        "input": "@sunsama what's on my plate today?",
+        "mocks": {
+          "get-tasks": {
+            "day": "2026-09-10",
+            "tasks": [
+              {
+                "id": "t1",
+                "title": "Write release notes",
+                "completed": false,
+                "plannedMinutes": 45,
+                "trackedMinutes": 0,
+                "channel": "Product",
+                "timerRunning": false,
+                "subtasks": []
+              },
+              {
+                "id": "t2",
+                "title": "Review PR #12",
+                "completed": true,
+                "plannedMinutes": 30,
+                "trackedMinutes": 25,
+                "channel": "Engineering",
+                "timerRunning": false,
+                "subtasks": []
+              }
+            ]
+          }
+        },
+        "expected": [
+          { "callsTool": "get-tasks" },
+          { "includes": "Write release notes" }
+        ]
+      },
+      {
+        "input": "@sunsama add a task to call the dentist tomorrow, 15 minutes",
+        "mocks": {
+          "create-task": {
+            "id": "t3",
+            "title": "Call the dentist"
+          }
+        },
+        "expected": [
+          {
+            "callsTool": {
+              "name": "create-task",
+              "arguments": {
+                "title": { "includes": "dentist" },
+                "timeEstimate": 15
+              }
+            }
+          }
+        ]
+      },
+      {
+        "input": "@sunsama mark 'Write release notes' as done",
+        "mocks": {
+          "get-tasks": {
+            "day": "2026-09-10",
+            "tasks": [
+              {
+                "id": "t1",
+                "title": "Write release notes",
+                "completed": false,
+                "trackedMinutes": 0,
+                "timerRunning": false,
+                "subtasks": []
+              }
+            ]
+          },
+          "complete-task": { "completed": true }
+        },
+        "expected": [
+          { "callsTool": "get-tasks" },
+          {
+            "callsTool": {
+              "name": "complete-task",
+              "arguments": { "taskId": "t1" }
+            }
+          }
+        ]
+      },
+      {
+        "input": "@sunsama start the timer on Write release notes",
+        "mocks": {
+          "get-tasks": {
+            "day": "2026-09-10",
+            "tasks": [
+              {
+                "id": "t1",
+                "title": "Write release notes",
+                "completed": false,
+                "trackedMinutes": 0,
+                "timerRunning": false,
+                "subtasks": []
+              }
+            ]
+          },
+          "start-timer": { "running": true }
+        },
+        "expected": [
+          {
+            "callsTool": {
+              "name": "start-timer",
+              "arguments": { "taskId": "t1" }
+            }
+          }
+        ]
+      },
+      {
+        "input": "@sunsama push Write release notes to Monday",
+        "mocks": {
+          "get-tasks": {
+            "day": "2026-09-10",
+            "tasks": [
+              {
+                "id": "t1",
+                "title": "Write release notes",
+                "completed": false,
+                "trackedMinutes": 0,
+                "timerRunning": false,
+                "subtasks": []
+              }
+            ]
+          },
+          "reschedule-task": { "movedTo": "2026-09-14" }
+        },
+        "expected": [
+          {
+            "callsTool": {
+              "name": "reschedule-task",
+              "arguments": { "taskId": "t1" }
+            }
+          }
+        ]
+      }
+    ]
+  },
   "preferences": [
     {
       "name": "workspaceUrl",

--- a/extensions/sunsama/src/add-task.tsx
+++ b/extensions/sunsama/src/add-task.tsx
@@ -16,7 +16,9 @@ import {
   getDefaultChannel,
   getRecentChannel,
   rememberLastChannel,
+  setChannel,
 } from "./lib/sunsama-client";
+import { warmUp } from "./lib/mcp";
 import { toDayString } from "./lib/date";
 import { reportError } from "./lib/errors";
 import { parseDuration, parseSubtasks } from "./lib/time";
@@ -46,6 +48,11 @@ export default function AddTask() {
     getPreferenceValues<Preferences.AddTask>();
   const rememberFor = Number(rememberChannelMinutes) || 0;
   const channels = useChannels();
+
+  // Nothing else in this form touches the server — the stored channel list is
+  // read from disk — so without this the MCP handshake happens on submit, in
+  // front of the user. Opening it on mount overlaps it with the typing.
+  useEffect(warmUp, []);
 
   // The channel to start on: the one just used, while it's still recent, and
   // otherwise the saved default. Resolved together so the field is only set
@@ -117,28 +124,54 @@ export default function AddTask() {
       style: Toast.Style.Animated,
       title: "Creating task…",
     });
+    // A link may carry its own channel automation server-side (e.g. a Trello
+    // board mapped to a channel). Only worth deferring to it when the channel
+    // field is still whatever it auto-filled to — an explicit pick always wins.
+    const channelUntouched = values.channel === (startingChannel ?? "");
+    const deferToAutomation = !!url && channelUntouched;
+
     try {
-      const createdTitle = await createTask({
+      const created = await createTask({
         title,
         day: toDayString(values.day ?? new Date()),
         url,
         notes: values.notes.trim() || undefined,
-        channel: values.channel || undefined,
+        channel: deferToAutomation ? undefined : values.channel || undefined,
         position: values.position === "bottom" ? "bottom" : "top",
         timeEstimate,
         subtasks: parseSubtasks(values.subtasks),
       });
+
+      // No automation fired — fall back to the default/recent channel so a
+      // link without one still lands where every other task would.
+      let fellBackToDefault = false;
+      if (
+        deferToAutomation &&
+        !created.channel &&
+        created.id &&
+        values.channel
+      ) {
+        await setChannel(created.id, values.channel);
+        fellBackToDefault = true;
+      }
+
       // Recorded after the task lands, so the next one can start here while
-      // it's still recent.
-      await rememberLastChannel(values.channel);
+      // it's still recent — the picked channel, whichever channel automation
+      // assigned, or the default just applied as a fallback.
+      await rememberLastChannel(created.channel || values.channel || "");
       await toast.hide();
       // Close and go back to root. Without an explicit type this follows the
       // user's "Pop to Root Search" preference, which can leave the filled-in
       // form on the stack for the next launch.
-      await showHUD(`Added task: ${createdTitle}`, {
-        popToRootType: PopToRootType.Immediate,
-        clearRootSearch: true,
-      });
+      await showHUD(
+        created.channel && !fellBackToDefault
+          ? `Added task: ${created.title} → ${created.channel}`
+          : `Added task: ${created.title}`,
+        {
+          popToRootType: PopToRootType.Immediate,
+          clearRootSearch: true,
+        },
+      );
     } catch (error) {
       toast.hide();
       await reportError(error, "Failed to create task");

--- a/extensions/sunsama/src/add-task.tsx
+++ b/extensions/sunsama/src/add-task.tsx
@@ -19,6 +19,7 @@ import {
   setChannel,
 } from "./lib/sunsama-client";
 import { warmUp } from "./lib/mcp";
+import { ChannelPickState, nextChannelPickState } from "./lib/channels";
 import { toDayString } from "./lib/date";
 import { reportError } from "./lib/errors";
 import { parseDuration, parseSubtasks } from "./lib/time";
@@ -90,10 +91,21 @@ export default function AddTask() {
     },
   });
 
-  // On the very first run (no cache yet), apply it once it resolves.
+  // Whether the channel was picked by the user or filled in for them. Recorded
+  // as it happens rather than compared at submit, so switching away and back
+  // still counts as a deliberate choice.
+  const [channelPick, setChannelPick] = useState<ChannelPickState>({
+    autoFilled: null,
+    touched: false,
+  });
+
+  // On the very first run (no cache yet), apply it once it resolves — but never
+  // over a channel the user picked while it was still resolving.
   useEffect(() => {
-    if (startingChannel) setValue("channel", startingChannel);
-  }, [startingChannel, setValue]);
+    if (!startingChannel || channelPick.touched) return;
+    setChannelPick((pick) => ({ ...pick, autoFilled: startingChannel }));
+    setValue("channel", startingChannel);
+  }, [startingChannel, channelPick.touched, setValue]);
 
   async function submit(values: FormValues) {
     const entry = values.task.trim();
@@ -127,8 +139,7 @@ export default function AddTask() {
     // A link may carry its own channel automation server-side (e.g. a Trello
     // board mapped to a channel). Only worth deferring to it when the channel
     // field is still whatever it auto-filled to — an explicit pick always wins.
-    const channelUntouched = values.channel === (startingChannel ?? "");
-    const deferToAutomation = !!url && channelUntouched;
+    const deferToAutomation = !!url && !channelPick.touched;
 
     try {
       const created = await createTask({
@@ -224,7 +235,14 @@ export default function AddTask() {
         type={Form.DatePicker.Type.Date}
       />
       <Form.Separator />
-      <ChannelDropdown {...itemProps.channel} channels={channels} />
+      <ChannelDropdown
+        {...itemProps.channel}
+        channels={channels}
+        onChange={(value) => {
+          setChannelPick((pick) => nextChannelPickState(pick, value));
+          itemProps.channel.onChange?.(value);
+        }}
+      />
       <Form.Dropdown {...itemProps.position} title="Position">
         <Form.Dropdown.Item
           value="top"

--- a/extensions/sunsama/src/add-task.tsx
+++ b/extensions/sunsama/src/add-task.tsx
@@ -144,29 +144,41 @@ export default function AddTask() {
 
       // No automation fired — fall back to the default/recent channel so a
       // link without one still lands where every other task would.
-      let fellBackToDefault = false;
+      let channelFailed = false;
       if (
         deferToAutomation &&
         !created.channel &&
         created.id &&
         values.channel
       ) {
-        await setChannel(created.id, values.channel);
-        fellBackToDefault = true;
+        // The task exists by now, so a failure here is not a failed creation.
+        // Reporting it as one would send the user back to a filled-in form and
+        // invite a retry that creates a duplicate — say what actually went
+        // wrong instead and leave the task standing without a channel.
+        try {
+          await setChannel(created.id, values.channel);
+        } catch {
+          channelFailed = true;
+        }
       }
 
       // Recorded after the task lands, so the next one can start here while
       // it's still recent — the picked channel, whichever channel automation
-      // assigned, or the default just applied as a fallback.
-      await rememberLastChannel(created.channel || values.channel || "");
+      // assigned, or the default just applied as a fallback. Nothing to record
+      // when the fallback didn't take.
+      await rememberLastChannel(
+        channelFailed ? "" : created.channel || values.channel || "",
+      );
       await toast.hide();
       // Close and go back to root. Without an explicit type this follows the
       // user's "Pop to Root Search" preference, which can leave the filled-in
       // form on the stack for the next launch.
       await showHUD(
-        created.channel && !fellBackToDefault
-          ? `Added task: ${created.title} → ${created.channel}`
-          : `Added task: ${created.title}`,
+        channelFailed
+          ? `Added task: ${created.title} — couldn't set the channel`
+          : created.channel
+            ? `Added task: ${created.title} → ${created.channel}`
+            : `Added task: ${created.title}`,
         {
           popToRootType: PopToRootType.Immediate,
           clearRootSearch: true,

--- a/extensions/sunsama/src/lib/channels.test.ts
+++ b/extensions/sunsama/src/lib/channels.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { matchesChannel, matchesNoChannel } from "./channels";
+import {
+  matchesChannel,
+  matchesNoChannel,
+  nextChannelPickState,
+} from "./channels";
 import { Channel } from "./types";
 
 const channel = (name: string, categoryName?: string): Channel => ({
@@ -59,5 +63,33 @@ describe("matchesNoChannel", () => {
 
   it("stops matching once the query names something else", () => {
     expect(matchesNoChannel("bark")).toBe(false);
+  });
+});
+
+describe("nextChannelPickState", () => {
+  // The picks the field reports, in order, starting from the channel the form
+  // filled in for the user.
+  const pick = (autoFilled: string | null, ...picks: string[]) =>
+    picks.reduce(nextChannelPickState, { autoFilled, touched: false });
+
+  it("doesn't count the channel the form filled in", () => {
+    expect(pick("Work", "Work").touched).toBe(false);
+  });
+
+  it("counts a channel the user picked", () => {
+    expect(pick("Work", "Work", "The Lab").touched).toBe(true);
+    expect(pick(null, "The Lab").touched).toBe(true);
+  });
+
+  it("counts switching away and back to the channel filled in", () => {
+    expect(pick("Work", "Work", "The Lab", "Work").touched).toBe(true);
+  });
+
+  it("counts a pick made before the channel was filled in", () => {
+    expect(pick(null, "The Lab", "Work").touched).toBe(true);
+  });
+
+  it("counts clearing the channel", () => {
+    expect(pick("Work", "Work", "").touched).toBe(true);
   });
 });

--- a/extensions/sunsama/src/lib/channels.ts
+++ b/extensions/sunsama/src/lib/channels.ts
@@ -25,3 +25,41 @@ export function matchesNoChannel(query: string): boolean {
   const parts = query.toLowerCase().split(/\s+/).filter(Boolean);
   return parts.every((part) => "no channel".includes(part));
 }
+
+/**
+ * How a channel field stands relative to what the form filled in for the user.
+ *
+ * `autoFilled` is the channel that was applied programmatically — the recent or
+ * default one — and is still waiting to be seen come back through `onChange`,
+ * which Raycast also fires for a value set in code. `touched` is whether the
+ * user has picked a channel themselves.
+ */
+export interface ChannelPickState {
+  autoFilled: string | null;
+  touched: boolean;
+}
+
+/**
+ * Fold one channel selection into the pick state.
+ *
+ * A linked task can have its channel chosen server-side by an automation, and
+ * that should only happen while the user has left the field alone. Deciding
+ * that by comparing the field to the auto-filled channel at submit time gets it
+ * wrong when the user switches away and back: the values match again, but the
+ * choice was still deliberate. So the pick is recorded as it happens and never
+ * unrecorded.
+ *
+ * The one selection that doesn't count is the echo of the channel just applied
+ * in code, which is consumed the first time it arrives.
+ *
+ * @param  state The state so far.
+ * @param  pick  The channel name now selected ("" for no channel).
+ * @return The updated state.
+ */
+export function nextChannelPickState(
+  state: ChannelPickState,
+  pick: string,
+): ChannelPickState {
+  if (pick === state.autoFilled) return { ...state, autoFilled: null };
+  return { ...state, touched: true };
+}

--- a/extensions/sunsama/src/lib/mcp.ts
+++ b/extensions/sunsama/src/lib/mcp.ts
@@ -208,6 +208,19 @@ async function getClient(): Promise<Client> {
   return clientPromise;
 }
 
+/**
+ * Open the connection ahead of the first tool call.
+ *
+ * Connecting means an MCP initialize round trip, plus a token refresh when the
+ * stored one has expired — paid by whichever call goes first. A command that
+ * sits idle while the user fills in a form pays it on submit, where it's felt;
+ * calling this on mount moves it to where it isn't. Failures are swallowed:
+ * `getClient` drops the cached promise, so the real call retries and reports.
+ */
+export function warmUp(): void {
+  void getClient().catch(() => undefined);
+}
+
 function mapError(error: unknown): never {
   const text = error instanceof Error ? error.message : String(error);
   if (error instanceof UnauthorizedError || /401|unauthorized/i.test(text)) {

--- a/extensions/sunsama/src/lib/sunsama-client.ts
+++ b/extensions/sunsama/src/lib/sunsama-client.ts
@@ -408,9 +408,18 @@ export async function getTask(taskId: string): Promise<Task | null> {
   return t ? projectTask(t) : null;
 }
 
-/** Creates the task and returns its final title, which the server sets from a
- * linked item when no title was given. */
-export async function createTask(input: CreateTaskInput): Promise<string> {
+export interface CreatedTask {
+  id?: string;
+  title: string;
+  /** Set when the server assigned a channel we didn't pass — the linked
+   * item's board already maps to one, and channel prediction filled it in. */
+  channel?: string;
+}
+
+/** Creates the task and returns its final title (the server sets one from a
+ * linked item when no title was given) and, for a linked task created with no
+ * channel, whichever channel Sunsama's own prediction assigned. */
+export async function createTask(input: CreateTaskInput): Promise<CreatedTask> {
   const args: Record<string, unknown> = {
     day: input.day,
     position: input.position ?? "top",
@@ -426,18 +435,23 @@ export async function createTask(input: CreateTaskInput): Promise<string> {
     args.subtasks = input.subtasks.map((s) => ({ title: s.title }));
 
   const text = await callTool("create_task", args);
-  // Best-effort: pull the created title out of the JSON reply for the HUD.
+  // Best-effort: pull the created title/channel out of the JSON reply.
   try {
     const parsed = JSON.parse(text) as {
-      task?: { title?: string };
+      task?: { _id?: string; title?: string; channel?: string };
+      _id?: string;
       title?: string;
+      channel?: string;
     };
+    const id = parsed.task?._id ?? parsed._id;
     const title = parsed.task?.title ?? parsed.title;
-    if (title) return title;
+    const channel = parsed.task?.channel ?? parsed.channel;
+    if (title)
+      return { id, title, channel: input.channel ? undefined : channel };
   } catch {
     // non-JSON reply — fall through
   }
-  return input.title?.trim() || input.url || "New task";
+  return { title: input.title?.trim() || input.url || "New task" };
 }
 
 export async function completeTask(taskId: string): Promise<void> {

--- a/extensions/sunsama/src/tools/add-subtasks.ts
+++ b/extensions/sunsama/src/tools/add-subtasks.ts
@@ -1,0 +1,20 @@
+import { addSubtasks } from "../lib/sunsama-client";
+
+type Input = {
+  /** The task id, from get-tasks. */
+  taskId: string;
+  /** Subtask titles to add, in order. */
+  subtasks: string[];
+};
+
+/** Add subtasks to an existing task. */
+export default async function tool(input: Input) {
+  const titles = input.subtasks.map((s) => s.trim()).filter(Boolean);
+  if (titles.length === 0) throw new Error("Give at least one subtask.");
+
+  await addSubtasks(
+    input.taskId,
+    titles.map((title) => ({ title })),
+  );
+  return { added: titles.length };
+}

--- a/extensions/sunsama/src/tools/complete-task.ts
+++ b/extensions/sunsama/src/tools/complete-task.ts
@@ -1,0 +1,21 @@
+import { Tool } from "@raycast/api";
+import { completeTask, getTask } from "../lib/sunsama-client";
+
+type Input = {
+  /** The task id, from get-tasks. */
+  taskId: string;
+};
+
+/** Mark a task as completed today. */
+export default async function tool(input: Input) {
+  await completeTask(input.taskId);
+  return { completed: true };
+}
+
+export const confirmation: Tool.Confirmation<Input> = async (input) => {
+  const task = await getTask(input.taskId);
+  return {
+    message: "Mark this task as completed?",
+    info: [{ name: "Task", value: task?.title ?? input.taskId }],
+  };
+};

--- a/extensions/sunsama/src/tools/create-task.ts
+++ b/extensions/sunsama/src/tools/create-task.ts
@@ -1,0 +1,63 @@
+import { createTask, rememberLastChannel } from "../lib/sunsama-client";
+import { todayString } from "../lib/date";
+
+type Input = {
+  /**
+   * The task title. Optional when `url` is given — Sunsama then titles the
+   * task from the linked item.
+   */
+  title?: string;
+  /**
+   * The day to add it to, as YYYY-MM-DD in the user's local timezone. Leave
+   * empty for today.
+   */
+  day?: string;
+  /** Notes for the task, in Markdown. */
+  notes?: string;
+  /**
+   * The channel name to file it under. Use the exact name from get-channels.
+   * Leave empty to let Sunsama pick (it does for linked items).
+   */
+  channel?: string;
+  /** Planned time in whole minutes. */
+  timeEstimate?: number;
+  /** Subtask titles, in order. */
+  subtasks?: string[];
+  /**
+   * A link to attach natively — Trello, GitHub, Todoist, ClickUp, Jira,
+   * Linear, Asana, Notion, Gmail, Slack, or any web page.
+   */
+  url?: string;
+  /** Where the task lands in the day. Defaults to the top. */
+  position?: "top" | "bottom";
+};
+
+/**
+ * Add a task to Sunsama.
+ *
+ * Give a title, a link, or both. A link becomes a proper linked task with the
+ * provider's icon and a click-through to the original.
+ */
+export default async function tool(input: Input) {
+  if (!input.title?.trim() && !input.url?.trim()) {
+    throw new Error("Give a title or a url.");
+  }
+
+  const created = await createTask({
+    title: input.title,
+    day: input.day?.trim() || todayString(),
+    notes: input.notes,
+    channel: input.channel,
+    timeEstimate: input.timeEstimate,
+    subtasks: input.subtasks?.map((title) => ({ title })),
+    url: input.url,
+    position: input.position,
+  });
+
+  await rememberLastChannel(input.channel || created.channel || "");
+  return {
+    id: created.id,
+    title: created.title,
+    channel: input.channel || created.channel,
+  };
+}

--- a/extensions/sunsama/src/tools/delete-task.ts
+++ b/extensions/sunsama/src/tools/delete-task.ts
@@ -1,0 +1,22 @@
+import { Action, Tool } from "@raycast/api";
+import { deleteTask, getTask } from "../lib/sunsama-client";
+
+type Input = {
+  /** The task id, from get-tasks. */
+  taskId: string;
+};
+
+/** Delete a task. This cannot be undone. */
+export default async function tool(input: Input) {
+  await deleteTask(input.taskId);
+  return { deleted: true };
+}
+
+export const confirmation: Tool.Confirmation<Input> = async (input) => {
+  const task = await getTask(input.taskId);
+  return {
+    style: Action.Style.Destructive,
+    message: "Delete this task? This cannot be undone.",
+    info: [{ name: "Task", value: task?.title ?? input.taskId }],
+  };
+};

--- a/extensions/sunsama/src/tools/edit-task.ts
+++ b/extensions/sunsama/src/tools/edit-task.ts
@@ -1,0 +1,73 @@
+import { Tool } from "@raycast/api";
+import {
+  editNotes,
+  editTitle,
+  getTask,
+  setChannel,
+  setPlannedTime,
+} from "../lib/sunsama-client";
+
+type Input = {
+  /** The task id, from get-tasks. */
+  taskId: string;
+  /** A new title. */
+  title?: string;
+  /** New notes in Markdown. Replaces the existing notes entirely. */
+  notes?: string;
+  /**
+   * New planned time in whole minutes. Fails if any subtask has its own
+   * planned time — Sunsama derives the task total from those.
+   */
+  timeEstimate?: number;
+  /** The channel name to move it to. Use the exact name from get-channels. */
+  channel?: string;
+};
+
+/**
+ * Edit a task's title, notes, planned time, or channel. Only the fields given
+ * are changed.
+ */
+export default async function tool(input: Input) {
+  const { taskId } = input;
+  const changed: string[] = [];
+
+  if (input.title?.trim()) {
+    await editTitle(taskId, input.title.trim());
+    changed.push("title");
+  }
+  if (typeof input.notes === "string") {
+    await editNotes(taskId, input.notes);
+    changed.push("notes");
+  }
+  if (typeof input.timeEstimate === "number") {
+    await setPlannedTime(taskId, input.timeEstimate);
+    changed.push("timeEstimate");
+  }
+  if (input.channel?.trim()) {
+    await setChannel(taskId, input.channel.trim());
+    changed.push("channel");
+  }
+
+  if (changed.length === 0) throw new Error("Nothing to change.");
+  return { changed };
+}
+
+export const confirmation: Tool.Confirmation<Input> = async (input) => {
+  const task = await getTask(input.taskId);
+  return {
+    message: "Apply these changes?",
+    info: [
+      { name: "Task", value: task?.title ?? input.taskId },
+      { name: "Title", value: input.title },
+      { name: "Notes", value: input.notes },
+      {
+        name: "Planned time",
+        value:
+          typeof input.timeEstimate === "number"
+            ? `${input.timeEstimate} minutes`
+            : undefined,
+      },
+      { name: "Channel", value: input.channel },
+    ],
+  };
+};

--- a/extensions/sunsama/src/tools/edit-task.ts
+++ b/extensions/sunsama/src/tools/edit-task.ts
@@ -3,8 +3,9 @@ import {
   editNotes,
   editTitle,
   getTask,
+  plannedTimeSteps,
   setChannel,
-  setPlannedTime,
+  subtasksWithPlannedTime,
 } from "../lib/sunsama-client";
 
 type Input = {
@@ -15,8 +16,8 @@ type Input = {
   /** New notes in Markdown. Replaces the existing notes entirely. */
   notes?: string;
   /**
-   * New planned time in whole minutes. Fails if any subtask has its own
-   * planned time — Sunsama derives the task total from those.
+   * New planned time in whole minutes. Subtask planned times are cleared
+   * first, since Sunsama derives the task total from them.
    */
   timeEstimate?: number;
   /** The channel name to move it to. Use the exact name from get-channels. */
@@ -26,30 +27,63 @@ type Input = {
 /**
  * Edit a task's title, notes, planned time, or channel. Only the fields given
  * are changed.
+ *
+ * Each field is its own request to Sunsama, so one can fail after another has
+ * already landed. Every field is attempted, and the result says which ones
+ * changed and which failed, so a retry can be limited to what didn't take.
  */
 export default async function tool(input: Input) {
   const { taskId } = input;
-  const changed: string[] = [];
+  const edits: Array<[string, () => Promise<void>]> = [];
 
   if (input.title?.trim()) {
-    await editTitle(taskId, input.title.trim());
-    changed.push("title");
+    const title = input.title.trim();
+    edits.push(["title", () => editTitle(taskId, title)]);
   }
   if (typeof input.notes === "string") {
-    await editNotes(taskId, input.notes);
-    changed.push("notes");
+    const notes = input.notes;
+    edits.push(["notes", () => editNotes(taskId, notes)]);
   }
   if (typeof input.timeEstimate === "number") {
-    await setPlannedTime(taskId, input.timeEstimate);
-    changed.push("timeEstimate");
+    const minutes = input.timeEstimate;
+    // Sunsama derives the task total from subtask estimates and rejects a
+    // task-level one while any exist, so those are cleared first.
+    edits.push([
+      "timeEstimate",
+      async () => {
+        const task = await getTask(taskId);
+        const steps = plannedTimeSteps(
+          taskId,
+          minutes,
+          task ? subtasksWithPlannedTime(task) : [],
+        );
+        for (const step of steps) await step.run();
+      },
+    ]);
   }
   if (input.channel?.trim()) {
-    await setChannel(taskId, input.channel.trim());
-    changed.push("channel");
+    const channel = input.channel.trim();
+    edits.push(["channel", () => setChannel(taskId, channel)]);
   }
 
-  if (changed.length === 0) throw new Error("Nothing to change.");
-  return { changed };
+  if (edits.length === 0) throw new Error("Nothing to change.");
+
+  const changed: string[] = [];
+  const failed: Array<{ field: string; error: string }> = [];
+  for (const [field, run] of edits) {
+    try {
+      await run();
+      changed.push(field);
+    } catch (error) {
+      failed.push({
+        field,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  if (changed.length === 0) throw new Error(failed[0].error);
+  return { changed, failed };
 }
 
 export const confirmation: Tool.Confirmation<Input> = async (input) => {

--- a/extensions/sunsama/src/tools/get-channels.ts
+++ b/extensions/sunsama/src/tools/get-channels.ts
@@ -1,0 +1,16 @@
+import { loadChannels } from "../lib/sunsama-client";
+
+/**
+ * List every channel (and category) in the user's Sunsama workspace.
+ *
+ * Use it to find the exact channel name before creating a task in a channel
+ * or moving one. Names are what the other tools take, not ids.
+ */
+export default async function tool() {
+  const channels = await loadChannels();
+  return channels.map((c) => ({
+    name: c.name,
+    category: c.isCategory ? undefined : (c.categoryName ?? undefined),
+    isCategory: c.isCategory ?? false,
+  }));
+}

--- a/extensions/sunsama/src/tools/get-tasks.ts
+++ b/extensions/sunsama/src/tools/get-tasks.ts
@@ -1,0 +1,52 @@
+import {
+  getActiveTimer,
+  getTasksForDay,
+  withActiveTimer,
+} from "../lib/sunsama-client";
+import { todayString } from "../lib/date";
+
+type Input = {
+  /**
+   * The day to list, as YYYY-MM-DD in the user's local timezone. Leave empty
+   * for today.
+   */
+  day?: string;
+};
+
+/**
+ * List the tasks on a day, in Sunsama's own order.
+ *
+ * Returns each task's id, title, completion state, planned minutes, tracked
+ * minutes, channel, notes (Markdown), linked URL, whether a timer is running,
+ * and its subtasks. Call this first to find the id every other tool needs.
+ */
+export default async function tool(input: Input) {
+  const day = input.day?.trim() || todayString();
+  const [{ tasks }, timer] = await Promise.all([
+    getTasksForDay(day),
+    getActiveTimer().catch(() => null),
+  ]);
+
+  return {
+    day,
+    tasks: withActiveTimer(tasks, timer).map((t) => ({
+      id: t.id,
+      title: t.title,
+      completed: t.completed,
+      plannedMinutes: t.timeEstimate,
+      trackedMinutes: Math.round(t.trackedSeconds / 60),
+      channel: t.channelName,
+      notes: t.notes,
+      url: t.integrationUrl,
+      startTime: t.startTime,
+      timerRunning: t.isRunning,
+      subtasks: t.subtasks.map((s) => ({
+        id: s.id,
+        title: s.title,
+        completed: s.completed,
+        plannedMinutes: s.timeEstimate,
+        timerRunning: s.isRunning,
+      })),
+    })),
+  };
+}

--- a/extensions/sunsama/src/tools/reschedule-task.ts
+++ b/extensions/sunsama/src/tools/reschedule-task.ts
@@ -1,0 +1,29 @@
+import { Tool } from "@raycast/api";
+import { getTask, rescheduleTask } from "../lib/sunsama-client";
+
+type Input = {
+  /** The task id, from get-tasks. */
+  taskId: string;
+  /**
+   * The day to move it to, as YYYY-MM-DD in the user's local timezone. Leave
+   * empty to send it to the backlog instead.
+   */
+  day?: string;
+};
+
+/** Move a task to another day, or to the backlog. */
+export default async function tool(input: Input) {
+  const day = input.day?.trim() || null;
+  await rescheduleTask(input.taskId, day);
+  return { movedTo: day ?? "backlog" };
+}
+
+export const confirmation: Tool.Confirmation<Input> = async (input) => {
+  const task = await getTask(input.taskId);
+  return {
+    message: input.day?.trim()
+      ? `Move this task to ${input.day.trim()}?`
+      : "Move this task to the backlog?",
+    info: [{ name: "Task", value: task?.title ?? input.taskId }],
+  };
+};

--- a/extensions/sunsama/src/tools/start-timer.ts
+++ b/extensions/sunsama/src/tools/start-timer.ts
@@ -1,0 +1,17 @@
+import { startTimer } from "../lib/sunsama-client";
+
+type Input = {
+  /** The task id, from get-tasks. */
+  taskId: string;
+  /** A subtask id, from get-tasks, to time that subtask instead of the task. */
+  subtaskId?: string;
+};
+
+/**
+ * Start the timer on a task or one of its subtasks. Sunsama runs one timer at
+ * a time, so this stops whatever else was running.
+ */
+export default async function tool(input: Input) {
+  await startTimer(input.taskId, input.subtaskId);
+  return { running: true };
+}

--- a/extensions/sunsama/src/tools/stop-timer.ts
+++ b/extensions/sunsama/src/tools/stop-timer.ts
@@ -10,17 +10,21 @@ type Input = {
 
 /** Stop the running timer. */
 export default async function tool(input: Input) {
-  let taskId = input.taskId?.trim();
-  let subtaskId: string | undefined;
+  const taskId = input.taskId?.trim();
 
-  // Whatever is running is the thing to stop — including a subtask timer.
+  // Sunsama runs one timer at a time, so the active one is the only thing
+  // that can be stopped — including when it's on a subtask.
   const active = await getActiveTimer();
-  if (active && (!taskId || active.taskId === taskId)) {
-    taskId = active.taskId;
-    subtaskId = active.subtaskId;
+  const running = active?.taskId;
+  if (!running) return { stopped: false, reason: "No timer is running." };
+  if (taskId && running !== taskId) {
+    return {
+      stopped: false,
+      reason: "The running timer is on a different task.",
+      runningTaskId: running,
+    };
   }
-  if (!taskId) return { stopped: false, reason: "No timer is running." };
 
-  await stopTimer(taskId, subtaskId);
-  return { stopped: true };
+  await stopTimer(running, active.subtaskId);
+  return { stopped: true, taskId: running };
 }

--- a/extensions/sunsama/src/tools/stop-timer.ts
+++ b/extensions/sunsama/src/tools/stop-timer.ts
@@ -1,0 +1,26 @@
+import { getActiveTimer, stopTimer } from "../lib/sunsama-client";
+
+type Input = {
+  /**
+   * The task id, from get-tasks. Leave empty to stop whatever timer is
+   * running right now.
+   */
+  taskId?: string;
+};
+
+/** Stop the running timer. */
+export default async function tool(input: Input) {
+  let taskId = input.taskId?.trim();
+  let subtaskId: string | undefined;
+
+  // Whatever is running is the thing to stop — including a subtask timer.
+  const active = await getActiveTimer();
+  if (active && (!taskId || active.taskId === taskId)) {
+    taskId = active.taskId;
+    subtaskId = active.subtaskId;
+  }
+  if (!taskId) return { stopped: false, reason: "No timer is running." };
+
+  await stopTimer(taskId, subtaskId);
+  return { stopped: true };
+}


### PR DESCRIPTION
## Description

Update to the Sunsama extension: it is now also an AI Extension.

Mention `@sunsama` in AI Chat to list a day's tasks and channels, add tasks (with notes, a channel, planned time, subtasks, or a pasted link), edit, complete, reschedule and delete tasks, add subtasks, and start or stop timers.

Ten tools under `src/tools`, each a thin wrapper over the existing `sunsama-client` module:

- `get-tasks`, `get-channels` — read-only
- `create-task`, `add-subtasks`, `start-timer`, `stop-timer` — no confirmation
- `edit-task`, `complete-task`, `reschedule-task` — confirmation showing the task title
- `delete-task` — destructive confirmation

`package.json` carries the `tools` manifest, `ai.instructions` (day format, ids come from `get-tasks`, links go in `url`), and five evals. README gets an "Ask Raycast AI" section with example prompts.

## Screencast

Straightforward change to an existing extension; no new commands. Happy to add a screenshot of AI Chat if wanted.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

https://claude.ai/code/session_01GzpC5AFJqM88XD185oLaic
