### PR TITLE
[Menubar Weather] Fix type error when showing feels-like temperature

### DIFF
--- a/extensions/menubar-weather/CHANGELOG.md
+++ b/extensions/menubar-weather/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Menubar Weather Changelog
 
-## [Fix Type Error When Showing Feels-Like Temperature] - {PR_MERGE_DATE}
+## [Fix Type Error When Showing Feels-Like Temperature] - 2026-09-11
 
 - Fix the menu bar command crashing with a "Cannot read properties of undefined (reading 'apparent_temperature')" type error when the temperature display is set to "Feels like" and the latest weather data is incomplete (e.g. a failed or partial API response); it now falls back to the current temperature and skips unavailable readings instead of failing.
 - Invalid or error responses from the weather API are no longer cached.

--- a/extensions/menubar-weather/CHANGELOG.md
+++ b/extensions/menubar-weather/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Menubar Weather Changelog
 
+## [Fix Type Error When Showing Feels-Like Temperature] - {PR_MERGE_DATE}
+
+- Fix the menu bar command crashing with a "Cannot read properties of undefined (reading 'apparent_temperature')" type error when the temperature display is set to "Feels like" and the latest weather data is incomplete (e.g. a failed or partial API response); it now falls back to the current temperature and skips unavailable readings instead of failing.
+- Invalid or error responses from the weather API are no longer cached.
+
 ## [Update icons] - 2024-09-02
 
 - Update icons for Street and Country

--- a/extensions/menubar-weather/package.json
+++ b/extensions/menubar-weather/package.json
@@ -230,5 +230,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish"
-  }
+  },
+  "platforms": [
+    "macOS"
+  ]
 }

--- a/extensions/menubar-weather/src/menubar-weather.tsx
+++ b/extensions/menubar-weather/src/menubar-weather.tsx
@@ -1,5 +1,5 @@
 import { Cache, Clipboard, MenuBarExtra, open, openCommandPreferences, updateCommandMetadata } from "@raycast/api";
