### PR TITLE
[GitHub] Restore My Repositories filter combining personal and org repos

### DIFF
--- a/extensions/github/CHANGELOG.md
+++ b/extensions/github/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GitHub Changelog
 
+## [Restore My Repositories Filter] - {PR_MERGE_DATE}
+
+- Search Repositories, Issues, Pull Requests, and Discussions: Restore the **My Repositories** filter, which combines your personal repositories with those of your organizations.
+
 ## [Fix Star Action Icon] - 2026-09-09
 
 - Search Repositories: Fix the broken Star action icon

--- a/extensions/github/src/components/SearchRepositoryDropdown.tsx
+++ b/extensions/github/src/components/SearchRepositoryDropdown.tsx
@@ -11,6 +11,13 @@ export default function SearchRepositoryDropdown(props: { onFilterChange: (filte
     <List.Dropdown tooltip="Filter Repositories" onChange={props.onFilterChange} storeValue>
       <List.Dropdown.Section>
         <List.Dropdown.Item title={"All Repositories"} icon={Icon.List} value={""} />
+        {viewer && organizations.length >= 1 ? (
+          <List.Dropdown.Item
+            title={"My Repositories"}
+            icon={Icon.Person}
+            value={`user:${viewer.login} ${organizations.map((org) => `org:${org.login}`).join(" ")}`}
+          />
+        ) : null}
         {hasMultipleOrganizations ? (
           <List.Dropdown.Item
             title={"My Organizations"}


### PR DESCRIPTION
## Description

Fixes #30718.

#30309 replaced the **My Repositories** filter (`user:<login> org:<a> org:<b>`) with **My Organizations**, which only contains `org:` qualifiers. Since then there has been no way to search your personal repositories and your organizations' repositories together.

This adds **My Repositories** back next to **My Organizations**, which stays exactly as #30309 made it:

- Value: `user:<login>` plus every `org:<login>`, the same format as before #30309, so a selection remembered by `storeValue` keeps matching.
- Shown only when you belong to at least one organization. With none it would duplicate the personal-account item.
- The dropdown is shared, so this restores the filter in Search Repositories, Search Issues, Search Pull Requests and Search Discussions.

cc @Ernest0-Production, as this touches the dropdown from #30309.

I used Claude Code while writing this. I reviewed the change and tested it in Raycast myself (screenshot below: `spinner` under **My Repositories** returns a personal repo and an org repo together).

## Screencast

<img width="744" height="470" alt="raycast-30718-my-repositories" src="https://github.com/user-attachments/assets/77d393e4-8dec-429c-a273-5f2bd2872a74" />

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DN3mXHdYk1Q5B5DydSsoS3
