### PR TITLE
[Herdr] Fix agent focus not switching to the correct workspace

### DIFF
--- a/extensions/herdr/CHANGELOG.md
+++ b/extensions/herdr/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Fix Agent Focus Not Switching Workspace] - {PR_MERGE_DATE}
+
+- Fix "Focus Agent Needing Attention" and other agent-focus actions not switching the visible Herdr workspace after herdr v0.9.0. `agent focus` now resolves the agent's pane and routes through pane focus, which correctly switches workspace.
+
 ## [Fix Stuck Menu Bar Toast] - 2026-08-29
 
 - Report menu bar failures with a HUD instead of a toast held open across the action. Clicking an item unloads the menu bar command, which left the toast on screen with nothing to resolve it.

--- a/extensions/herdr/package.json
+++ b/extensions/herdr/package.json
@@ -5,6 +5,9 @@
   "description": "Control Herdr workspaces and coding agents from Raycast",
   "icon": "extension-icon.png",
   "author": "vlades",
+  "contributors": [
+    "alastairsounds"
+  ],
   "type": "module",
   "license": "MIT",
   "platforms": [

--- a/extensions/herdr/src/lib/herdr.ts
+++ b/extensions/herdr/src/lib/herdr.ts
@@ -4,7 +4,7 @@ import { delimiter, join } from "node:path";
 import { homedir } from "node:os";
 import { execFile } from "node:child_process";
 import { getHerdrPreferences } from "./preferences";
-import type { HerdrSession, HerdrSnapshot, PaneInfo } from "./types";
+import type { AgentInfo, HerdrSession, HerdrSnapshot, PaneInfo } from "./types";
 
 interface RunOptions {
   timeout?: number;
@@ -162,6 +162,12 @@ export async function getSessions(): Promise<HerdrSession[]> {
 }
 
 export async function focusResource(kind: "workspace" | "tab" | "pane" | "agent", id: string): Promise<void> {
+  if (kind === "agent") {
+    // herdr v0.9.0's `agent focus` doesn't push workspace switches to attached clients; route through pane focus.
+    const target = await runHerdrJson<{ agent: AgentInfo }>(["agent", "get", id]);
+    await focusPane(target.agent.pane_id);
+    return;
+  }
   if (kind === "pane") {
     await focusPane(id);
     return;


### PR DESCRIPTION
## Description

Fixes #31018

`herdr agent focus` (used by "Focus Agent Needing Attention" and other agent-focus actions) stopped switching the visible Herdr workspace after herdr v0.9.0. It still activates the correct terminal, but the attached Herdr TUI stayed on whatever workspace was already focused.

Root cause: herdr v0.9.0's server only pushes workspace changes to attached shell clients for `workspace.focus`, `tab.focus`, and `pane.focus`. So, `agent.focus` was left out of that list, so its workspace change never reached the client. This is confirmed against a vanilla v0.9.0 Homebrew install.

Since `agent.focus` isn't fixable from this extension's side of the wire, this PR routes agent-focus actions through `agent get` (to resolve the agent's pane) followed by the existing `focusPane` helper, which already uses `tab.focus`/`pane.focus` and works correctly. No changes are needed in herdr itself.

## Verify

To verify: have agents running in two different Herdr workspaces, then run "Focus Agent Needing Attention" (or any agent-focus action) on an agent in the non-active workspace. The Herdr TUI should switch to that agent's workspace, not just bring the terminal app forward.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our metadata tool
