### PR TITLE
[Kill Process] Make app grouping work on Windows

### DIFF
--- a/extensions/kill-process/CHANGELOG.md
+++ b/extensions/kill-process/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Kill Process Changelog
 
+## [Fix] - {PR_MERGE_DATE}
+
+- App grouping now works on Windows, where it groups processes by executable path (fixes #26386)
+- Killing a grouped app on Windows now terminates every process in the group rather than only the main process and its children
+
 ## [Improvements] - 2026-06-25
 
 - App grouping is now enabled by default and groups processes by `.app` bundle path for more accurate CPU and memory totals (fixes #25095)

--- a/extensions/kill-process/package.json
+++ b/extensions/kill-process/package.json
@@ -15,7 +15,8 @@
     "dead_hikikomori",
     "mateus_badalotti",
     "jomifepe",
-    "0xdhrv"
+    "0xdhrv",
+    "just_me"
   ],
   "platforms": [
     "macOS",

--- a/extensions/kill-process/src/index.tsx
+++ b/extensions/kill-process/src/index.tsx
@@ -28,7 +28,7 @@ import {
   fetchRunningProcesses,
   restartProcess as restartSelectedProcess,
   terminateProcess,
-  terminateProcessTree,
+  terminateProcessGroup,
   terminateProcessesByName,
 } from "./utils/process";
 
@@ -242,7 +242,7 @@ export default function ProcessList() {
 
     try {
       if (process.type === "aggregatedApp") {
-        await terminateProcessTree(process.id, force);
+        await terminateProcessGroup(process, force);
       } else {
         await terminateProcess(process.id, force);
       }

--- a/extensions/kill-process/src/utils/platform.ts
+++ b/extensions/kill-process/src/utils/platform.ts
@@ -31,17 +31,20 @@ function escapePowerShellSingleQuotedString(value: string): string {
 
 /**
  * Windows PowerShell script to quickly list all processes
- * Returns: pid, name, cpu (placeholder 0), mem (KB), path
+ * Returns: pid, ppid, name, cpu (placeholder 0), mem (KB), path
  * Note: CPU is set to 0 here; actual CPU usage comes from getProcessPerformanceCommand()
+ * Win32_Process is used rather than Get-Process because it reports ParentProcessId,
+ * which app grouping needs to find the process that owns a group.
  */
 const WINDOWS_PROCESS_LIST_SCRIPT = `
-$result = Get-Process | Where-Object { $_.Id -ne 0 } | ForEach-Object {
+$result = Get-CimInstance -ClassName Win32_Process | Where-Object { $_.ProcessId -ne 0 } | ForEach-Object {
   [PSCustomObject]@{
-    pid = $_.Id
-    name = $_.ProcessName
+    pid = $_.ProcessId
+    ppid = $_.ParentProcessId
+    name = [System.IO.Path]::GetFileNameWithoutExtension($_.Name)
     cpu = 0
-    mem = [math]::Round($_.WorkingSet64 / 1KB, 0)
-    path = if ($_.Path) { $_.Path } else { '' }
+    mem = [math]::Round($_.WorkingSetSize / 1KB, 0)
+    path = if ($_.ExecutablePath) { $_.ExecutablePath } else { '' }
   }
 }
 $result | ConvertTo-Json -Compress
@@ -120,6 +123,15 @@ export function getKillCommand(pid: number, force = false): string {
     return force ? `taskkill /F /PID ${pid}` : `taskkill /PID ${pid}`;
   }
   return force ? `zsh -c 'sudo kill -9 ${pid}'` : `kill -9 ${pid}`;
+}
+
+/**
+ * Windows only. Grouped processes are siblings rather than a tree, so each one
+ * needs naming: taskkill /T on the group's main process leaves the rest running.
+ */
+export function getKillGroupCommand(pids: number[], force = false): string {
+  const targets = pids.map((pid) => `/PID ${pid}`).join(" ");
+  return force ? `taskkill /F /T ${targets}` : `taskkill /T ${targets}`;
 }
 
 export function getKillTreeCommand(pid: number, force = false): string {
@@ -280,14 +292,16 @@ export function parseWindowsProcesses(output: string): Partial<Process>[] {
     const data = JSON.parse(output);
     const processes = Array.isArray(data) ? data : [data];
 
-    return processes.map((proc: { pid: number; name: string; cpu: number; mem: number; path: string }) => ({
-      id: proc.pid,
-      pid: 0,
-      cpu: proc.cpu,
-      mem: proc.mem,
-      path: proc.path || "",
-      processName: proc.name || "",
-    }));
+    return processes.map(
+      (proc: { pid: number; ppid: number; name: string; cpu: number; mem: number; path: string }) => ({
+        id: proc.pid,
+        pid: proc.ppid ?? 0,
+        cpu: proc.cpu,
+        mem: proc.mem,
+        path: (proc.path || "").replace(/^\\\\\?\\/, ""),
+        processName: proc.name || "",
+      }),
+    );
   } catch {
     console.error("Failed to parse Windows process output");
     return [];

--- a/extensions/kill-process/src/utils/platform.ts
+++ b/extensions/kill-process/src/utils/platform.ts
@@ -285,6 +285,15 @@ export function parseProcessLine(line: string): Partial<Process> | null {
 }
 
 /**
+ * Win32_Process reports some paths in extended-length form. The UNC prefix has to be
+ * turned back into a leading double backslash rather than stripped, or the path stops
+ * pointing anywhere and Restart kills a process it cannot relaunch.
+ */
+export function normalizeWindowsPath(path: string): string {
+  return path.replace(/^\\\\\?\\UNC\\/i, "\\\\").replace(/^\\\\\?\\(?=[A-Za-z]:\\)/, "");
+}
+
+/**
  * Parse Windows process list JSON output
  */
 export function parseWindowsProcesses(output: string): Partial<Process>[] {
@@ -298,7 +307,7 @@ export function parseWindowsProcesses(output: string): Partial<Process>[] {
         pid: proc.ppid ?? 0,
         cpu: proc.cpu,
         mem: proc.mem,
-        path: (proc.path || "").replace(/^\\\\\?\\/, ""),
+        path: normalizeWindowsPath(proc.path || ""),
         processName: proc.name || "",
       }),
     );

--- a/extensions/kill-process/src/utils/process-grouping.ts
+++ b/extensions/kill-process/src/utils/process-grouping.ts
@@ -2,10 +2,43 @@ import { Process } from "../types";
 import { isWindows } from "./platform";
 
 function getOuterAppBundlePath(path: string): string | undefined {
-  if (isWindows) {
-    return path ? path.toLowerCase() : undefined;
-  }
   return path.match(/^(.+?\.app)(?:\/|$)/)?.[1];
+}
+
+/**
+ * Windows has no app bundle to group by, and the executable alone is not enough:
+ * unrelated node.exe or cmd.exe instances would merge into one entry. A group is
+ * a process plus the descendants running the same executable, so the key is the
+ * topmost ancestor still running it.
+ */
+export function createWindowsGroupKeyResolver(processes: Process[]): (process: Process) => string | undefined {
+  const processesById = new Map(processes.map((process) => [process.id, process]));
+
+  return (process) => {
+    if (!process.path) {
+      return undefined;
+    }
+
+    const executable = process.path.toLowerCase();
+    const visited = new Set([process.id]);
+    let root = process;
+
+    for (;;) {
+      const parent = processesById.get(root.pid);
+      if (!parent || visited.has(parent.id) || parent.path.toLowerCase() !== executable) {
+        return `${executable}#${root.id}`;
+      }
+
+      visited.add(parent.id);
+      root = parent;
+    }
+  };
+}
+
+function createGroupKeyResolver(processes: Process[]): (process: Process) => string | undefined {
+  const resolveWindowsGroupKey = createWindowsGroupKeyResolver(processes);
+
+  return (process) => getOuterAppBundlePath(process.path) ?? (isWindows ? resolveWindowsGroupKey(process) : undefined);
 }
 
 function getAppNameFromBundlePath(bundlePath: string, processes: Process[]): string {
@@ -45,9 +78,10 @@ function aggregateAppProcesses(bundlePath: string, processes: Process[]): Proces
 export function groupRelatedProcesses(processes: Process[]): Process[] {
   const appGroups = new Map<string, Process[]>();
   const ungroupedProcesses: Process[] = [];
+  const getGroupKey = createGroupKeyResolver(processes);
 
   for (const process of processes) {
-    const bundlePath = getOuterAppBundlePath(process.path);
+    const bundlePath = getGroupKey(process);
     if (!bundlePath) {
       ungroupedProcesses.push(process);
       continue;

--- a/extensions/kill-process/src/utils/process-grouping.ts
+++ b/extensions/kill-process/src/utils/process-grouping.ts
@@ -1,24 +1,31 @@
 import { Process } from "../types";
+import { isWindows } from "./platform";
 
 function getOuterAppBundlePath(path: string): string | undefined {
+  if (isWindows) {
+    return path ? path.toLowerCase() : undefined;
+  }
   return path.match(/^(.+?\.app)(?:\/|$)/)?.[1];
 }
 
-function getAppNameFromBundlePath(bundlePath: string): string {
+function getAppNameFromBundlePath(bundlePath: string, processes: Process[]): string {
+  if (isWindows) {
+    return processes[0].processName;
+  }
   return bundlePath.match(/([^/]+)\.app$/)?.[1] ?? bundlePath;
 }
 
 function findMainProcess(processes: Process[], appName: string): Process {
   const processIds = new Set(processes.map((process) => process.id));
-  return (
-    processes.find((process) => process.processName === appName) ??
-    processes.find((process) => !processIds.has(process.pid)) ??
-    processes[0]
-  );
+  const rootProcess = processes.find((process) => !processIds.has(process.pid));
+  if (isWindows) {
+    return rootProcess ?? processes[0];
+  }
+  return processes.find((process) => process.processName === appName) ?? rootProcess ?? processes[0];
 }
 
 function aggregateAppProcesses(bundlePath: string, processes: Process[]): Process {
-  const appName = getAppNameFromBundlePath(bundlePath);
+  const appName = getAppNameFromBundlePath(bundlePath, processes);
   const mainProcess = findMainProcess(processes, appName);
   const childProcesses = processes.filter((process) => process.id !== mainProcess.id);
 

--- a/extensions/kill-process/src/utils/process.ts
+++ b/extensions/kill-process/src/utils/process.ts
@@ -7,6 +7,7 @@ import {
   isWindows,
   getKillAllCommand,
   getKillCommand,
+  getKillGroupCommand,
   getKillTreeCommand,
   getProcessListCommandSpec,
   getProcessPerformanceCommandSpec,
@@ -153,6 +154,16 @@ export async function terminateProcessesByName(processName: string, force = fals
 
 export async function terminateProcessTree(processId: number, force = false): Promise<void> {
   await executeCommand(getKillTreeCommand(processId, force));
+}
+
+export async function terminateProcessGroup(process: Process, force = false): Promise<void> {
+  const childProcessIds = process.childProcessIds ?? [];
+  if (!isWindows || childProcessIds.length === 0) {
+    await terminateProcessTree(process.id, force);
+    return;
+  }
+
+  await executeCommand(getKillGroupCommand([process.id, ...childProcessIds], force));
 }
 
 export async function relaunchProcess(process: Process): Promise<void> {

--- a/extensions/kill-process/test/platform.test.ts
+++ b/extensions/kill-process/test/platform.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "node:assert/strict";
 import { test } from "node:test";
-import { getProcessListCommandSpec, isMac } from "../src/utils/platform";
+import { getProcessListCommandSpec, isMac, parseWindowsProcesses } from "../src/utils/platform";
 
 test("uses direct ps invocation for macOS process listing", () => {
   if (!isMac) {
@@ -11,4 +11,25 @@ test("uses direct ps invocation for macOS process listing", () => {
     executable: "ps",
     args: ["-eo", "pid,ppid,pcpu,rss,comm"],
   });
+});
+
+const windowsProcess = (path: string) =>
+  JSON.stringify([{ pid: 10, ppid: 4, name: "App", cpu: 0, mem: 100, path }]);
+
+test("keeps extended length windows paths pointing at the same file", () => {
+  const cases: [string, string][] = [
+    [String.raw`\\?\C:\Program Files\App\App.exe`, String.raw`C:\Program Files\App\App.exe`],
+    [String.raw`C:\Program Files\App\App.exe`, String.raw`C:\Program Files\App\App.exe`],
+    [String.raw`\\?\UNC\server\share\App.exe`, String.raw`\\server\share\App.exe`],
+    [String.raw`\\server\share\App.exe`, String.raw`\\server\share\App.exe`],
+    ["", ""],
+  ];
+
+  for (const [input, expected] of cases) {
+    assert.equal(parseWindowsProcesses(windowsProcess(input))[0]?.path, expected, input);
+  }
+});
+
+test("keeps the parent process id from the windows process list", () => {
+  assert.equal(parseWindowsProcesses(windowsProcess("C:\\App.exe"))[0]?.pid, 4);
 });

--- a/extensions/kill-process/test/process-grouping.test.ts
+++ b/extensions/kill-process/test/process-grouping.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "node:assert/strict";
 import { test } from "node:test";
-import { groupRelatedProcesses } from "../src/utils/process-grouping";
+import { createWindowsGroupKeyResolver, groupRelatedProcesses } from "../src/utils/process-grouping";
 import { Process } from "../src/types";
 
 const process = (overrides: Partial<Process>): Process => ({
@@ -69,4 +69,43 @@ test("groups app helpers into the main app process", () => {
   assert.deepEqual(notion.childProcessIds, [101, 102]);
 
   assert.ok(grouped.some((item) => item.processName === "ssh"));
+});
+
+const SPOTIFY = String.raw`C:\Users\me\AppData\Roaming\Spotify\Spotify.exe`;
+const NODE = String.raw`C:\Program Files\nodejs\node.exe`;
+
+test("windows groups an app with the helpers it spawned", () => {
+  const processes = [
+    process({ id: 500, pid: 42, path: SPOTIFY, processName: "Spotify" }),
+    process({ id: 501, pid: 500, path: SPOTIFY, processName: "Spotify" }),
+    process({ id: 502, pid: 501, path: SPOTIFY, processName: "Spotify" }),
+  ];
+  const resolve = createWindowsGroupKeyResolver(processes);
+  const keys = processes.map(resolve);
+
+  assert.equal(new Set(keys).size, 1);
+  assert.ok(keys[0]?.endsWith("#500"));
+});
+
+test("windows keeps unrelated instances of the same executable apart", () => {
+  const processes = [
+    process({ id: 600, pid: 10, path: NODE, processName: "node" }),
+    process({ id: 601, pid: 11, path: NODE, processName: "node" }),
+    process({ id: 602, pid: 12, path: NODE, processName: "node" }),
+  ];
+  const resolve = createWindowsGroupKeyResolver(processes);
+
+  assert.equal(new Set(processes.map(resolve)).size, 3);
+});
+
+test("windows ignores processes with no path and survives a parent cycle", () => {
+  const processes = [
+    process({ id: 700, pid: 701, path: NODE, processName: "node" }),
+    process({ id: 701, pid: 700, path: NODE, processName: "node" }),
+    process({ id: 702, pid: 0, path: "", processName: "protected" }),
+  ];
+  const resolve = createWindowsGroupKeyResolver(processes);
+
+  assert.equal(resolve(processes[2]), undefined);
+  assert.ok(resolve(processes[0]));
 });


### PR DESCRIPTION
## Description

Closes #26386.

App Grouping does nothing on Windows. `groupRelatedProcesses` keys off the outer `.app` bundle path, and no Windows path has one, so every process falls straight through to the ungrouped list. Against 434 live processes on my machine, exactly 0 matched that regex, which is why the reporter sees Spotify running as eight separate rows with the toggle on.

Windows now groups by executable path. On the same machine that takes the list from 434 rows to 250, with Spotify's 8 processes collapsing into one row the way the report expects.

Two things came out of testing that changed the shape of this.

**Grouped processes on Windows are usually siblings, not a tree.** Killing a group ran `taskkill /T` on the group's main process, which is right on macOS where a bundle's processes really are descendants of the app. On Windows I measured how many group members that actually reaches:

| Group | Size | Killed by `/T` | Survives |
| --- | --- | --- | --- |
| Spotify | 8 | 8 | 0 |
| Dia | 21 | 21 | 0 |
| DiscordCanary | 6 | 6 | 0 |
| conhost | 29 | 1 | 28 |
| cmd | 25 | 3 | 22 |
| node | 22 | 1 | 21 |
| svchost | 9 | 1 | 8 |

117 of 187 grouped children would have survived, while the UI removed their rows anyway, since it drops `[id, ...childProcessIds]` from the list on success. Apps that spawn their own helpers are fine. Utility processes are siblings under different parents, so no member is an ancestor of the others. The group kill now names every process it is removing, which is exact regardless of the tree shape. I verified `taskkill /F /T /PID a /PID b /PID c` on three sibling processes: all three terminated.

**The Windows process list had no parent ids.** `parseWindowsProcesses` hardcoded `pid: 0`, so `findMainProcess` could not tell which process owned a group and would have picked an arbitrary one. `Get-Process` does not report a parent at all, so the list now comes from `Win32_Process`, which does. Costs are 472ms before and 621ms after on my machine. Building the parent map from a separate `Get-CimInstance` call and joining it to `Get-Process` was much worse at 2318ms, so the single query is the cheaper of the two ways to get this.

Swapping the source needed two adjustments to keep the data identical:

- `Win32_Process` reports `Spotify.exe` where `Get-Process` reports `Spotify`, and that name is fed to `Get-Process -Name` by `getKillAllCommand`, which wants it without the extension. The script strips it. I compared both sources across all 435 processes: 0 name mismatches after stripping.
- `Win32_Process` sometimes returns the `\\?\` extended-length prefix on a path. 4 of 435 differed, all `conhost.exe`. Left alone that would have split conhost into two groups, so the parser normalises it.

One judgement call worth your view: grouping strictly by executable means `conhost.exe` becomes a single row of 29, and `svchost.exe` a single row of 9. It is consistent and the kill is now honest about what it removes, but if you would rather leave system paths ungrouped I am happy to add that.


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
