### PR TITLE
Update mozilla-firefox extension

### DIFF
--- a/extensions/mozilla-firefox/CHANGELOG.md
+++ b/extensions/mozilla-firefox/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Mozilla Firefox Changelog
 
-## [Live Bookmarks & Search Fixes] - 2026-09-12
+## [Live Bookmarks & Search Fixes] - {PR_MERGE_DATE}
 
 - Search Bookmarks now reads live from `moz_bookmarks` in `places.sqlite` instead of the daily `bookmarkbackups` lz4 file, so new bookmarks show up immediately
 - Search History hides redirect artifacts (`hidden = 0`) and entries that were never visited
 - Search History and Search Bookmarks match the query against the URL as well as the title
 - Fixed history entries being grouped under the wrong day when the UTC and local dates differ
-- Search terms containing a single quote no longer break the SQL query
+- Tag assignments are excluded from Search Bookmarks, so tagged URLs no longer appear once per tag
+- Search terms containing a single quote no longer break the SQL query, and `%` / `_` are matched literally instead of acting as wildcards
 - Removed the built-in lz4 decoder and the "no bookmarks" error view, which are no longer needed
 
 ## [Windows Support] - 2026-09-09

--- a/extensions/mozilla-firefox/CHANGELOG.md
+++ b/extensions/mozilla-firefox/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Mozilla Firefox Changelog
 
-## [Live Bookmarks & Search Fixes] - {PR_MERGE_DATE}
+## [Live Bookmarks & Search Fixes] - 2026-09-12
 
 - Search Bookmarks now reads live from `moz_bookmarks` in `places.sqlite` instead of the daily `bookmarkbackups` lz4 file, so new bookmarks show up immediately
 - Search History hides redirect artifacts (`hidden = 0`) and entries that were never visited

--- a/extensions/mozilla-firefox/CHANGELOG.md
+++ b/extensions/mozilla-firefox/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Mozilla Firefox Changelog
 
+## [Live Bookmarks & Search Fixes] - 2026-09-12
+
+- Search Bookmarks now reads live from `moz_bookmarks` in `places.sqlite` instead of the daily `bookmarkbackups` lz4 file, so new bookmarks show up immediately
+- Search History hides redirect artifacts (`hidden = 0`) and entries that were never visited
+- Search History and Search Bookmarks match the query against the URL as well as the title
+- Fixed history entries being grouped under the wrong day when the UTC and local dates differ
+- Search terms containing a single quote no longer break the SQL query
+- Removed the built-in lz4 decoder and the "no bookmarks" error view, which are no longer needed
+
 ## [Windows Support] - 2026-09-09
 
 - Added Windows support for all three commands: New Tab, Search History, Search Bookmarks

--- a/extensions/mozilla-firefox/package.json
+++ b/extensions/mozilla-firefox/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "mozilla-firefox",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "title": "Mozilla Firefox",
   "description": "Search and open tabs from bookmarks and history in Mozilla Firefox.",
   "icon": "firefox-logo.png",
@@ -10,7 +10,8 @@
     "serhii_kravchenko",
     "Laptop765",
     "kud",
