### PR TITLE
Update zlib-search extension

### DIFF
--- a/extensions/zlib-search/CHANGELOG.md
+++ b/extensions/zlib-search/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Bulk Download] - {PR_MERGE_DATE}
+## [Bulk Download] - 2026-09-11
 
 ### Added
 

--- a/extensions/zlib-search/CHANGELOG.md
+++ b/extensions/zlib-search/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Bulk Download] - {PR_MERGE_DATE}
+
+### Added
+
+- Select multiple books in Search Books and download them all at once with Download Selected
+- Add to Queue action to save books for later without downloading immediately
+- New Download Queue command to review, bulk-download, and manage saved books, even across Raycast restarts
+- Downloaded queue items are marked Downloaded and kept until manually cleared or removed
+
 ## [1.0.0] - 2026-09-10
 
 ### Added

--- a/extensions/zlib-search/README.md
+++ b/extensions/zlib-search/README.md
@@ -6,6 +6,8 @@ Search Z-Library and download books directly from Raycast.
 
 - **Search Books** - Type a title, author, or keyword to search Z-Library in real-time
 - **Quick Download** - Press Enter to download any book to your preferred folder
+- **Bulk Download** - Select multiple books in the search results and download them all at once
+- **Download Queue** - Save books for later with Add to Queue, then review and bulk-download them whenever you're ready, even across Raycast restarts
 - **Book Details** - View authors, year, format, size, and rating for each result
 - **Browse Online** - Open books in your browser to read previews or get more info
 - **Copy Book ID** - Quickly copy book IDs for command-line use
@@ -34,6 +36,19 @@ Search Z-Library and download books directly from Raycast.
 4. Press ⏎ to download, or use other actions:
    - **Open in Browser** - Visit the book's Z-Library page
    - **Copy Book ID** - Copy the book's identifier
+
+### Bulk Download (select and download now)
+
+1. In Search Books, select a book with **Select** (⌘S) - its row shows a checkmark
+2. Repeat for as many books as you want, including across different searches
+3. Run **Download Selected** (⌘⇧D) to download all of them, one at a time
+
+### Download Queue (save for later)
+
+1. In Search Books, use **Add to Queue** (⌘B) on any book to save it without downloading
+2. Open the **Download Queue** command any time - even after restarting Raycast - to see everything you've saved
+3. Download individual books, or run **Download All Queued** (⌘⇧D) to download everything at once
+4. Downloaded books stay in the queue marked **Downloaded** until you remove them or clear them with **Clear All Downloaded**
 
 ## Domain Issues?
 

--- a/extensions/zlib-search/package.json
+++ b/extensions/zlib-search/package.json
@@ -16,6 +16,13 @@
       "subtitle": "Z-Library",
       "description": "Search Z-Library and download books",
       "mode": "view"
