### PR TITLE
[Everything Search] Select the file when showing it in Explorer

### DIFF
--- a/extensions/everything-search/CHANGELOG.md
+++ b/extensions/everything-search/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Everything Search Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+- Fixed `Show in Explorer` opening the containing folder without selecting the file
+
 ## [Added SDK support for ARM64] - 2026-03-02
 - Added support for the Everything SDK on ARM64 architecture.
 

--- a/extensions/everything-search/CHANGELOG.md
+++ b/extensions/everything-search/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Everything Search Changelog
 
-## [Fix] - {PR_MERGE_DATE}
+## [Fix] - 2026-09-11
 - Fixed `Show in Explorer` opening the containing folder without selecting the file
 
 ## [Added SDK support for ARM64] - 2026-03-02

--- a/extensions/everything-search/package.json
+++ b/extensions/everything-search/package.json
@@ -7,7 +7,8 @@
   "author": "anastasiy_safari",
   "contributors": [
     "laurynas_gailius",
-    "marioparaschiv"
+    "marioparaschiv",
+    "just_me"
   ],
   "pastContributors": [
     "doug_fernando"

--- a/extensions/everything-search/src/services/fileOperations.ts
+++ b/extensions/everything-search/src/services/fileOperations.ts
@@ -82,7 +82,7 @@ export async function showInExplorer(path: string, preferences: Preferences) {
       });
     }
   } else {
-    await open(targetPath);
+    exec(`explorer.exe /select,"${path}"`);
   }
 }
 

--- a/extensions/everything-search/src/services/fileOperations.ts
+++ b/extensions/everything-search/src/services/fileOperations.ts
@@ -82,7 +82,7 @@ export async function showInExplorer(path: string, preferences: Preferences) {
       });
     }
   } else {
-    exec(`explorer.exe /select,"${path}"`);
+    execFile("explorer.exe", [`/select,${path}`]);
   }
 }
 


### PR DESCRIPTION
## Description

Closes #27343.

`Show in Explorer` opened the containing folder but left nothing selected, so in a folder with a lot of files you still had to find the one you just searched for. Everything's own Ctrl+Enter selects it, which is what the report is comparing against.

`showInExplorer` was passing `dirname(path)` to `open`, so Explorer only ever heard about the folder. Passing the path itself to `/select,` opens the same folder with the item highlighted, and it works for a folder as well as a file.

Two details worth calling out:

The path has to be quoted. Explorer treats a comma as an argument separator, so with an unquoted path a file named `report, final.txt` makes it stop reading partway through the name and fall back to opening a default folder. I hit this while testing and it is why this builds the command line rather than passing an argument array.

The result is not awaited. `explorer.exe` exits with code 1 even when it succeeds, so awaiting it only produces a false failure. `runAsAdministrator` just above already fires `execAsync` the same way.

I left the `Custom File Explorer Command` branch alone. Its preference description tells people `%s` is a directory, so handing it a file path would break existing configurations.

## Screencast

The before and after are the two screenshots in #27343.

Tested on Windows 11 with three cases: a plain filename, a filename containing a comma, and a filename containing spaces. The plain one worked unquoted, the comma one only worked once quoted, and the quoted form handles all three. `ray lint` and `ray build -e dev` pass.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