-    "BryanG02"
+    "BryanG02",
+    "rockschtar"
   ],
   "categories": [
     "Applications",

--- a/extensions/mozilla-firefox/src/components/error/NoBookmarksError.tsx
+++ b/extensions/mozilla-firefox/src/components/error/NoBookmarksError.tsx
@@ -1,6 +1,0 @@
-import { Detail } from "@raycast/api";
-import { NoBookmarksText } from "../../constants";
-
-export function NoBookmarksError() {
-  return <Detail markdown={NoBookmarksText} />;
-}

--- a/extensions/mozilla-firefox/src/components/error/index.ts
+++ b/extensions/mozilla-firefox/src/components/error/index.ts
@@ -1,3 +1,2 @@
-export * from "./NoBookmarksError";
 export * from "./NotInstalledError";
 export * from "./UnknownError";

--- a/extensions/mozilla-firefox/src/constants.ts
+++ b/extensions/mozilla-firefox/src/constants.ts
@@ -19,12 +19,6 @@ const makeDownloadText = (installer: string, installerUrl: string) => `
 export const DownloadText = makeDownloadText("Homebrew", "https://brew.sh/");
 export const DownloadTextWindows = makeDownloadText("Winget", "https://aka.ms/winget");
 
-export const NoBookmarksText = `
-# 🚨Error: Mozilla Firefox browser has no bookmarks. Please add some bookmarks to continue using this command.
-
-[![Mozilla Firefox](https://mozilla.design/files/2019/10/logo-firefox.svg)]()
-`;
-
 export const UnknownErrorText = `
 # 🚨Error: Something happened while trying to run your command
   
@@ -34,4 +28,3 @@ export const UnknownErrorText = `
 export const DEFAULT_ERROR_TITLE = "An Error Occurred";
 
 export const NOT_INSTALLED_MESSAGE = "Mozilla Firefox not installed";
-export const NO_BOOKMARKS_MESSAGE = "Mozilla Firefox has no bookmarks";

--- a/extensions/mozilla-firefox/src/hooks/useBookmarkSearch.tsx
+++ b/extensions/mozilla-firefox/src/hooks/useBookmarkSearch.tsx
@@ -1,80 +1,31 @@
-import { promises, existsSync, readdirSync } from "fs";
-import { ReactElement, useEffect, useState } from "react";
-import { HistoryEntry, SearchResult } from "../interfaces";
-import { getBookmarksDirectoryPath, decodeLZ4 } from "../util";
-import { NO_BOOKMARKS_MESSAGE, NOT_INSTALLED_MESSAGE } from "../constants";
-import { NoBookmarksError, NotInstalledError, UnknownError } from "../components";
+import { ReactElement } from "react";
+import { existsSync } from "fs";
+import { useSQL } from "@raycast/utils";
+import { SearchResult, HistoryEntry } from "../interfaces";
+import { getHistoryDbPath, searchWhereClause } from "../util";
+import { NotInstalledError } from "../components";
 
-interface FirefoxBookmarkNode {
-  type: string;
-  id: number;
-  title: string;
-  uri?: string;
-  dateAdded: Date;
-  children?: FirefoxBookmarkNode[];
-}
+// Bookmarks live in the same places.sqlite as the history (moz_bookmarks.type = 1 → bookmark).
+const getBookmarkQuery = (query?: string) =>
+  `SELECT b.id AS id, p.url AS url, b.title AS title,
+          datetime(b.dateAdded/1000000,'unixepoch','localtime') AS lastVisited
+   FROM moz_bookmarks b
+   JOIN moz_places p ON b.fk = p.id
+   WHERE b.type = 1
+   ${searchWhereClause(query, "b.title", "p.url")}
+   ORDER BY b.dateAdded DESC LIMIT 100;`;
 
-function extractBookmarkFromBookmarkDirectory(bookmarkDirectory: FirefoxBookmarkNode): HistoryEntry[] {
-  const bookmarks: HistoryEntry[] = [];
-  if (bookmarkDirectory.type === "text/x-moz-place-container" && bookmarkDirectory.children) {
-    bookmarkDirectory.children.forEach((child: FirefoxBookmarkNode) => {
-      const bookmarkEntries = extractBookmarkFromBookmarkDirectory(child);
-      bookmarks.push(...bookmarkEntries);
-    });
-  } else if (bookmarkDirectory.type === "text/x-moz-place" && bookmarkDirectory.uri) {
-    bookmarks.push({
-      id: bookmarkDirectory.id,
-      title: bookmarkDirectory.title,
-      url: bookmarkDirectory.uri,
-      lastVisited: bookmarkDirectory.dateAdded,
-    });
+export function useBookmarkSearch(query: string | undefined): SearchResult<HistoryEntry> {
+  const dbPath = getHistoryDbPath();
+  const dbExists = existsSync(dbPath);
+
+  const { isLoading, data, permissionView } = useSQL<HistoryEntry>(dbPath, getBookmarkQuery(query), {
+    execute: dbExists,
+  });
+
+  if (!dbExists) {
+    return { data: [], isLoading: false, errorView: <NotInstalledError /> };
   }
-  return bookmarks;
-}
 
-async function extractBookmarks(): Promise<HistoryEntry[]> {
-  const bookmarksPath = getBookmarksDirectoryPath();
-  if (!existsSync(bookmarksPath)) {
-    throw new Error(NO_BOOKMARKS_MESSAGE);
-  }
-  const files = readdirSync(bookmarksPath);
-  if (files.length === 0) {
-    throw new Error(NO_BOOKMARKS_MESSAGE);
-  }
-  const fileBuffer = await promises.readFile(`${bookmarksPath}/${files[files.length - 1]}`);
-  const rawBookmarks = decodeLZ4(fileBuffer);
-
-  return extractBookmarkFromBookmarkDirectory(rawBookmarks);
-}
-
-export function useBookmarkSearch(query?: string): SearchResult<HistoryEntry> {
-  const [data, setData] = useState<HistoryEntry[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [errorView, setErrorView] = useState<ReactElement>();
-
-  useEffect(() => {
-    extractBookmarks()
-      .then((bookmarks) => {
-        setData(
-          bookmarks.filter(
-            (bookmark) =>
-              bookmark.title.toLowerCase().includes(query?.toLowerCase() || "") ||
-              bookmark.url.toLowerCase().includes(query?.toLowerCase() || ""),
-          ),
-        );
-        setIsLoading(false);
-      })
-      .catch((e) => {
-        if (e.message === NOT_INSTALLED_MESSAGE) {
-          setErrorView(<NotInstalledError />);
-        } else if (e.message === NO_BOOKMARKS_MESSAGE) {
-          setErrorView(<NoBookmarksError />);
-        } else {
-          setErrorView(<UnknownError message={e.message} />);
-        }
-        setIsLoading(false);
-      });
-  }, [query]);
-
-  return { errorView, isLoading, data };
+  return { data, isLoading, errorView: permissionView as ReactElement };
 }

--- a/extensions/mozilla-firefox/src/hooks/useBookmarkSearch.tsx
+++ b/extensions/mozilla-firefox/src/hooks/useBookmarkSearch.tsx
@@ -6,12 +6,14 @@ import { getHistoryDbPath, searchWhereClause } from "../util";
 import { NotInstalledError } from "../components";
 
 // Bookmarks live in the same places.sqlite as the history (moz_bookmarks.type = 1 → bookmark).
+// Tag assignments are also type-1 rows (children of the tag folders under guid "tags________") and are excluded.
 const getBookmarkQuery = (query?: string) =>
   `SELECT b.id AS id, p.url AS url, b.title AS title,
           datetime(b.dateAdded/1000000,'unixepoch','localtime') AS lastVisited
    FROM moz_bookmarks b
    JOIN moz_places p ON b.fk = p.id
    WHERE b.type = 1
+     AND b.parent NOT IN (SELECT id FROM moz_bookmarks WHERE parent = (SELECT id FROM moz_bookmarks WHERE guid = 'tags________'))
    ${searchWhereClause(query, "b.title", "p.url")}
    ORDER BY b.dateAdded DESC LIMIT 100;`;
 

--- a/extensions/mozilla-firefox/src/hooks/useHistorySearch.tsx
+++ b/extensions/mozilla-firefox/src/hooks/useHistorySearch.tsx
@@ -2,31 +2,28 @@ import { ReactElement } from "react";
 import { existsSync } from "fs";
 import { useSQL } from "@raycast/utils";
 import { SearchResult, HistoryEntry } from "../interfaces";
-import { getHistoryDbPath } from "../util";
+import { getHistoryDbPath, searchWhereClause } from "../util";
 import { NotInstalledError } from "../components";
 
-const whereClauses = (terms: string[]) => {
-  return terms.map((t) => `moz_places.title LIKE '%${t}%'`).join(" AND ");
-};
-
-const getHistoryQuery = (query?: string) => {
-  const terms = query ? query.trim().split(" ") : [];
-  const whereClause = terms.length > 0 ? `WHERE ${whereClauses(terms)}` : "";
-  return `SELECT
-            id, url, title,
-            datetime(last_visit_date/1000000,'unixepoch') as lastVisited
-          FROM moz_places
-          ${whereClause}
-          ORDER BY last_visit_date DESC LIMIT 30;`;
-};
+const getHistoryQuery = (query?: string) =>
+  `SELECT id, url, title,
+          datetime(last_visit_date/1000000,'unixepoch','localtime') AS lastVisited
+   FROM moz_places
+   WHERE last_visit_date IS NOT NULL AND hidden = 0
+   ${searchWhereClause(query, "title", "url")}
+   ORDER BY last_visit_date DESC LIMIT 30;`;
 
 export function useHistorySearch(query: string | undefined): SearchResult<HistoryEntry> {
-  const inQuery = getHistoryQuery(query);
   const dbPath = getHistoryDbPath();
+  const dbExists = existsSync(dbPath);
 
-  if (!existsSync(dbPath)) {
+  const { isLoading, data, permissionView } = useSQL<HistoryEntry>(dbPath, getHistoryQuery(query), {
+    execute: dbExists,
+  });
+
+  if (!dbExists) {
     return { data: [], isLoading: false, errorView: <NotInstalledError /> };
   }
-  const { isLoading, data, permissionView } = useSQL<HistoryEntry>(dbPath, inQuery);
+
   return { data, isLoading, errorView: permissionView as ReactElement };
 }

--- a/extensions/mozilla-firefox/src/util/__tests__/index.test.ts
+++ b/extensions/mozilla-firefox/src/util/__tests__/index.test.ts
@@ -12,7 +12,7 @@ vi.mock("@raycast/api", () => ({
 import { getPreferenceValues } from "@raycast/api";
 
 // Import after the mock is in place so the module picks up the stub.
-import { getBookmarksDirectoryPath, getHistoryDbPath } from "../index";
+import { getHistoryDbPath, searchWhereClause } from "../index";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -278,17 +278,6 @@ describe("getProfileName (via getHistoryDbPath)", () => {
     // No valid profile for Nightly — safer to return empty than silently read release data.
     expect(result).toBe(path.join(PROFILES_BASE, "places.sqlite"));
   });
-
-  // --- Public API surface (bookmarks path delegates to same logic) ----------
-
-  it("getBookmarksDirectoryPath uses the same profile resolution", () => {
-    setPrefs("default-release");
-    mockProfiles(["abc123.default-release"]);
-
-    const result = getBookmarksDirectoryPath();
-
-    expect(result).toBe(path.join(PROFILES_BASE, "abc123.default-release", "bookmarkbackups"));
-  });
 });
 
 // ---------------------------------------------------------------------------
@@ -452,15 +441,6 @@ describe("getProfileName on Windows (via getHistoryDbPath)", () => {
     expect(result).toBe(path.join(PROFILES_BASE_WIN, "places.sqlite"));
   });
 
-  it("getBookmarksDirectoryPath uses APPDATA on Windows", () => {
-    setPrefs("default-release");
-    mockProfiles(["abc123.default-release"]);
-
-    const result = getBookmarksDirectoryPath();
-
-    expect(result).toBe(path.join(PROFILES_BASE_WIN, "abc123.default-release", "bookmarkbackups"));
-  });
-
   it("returns an empty path segment when the Profiles directory does not exist on Windows", () => {
     setPrefs("default-release");
     vi.spyOn(fs, "readdirSync").mockImplementation(() => {
@@ -502,5 +482,22 @@ describe("getProfileName on Windows (via getHistoryDbPath)", () => {
     const result = getHistoryDbPath();
 
     expect(result).toBe(path.join(PROFILES_BASE_WIN, "good.profile", "places.sqlite"));
+  });
+});
+
+describe("searchWhereClause", () => {
+  it("returns an empty clause for no query", () => {
+    expect(searchWhereClause(undefined, "title", "url")).toBe("");
+    expect(searchWhereClause("   ", "title", "url")).toBe("");
+  });
+
+  it("matches every term against title or url", () => {
+    expect(searchWhereClause("foo bar", "title", "url")).toBe(
+      "AND (title LIKE '%foo%' OR url LIKE '%foo%') AND (title LIKE '%bar%' OR url LIKE '%bar%')",
+    );
+  });
+
+  it("escapes single quotes", () => {
+    expect(searchWhereClause("o'reilly", "t", "u")).toBe("AND (t LIKE '%o''reilly%' OR u LIKE '%o''reilly%')");
   });
 });

--- a/extensions/mozilla-firefox/src/util/__tests__/index.test.ts
+++ b/extensions/mozilla-firefox/src/util/__tests__/index.test.ts
@@ -493,11 +493,26 @@ describe("searchWhereClause", () => {
 
   it("matches every term against title or url", () => {
     expect(searchWhereClause("foo bar", "title", "url")).toBe(
-      "AND (title LIKE '%foo%' OR url LIKE '%foo%') AND (title LIKE '%bar%' OR url LIKE '%bar%')",
+      "AND (title LIKE '%foo%' ESCAPE '\\' OR url LIKE '%foo%' ESCAPE '\\') " +
+        "AND (title LIKE '%bar%' ESCAPE '\\' OR url LIKE '%bar%' ESCAPE '\\')",
     );
   });
 
   it("escapes single quotes", () => {
-    expect(searchWhereClause("o'reilly", "t", "u")).toBe("AND (t LIKE '%o''reilly%' OR u LIKE '%o''reilly%')");
+    expect(searchWhereClause("o'reilly", "t", "u")).toBe(
+      "AND (t LIKE '%o''reilly%' ESCAPE '\\' OR u LIKE '%o''reilly%' ESCAPE '\\')",
+    );
+  });
+
+  it("treats LIKE wildcards and backslashes as literals", () => {
+    expect(searchWhereClause("%20", "t", "u")).toBe(
+      "AND (t LIKE '%\\%20%' ESCAPE '\\' OR u LIKE '%\\%20%' ESCAPE '\\')",
+    );
+    expect(searchWhereClause("my_file", "t", "u")).toBe(
+      "AND (t LIKE '%my\\_file%' ESCAPE '\\' OR u LIKE '%my\\_file%' ESCAPE '\\')",
+    );
+    expect(searchWhereClause("a\\b", "t", "u")).toBe(
+      "AND (t LIKE '%a\\\\b%' ESCAPE '\\' OR u LIKE '%a\\\\b%' ESCAPE '\\')",
+    );
   });
 });

--- a/extensions/mozilla-firefox/src/util/index.ts
+++ b/extensions/mozilla-firefox/src/util/index.ts
@@ -80,11 +80,6 @@ export const getHistoryDbPath = (): string => {
   return path.join(userDirectoryPath, getProfileName(userDirectoryPath), "places.sqlite");
 };
 
-export const getBookmarksDirectoryPath = (): string => {
-  const userDirectoryPath = userDataDirectoryPath();
-  return path.join(userDirectoryPath, getProfileName(userDirectoryPath), "bookmarkbackups");
-};
-
 export const getSessionManagerExtensionPath = (extensionId: string) => {
   const userDirectoryPath = userDataDirectoryPath();
   return path.join(
@@ -107,68 +102,11 @@ export const getSessionActivePath = (): string => {
   return path.join(userDirectoryPath, getProfileName(userDirectoryPath), "sessionstore-backups", "recovery.jsonlz4");
 };
 
-export function decodeLZ4(buffer: Buffer) {
-  const u8sz = buffer.slice(8, 12);
-  const origLen = u8sz[0] + u8sz[1] * 256 + u8sz[2] * 256 * 256 + u8sz[3] * 256 * 256 * 256;
-  // Extract compressed data (past mozilla jsonlz4 header of 12 bytes)
-  const jsonStart = 12;
-  const u8Comp = buffer.slice(jsonStart);
-  // Create LZ4 buffer
-  const comp = Buffer.from(u8Comp);
-  const orig = Buffer.alloc(origLen);
-  // perform lz4 decompression
-  const decompressedLen = decodeBlock(comp, orig);
-  const data = orig.subarray(0, decompressedLen);
-  return JSON.parse(data.toString());
-}
+const escapeSql = (term: string) => term.replace(/'/g, "''");
 
-function decodeBlock(input: Buffer, output: Buffer, sIdx?: number, eIdx?: number) {
-  sIdx = sIdx || 0;
-  eIdx = eIdx || input.length - sIdx;
-  let a;
-  // Process each sequence in the incoming data
-  for (let i = sIdx, n = eIdx, j = 0; i < n; ) {
-    a = j;
-    const token = input[i++];
-
-    // Literals
-    let literals_length = token >> 4;
-    if (literals_length > 0) {
-      // length of literals
-      let l = literals_length + 240;
-      while (l === 255) {
-        l = input[i++];
-        literals_length += l;
-      }
-
-      // Copy the literals
-      const end = i + literals_length;
-      while (i < end) output[j++] = input[i++];
-
-      // End of buffer?
-      if (i === n) return j;
-    }
-
-    // Match copy
-    // 2 bytes offset (little endian)
-    const offset = input[i++] | (input[i++] << 8);
-
-    // 0 is an invalid offset value
-    if (offset === 0 || offset > j) return -(i - 2);
-
-    // length of match copy
-    let match_length = token & 0xf;
-    let l = match_length + 240;
-    while (l === 255) {
-      l = input[i++];
-      match_length += l;
-    }
-
-    // Copy the match
-    let pos = j - offset; // position of the match copy in the current output
-    const end = j + match_length + 4; // minmatch = 4
-    while (j < end) output[j++] = output[pos++];
-  }
-
-  return a;
-}
+export const searchWhereClause = (query: string | undefined, titleColumn: string, urlColumn: string): string => {
+  const terms = query?.trim().split(/\s+/).filter(Boolean) ?? [];
+  return terms
+    .map((t) => `AND (${titleColumn} LIKE '%${escapeSql(t)}%' OR ${urlColumn} LIKE '%${escapeSql(t)}%')`)
+    .join(" ");
+};

--- a/extensions/mozilla-firefox/src/util/index.ts
+++ b/extensions/mozilla-firefox/src/util/index.ts
@@ -102,11 +102,15 @@ export const getSessionActivePath = (): string => {
   return path.join(userDirectoryPath, getProfileName(userDirectoryPath), "sessionstore-backups", "recovery.jsonlz4");
 };
 
-const escapeSql = (term: string) => term.replace(/'/g, "''");
+// Escape ' for SQL and the LIKE wildcards % and _ (plus the escape char itself) so they match literally.
+const escapeLike = (term: string) => term.replace(/'/g, "''").replace(/[\\%_]/g, "\\$&");
 
 export const searchWhereClause = (query: string | undefined, titleColumn: string, urlColumn: string): string => {
   const terms = query?.trim().split(/\s+/).filter(Boolean) ?? [];
   return terms
-    .map((t) => `AND (${titleColumn} LIKE '%${escapeSql(t)}%' OR ${urlColumn} LIKE '%${escapeSql(t)}%')`)
+    .map(
+      (t) =>
+        `AND (${titleColumn} LIKE '%${escapeLike(t)}%' ESCAPE '\\' OR ${urlColumn} LIKE '%${escapeLike(t)}%' ESCAPE '\\')`,
+    )
     .join(" ");
 };


### PR DESCRIPTION
## Description

Follow-up to #30663, where @0xdhrv suggested contributing the improvements from my Windows-only Firefox extension to this one instead of maintaining a second Store listing.

- **Search Bookmarks** now reads live from `moz_bookmarks` in `places.sqlite` instead of the daily `bookmarkbackups` lz4 file, so new bookmarks show up immediately
- **Search History** hides redirect artifacts (`hidden = 0`) and entries that were never visited
- Both commands match the query against the URL as well as the title
- History timestamps use `localtime`, so entries are grouped under the correct day when the UTC and local dates differ
- Search terms containing a single quote are escaped and no longer break the SQL query
- Removed the now-unused lz4 decoder, `getBookmarksDirectoryPath` and the "no bookmarks" error view (bookmarks come from the same database as the history, so `NotInstalledError` covers the missing-profile case)
- Added unit tests for the shared `searchWhereClause` helper

Tested on Windows 11 with Firefox release. The queries are platform-independent and work unchanged against a macOS `places.sqlite`.

## Screencast

n/a - no UI changes

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder
