### PR TITLE
Toggl Track: clamp running-entry elapsed time to zero

### DIFF
--- a/extensions/toggl-track/CHANGELOG.md
+++ b/extensions/toggl-track/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Toggl Track Changelog
 
+## [Fix Negative Running Durations] - {PR_MERGE_DATE}
+
+- Clamped elapsed-time calculations for the running entry to zero, so a start time in the future no longer renders a garbled negative duration in the list and menu bar, or subtracts from today's total
+
 ## [Fix Duplicate Billable Checkbox] - 2026-09-11
 
 - Fixed two `Billable` checkboxes rendering with the same `billable` form ID when a billable project is selected in a premium workspace — they are now a single checkbox, shown whenever either condition applies

--- a/extensions/toggl-track/CHANGELOG.md
+++ b/extensions/toggl-track/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Toggl Track Changelog
 
-## [Fix Negative Running Durations] - {PR_MERGE_DATE}
+## [Fix Negative Running Durations] - 2026-09-13
 
 - Clamped elapsed-time calculations for the running entry to zero, so a start time in the future no longer renders a garbled negative duration in the list and menu bar, or subtracts from today's total
 

--- a/extensions/toggl-track/src/components/RunningTimeEntry.tsx
+++ b/extensions/toggl-track/src/components/RunningTimeEntry.tsx
@@ -32,7 +32,9 @@ function RunningTimeEntry({
         subtitle={
           (runningTimeEntry.client_name ? runningTimeEntry.client_name + " | " : "") +
           (runningTimeEntry.project_name ? runningTimeEntry.project_name + " | " : "") +
-          dayjs.duration(dayjs(currentTime).diff(runningTimeEntry.start), "milliseconds").format("HH:mm:ss")
+          dayjs
+            .duration(Math.max(0, dayjs(currentTime).diff(runningTimeEntry.start)), "milliseconds")
+            .format("HH:mm:ss")
         }
         accessories={[
           ...runningTimeEntry.tags.map((tag) => ({ tag })),

--- a/extensions/toggl-track/src/hooks/useTotalDurationToday.ts
+++ b/extensions/toggl-track/src/hooks/useTotalDurationToday.ts
@@ -8,7 +8,7 @@ export function useTotalDurationToday(timeEntries: TimeEntry[], runningTimeEntry
     let seconds = timeEntries
       .filter((timeEntry) => timeEntry.duration >= 0 && dayjs(timeEntry.start).isSame(dayjs(), "day"))
       .reduce((acc, timeEntry) => acc + timeEntry.duration, 0);
-    if (runningTimeEntry) seconds += dayjs().diff(dayjs(runningTimeEntry.start), "second");
+    if (runningTimeEntry) seconds += Math.max(0, dayjs().diff(dayjs(runningTimeEntry.start), "second"));
     return seconds;
   }, [timeEntries, runningTimeEntry]);
 }

--- a/extensions/toggl-track/src/menuBar.tsx
+++ b/extensions/toggl-track/src/menuBar.tsx
@@ -76,7 +76,9 @@ export default function Command() {
   const { currentTime } = useCurrentTime();
   const runningEntry = runningTimeEntry;
 
-  const currentDuration = runningEntry ? dayjs.duration(dayjs(currentTime).diff(runningEntry.start)) : undefined;
+  const currentDuration = runningEntry
+    ? dayjs.duration(Math.max(0, dayjs(currentTime).diff(runningEntry.start)))
+    : undefined;
   const currentDurationHhMmSs = currentDuration?.format("HH:mm:ss") || "";
   const currentDurationHhMm = currentDuration?.format("HH:mm") || "";
 


### PR DESCRIPTION
## Description

A running time entry whose `start` is in the future produces a **negative** elapsed time, which is then formatted directly. The result is garbled output like `-23:-35:-22` in the running-entry row and menu bar title, and a running entry that *subtracts* from today's total.

This is reachable through the extension's own UI: **Change Start Time** on the running entry is an `Action.PickDate` with no upper bound, so picking a future time is a couple of keystrokes away. Clock skew can do it too.

Three unguarded sites, all clamped with `Math.max(0, …)`:

| File | Expression |
|---|---|
| `components/RunningTimeEntry.tsx` | subtitle elapsed duration |
| `menuBar.tsx` | `currentDuration` (menu bar title) |
| `hooks/useTotalDurationToday.ts` | the running entry's contribution to today's total |

This matches the guard already present in `helpers/formatSeconds.ts`, which clamps for exactly this reason — these three call sites compute their durations with `dayjs` and never reach it.

Display-only; no API or cache behaviour changes.

## Screencast

Not included — a one-line before/after: `-23:-35:-22` becomes `00:00:00` until the start time is reached.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
