### PR TITLE
Update Herdr: fix agent focus and agent names

### DIFF
--- a/extensions/herdr/CHANGELOG.md
+++ b/extensions/herdr/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Fix Agent Focus and Agent Names] - {PR_MERGE_DATE}
+## [Fix Agent Focus and Agent Names] - 2026-09-11
 
 - Switch to the agent's tab when focusing an agent. `agent focus` moves the server's focus but leaves the attached client drawing the tab it is already on, so the agent's pane never came into view. Workspaces and tabs were unaffected, because `workspace focus` and `tab focus` are what move the client.
 - Name agents by the session title they set, rather than by their working directory. Two agents in one repository were indistinguishable. A title that is only the agent's own product name still yields to the directory.

--- a/extensions/herdr/CHANGELOG.md
+++ b/extensions/herdr/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Fix Agent Focus and Agent Names] - {PR_MERGE_DATE}
+
+- Switch to the agent's tab when focusing an agent. `agent focus` moves the server's focus but leaves the attached client drawing the tab it is already on, so the agent's pane never came into view. Workspaces and tabs were unaffected, because `workspace focus` and `tab focus` are what move the client.
+- Name agents by the session title they set, rather than by their working directory. Two agents in one repository were indistinguishable. A title that is only the agent's own product name still yields to the directory.
+
 ## [Menu Bar Background Refresh] - 2026-09-03
 
 - Refresh the menu bar in the background every minute instead of only when it is opened.

--- a/extensions/herdr/src/lib/agent-appearance.ts
+++ b/extensions/herdr/src/lib/agent-appearance.ts
@@ -99,11 +99,21 @@ export function agentTitle(value?: string): string {
     .replace(/\b\w/g, (letter) => letter.toUpperCase());
 }
 
+// An agent that titles its terminal after its own product identifies no single
+// agent once several of them run, so such a title is not a name.
+function isSelfTitled(title: string, agent?: string): boolean {
+  return title.toLowerCase() === agentTitle(agent).toLowerCase() || normalizeAgentKind(title) !== undefined;
+}
+
 // display_agent is a Nerd Font glyph for herdr's own status line and never
