### PR TITLE
fix(skills): stop commands waiting indefinitely behind each other

### DIFF
--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 - Stop a second command from waiting indefinitely behind a running one: opening Manage Skills during "Update All Skills" now either gets its turn or reports that another skills command is still running, instead of showing an empty list and spinning for minutes
 - Fail immediately on a permanent problem such as a support directory that cannot be written, which was previously retried forever
-- Keep a lost lock from taking down the command that is running, and stop a failed lock release from replacing the real error
+- Stop the running command when it loses its lock, rather than letting it keep changing the same skills another process is now free to change, and stop a failed lock release from replacing the real error
 - Give read-only commands room for the initial download of the `skills` CLI, so an ordinary first run on a slow connection no longer fails
-- Say whether a timed-out command never started, meaning the CLI itself was still downloading, or started and then ran long, instead of giving one message for both
+- Point a timed-out command at the custom package registry setup as well as the network, since a proxied registry is a common cause
 
 ## [Fix Update All Skills Timing Out] - 2026-09-11
 

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Skills Changelog
 
+## [Fix Commands Waiting Forever Behind Each Other] - {PR_MERGE_DATE}
+
+- Stop a second command from waiting indefinitely behind a running one: opening Manage Skills during "Update All Skills" now either gets its turn or reports that another skills command is still running, instead of showing an empty list and spinning for minutes
+- Fail immediately on a permanent problem such as a support directory that cannot be written, which was previously retried forever
+- Keep a lost lock from taking down the command that is running, and stop a failed lock release from replacing the real error
+- Give read-only commands room for the initial download of the `skills` CLI, so an ordinary first run on a slow connection no longer fails
+- Say whether a timed-out command never started, meaning the CLI itself was still downloading, or started and then ran long, instead of giving one message for both
+
 ## [Fix Update All Skills Timing Out] - 2026-09-11
 
 - Allow `add`, `remove`, and `update` up to 5 minutes instead of 30 seconds, so "Update All Skills" no longer fails with a bare "Command failed: npx -y skills@latest update -g -y" once checking every installed skill's source takes longer than that

--- a/extensions/skills/CHANGELOG.md
+++ b/extensions/skills/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Skills Changelog
 
-## [Fix Commands Waiting Forever Behind Each Other] - {PR_MERGE_DATE}
+## [Fix Commands Waiting Forever Behind Each Other] - 2026-09-12
 
 - Stop a second command from waiting indefinitely behind a running one: opening Manage Skills during "Update All Skills" now either gets its turn or reports that another skills command is still running, instead of showing an empty list and spinning for minutes
 - Fail immediately on a permanent problem such as a support directory that cannot be written, which was previously retried forever