-import { OPEN_METEO } from "./utils/axios-utils";
+import { OPEN_METEO, isValidWeatherResponse } from "./utils/axios-utils";
 import { CacheKey, getDateIcon, getMenuItem, getUnits, isoToDateTime, isoToTime, timeHour } from "./utils/common-utils";
 import { getMenuIcon, getWeatherIcon } from "./utils/icon-utils";
 import {
@@ -26,7 +26,10 @@ export default function MenubarWeather() {
       const cache = new Cache();
       const cacheStr = cache.get(CacheKey.LATEST_WEATHER);
       if (cacheStr) {
-        return JSON.parse(cacheStr) as OpenMeteoWeather;
+        const cachedWeather = JSON.parse(cacheStr) as unknown;
+        if (isValidWeatherResponse(cachedWeather)) {
+          return cachedWeather;
+        }
       }
     }
     return weatherData;

--- a/extensions/menubar-weather/src/menubar-weather.tsx
+++ b/extensions/menubar-weather/src/menubar-weather.tsx
@@ -22,17 +22,24 @@ export default function MenubarWeather() {
   const { data: weatherData, isLoading } = useLatestWeather(kLocation);
 
   const weather: OpenMeteoWeather | undefined = useMemo(() => {
-    if (!weatherData) {
-      const cache = new Cache();
-      const cacheStr = cache.get(CacheKey.LATEST_WEATHER);
-      if (cacheStr) {
+    // useCachedPromise with keepPreviousData can hand back stale data, so
+    // validate it before use and only then fall back to the cached payload.
+    if (isValidWeatherResponse(weatherData)) {
+      return weatherData;
+    }
+    const cache = new Cache();
+    const cacheStr = cache.get(CacheKey.LATEST_WEATHER);
+    if (cacheStr) {
+      try {
         const cachedWeather = JSON.parse(cacheStr) as unknown;
         if (isValidWeatherResponse(cachedWeather)) {
           return cachedWeather;
         }
+      } catch {
+        // Ignore a corrupt cache entry.
       }
     }
-    return weatherData;
+    return undefined;
   }, [weatherData]);
 
   const menuItems: string[] = useMemo(() => {

--- a/extensions/menubar-weather/src/utils/axios-utils.ts
+++ b/extensions/menubar-weather/src/utils/axios-utils.ts
@@ -5,6 +5,33 @@ import { precipitationUnits, tempUnits, windSpeedUnits } from "./weather-utils";
 export const OPEN_METEO = "https://open-meteo.com/en";
 const OPEN_METEO_WEATHER = "https://api.open-meteo.com/v1/forecast";
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasNonEmptyArrays(record: Record<string, unknown>, keys: string[]) {
+  return keys.every((key) => Array.isArray(record[key]) && (record[key] as unknown[]).length > 0);
+}
+
+export function isValidWeatherResponse(data: unknown): data is OpenMeteoWeather {
+  if (!isRecord(data) || data.error === true) return false;
+  const { current_weather, hourly, daily, hourly_units } = data;
+  if (!isRecord(current_weather) || !isRecord(hourly_units) || !isRecord(hourly) || !isRecord(daily)) {
+    return false;
+  }
+  if (
+    typeof current_weather.temperature !== "number" ||
+    typeof current_weather.windspeed !== "number" ||
+    typeof current_weather.winddirection !== "number"
+  ) {
+    return false;
+  }
+  return (
+    hasNonEmptyArrays(hourly, ["apparent_temperature", "relativehumidity_2m", "surface_pressure", "visibility"]) &&
+    hasNonEmptyArrays(daily, ["temperature_2m_min", "temperature_2m_max", "uv_index_max", "sunrise", "sunset"])
+  );
+}
+
 export async function getOpenMeteoWeather(lat: string, lon: string) {
   const axiosResponse = await axios({
     method: "GET",
@@ -24,5 +51,8 @@ export async function getOpenMeteoWeather(lat: string, lon: string) {
       timezone: "auto",
     },
   });
-  return axiosResponse.data as OpenMeteoWeather;
+  if (!isValidWeatherResponse(axiosResponse.data)) {
+    throw new Error("Invalid weather data returned from Open-Meteo");
+  }
+  return axiosResponse.data;
 }

--- a/extensions/menubar-weather/src/utils/axios-utils.ts
+++ b/extensions/menubar-weather/src/utils/axios-utils.ts
@@ -9,27 +9,71 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function hasNonEmptyArrays(record: Record<string, unknown>, keys: string[]) {
-  return keys.every((key) => Array.isArray(record[key]) && (record[key] as unknown[]).length > 0);
+const HOURLY_INDEXED_KEYS = ["apparent_temperature", "relativehumidity_2m", "surface_pressure", "visibility"];
+const DAILY_NUMBER_KEYS = [
+  "weathercode",
+  "windspeed_10m_max",
+  "winddirection_10m_dominant",
+  "temperature_2m_max",
+  "temperature_2m_min",
+  "rain_sum",
+  "uv_index_max",
+];
+const DAILY_STRING_KEYS = ["time", "sunrise", "sunset"];
+const HOURLY_UNIT_KEYS = ["relativehumidity_2m", "surface_pressure", "visibility"];
+
+// The menu command renders 24 hours (timeHour() is 0-23), so hourly arrays
+// must cover the current-hour index and every entry be a number or null.
+function isIndexedNumberArray(value: unknown): value is (number | null)[] {
+  return (
+    Array.isArray(value) && value.length >= 24 && value.every((entry) => typeof entry === "number" || entry === null)
+  );
+}
+
+function isNumberOrNullArray(value: unknown): value is (number | null)[] {
+  return (
+    Array.isArray(value) && value.length > 0 && value.every((entry) => typeof entry === "number" || entry === null)
+  );
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.length > 0 && value.every((entry) => typeof entry === "string");
 }
 
 export function isValidWeatherResponse(data: unknown): data is OpenMeteoWeather {
   if (!isRecord(data) || data.error === true) return false;
-  const { current_weather, hourly, daily, hourly_units } = data;
-  if (!isRecord(current_weather) || !isRecord(hourly_units) || !isRecord(hourly) || !isRecord(daily)) {
+  const { current_weather, hourly, daily, hourly_units, daily_units } = data;
+  if (!isRecord(current_weather) || !isRecord(hourly) || !isRecord(daily) || !isRecord(hourly_units)) {
     return false;
   }
+
   if (
     typeof current_weather.temperature !== "number" ||
     typeof current_weather.windspeed !== "number" ||
-    typeof current_weather.winddirection !== "number"
+    typeof current_weather.winddirection !== "number" ||
+    typeof current_weather.weathercode !== "number" ||
+    typeof current_weather.time !== "string"
   ) {
     return false;
   }
-  return (
-    hasNonEmptyArrays(hourly, ["apparent_temperature", "relativehumidity_2m", "surface_pressure", "visibility"]) &&
-    hasNonEmptyArrays(daily, ["temperature_2m_min", "temperature_2m_max", "uv_index_max", "sunrise", "sunset"])
-  );
+
+  if (!HOURLY_INDEXED_KEYS.every((key) => isIndexedNumberArray(hourly[key]))) return false;
+  if (!HOURLY_UNIT_KEYS.every((key) => typeof hourly_units[key] === "string")) return false;
+
+  if (!DAILY_STRING_KEYS.every((key) => isStringArray(daily[key]))) return false;
+  if (!DAILY_NUMBER_KEYS.every((key) => isNumberOrNullArray(daily[key]))) return false;
+
+  // Forecast submenus map over each numeric array but index daily.time at the
+  // same position, so all daily arrays must have the same length.
+  const dayCount = (daily.time as unknown[]).length;
+  const allDailyKeys = [...DAILY_STRING_KEYS, ...DAILY_NUMBER_KEYS];
+  if (!allDailyKeys.every((key) => (daily[key] as unknown[]).length === dayCount)) return false;
+
+  if (daily_units !== undefined && (!isRecord(daily_units) || typeof daily_units.rain_sum !== "string")) {
+    return false;
+  }
+
+  return true;
 }
 
 export async function getOpenMeteoWeather(lat: string, lon: string) {

--- a/extensions/menubar-weather/src/utils/common-utils.ts
+++ b/extensions/menubar-weather/src/utils/common-utils.ts
@@ -193,30 +193,38 @@ export function getMenuItem(weather: OpenMeteoWeather | undefined): string[] {
   const { tempUnit, windUnit } = getUnits();
 
   if (typeof weather !== "undefined") {
-    menuItems.push(
-      Math.round(
-        tempType == "apparent_temperature"
-          ? weather?.hourly.apparent_temperature[timeHour()]
-          : weather?.current_weather?.temperature,
-      ) + tempUnit,
-    );
-    if (menuUVI && weather.daily?.uv_index_max.length != 0) {
-      menuItems.push("☀ " + Math.round(weather.daily.uv_index_max[0]));
+    const apparentTemperature = weather.hourly?.apparent_temperature?.[timeHour()];
+    const currentTemperature = weather.current_weather?.temperature;
+    const preferredTemperature =
+      tempType == "apparent_temperature" ? (apparentTemperature ?? currentTemperature) : currentTemperature;
+    if (typeof preferredTemperature === "number") {
+      menuItems.push(Math.round(preferredTemperature) + tempUnit);
     }
-    if (menuPressure && weather.hourly?.surface_pressure.length != 0) {
-      menuItems.push("㍱ " + Math.round(weather.hourly.surface_pressure[timeHour()]));
+
+    const uvIndex = weather.daily?.uv_index_max?.[0];
+    if (menuUVI && typeof uvIndex === "number") {
+      menuItems.push("☀ " + Math.round(uvIndex));
     }
-    if (menuHumidity && weather.hourly?.relativehumidity_2m.length != 0) {
+
+    const surfacePressure = weather.hourly?.surface_pressure?.[timeHour()];
+    if (menuPressure && typeof surfacePressure === "number") {
+      menuItems.push("㍱ " + Math.round(surfacePressure));
+    }
+
+    const relativeHumidity = weather.hourly?.relativehumidity_2m?.[timeHour()];
+    if (menuHumidity && typeof relativeHumidity === "number") {
+      menuItems.push("🜄 " + Math.round(relativeHumidity) + (weather.hourly_units?.relativehumidity_2m ?? ""));
+    }
+
+    const currentWeather = weather.current_weather;
+    if (
+      menuWind &&
+      currentWeather &&
+      typeof currentWeather.winddirection === "number" &&
+      typeof currentWeather.windspeed === "number"
+    ) {
       menuItems.push(
-        "🜄 " + Math.round(weather.hourly.relativehumidity_2m[timeHour()]) + weather.hourly_units.relativehumidity_2m,
-      );
-    }
-    if (menuWind) {
-      menuItems.push(
-        windAngle2Direction(weather.current_weather.winddirection).icon +
-          " " +
-          Math.round(weather.current_weather.windspeed) +
-          windUnit,
+        windAngle2Direction(currentWeather.winddirection).icon + " " + Math.round(currentWeather.windspeed) + windUnit,
       );
     }
   }


### PR DESCRIPTION
Fixes #30896

## Root cause

With the temperature preference set to "Feels like", `getMenuItem` read `weather?.hourly.apparent_temperature[...]`. The optional chaining only covered `weather` — when the latest weather data was missing the `hourly` section (a failed or partial API response, or a stale/invalid cached payload), reading `apparent_temperature` threw `TypeError: Cannot read properties of undefined (reading 'apparent_temperature')` and crashed the menu bar command.

## Changes

- `common-utils.ts`: guard every optional section in `getMenuItem`; when the hourly feels-like value is unavailable, fall back to the current temperature; skip the temperature item entirely if neither exists instead of rendering `NaN℃`. The wind item is similarly skipped when `current_weather` is missing, and the humidity unit falls back to an empty string.
- `axios-utils.ts`: responses that are not valid weather objects or carry an Open-Meteo `error` flag are rejected, so they are never written to the latest-weather cache (which `menubar-weather.tsx` falls back to while a refresh is in flight).

## Validation

- Reproduced the crash with a harness importing the real `getMenuItem`: partial payloads (`{}`, a non-object cached body, `current_weather` only, missing `daily`) all threw the reported `TypeError` before the fix and return safe item lists after; a complete payload still renders `25℃ | ☀ 5 | ↑ 10Km/h`.
- `ray lint` clean; `tsc --noEmit` reports only the pre-existing `swift:` module-resolution warning; `ray build` fails the same way on pristine `main` in this environment (Swift module export resolution) — the failure is unrelated to these changes.