-// renders as text in Raycast, so unnamed agents show their working directory.
-export function agentName(agent: Pick<PaneInfo, "name" | "agent" | "cwd" | "foreground_cwd">): string {
+// renders as text in Raycast, so it is absent from the chain below.
+export function agentName(
+  agent: Pick<PaneInfo, "name" | "agent" | "cwd" | "foreground_cwd" | "terminal_title_stripped">,
+): string {
   const name = agent.name?.trim();
   if (name) return name;
+  const title = agent.terminal_title_stripped?.trim();
+  if (title && !isSelfTitled(title, agent.agent)) return title;
   const dir = (agent.foreground_cwd || agent.cwd)?.replace(/\/+$/, "");
   if (dir && dir !== homedir()) {
     const base = dir.slice(dir.lastIndexOf("/") + 1);

--- a/extensions/herdr/src/lib/herdr.ts
+++ b/extensions/herdr/src/lib/herdr.ts
@@ -166,6 +166,14 @@ export async function focusResource(kind: "workspace" | "tab" | "pane" | "agent"
     await focusPane(id);
     return;
   }
+  // `agent focus` moves the server's focus but leaves the attached client on
+  // the tab it is drawing, so the agent's pane is focused again through the
+  // tab-switching path. The call answers with the agent, naming that pane.
+  if (kind === "agent") {
+    const focused = await runHerdrJson<{ agent: PaneInfo }>(["agent", "focus", id]);
+    if (focused.agent?.pane_id) await focusPane(focused.agent.pane_id);
+    return;
+  }
   await runHerdr([kind, "focus", id]);
 }
 

--- a/extensions/herdr/tests/agent-appearance.test.ts
+++ b/extensions/herdr/tests/agent-appearance.test.ts
@@ -17,6 +17,33 @@ describe("agentName", () => {
     expect(name).toBe("project");
   });
 
+  it("prefers the session title the agent set over the working directory", () => {
+    const name = agentName({
+      agent: "claude",
+      cwd: "/home/user/src/octant",
+      terminal_title_stripped: "Task dispatcher plugin for octant",
+    });
+    expect(name).toBe("Task dispatcher plugin for octant");
+  });
+
+  it("ignores a title that is only the agent's own product name", () => {
+    const name = agentName({
+      agent: "claude",
+      cwd: "/home/user/src/project",
+      terminal_title_stripped: "Claude Code",
+    });
+    expect(name).toBe("project");
+  });
+
+  it("keeps an explicit name ahead of the session title", () => {
+    const name = agentName({
+      name: "billing-fix",
+      agent: "claude",
+      terminal_title_stripped: "Something else entirely",
+    });
+    expect(name).toBe("billing-fix");
+  });
+
   it("uses the foreground cwd over the pane cwd", () => {
     const name = agentName({
       agent: "claude",

--- a/extensions/herdr/tests/herdr.test.ts
+++ b/extensions/herdr/tests/herdr.test.ts
@@ -4,7 +4,7 @@ import { access } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { resolveHerdrBinary, runHerdr } from "../src/lib/herdr";
+import { focusResource, resolveHerdrBinary, runHerdr } from "../src/lib/herdr";
 
 vi.mock("node:fs/promises", () => ({ access: vi.fn() }));
 vi.mock("node:child_process", () => ({ execFile: vi.fn() }));
@@ -78,5 +78,53 @@ describe("runHerdr", () => {
 
     await runHerdr(["session", "list", "--json"], { session: "" });
     expect(executedArgs()).toEqual(["session", "list", "--json"]);
+  });
+});
+
+describe("focusResource", () => {
+  function mockCli(reply: (command: string) => string) {
+    vi.mocked(execFile).mockImplementation(((...callArgs: unknown[]) => {
+      const args = (callArgs[1] as string[]).slice(2);
+      const callback = callArgs.at(-1) as (error: Error | null, stdout: string, stderr: string) => void;
+      callback(null, reply(args.join(" ")), "");
+      return {};
+    }) as never);
+  }
+
+  function issuedCommands(): string[][] {
+    return vi.mocked(execFile).mock.calls.map((call) => (call[1] as string[]).slice(2));
+  }
+
+  it("focuses a workspace with a single call", async () => {
+    mockCli(() => "{}");
+
+    await focusResource("workspace", "w1");
+    expect(issuedCommands()).toEqual([["workspace", "focus", "w1"]]);
+  });
+
+  // Regression: `agent focus` moves the server's focus but leaves the attached
+  // client drawing the tab it was already on, so the agent stayed off screen.
+  it("switches to the agent's tab rather than only focusing the agent", async () => {
+    mockCli((command) => {
+      if (command.startsWith("agent focus")) {
+        return JSON.stringify({ result: { agent: { pane_id: "w1:p2", tab_id: "w1:t1" } } });
+      }
+      if (command.startsWith("pane get")) {
+        return JSON.stringify({ result: { pane: { pane_id: "w1:p2", tab_id: "w1:t1" } } });
+      }
+      if (command.startsWith("pane layout")) {
+        return JSON.stringify({ result: { layout: { focused_pane_id: "w1:p2", panes: [{ pane_id: "w1:p2" }] } } });
+      }
+      return "{}";
+    });
+
+    await focusResource("agent", "billing-fix");
+
+    expect(issuedCommands()).toEqual([
+      ["agent", "focus", "billing-fix"],
+      ["pane", "get", "w1:p2"],
+      ["tab", "focus", "w1:t1"],
+      ["pane", "layout", "--pane", "w1:p2"],
+    ]);
   });
 });


### PR DESCRIPTION
## Description

Two bug fixes in the Herdr extension. No manifest, command, asset or dependency changes.

**Focusing an agent left its pane off screen.** `herdr agent focus` moves the server's focus but leaves the attached client drawing the tab it is already on, so the selected agent never came into view. Workspaces and tabs were unaffected, because `workspace focus` and `tab focus` are exactly what move the client. `focusPane` already solves this for panes, and `agent focus` answers with the agent record, so the pane id needed to reuse it comes free.

This works around herdr's own behaviour rather than fixing it there, so it may be worth a herdr-side issue too. Verified against herdr 0.9.0.

**Agents were named after their working directory.** `terminal_title_stripped` carries the session title an agent sets for itself, and the fallback chain skipped it, so two agents running in one repository were indistinguishable. It now precedes the directory basename. A title that is only the agent's own product name (`"Claude Code"`) identifies nothing once several agents run, so that case still yields to the directory.

Both changes are covered by unit tests. The focus test asserts the full command sequence, so it fails against the previous single-call behaviour.

## Screencast

No UI change to show: both fixes are behavioural. Verified instead by instrumenting the focus path in a dev build and driving it from the Dashboard, confirming herdr's snapshot landed on the requested workspace, tab and pane, and that the client followed.

Scope of what was exercised, for transparency: macOS with Ghostty as the terminal, herdr 0.9.0, Claude Code agents. Other terminals and agent kinds are unchanged by these diffs but were not exercised.

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

`npm run build`, `npm run typecheck`, `npm test` (69 tests) and `npm run lint` all pass. The two asset boxes are ticked as unchanged: this PR adds and touches no assets.
