### PR TITLE
Add Vibe Prospecting to MCP Registry

### DIFF
--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Model Context Protocol Registry Changelog
 
-## [Add Vibe Prospecting MCP Server] - 2026-09-11
+## [Add Vibe Prospecting MCP Server] - {PR_MERGE_DATE}
 
-Add Vibe Prospecting to the community registry for B2B company and contact intelligence in prospecting workflows. Connects to the remote OAuth MCP server through `mcp-remote`.
+- Add Vibe Prospecting to the community registry for B2B company and contact intelligence in prospecting workflows. Connects to the remote OAuth MCP server through `mcp-remote`.
 
 ## [Add Metabrain, AgentMailKit and Site Spec MCP Servers] - 2026-09-11
 

--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Model Context Protocol Registry Changelog
 
-## [Add Vibe Prospecting MCP Server] - {PR_MERGE_DATE}
+## [Add Vibe Prospecting MCP Server] - 2026-09-12
 
 - Add Vibe Prospecting to the community registry for B2B company and contact intelligence in prospecting workflows. Connects to the remote OAuth MCP server through `mcp-remote`.
 

--- a/extensions/model-context-protocol-registry/CHANGELOG.md
+++ b/extensions/model-context-protocol-registry/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Model Context Protocol Registry Changelog
 
+## [Add Vibe Prospecting MCP Server] - 2026-09-11
+
+Add Vibe Prospecting to the community registry for B2B company and contact intelligence in prospecting workflows. Connects to the remote OAuth MCP server through `mcp-remote`.
+
 ## [Add Metabrain, AgentMailKit and Site Spec MCP Servers] - 2026-09-11
 
 Add three community servers. Metabrain gives coding agents persistent memory in a local SQLite file (learn, recall, verdict, hypotheses, start_brief, stats, capture_error). AgentMailKit runs email sends as named jobs with a preview step and dry_run defaulting to true (list_jobs, run_job, preview_job, list_plugins). Site Spec audits and repairs a website across 40 SEO, accessibility, privacy, structured data and AI searchability checks (audit_site, fix_issue, compile_spec, list_checks). All three are local stdio servers that need no API key.

--- a/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
+++ b/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
@@ -1270,4 +1270,17 @@ export const COMMUNITY_ENTRIES: RegistryEntry[] = [
       args: ["-y", "@gitdealflow/mcp-signal@latest"],
     },
   },
+
+  {
+    name: "vibe-prospecting",
+    title: "Vibe Prospecting",
+    description:
+      "Power your chat with live B2B data to create lead lists, research companies, enrich contacts, personalize outreach, and inspect business signals, technology stacks, events, and website changes.",
+    icon: "https://raw.githubusercontent.com/explorium-ai/vibeprospecting-plugin/main/assets/icon.png",
+    homepage: "https://vibeprospecting.ai",
+    configuration: {
+      command: "npx",
+      args: ["-y", "mcp-remote", "https://vibeprospecting.explorium.ai/mcp"],
+    },
+  },
 ];

--- a/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
+++ b/extensions/model-context-protocol-registry/src/registries/builtin/entries.ts
@@ -1270,7 +1270,6 @@ export const COMMUNITY_ENTRIES: RegistryEntry[] = [
       args: ["-y", "@gitdealflow/mcp-signal@latest"],
     },
   },
-
   {
     name: "vibe-prospecting",
     title: "Vibe Prospecting",


### PR DESCRIPTION
## Summary
- Adds Vibe Prospecting to COMMUNITY_ENTRIES in the Model Context Protocol Registry.
- Uses the remote mcp-remote pattern with https://vibeprospecting.explorium.ai/mcp.
- Auth is OAuth. Homepage is https://vibeprospecting.ai. Source repo is https://github.com/explorium-ai/vibeprospecting-mcp.

## Test plan
- [ ] Confirm the new entry appears under community MCP servers in the extension.
- [ ] Confirm npx mcp-remote connects to https://vibeprospecting.explorium.ai/mcp.
- [ ] Confirm the icon URL loads.