### PR TITLE
Done Bear: Publish under the Done Bear organisation

### DIFF
--- a/.github/public_raycast_extensions.txt
+++ b/.github/public_raycast_extensions.txt
@@ -78,4 +78,4 @@ buffer
 mutedeck
 nocal
 openqr
-donebear
+done-bear

--- a/.github/public_raycast_extensions.txt
+++ b/.github/public_raycast_extensions.txt
@@ -78,3 +78,4 @@ buffer
 mutedeck
 nocal
 openqr
+donebear

--- a/extensions/done-bear/package.json
+++ b/extensions/done-bear/package.json
@@ -8,6 +8,8 @@
   ],
   "license": "MIT",
   "author": "mblode",
+  "owner": "donebear",
+  "access": "public",
   "scripts": {
     "build": "ray build",
     "dev": "ray develop",


### PR DESCRIPTION
## Description

Moves the Done Bear extension to the `donebear` organisation. The only change is the manifest: `owner: "donebear"` alongside `access: "public"`, so the extension keeps its public store listing but is owned and branded by the organisation rather than by my personal handle. `author` stays `mblode`.

No source, asset, metadata, or dependency changes.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and `ray lint` against the new manifest; the org handle resolves and the extension builds
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

No screencast: this change is manifest-only and does not alter any command's behaviour or appearance.