--- a/extensions/skills/src/manage-skills.tsx
+++ b/extensions/skills/src/manage-skills.tsx
@@ -2,11 +2,48 @@ import { List, Detail, Icon, ActionPanel, Action, Color, openExtensionPreference
 import { useState } from "react";
 import { ensureSupportDir } from "./utils/ensure-support-dir";
 import { useInstalledSkills } from "./hooks/useInstalledSkills";
-import { isInvalidCustomNpxPathError, isNpxResolutionError } from "./utils/skills-cli";
+import { isInvalidCustomNpxPathError, isNpxResolutionError, isSkillsCliBusyError } from "./utils/skills-cli";
 import { InstalledSkillListItem } from "./components/InstalledSkillListItem";
 import { UpdateSkillAction } from "./components/actions/UpdateSkillAction";
 
 ensureSupportDir();
+
+interface SkillsErrorDescription {
+  errorTitle: string;
+  errorDetails: string;
+}
+
+function describeSkillsError(error: Error): SkillsErrorDescription {
+  if (isSkillsCliBusyError(error)) {
+    return {
+      errorTitle: "Another Skills Command Is Running",
+      errorDetails:
+        "Only one skills command can use the Skills CLI at a time, and the one holding it has not finished yet.\n\n1. Wait for the running command, such as **Update All Skills**, to finish.\n2. Press **Retry** to load the list again.",
+    };
+  }
+
+  if (isInvalidCustomNpxPathError(error)) {
+    return {
+      errorTitle: "Invalid Custom npx Path",
+      errorDetails:
+        "The configured **Custom npx Path** does not point to a valid `npx` executable.\n\n1. Open Extension Preferences (`Cmd+Shift+,`).\n2. Fix or clear **Custom npx Path**.\n3. If unsure, run `which npx` in Terminal and use that value.",
+    };
+  }
+
+  if (isNpxResolutionError(error)) {
+    return {
+      errorTitle: "Unable to Load Installed Skills",
+      errorDetails:
+        "This is a package runner resolution issue in the local CLI runtime.\n\n1. Install or repair Bun so `bunx` works.\n2. If you need to force Node/npm instead, run `which npx` in Terminal.\n3. Open Extension Preferences (`Cmd+Shift+,`) and set **Custom npx Path** to the path from step 2, then retry.",
+    };
+  }
+
+  return {
+    errorTitle: "Unable to Load Installed Skills",
+    errorDetails:
+      "This is a local Skills CLI execution failure.\n\n1. Retry the command.\n2. Open Extension Preferences and verify **Custom npx Path** if you force a non-standard Node.js setup.\n3. Run `bunx skills@latest list -g` (or `npx -y skills@latest list -g` if Bun is not installed) in Terminal to inspect the underlying CLI error.",
+  };
+}
 
 export default function Command() {
   const { skills, isLoading, error, revalidate, mutate } = useInstalledSkills();
@@ -14,27 +51,8 @@ export default function Command() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [isShowingDetail, setIsShowingDetail] = useState(true);
   const toggleDetail = () => setIsShowingDetail((prev) => !prev);
-  const hasInvalidCustomNpxPathError = error ? isInvalidCustomNpxPathError(error) : false;
-  const hasNpxResolutionError = error ? isNpxResolutionError(error) : false;
-
   if (error && skills.length === 0) {
-    const { errorTitle, errorDetails } = hasInvalidCustomNpxPathError
-      ? {
-          errorTitle: "Invalid Custom npx Path",
-          errorDetails:
-            "The configured **Custom npx Path** does not point to a valid `npx` executable.\n\n1. Open Extension Preferences (`Cmd+Shift+,`).\n2. Fix or clear **Custom npx Path**.\n3. If unsure, run `which npx` in Terminal and use that value.",
-        }
-      : hasNpxResolutionError
-        ? {
-            errorTitle: "Unable to Load Installed Skills",
-            errorDetails:
-              "This is a package runner resolution issue in the local CLI runtime.\n\n1. Install or repair Bun so `bunx` works.\n2. If you need to force Node/npm instead, run `which npx` in Terminal.\n3. Open Extension Preferences (`Cmd+Shift+,`) and set **Custom npx Path** to the path from step 2, then retry.",
-          }
-        : {
-            errorTitle: "Unable to Load Installed Skills",
-            errorDetails:
-              "This is a local Skills CLI execution failure.\n\n1. Retry the command.\n2. Open Extension Preferences and verify **Custom npx Path** if you force a non-standard Node.js setup.\n3. Run `bunx skills@latest list -g` (or `npx -y skills@latest list -g` if Bun is not installed) in Terminal to inspect the underlying CLI error.",
-          };
+    const { errorTitle, errorDetails } = describeSkillsError(error);
 
     return (
       <Detail

--- a/extensions/skills/src/utils/skills-cli-runner.ts
+++ b/extensions/skills/src/utils/skills-cli-runner.ts
@@ -17,12 +17,24 @@ let bunxResolutionFailed = false;
 const SKILLS_CLI_LOCK_TARGET = join(environment.supportPath, "skills-cli");
 
 /**
- * `list` only reads local state. `add`, `remove` and `update` fetch every
- * involved skill from its git source, and "update all" does so for each
- * installed skill in turn, so it easily outgrows a 30-second budget.
+ * Every run starts by resolving `skills@latest`, which downloads roughly 8 MB
+ * on a cold cache, so even read-only `list` needs room for that download on a
+ * slow connection. `add`, `remove` and `update` then fetch every involved skill
+ * from its git source, and "update all" does so for each installed skill in
+ * turn, which is what outgrew the original 30-second budget.
  */
-const READ_ONLY_TIMEOUT_MS = 30_000;
+const READ_ONLY_TIMEOUT_MS = 2 * 60_000;
 const MUTATING_TIMEOUT_MS = 5 * 60_000;
+
+/**
+ * How long a command waits for its turn when another one holds the CLI. A
+ * legitimate holder can occupy it for a whole mutating timeout, so the wait has
+ * to outlast that; past it the holder is not coming back, and waiting longer is
+ * indistinguishable from a hang.
+ */
+const CLI_TURN_TIMEOUT_MS = MUTATING_TIMEOUT_MS + 30_000;
+
+const LOCK_RETRY_INTERVAL_MS = 100;
 
 type ExecFailure = Error & {
   cmd?: string;
@@ -44,6 +56,17 @@ export class NpxResolutionError extends Error {
 
 export function isNpxResolutionError(error: unknown): boolean {
   return error instanceof NpxResolutionError;
+}
+
+export class SkillsCliBusyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SkillsCliBusyError";
+  }
+}
+
+export function isSkillsCliBusyError(error: unknown): boolean {
+  return error instanceof SkillsCliBusyError;
 }
 
 export class InvalidCustomNpxPathError extends Error {
@@ -82,29 +105,111 @@ export async function runSkillsCli(args: string[], options: RunSkillsCliOptions 
 }
 
 export async function withSkillsCliLock<T>(run: (runLocked: SkillsCliRunner) => Promise<T>): Promise<T> {
-  return enqueueSkillsCliRun(() =>
-    withCrossProcessSkillsCliLock(() =>
-      run((args, options = {}) => runSkillsCliCommand(args, options.readOnly ?? false)),
-    ),
+  const turnDeadline = Date.now() + CLI_TURN_TIMEOUT_MS;
+  return enqueueSkillsCliRun(
+    () =>
+      withCrossProcessSkillsCliLock(
+        () => run((args, options = {}) => runSkillsCliCommand(args, options.readOnly ?? false)),
+        turnDeadline,
+      ),
+    turnDeadline,
   );
 }
 
-async function enqueueSkillsCliRun<T>(run: () => Promise<T>): Promise<T> {
-  const runAfterPending = pendingSkillsCliRun.then(run, run);
-  pendingSkillsCliRun = runAfterPending.catch(() => undefined);
-  return runAfterPending;
+function skillsCliBusyError(): SkillsCliBusyError {
+  return new SkillsCliBusyError("Another skills command is still running. Wait for it to finish and try again.");
 }
 
-async function withCrossProcessSkillsCliLock<T>(run: () => Promise<T>): Promise<T> {
-  await mkdir(environment.supportPath, { recursive: true });
-  await writeFile(SKILLS_CLI_LOCK_TARGET, "", { flag: "a" });
-  const release = await lockfile.lock(SKILLS_CLI_LOCK_TARGET, {
-    retries: { forever: true, factor: 1, minTimeout: 100, maxTimeout: 100, randomize: true },
-  });
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+async function enqueueSkillsCliRun<T>(run: () => Promise<T>, turnDeadline: number): Promise<T> {
+  // Claim the next place in the chain synchronously, so two callers can never
+  // wake up on the same predecessor and run at once.
+  const predecessor = pendingSkillsCliRun;
+  let releasePlace: () => void = () => {};
+  pendingSkillsCliRun = new Promise<void>((resolve) => (releasePlace = resolve));
+
+  try {
+    await waitForTurn(predecessor, turnDeadline);
+  } catch (error) {
+    // This run never started, so whoever is next still has to wait for the
+    // predecessor rather than for us.
+    predecessor.then(releasePlace, releasePlace);
+    throw error;
+  }
+
   try {
     return await run();
   } finally {
+    releasePlace();
+  }
+}
+
+async function waitForTurn(predecessor: Promise<unknown>, turnDeadline: number): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      predecessor.catch(() => undefined),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(skillsCliBusyError()), Math.max(0, turnDeadline - Date.now()));
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function withCrossProcessSkillsCliLock<T>(run: () => Promise<T>, turnDeadline: number): Promise<T> {
+  await mkdir(environment.supportPath, { recursive: true });
+  await writeFile(SKILLS_CLI_LOCK_TARGET, "", { flag: "a" });
+  const release = await acquireSkillsCliLock(turnDeadline);
+  try {
+    return await run();
+  } finally {
+    await releaseSkillsCliLock(release);
+  }
+}
+
+/**
+ * Retries only while the lock is genuinely held by someone else. The previous
+ * `retries: forever` also retried permanent failures such as a support
+ * directory we cannot write to, which could never succeed.
+ */
+async function acquireSkillsCliLock(turnDeadline: number): Promise<() => Promise<void>> {
+  for (;;) {
+    try {
+      return await lockfile.lock(SKILLS_CLI_LOCK_TARGET, {
+        retries: 0,
+        onCompromised: reportCompromisedLock,
+      });
+    } catch (error) {
+      if (!isLockHeldError(error)) throw error;
+      if (Date.now() >= turnDeadline) throw skillsCliBusyError();
+      await delay(LOCK_RETRY_INTERVAL_MS);
+    }
+  }
+}
+
+function isLockHeldError(error: unknown): boolean {
+  return (error as { code?: string } | undefined)?.code === "ELOCKED";
+}
+
+/**
+ * The default handler throws from a timer callback, which takes the whole
+ * command down with it. Our CLI run is already in flight by then, and killing
+ * it mid-change is worse than finishing it, so record it and carry on.
+ */
+function reportCompromisedLock(error: Error): void {
+  console.error("[skills] Lost the skills CLI lock while a command was running:", error);
+}
+
+async function releaseSkillsCliLock(release: () => Promise<void>): Promise<void> {
+  try {
     await release();
+  } catch (error) {
+    // A lock that was compromised is already gone, so releasing it fails. That
+    // must never replace whatever error the command itself produced.
+    console.error("[skills] Failed to release the skills CLI lock:", error);
   }
 }
 
@@ -208,7 +313,26 @@ function isTimeoutFailure(error: unknown): boolean {
 }
 
 function formatTimeout(timeoutMs: number): string {
-  return timeoutMs >= 60_000 ? `${timeoutMs / 60_000} minutes` : `${timeoutMs / 1000} seconds`;
+  return timeoutMs >= 60_000 ? pluralize(timeoutMs / 60_000, "minute") : pluralize(timeoutMs / 1000, "second");
+}
+
+function pluralize(value: number, unit: string): string {
+  return `${value} ${unit}${value === 1 ? "" : "s"}`;
+}
+
+/**
+ * The two ways a run can time out need different things from the user. Nothing
+ * printed means `bunx`/`npx` never finished downloading the `skills` package,
+ * which a proxied registry can cause; output means the CLI was running and its
+ * own fetches from skill sources are what took too long.
+ */
+function describeTimeout(error: Error, npxCommand: string, timeoutMs: number): string {
+  const command = (error as ExecFailure).cmd ?? npxCommand;
+  const budget = formatTimeout(timeoutMs);
+  const explanation = hasDiagnosticOutput(error)
+    ? `The skills CLI started but did not finish within ${budget} while fetching skills from their sources. Check your network connection and try again.`
+    : `The skills CLI produced no output within ${budget}, so downloading it most likely ran long. Check your network connection, or set a custom package registry if you install packages through a corporate proxy.`;
+  return `${explanation}\nCommand: ${command}`;
 }
 
 function normalizeCliError(error: unknown, npxCommand: string, timeoutMs: number): Error {
@@ -223,11 +347,7 @@ function normalizeCliError(error: unknown, npxCommand: string, timeoutMs: number
   }
 
   if (isTimeoutFailure(error)) {
-    const command = (error as ExecFailure).cmd ?? npxCommand;
-    return withCliOutput(
-      error,
-      `The skills CLI did not finish within ${formatTimeout(timeoutMs)}. Check your network connection and try again.\nCommand: ${command}`,
-    );
+    return withCliOutput(error, describeTimeout(error, npxCommand, timeoutMs));
   }
 
   return withCliOutput(error);

--- a/extensions/skills/src/utils/skills-cli-runner.ts
+++ b/extensions/skills/src/utils/skills-cli-runner.ts
@@ -109,7 +109,7 @@ export async function withSkillsCliLock<T>(run: (runLocked: SkillsCliRunner) => 
   return enqueueSkillsCliRun(
     () =>
       withCrossProcessSkillsCliLock(
-        () => run((args, options = {}) => runSkillsCliCommand(args, options.readOnly ?? false)),
+        (lockLost) => run((args, options = {}) => runSkillsCliCommand(args, options.readOnly ?? false, lockLost)),
         turnDeadline,
       ),
     turnDeadline,
@@ -159,12 +159,16 @@ async function waitForTurn(predecessor: Promise<unknown>, turnDeadline: number):
   }
 }
 
-async function withCrossProcessSkillsCliLock<T>(run: () => Promise<T>, turnDeadline: number): Promise<T> {
+async function withCrossProcessSkillsCliLock<T>(
+  run: (lockLost: AbortSignal) => Promise<T>,
+  turnDeadline: number,
+): Promise<T> {
   await mkdir(environment.supportPath, { recursive: true });
   await writeFile(SKILLS_CLI_LOCK_TARGET, "", { flag: "a" });
-  const release = await acquireSkillsCliLock(turnDeadline);
+  const lockLost = new AbortController();
+  const release = await acquireSkillsCliLock(turnDeadline, lockLost);
   try {
-    return await run();
+    return await run(lockLost.signal);
   } finally {
     await releaseSkillsCliLock(release);
   }
@@ -175,12 +179,12 @@ async function withCrossProcessSkillsCliLock<T>(run: () => Promise<T>, turnDeadl
  * `retries: forever` also retried permanent failures such as a support
  * directory we cannot write to, which could never succeed.
  */
-async function acquireSkillsCliLock(turnDeadline: number): Promise<() => Promise<void>> {
+async function acquireSkillsCliLock(turnDeadline: number, lockLost: AbortController): Promise<() => Promise<void>> {
   for (;;) {
     try {
       return await lockfile.lock(SKILLS_CLI_LOCK_TARGET, {
         retries: 0,
-        onCompromised: reportCompromisedLock,
+        onCompromised: (error) => stopRunOnLostLock(error, lockLost),
       });
     } catch (error) {
       if (!isLockHeldError(error)) throw error;
@@ -195,12 +199,15 @@ function isLockHeldError(error: unknown): boolean {
 }
 
 /**
- * The default handler throws from a timer callback, which takes the whole
- * command down with it. Our CLI run is already in flight by then, and killing
- * it mid-change is worse than finishing it, so record it and carry on.
+ * Losing the lock means another process can now run its own command against the
+ * same skills and npx cache, which is the race the lock exists to prevent, so
+ * stop our run rather than let two proceed at once. The library default instead
+ * throws from a timer callback, which takes the command down without stopping
+ * the child process it spawned.
  */
-function reportCompromisedLock(error: Error): void {
+function stopRunOnLostLock(error: Error, lockLost: AbortController): void {
   console.error("[skills] Lost the skills CLI lock while a command was running:", error);
+  lockLost.abort();
 }
 
 async function releaseSkillsCliLock(release: () => Promise<void>): Promise<void> {
@@ -213,14 +220,14 @@ async function releaseSkillsCliLock(release: () => Promise<void>): Promise<void>
   }
 }
 
-async function runSkillsCliCommand(args: string[], readOnly: boolean): Promise<string> {
+async function runSkillsCliCommand(args: string[], readOnly: boolean, lockLost: AbortSignal): Promise<string> {
   const timeoutMs = readOnly ? READ_ONLY_TIMEOUT_MS : MUTATING_TIMEOUT_MS;
 
   const customNpxPath = getCustomNpxPath();
   if (customNpxPath) {
     await validateCustomNpxPath(customNpxPath);
     try {
-      return await executeSkillsCli("npx", args, timeoutMs, customNpxPath);
+      return await executeSkillsCli("npx", args, timeoutMs, lockLost, customNpxPath);
     } catch (error) {
       throw normalizeCliError(error, customNpxPath, timeoutMs);
     }
@@ -228,7 +235,7 @@ async function runSkillsCliCommand(args: string[], readOnly: boolean): Promise<s
 
   if (!bunxResolutionFailed) {
     try {
-      return await executeSkillsCli("bunx", args, timeoutMs);
+      return await executeSkillsCli("bunx", args, timeoutMs, lockLost);
     } catch (error) {
       if (isNpxCommandResolutionFailure(error, "bunx")) {
         bunxResolutionFailed = true;
@@ -239,7 +246,7 @@ async function runSkillsCliCommand(args: string[], readOnly: boolean): Promise<s
   }
 
   try {
-    return await executeSkillsCli("npx", args, timeoutMs);
+    return await executeSkillsCli("npx", args, timeoutMs, lockLost);
   } catch (npxError) {
     throw normalizeCliError(npxError, "npx", timeoutMs);
   }
@@ -248,17 +255,18 @@ async function runSkillsCliCommand(args: string[], readOnly: boolean): Promise<s
 /**
  * Retrying through npx is only worth it when bunx failed without saying why.
  * A mutating command may already have changed state, a failure with output has
- * already explained itself, and a timeout means bunx works but the command is
- * slow — running it again would only double the wait.
+ * already explained itself, a timeout means bunx works but the command is slow,
+ * and a lost lock means we must not be running at all.
  */
 function canRetryThroughNpx(error: unknown, readOnly: boolean): boolean {
-  return readOnly && !hasDiagnosticOutput(error) && !isTimeoutFailure(error);
+  return readOnly && !hasDiagnosticOutput(error) && !isTimeoutFailure(error) && !isLostLockFailure(error);
 }
 
 async function executeSkillsCli(
   runner: PackageRunner,
   args: string[],
   timeoutMs: number,
+  lockLost: AbortSignal,
   executable: string = runner,
 ): Promise<string> {
   const execOptions = await getExecOptions();
@@ -271,6 +279,7 @@ async function executeSkillsCli(
     ...execOptions,
     env,
     timeout: timeoutMs,
+    signal: lockLost,
     shell: isWindows,
   });
   return stdout.toString();
@@ -321,21 +330,21 @@ function pluralize(value: number, unit: string): string {
 }
 
 /**
- * The two ways a run can time out need different things from the user. Nothing
- * printed means `bunx`/`npx` never finished downloading the `skills` package,
- * which a proxied registry can cause; output means the CLI was running and its
- * own fetches from skill sources are what took too long.
+ * The lost-lock handler is the only thing that aborts a run, so an aborted run
+ * always means exclusive access went away underneath it.
  */
-function describeTimeout(error: Error, npxCommand: string, timeoutMs: number): string {
-  const command = (error as ExecFailure).cmd ?? npxCommand;
-  const budget = formatTimeout(timeoutMs);
-  const explanation = hasDiagnosticOutput(error)
-    ? `The skills CLI started but did not finish within ${budget} while fetching skills from their sources. Check your network connection and try again.`
-    : `The skills CLI produced no output within ${budget}, so downloading it most likely ran long. Check your network connection, or set a custom package registry if you install packages through a corporate proxy.`;
-  return `${explanation}\nCommand: ${command}`;
+function isLostLockFailure(error: unknown): boolean {
+  const failure = error as { code?: unknown; name?: unknown } | undefined;
+  return failure?.code === "ABORT_ERR" || failure?.name === "AbortError";
 }
 
 function normalizeCliError(error: unknown, npxCommand: string, timeoutMs: number): Error {
+  if (isLostLockFailure(error)) {
+    return new Error(
+      "The skills CLI lost exclusive access while running, so the command was stopped before it could finish. Try again.",
+    );
+  }
+
   if (isNpxCommandResolutionFailure(error, npxCommand)) {
     return new NpxResolutionError(
       "Unable to find a working bunx or npx command. Install Bun, or install Node.js/npm. If you need to force a custom npx executable, set it in the extension configuration under 'Custom npx Path'.",
@@ -347,7 +356,11 @@ function normalizeCliError(error: unknown, npxCommand: string, timeoutMs: number
   }
 
   if (isTimeoutFailure(error)) {
-    return withCliOutput(error, describeTimeout(error, npxCommand, timeoutMs));
+    const command = (error as ExecFailure).cmd ?? npxCommand;
+    return withCliOutput(
+      error,
+      `The skills CLI did not finish within ${formatTimeout(timeoutMs)}. Check your network connection and try again. If packages install through a corporate proxy, set a custom package registry as the extension README describes.\nCommand: ${command}`,
+    );
   }
 
   return withCliOutput(error);

--- a/extensions/skills/src/utils/skills-cli.ts
+++ b/extensions/skills/src/utils/skills-cli.ts
@@ -4,8 +4,10 @@ import { agentDisplayNameToId, KNOWN_AGENT_NAMES } from "./skills-cli-agents";
 import {
   InvalidCustomNpxPathError,
   NpxResolutionError,
+  SkillsCliBusyError,
   isInvalidCustomNpxPathError,
   isNpxResolutionError,
+  isSkillsCliBusyError,
   runSkillsCli,
   type SkillsCliRunner,
 } from "./skills-cli-runner";
@@ -15,8 +17,10 @@ const home = homedir();
 export {
   InvalidCustomNpxPathError,
   NpxResolutionError,
+  SkillsCliBusyError,
   isInvalidCustomNpxPathError,
   isNpxResolutionError,
+  isSkillsCliBusyError,
   KNOWN_AGENT_NAMES,
 };
 


### PR DESCRIPTION
## Description

Follow-up to #30985, which raised the timeout for mutating `skills` commands from 30 seconds to 5 minutes. Only one command may use the CLI at a time, and the wait for that turn was unbounded, so lengthening the run also lengthened how long everything else sat behind it. Triggering "Update All Skills" and then opening Manage Skills left the list empty and spinning, with no way to tell a slow update from a hang.

The read-only budget is an arbitrary number, and it only treats the symptom because the time is spent downloading, not listing skills. Separating resolution from execution would require spawning a second process for every command, which did not seem worthwhile here.

## Screencast

No UI Update

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)