### PR TITLE
[Terminal Finder] Fix crash when Terminal is running without open windows

### DIFF
--- a/extensions/terminalfinder/CHANGELOG.md
+++ b/extensions/terminalfinder/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Terminal Finder Changelog
 
-## [Fix Crash With No Terminal Window] - {PR_MERGE_DATE}
+## [Fix Crash With No Terminal Window] - 2026-09-11
 
 - Show a friendly error instead of crashing when Terminal is running with no open windows (ref: [Issue #30965](https://github.com/raycast/extensions/issues/30965))
 

--- a/extensions/terminalfinder/CHANGELOG.md
+++ b/extensions/terminalfinder/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Terminal Finder Changelog
 
+## [Fix Crash With No Terminal Window] - {PR_MERGE_DATE}
+
+- Show a friendly error instead of crashing when Terminal is running with no open windows (ref: [Issue #30965](https://github.com/raycast/extensions/issues/30965))
+
 ## [Bugfix] - 2026-05-27
 
 - Show a helpful recovery message when cmux reports a broken automation socket.

--- a/extensions/terminalfinder/src/terminalToFinder.tsx
+++ b/extensions/terminalfinder/src/terminalToFinder.tsx
@@ -9,6 +9,9 @@ export default async () => {
       end if
   
       tell application "Terminal"
+      if (count of windows) is 0 then
+          error "No Terminal window open"
+      end if
       do script "open -a Finder ./" in first window
       end tell
   `;


### PR DESCRIPTION
## Summary

Fixes #30965.

The **Terminal → Finder** command runs:

```applescript
tell application "Terminal"
  do script "open -a Finder ./" in first window
end tell
```

When Terminal is running but every window has been closed, `first window` cannot be resolved and AppleScript throws error **-1728** ("Can't get window 1"), which surfaces to the user as a raw crash (as reported in #30965).

This adds the same window-count guard the sibling Terminal commands already use (`finderToTerminal` and `clipboardToTerminal` both check `(count of windows) is 0`), returning a friendly `No Terminal window open` error instead.

## Reproduction

With Terminal running and zero open windows, the old script fails:

```
execution error: Terminal got an error: Can't get window 1. (-1728)
```

With the guard, it returns `No Terminal window open`, and with a window present the command still runs unchanged. The edited AppleScript was verified with `osacompile` and against live Terminal.app.

Only `terminalToFinder.tsx` was affected — the other `*ToFinder` commands do not address `first window`.

## Checklist

- [x] I looked at the guidelines and tried to follow them
- [x] I ran `npm run lint` and it passed
- [x] `CHANGELOG.md` entry added with the `{PR_MERGE_DATE}` placeholder