+    },
+    {
+      "name": "download-queue",
+      "title": "Download Queue",
+      "subtitle": "Z-Library",
+      "description": "Review and bulk-download books you've saved for later",
+      "mode": "view"
     }
   ],
   "preferences": [

--- a/extensions/zlib-search/src/download-queue.tsx
+++ b/extensions/zlib-search/src/download-queue.tsx
@@ -1,0 +1,211 @@
+import React from "react";
+import {
+  ActionPanel,
+  Action,
+  List,
+  Icon,
+  Color,
+  getPreferenceValues,
+  showToast,
+  Toast,
+  confirmAlert,
+  Alert,
+} from "@raycast/api";
+import { useLocalStorage } from "@raycast/utils";
+import {
+  QueueItem,
+  QUEUE_STORAGE_KEY,
+  buildExecEnv,
+  downloadBook,
+  resolveZlibPath,
+  runBulkDownload,
+  truncate,
+} from "./lib/zlib";
+
+export default function Command() {
+  const prefs = getPreferenceValues<Preferences>();
+  const zlibPath = resolveZlibPath(prefs.zlibPath);
+  const downloadDir = prefs.downloadDir || "~/Downloads";
+  const execEnv = buildExecEnv(prefs.zlibDomain);
+
+  const {
+    value: queue = [],
+    setValue: setQueue,
+    isLoading,
+  } = useLocalStorage<QueueItem[]>(QUEUE_STORAGE_KEY, []);
+
+  const pending = queue.filter((item) => !item.downloaded);
+  const downloaded = queue.filter((item) => item.downloaded);
+
+  function markDownloaded(id: string) {
+    setQueue(
+      queue.map((item) =>
+        item.id === id ? { ...item, downloaded: true } : item,
+      ),
+    );
+  }
+
+  async function removeFromQueue(id: string) {
+    await setQueue(queue.filter((item) => item.id !== id));
+  }
+
+  async function handleDownloadOne(item: QueueItem) {
+    const toast = await showToast({
+      style: Toast.Style.Animated,
+      title: `Downloading ${truncate(item.name)}`,
+      message: "0s",
+    });
+    const startedAt = Date.now();
+    const elapsedTimer = setInterval(() => {
+      toast.message = `${Math.round((Date.now() - startedAt) / 1000)}s`;
+    }, 1000);
+
+    try {
+      await downloadBook(zlibPath, item, downloadDir, execEnv);
+      toast.style = Toast.Style.Success;
+      toast.title = "Downloaded";
+      toast.message = item.name;
+      markDownloaded(item.id);
+    } catch (err) {
+      toast.style = Toast.Style.Failure;
+      toast.title = "Download failed";
+      toast.message = err instanceof Error ? err.message : String(err);
+    } finally {
+      clearInterval(elapsedTimer);
+    }
+  }
+
+  async function handleDownloadAllPending() {
+    if (pending.length === 0) return;
+    await runBulkDownload(pending, {
+      zlibPath,
+      downloadDir,
+      execEnv,
+      onEachResult: (result) => {
+        if (result.success) markDownloaded(result.book.id);
+      },
+    });
+  }
+
+  async function handleClearDownloaded() {
+    if (downloaded.length === 0) return;
+    const confirmed = await confirmAlert({
+      title: "Clear downloaded books?",
+      message: `This removes ${downloaded.length} downloaded book${downloaded.length === 1 ? "" : "s"} from the queue. This doesn't delete the files themselves.`,
+      primaryAction: { title: "Clear", style: Alert.ActionStyle.Destructive },
+    });
+    if (confirmed) {
+      await setQueue(queue.filter((item) => !item.downloaded));
+    }
+  }
+
+  return (
+    <List isLoading={isLoading} searchBarPlaceholder="Filter queued books…">
+      {queue.length === 0 ? (
+        <List.EmptyView
+          icon={Icon.Tray}
+          title="Queue is empty"
+          description='Add books from "Search Books" with the Add to Queue action.'
+        />
+      ) : (
+        <>
+          <List.Section title="Queued" subtitle={`${pending.length}`}>
+            {pending.map((item) => (
+              <List.Item
+                key={item.id}
+                title={item.name}
+                subtitle={item.authors?.join(", ") ?? ""}
+                icon={{ source: Icon.Bookmark, tintColor: Color.Blue }}
+                accessories={[
+                  item.extension ? { tag: item.extension } : {},
+                  item.size ? { text: item.size } : {},
+                  item.year ? { text: item.year } : {},
+                ]}
+                actions={
+                  <ActionPanel>
+                    <Action
+                      title="Download"
+                      icon={Icon.Download}
+                      onAction={() => handleDownloadOne(item)}
+                    />
+                    {pending.length > 1 ? (
+                      <Action
+                        title={`Download All Queued (${pending.length})`}
+                        icon={Icon.Tray}
+                        shortcut={{ modifiers: ["cmd", "shift"], key: "d" }}
+                        onAction={handleDownloadAllPending}
+                      />
+                    ) : null}
+                    {item.url ? (
+                      <Action.OpenInBrowser
+                        url={item.url}
+                        title="Open in Browser"
+                      />
+                    ) : null}
+                    <Action.CopyToClipboard
+                      title="Copy to Clipboard"
+                      content={item.id}
+                    />
+                    <Action
+                      title="Remove from Queue"
+                      icon={Icon.Trash}
+                      style={Action.Style.Destructive}
+                      shortcut={{ modifiers: ["cmd"], key: "backspace" }}
+                      onAction={() => removeFromQueue(item.id)}
+                    />
+                  </ActionPanel>
+                }
+              />
+            ))}
+          </List.Section>
+          <List.Section title="Downloaded" subtitle={`${downloaded.length}`}>
+            {downloaded.map((item) => (
+              <List.Item
+                key={item.id}
+                title={item.name}
+                subtitle={item.authors?.join(", ") ?? ""}
+                icon={{ source: Icon.CheckCircle, tintColor: Color.Green }}
+                accessories={[
+                  { tag: { value: "Downloaded", color: Color.Green } },
+                  item.extension ? { tag: item.extension } : {},
+                ]}
+                actions={
+                  <ActionPanel>
+                    <Action
+                      title="Download Again"
+                      icon={Icon.Download}
+                      onAction={() => handleDownloadOne(item)}
+                    />
+                    {item.url ? (
+                      <Action.OpenInBrowser
+                        url={item.url}
+                        title="Open in Browser"
+                      />
+                    ) : null}
+                    <Action
+                      title="Remove from Queue"
+                      icon={Icon.Trash}
+                      style={Action.Style.Destructive}
+                      shortcut={{ modifiers: ["cmd"], key: "backspace" }}
+                      onAction={() => removeFromQueue(item.id)}
+                    />
+                    <Action
+                      title="Clear All Downloaded"
+                      icon={Icon.Trash}
+                      style={Action.Style.Destructive}
+                      shortcut={{
+                        modifiers: ["cmd", "shift"],
+                        key: "backspace",
+                      }}
+                      onAction={handleClearDownloaded}
+                    />
+                  </ActionPanel>
+                }
+              />
+            ))}
+          </List.Section>
+        </>
+      )}
+    </List>
+  );
+}

--- a/extensions/zlib-search/src/download-queue.tsx
+++ b/extensions/zlib-search/src/download-queue.tsx
@@ -77,12 +77,23 @@ export default function Command() {
 
   async function handleDownloadAllPending() {
     if (pending.length === 0) return;
+
+    // Track our own running copy instead of calling markDownloaded (which
+    // closes over the `queue` from this render) for every result: since
+    // runBulkDownload awaits between items but this function's closure never
+    // sees a fresh `queue`, successive markDownloaded calls would each start
+    // from the same stale array and overwrite each other's updates.
+    let latestQueue = queue;
     await runBulkDownload(pending, {
       zlibPath,
       downloadDir,
       execEnv,
       onEachResult: (result) => {
-        if (result.success) markDownloaded(result.book.id);
+        if (!result.success) return;
+        latestQueue = latestQueue.map((item) =>
+          item.id === result.book.id ? { ...item, downloaded: true } : item,
+        );
+        setQueue(latestQueue);
       },
     });
   }

--- a/extensions/zlib-search/src/lib/zlib.ts
+++ b/extensions/zlib-search/src/lib/zlib.ts
@@ -1,0 +1,122 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { existsSync } from "fs";
+import { showToast, Toast } from "@raycast/api";
+
+export const execFileAsync = promisify(execFile);
+
+const ZLIB_PATH_CANDIDATES = ["/opt/homebrew/bin/zlib", "/usr/local/bin/zlib"];
+
+export function resolveZlibPath(configuredPath: string): string {
+  if (configuredPath) return configuredPath;
+  return ZLIB_PATH_CANDIDATES.find((path) => existsSync(path)) ?? "zlib";
+}
+
+export function truncate(text: string, max = 40): string {
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}
+
+export function buildExecEnv(zlibDomain?: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  if (zlibDomain) env.ZLIB_DOMAIN = zlibDomain;
+  return env;
+}
+
+export interface Book {
+  id: string;
+  hash?: string;
+  url: string;
+  name: string;
+  authors?: string[];
+  year?: string;
+  extension?: string;
+  size?: string;
+  rating?: string;
+}
+
+export interface QueueItem extends Book {
+  downloaded: boolean;
+  queuedAt: number;
+}
+
+export const QUEUE_STORAGE_KEY = "download-queue";
+
+export async function downloadBook(
+  zlibPath: string,
+  book: Pick<Book, "id">,
+  downloadDir: string,
+  execEnv: NodeJS.ProcessEnv,
+): Promise<void> {
+  await execFileAsync(zlibPath, ["download", book.id, "--dir", downloadDir], {
+    env: execEnv,
+  });
+}
+
+export interface BulkDownloadResult {
+  book: Book;
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * Downloads books one at a time (sequential, not parallel — kinder to
+ * Z-Library's rate limits) while keeping a single progress toast updated.
+ * Calls `onEachResult` right after each book settles, so callers can persist
+ * per-item state (e.g. marking a queue entry as downloaded) incrementally
+ * rather than only at the very end.
+ */
+export async function runBulkDownload(
+  books: Book[],
+  options: {
+    zlibPath: string;
+    downloadDir: string;
+    execEnv: NodeJS.ProcessEnv;
+    onEachResult?: (result: BulkDownloadResult) => void;
+  },
+): Promise<BulkDownloadResult[]> {
+  const { zlibPath, downloadDir, execEnv, onEachResult } = options;
+  const results: BulkDownloadResult[] = [];
+
+  if (books.length === 0) return results;
+
+  const toast = await showToast({
+    style: Toast.Style.Animated,
+    title: `Downloading 1 of ${books.length}`,
+    message: truncate(books[0].name),
+  });
+
+  for (let i = 0; i < books.length; i++) {
+    const book = books[i];
+    toast.title = `Downloading ${i + 1} of ${books.length}`;
+    toast.message = truncate(book.name);
+
+    let result: BulkDownloadResult;
+    try {
+      await downloadBook(zlibPath, book, downloadDir, execEnv);
+      result = { book, success: true };
+    } catch (err) {
+      result = {
+        book,
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+    results.push(result);
+    onEachResult?.(result);
+  }
+
+  const succeeded = results.filter((r) => r.success).length;
+  const failed = results.length - succeeded;
+
+  if (failed === 0) {
+    toast.style = Toast.Style.Success;
+    toast.title = `Downloaded ${succeeded} book${succeeded === 1 ? "" : "s"}`;
+    toast.message = "";
+  } else {
+    toast.style = Toast.Style.Failure;
+    toast.title = `Downloaded ${succeeded}, failed ${failed}`;
+    toast.message = results.find((r) => !r.success)?.error ?? "";
+  }
+
+  return results;
+}

--- a/extensions/zlib-search/src/search-books.tsx
+++ b/extensions/zlib-search/src/search-books.tsx
@@ -7,36 +7,19 @@ import {
   Toast,
   getPreferenceValues,
   Icon,
+  Color,
 } from "@raycast/api";
-import { useExec } from "@raycast/utils";
-import { execFile } from "child_process";
-import { promisify } from "util";
-import { existsSync } from "fs";
-
-const execFileAsync = promisify(execFile);
-
-const ZLIB_PATH_CANDIDATES = ["/opt/homebrew/bin/zlib", "/usr/local/bin/zlib"];
-
-function resolveZlibPath(configuredPath: string): string {
-  if (configuredPath) return configuredPath;
-  return ZLIB_PATH_CANDIDATES.find((path) => existsSync(path)) ?? "zlib";
-}
-
-function truncate(text: string, max = 40): string {
-  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
-}
-
-interface Book {
-  id: string;
-  hash?: string;
-  url: string;
-  name: string;
-  authors?: string[];
-  year?: string;
-  extension?: string;
-  size?: string;
-  rating?: string;
-}
+import { useExec, useLocalStorage } from "@raycast/utils";
+import {
+  Book,
+  QueueItem,
+  QUEUE_STORAGE_KEY,
+  buildExecEnv,
+  downloadBook,
+  resolveZlibPath,
+  runBulkDownload,
+  truncate,
+} from "./lib/zlib";
 
 interface SearchResult {
   books: Book[];
@@ -48,12 +31,15 @@ const EMPTY_RESULT: SearchResult = { books: [], page: 0, total_pages: 0 };
 
 export default function Command() {
   const [searchText, setSearchText] = useState("");
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const prefs = getPreferenceValues<Preferences>();
   const zlibPath = resolveZlibPath(prefs.zlibPath);
   const downloadDir = prefs.downloadDir || "~/Downloads";
+  const execEnv = buildExecEnv(prefs.zlibDomain);
 
-  const execEnv: NodeJS.ProcessEnv = { ...process.env };
-  if (prefs.zlibDomain) execEnv.ZLIB_DOMAIN = prefs.zlibDomain;
+  const { value: queue = [], setValue: setQueue } = useLocalStorage<
+    QueueItem[]
+  >(QUEUE_STORAGE_KEY, []);
 
   const { isLoading, data } = useExec(
     zlibPath,
@@ -81,6 +67,7 @@ export default function Command() {
   );
 
   const books = data?.books ?? [];
+  const isQueued = (id: string) => queue.some((item) => item.id === id);
 
   async function handleDownload(book: Book) {
     const toast = await showToast({
@@ -96,11 +83,7 @@ export default function Command() {
     }, 1000);
 
     try {
-      await execFileAsync(
-        zlibPath,
-        ["download", book.id, "--dir", downloadDir],
-        { env: execEnv },
-      );
+      await downloadBook(zlibPath, book, downloadDir, execEnv);
       toast.style = Toast.Style.Success;
       toast.title = "Downloaded";
       toast.message = book.name;
@@ -111,6 +94,47 @@ export default function Command() {
     } finally {
       clearInterval(elapsedTimer);
     }
+  }
+
+  function toggleSelected(id: string) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  async function toggleQueued(book: Book) {
+    if (isQueued(book.id)) {
+      await setQueue(queue.filter((item) => item.id !== book.id));
+      await showToast({ title: "Removed from queue", message: book.name });
+    } else {
+      const entry: QueueItem = {
+        ...book,
+        downloaded: false,
+        queuedAt: Date.now(),
+      };
+      await setQueue([...queue, entry]);
+      await showToast({ title: "Added to queue", message: book.name });
+    }
+  }
+
+  async function handleDownloadSelected() {
+    const selected = books.filter((book) => selectedIds.has(book.id));
+    if (selected.length === 0) return;
+
+    const results = await runBulkDownload(selected, {
+      zlibPath,
+      downloadDir,
+      execEnv,
+    });
+
+    // Keep failed downloads selected so the user can retry; clear the rest.
+    const failedIds = new Set(
+      results.filter((r) => !r.success).map((r) => r.book.id),
+    );
+    setSelectedIds(failedIds);
   }
 
   return (
@@ -132,37 +156,75 @@ export default function Command() {
           description={`No books found for "${searchText}"`}
         />
       ) : (
-        books.map((book, i) => (
-          <List.Item
-            key={`${book.id}-${i}`}
-            title={book.name}
-            subtitle={book.authors?.join(", ") ?? ""}
-            accessories={[
-              book.extension ? { tag: book.extension } : {},
-              book.size ? { text: book.size } : {},
-              book.year ? { text: book.year } : {},
-            ]}
-            actions={
-              <ActionPanel>
-                <Action
-                  title="Download"
-                  icon={Icon.Download}
-                  onAction={() => handleDownload(book)}
-                />
-                {book.url ? (
-                  <Action.OpenInBrowser
-                    url={book.url}
-                    title="Open in Browser"
-                  />
-                ) : null}
-                <Action.CopyToClipboard
-                  title="Copy to Clipboard"
-                  content={book.id}
-                />
-              </ActionPanel>
-            }
-          />
-        ))
+        books.map((book, i) => {
+          const selected = selectedIds.has(book.id);
+          const queued = isQueued(book.id);
+          return (
+            <List.Item
+              key={`${book.id}-${i}`}
+              title={book.name}
+              subtitle={book.authors?.join(", ") ?? ""}
+              icon={
+                selected
+                  ? { source: Icon.CheckCircle, tintColor: Color.Blue }
+                  : Icon.Circle
+              }
+              accessories={[
+                queued
+                  ? { icon: Icon.Bookmark, tooltip: "In download queue" }
+                  : {},
+                book.extension ? { tag: book.extension } : {},
+                book.size ? { text: book.size } : {},
+                book.year ? { text: book.year } : {},
+              ]}
+              actions={
+                <ActionPanel>
+                  <ActionPanel.Section>
+                    <Action
+                      title="Download"
+                      icon={Icon.Download}
+                      onAction={() => handleDownload(book)}
+                    />
+                    {book.url ? (
+                      <Action.OpenInBrowser
+                        url={book.url}
+                        title="Open in Browser"
+                      />
+                    ) : null}
+                    <Action.CopyToClipboard
+                      title="Copy to Clipboard"
+                      content={book.id}
+                    />
+                  </ActionPanel.Section>
+                  <ActionPanel.Section title="Selection">
+                    <Action
+                      title={selected ? "Deselect" : "Select"}
+                      icon={selected ? Icon.Circle : Icon.CheckCircle}
+                      shortcut={{ modifiers: ["cmd"], key: "s" }}
+                      onAction={() => toggleSelected(book.id)}
+                    />
+                    {selectedIds.size > 0 ? (
+                      <Action
+                        title={`Download Selected (${selectedIds.size})`}
+                        icon={Icon.Tray}
+                        shortcut={{ modifiers: ["cmd", "shift"], key: "d" }}
+                        onAction={handleDownloadSelected}
+                      />
+                    ) : null}
+                  </ActionPanel.Section>
+                  <ActionPanel.Section title="Download Queue">
+                    <Action
+                      title={queued ? "Remove from Queue" : "Add to Queue"}
+                      icon={queued ? Icon.BookmarkFilled : Icon.Bookmark}
+                      shortcut={{ modifiers: ["cmd"], key: "b" }}
+                      onAction={() => toggleQueued(book)}
+                    />
+                  </ActionPanel.Section>
+                </ActionPanel>
+              }
+            />
+          );
+        })
       )}
     </List>
   );

--- a/extensions/zlib-search/src/search-books.tsx
+++ b/extensions/zlib-search/src/search-books.tsx
@@ -223,7 +223,11 @@ export default function Command() {
                   <ActionPanel.Section title="Download Queue">
                     <Action
                       title={queued ? "Remove from Queue" : "Add to Queue"}
-                      icon={queued ? Icon.BookmarkFilled : Icon.Bookmark}
+                      icon={
+                        queued
+                          ? { source: Icon.Bookmark, tintColor: Color.Blue }
+                          : Icon.Bookmark
+                      }
                       shortcut={{ modifiers: ["cmd"], key: "b" }}
                       onAction={() => toggleQueued(book)}
                     />

--- a/extensions/zlib-search/src/search-books.tsx
+++ b/extensions/zlib-search/src/search-books.tsx
@@ -31,7 +31,12 @@ const EMPTY_RESULT: SearchResult = { books: [], page: 0, total_pages: 0 };
 
 export default function Command() {
   const [searchText, setSearchText] = useState("");
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  // Keyed by id but storing the full Book, not just the id: a book selected
+  // in an earlier search no longer appears in `books` once the user searches
+  // again, so resolving selections against the current results would lose it.
+  const [selectedBooks, setSelectedBooks] = useState<Map<string, Book>>(
+    new Map(),
+  );
   const prefs = getPreferenceValues<Preferences>();
   const zlibPath = resolveZlibPath(prefs.zlibPath);
   const downloadDir = prefs.downloadDir || "~/Downloads";
@@ -96,11 +101,11 @@ export default function Command() {
     }
   }
 
-  function toggleSelected(id: string) {
-    setSelectedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
+  function toggleSelected(book: Book) {
+    setSelectedBooks((prev) => {
+      const next = new Map(prev);
+      if (next.has(book.id)) next.delete(book.id);
+      else next.set(book.id, book);
       return next;
     });
   }
@@ -121,7 +126,7 @@ export default function Command() {
   }
 
   async function handleDownloadSelected() {
-    const selected = books.filter((book) => selectedIds.has(book.id));
+    const selected = Array.from(selectedBooks.values());
     if (selected.length === 0) return;
 
     const results = await runBulkDownload(selected, {
@@ -130,11 +135,14 @@ export default function Command() {
       execEnv,
     });
 
-    // Keep failed downloads selected so the user can retry; clear the rest.
-    const failedIds = new Set(
-      results.filter((r) => !r.success).map((r) => r.book.id),
+    // Keep failed downloads selected (with their full data) so the user can
+    // retry; clear the rest.
+    const failed = new Map(
+      results
+        .filter((r) => !r.success)
+        .map((r) => [r.book.id, r.book] as const),
     );
-    setSelectedIds(failedIds);
+    setSelectedBooks(failed);
   }
 
   return (
@@ -157,7 +165,7 @@ export default function Command() {
         />
       ) : (
         books.map((book, i) => {
-          const selected = selectedIds.has(book.id);
+          const selected = selectedBooks.has(book.id);
           const queued = isQueued(book.id);
           return (
             <List.Item
@@ -201,11 +209,11 @@ export default function Command() {
                       title={selected ? "Deselect" : "Select"}
                       icon={selected ? Icon.Circle : Icon.CheckCircle}
                       shortcut={{ modifiers: ["cmd"], key: "s" }}
-                      onAction={() => toggleSelected(book.id)}
+                      onAction={() => toggleSelected(book)}
                     />
-                    {selectedIds.size > 0 ? (
+                    {selectedBooks.size > 0 ? (
                       <Action
-                        title={`Download Selected (${selectedIds.size})`}
+                        title={`Download Selected (${selectedBooks.size})`}
                         icon={Icon.Tray}
                         shortcut={{ modifiers: ["cmd", "shift"], key: "d" }}
                         onAction={handleDownloadSelected}


### PR DESCRIPTION
## Description

This adds bulk-download support to the Z-Library extension, in two independent ways:

### 1. Multi-select in Search Books

- **Select** (⌘S) toggles a checkmark on any book in the results, across as many searches as you like in the same session
- **Download Selected (N)** (⌘⇧D) — appears once at least one book is selected — downloads them one at a time (sequential, not parallel, to stay kind to Z-Library's rate limits), with a single progress toast ("Downloading 2 of 5…")
- Books that fail stay selected so they're easy to retry; successful ones are cleared automatically

### 2. Download Queue (save for later)

- **Add to Queue** (⌘B) on any book in Search Books saves it for later without downloading immediately, persisted via Raycast's `LocalStorage` so it survives Raycast restarts
- New **Download Queue** command lists everything you've saved, split into "Queued" and "Downloaded" sections
- From there: download one book, download everything pending at once (same sequential download with progress toast), remove a single item, or clear everything already downloaded
- Downloaded items stay in the queue marked **Downloaded** (rather than disappearing) until removed or cleared, so you can see what you've already grabbed

Both features share the same download + progress-toast logic (now factored into `src/lib/zlib.ts`), which is the same logic already used by the existing single-book Download action.

## Screencast

Verified locally via `ray develop`: selected multiple books and downloaded them together, added a book to the queue, downloaded it from the new Download Queue command, and confirmed the queue (with its Downloaded marker) persists across a full Raycast restart.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder