### PR TITLE
Toggl Track: fix duplicate billable checkbox form ID

### DIFF
--- a/extensions/toggl-track/CHANGELOG.md
+++ b/extensions/toggl-track/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Toggl Track Changelog
 
+## [Fix Duplicate Billable Checkbox] - {PR_MERGE_DATE}
+
+- Fixed two `Billable` checkboxes rendering with the same `billable` form ID when a billable project is selected in a premium workspace — they are now a single checkbox, shown whenever either condition applies
+
 ## [Show total duration of current project] - 2026-06-18
 
 - In the menu bar, show the total time of all time entries of the current project in addition to the total time of all entries.

--- a/extensions/toggl-track/CHANGELOG.md
+++ b/extensions/toggl-track/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Toggl Track Changelog
 
-## [Fix Duplicate Billable Checkbox] - {PR_MERGE_DATE}
+## [Fix Duplicate Billable Checkbox] - 2026-09-11
 
 - Fixed two `Billable` checkboxes rendering with the same `billable` form ID when a billable project is selected in a premium workspace — they are now a single checkbox, shown whenever either condition applies
 

--- a/extensions/toggl-track/src/components/CreateTimeEntryForm.tsx
+++ b/extensions/toggl-track/src/components/CreateTimeEntryForm.tsx
@@ -280,8 +280,6 @@ function CreateTimeEntryForm({
               )}
             </Form.Dropdown>
           )}
-
-          {selectedProject?.billable && <Form.Checkbox id="billable" label="" title="Billable" />}
         </>
       )}
 
@@ -295,7 +293,9 @@ function CreateTimeEntryForm({
         </Form.TagPicker>
       )}
 
-      {isWorkspacePremium && <Form.Checkbox id="billable" label="Billable" value={billable} onChange={setBillable} />}
+      {(isWorkspacePremium || selectedProject?.billable) && (
+        <Form.Checkbox id="billable" label="Billable" value={billable} onChange={setBillable} />
+      )}
     </Form>
   );
 }


### PR DESCRIPTION
## Description

`CreateTimeEntryForm` renders two `Form.Checkbox` elements that share the same `billable` form ID:

```tsx
// inside the project block
{selectedProject?.billable && <Form.Checkbox id="billable" label="" title="Billable" />}
// near the end of the form
{isWorkspacePremium && <Form.Checkbox id="billable" label="Billable" value={billable} onChange={setBillable} />}
```

When a **billable project** is selected in a **premium workspace**, both conditions are true and both render, so the form has a duplicate ID. The two also disagree: one is uncontrolled with an empty `label`, the other is controlled by the `billable` state.

This consolidates them into the single controlled checkbox, displayed whenever either condition applies — so the option is still offered in both situations, without the collision.

No change for workspaces/projects that only ever satisfied one of the two conditions.

## Screencast

Not included — the visible change is one `Billable` checkbox instead of two in the overlapping case.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
