### PR TITLE
Qobuz: convert the Now Playing track, with clipboard fallback

### DIFF
--- a/extensions/qobuz/CHANGELOG.md
+++ b/extensions/qobuz/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Qobuz Changelog
 
-## [Now Playing fallback] - {PR_MERGE_DATE}
+## [Now Playing fallback] - 2026-09-12
 
 - Convert Track Link: convert the track Qobuz is currently on, falling back to a track link on the clipboard; when both are available, an action switches to the other one
 - Convert Track Link: accept an optional track link as a command argument, which takes precedence over both

--- a/extensions/qobuz/CHANGELOG.md
+++ b/extensions/qobuz/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Now Playing fallback] - {PR_MERGE_DATE}
 
-- Convert Track Link: when the clipboard holds no usable track link, convert the track Qobuz is currently on instead; a "Use Now Playing Instead" action switches to it when both are available
+- Convert Track Link: convert the track Qobuz is currently on, falling back to a track link on the clipboard; when both are available, an action switches to the other one
 - Convert Track Link: show where the input came from (clipboard or Qobuz) in the metadata
 - Convert Track Link: show the "Nothing to convert" hint when the clipboard is empty instead of a blank view
 

--- a/extensions/qobuz/CHANGELOG.md
+++ b/extensions/qobuz/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Qobuz Changelog
 
-## [Explain an empty clipboard] - {PR_MERGE_DATE}
+## [Now Playing fallback] - {PR_MERGE_DATE}
 
+- Convert Track Link: when the clipboard holds no usable track link, convert the track Qobuz is currently on instead; a "Use Now Playing Instead" action switches to it when both are available
+- Convert Track Link: show where the input came from (clipboard or Qobuz) in the metadata
 - Convert Track Link: show the "Nothing to convert" hint when the clipboard is empty instead of a blank view
 
 ## [Initial Version] - 2026-07-22

--- a/extensions/qobuz/CHANGELOG.md
+++ b/extensions/qobuz/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Convert Track Link: convert the track Qobuz is currently on, falling back to a track link on the clipboard; when both are available, an action switches to the other one
 - Convert Track Link: accept an optional track link as a command argument, which takes precedence over both
+- Convert Track Link: a resolved Qobuz track also offers Open in Qobuz, Play Track in Qobuz, Open in Browser and Copy Qobuz Link in the Qobuz → other services direction
 - Convert Track Link: show where the input came from (clipboard or Qobuz) in the metadata
 - Convert Track Link: show the "Nothing to convert" hint when the clipboard is empty instead of a blank view
 

--- a/extensions/qobuz/CHANGELOG.md
+++ b/extensions/qobuz/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Now Playing fallback] - {PR_MERGE_DATE}
 
 - Convert Track Link: convert the track Qobuz is currently on, falling back to a track link on the clipboard; when both are available, an action switches to the other one
+- Convert Track Link: accept an optional track link as a command argument, which takes precedence over both
 - Convert Track Link: show where the input came from (clipboard or Qobuz) in the metadata
 - Convert Track Link: show the "Nothing to convert" hint when the clipboard is empty instead of a blank view
 

--- a/extensions/qobuz/CHANGELOG.md
+++ b/extensions/qobuz/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Qobuz Changelog
 
+## [Explain an empty clipboard] - {PR_MERGE_DATE}
+
+- Convert Track Link: show the "Nothing to convert" hint when the clipboard is empty instead of a blank view
+
 ## [Initial Version] - 2026-07-22
 
 - Search Qobuz albums, artists, and tracks in a grid, with a type filter and in-Raycast detail views

--- a/extensions/qobuz/package.json
+++ b/extensions/qobuz/package.json
@@ -21,7 +21,7 @@
       "name": "convert-link",
       "title": "Convert Track Link",
       "subtitle": "Qobuz",
-      "description": "Copy a Spotify, YouTube Music, or Qobuz track link, then run this to convert it to the other services.",
+      "description": "Convert a Spotify, YouTube Music, or Qobuz track link from the clipboard to the other services — or the track playing in Qobuz when the clipboard holds none.",
       "mode": "view"
     },
     {

--- a/extensions/qobuz/package.json
+++ b/extensions/qobuz/package.json
@@ -21,7 +21,7 @@
       "name": "convert-link",
       "title": "Convert Track Link",
       "subtitle": "Qobuz",
-      "description": "Convert a Spotify, YouTube Music, or Qobuz track link from the clipboard to the other services — or the track playing in Qobuz when the clipboard holds none.",
+      "description": "Convert the track playing in Qobuz — or a Spotify, YouTube Music, or Qobuz track link from the clipboard — to the other services.",
       "mode": "view"
     },
     {

--- a/extensions/qobuz/package.json
+++ b/extensions/qobuz/package.json
@@ -22,7 +22,15 @@
       "title": "Convert Track Link",
       "subtitle": "Qobuz",
       "description": "Convert the track playing in Qobuz — or a Spotify, YouTube Music, or Qobuz track link from the clipboard — to the other services.",
-      "mode": "view"
+      "mode": "view",
+      "arguments": [
+        {
+          "name": "link",
+          "placeholder": "Track link (optional)",
+          "type": "text",
+          "required": false
+        }
+      ]
     },
     {
       "name": "now-playing",

--- a/extensions/qobuz/src/convert-link.tsx
+++ b/extensions/qobuz/src/convert-link.tsx
@@ -1,4 +1,4 @@
-import { Action, ActionPanel, Color, Detail, Icon } from "@raycast/api";
+import { Action, ActionPanel, Color, Detail, Icon, type LaunchProps } from "@raycast/api";
 import { showFailureToast, usePromise } from "@raycast/utils";
 import { Clipboard } from "@raycast/api";
 import { readNowPlayingTrackId, type Album, type QobuzClient, type Track } from "@kud/qobuz";
@@ -16,11 +16,11 @@ import {
   type ResolvedTrack,
 } from "./lib/resolve";
 
-type Source = "clipboard" | "now-playing";
+type Source = "argument" | "now-playing" | "clipboard";
 
 // Where the input came from, and which other source the panel can offer to
 // switch to, when one is available.
-type Input = { source: Source; alternative?: Source };
+type Input = { source: Source; alternative?: Exclude<Source, "argument"> };
 
 type ToQobuz = Input & {
   mode: "to-qobuz";
@@ -40,8 +40,13 @@ type FromQobuz = Input & {
 
 type Conversion = { mode: "empty" } | { mode: "error"; reason: ResolveFailure } | ToQobuz | FromQobuz;
 
-const SUPPORTED_HINT =
-  "Play something in Qobuz, or copy a **Spotify**, **YouTube Music**, or **Qobuz** track link, then run this command.";
+const SUPPORTED_HINT = [
+  "This command converts, in order:",
+  "",
+  "1. the track link typed after the command, if any",
+  "2. the track the **Qobuz** app is currently on",
+  "3. a **Spotify**, **YouTube Music**, or **Qobuz** track link on the clipboard",
+].join("\n");
 
 const UNRESOLVED_MESSAGE: Record<ResolveFailure, string> = {
   invalid: ["# Nothing to convert", "", SUPPORTED_HINT].join("\n"),
@@ -84,12 +89,26 @@ const convertToQobuz = async (client: QobuzClient, resolved: ResolvedTrack): Pro
   return { mode: "to-qobuz", resolved, track, album, exact };
 };
 
-// Precedence: the track Qobuz is currently on wins, a track link on the
-// clipboard is the fallback. Qobuz's state file carries no playing flag, only a
-// queue position, so the current track is present whenever the queue is — the
-// clipboard is reached by choice (the switch action) far more often than by
-// fallback.
-const convert = async (preferred: Source | undefined): Promise<Conversion> => {
+const convertUrl = async (url: string, input: Input): Promise<Conversion> => {
+  const outcome = await resolveLink(url);
+  if (!outcome.ok) return { mode: "error", reason: outcome.reason };
+
+  const client = await getClient();
+  const converted =
+    outcome.direction === "from-qobuz"
+      ? await convertFromQobuz(client, outcome.qobuzTrackId)
+      : await convertToQobuz(client, outcome.track);
+  return { ...converted, ...input };
+};
+
+// Precedence: a link typed as the argument, then the track Qobuz is currently
+// on, then a track link on the clipboard. Qobuz's state file carries no playing
+// flag, only a queue position, so the current track is present whenever the
+// queue is — the clipboard is reached by choice (the switch action) far more
+// often than by fallback. A typed link is deliberate, so it never falls through.
+const convert = async (argument: string, preferred: Source | undefined): Promise<Conversion> => {
+  if (argument) return convertUrl(argument, { source: "argument" });
+
   const nowPlayingId = await readNowPlayingTrackId();
   const url = (await Clipboard.readText())?.trim() || "";
   const clipboardUsable = looksLikeTrackLink(url);
@@ -100,20 +119,13 @@ const convert = async (preferred: Source | undefined): Promise<Conversion> => {
   }
 
   if (!url) return { mode: "empty" };
-  const outcome = await resolveLink(url);
-  if (!outcome.ok) return { mode: "error", reason: outcome.reason };
-
-  const client = await getClient();
-  const converted =
-    outcome.direction === "from-qobuz"
-      ? await convertFromQobuz(client, outcome.qobuzTrackId)
-      : await convertToQobuz(client, outcome.track);
-  return { ...converted, source: "clipboard", alternative: nowPlayingId !== undefined ? "now-playing" : undefined };
+  return convertUrl(url, { source: "clipboard", alternative: nowPlayingId !== undefined ? "now-playing" : undefined });
 };
 
-export default function Command() {
+export default function Command(props: LaunchProps<{ arguments: Arguments.ConvertLink }>) {
+  const argument = props.arguments.link?.trim() ?? "";
   const [preferred, setPreferred] = useState<Source | undefined>(undefined);
-  const { data, isLoading } = usePromise(convert, [preferred], {
+  const { data, isLoading } = usePromise(convert, [argument, preferred], {
     onError: (error) => {
       showFailureToast(error, { title: "Couldn't convert link" });
     },
@@ -136,7 +148,7 @@ const renderMetadata = (data: Conversion | undefined) => {
   return undefined;
 };
 
-const SWITCH_ACTION: Record<Source, { title: string; icon: Icon }> = {
+const SWITCH_ACTION: Record<Exclude<Source, "argument">, { title: string; icon: Icon }> = {
   "now-playing": { title: "Use Now Playing Instead", icon: Icon.Music },
   clipboard: { title: "Use Clipboard Link Instead", icon: Icon.Clipboard },
 };
@@ -205,7 +217,11 @@ const renderActions = (data: Conversion | undefined, onSwitch: (source: Source) 
   return undefined;
 };
 
-const SOURCE_LABEL: Record<Source, string> = { clipboard: "Clipboard", "now-playing": "Now Playing in Qobuz" };
+const SOURCE_LABEL: Record<Source, string> = {
+  argument: "Typed link",
+  "now-playing": "Now Playing in Qobuz",
+  clipboard: "Clipboard",
+};
 
 function ToQobuzMetadata({ data, track }: { data: ToQobuz; track: Track }) {
   return (

--- a/extensions/qobuz/src/convert-link.tsx
+++ b/extensions/qobuz/src/convert-link.tsx
@@ -8,6 +8,7 @@ import {
   deezerByIsrc,
   findIsrc,
   isLikelyMatch,
+  looksLikeTrackLink,
   resolveLink,
   spotifySearchUrl,
   ytMusicSearchUrl,
@@ -17,10 +18,9 @@ import {
 
 type Source = "clipboard" | "now-playing";
 
-// Where the input came from, and whether the other source is available to
-// switch to. nowPlayingId is only set when the clipboard won, so the panel can
-// offer the currently playing track as an alternative.
-type Input = { source: Source; nowPlayingId?: number };
+// Where the input came from, and which other source the panel can offer to
+// switch to, when one is available.
+type Input = { source: Source; alternative?: Source };
 
 type ToQobuz = Input & {
   mode: "to-qobuz";
@@ -41,13 +41,7 @@ type FromQobuz = Input & {
 type Conversion = { mode: "empty" } | { mode: "error"; reason: ResolveFailure } | ToQobuz | FromQobuz;
 
 const SUPPORTED_HINT =
-  "Copy a **Spotify**, **YouTube Music**, or **Qobuz** track link — or play something in Qobuz — then run this command.";
-
-// A clipboard that is not a track link from a known service says nothing about
-// intent, so the currently playing track takes over. A link from a known
-// service of the wrong kind (album, playlist) is a deliberate paste and keeps
-// its error instead.
-const YIELDS_TO_NOW_PLAYING: ReadonlySet<ResolveFailure> = new Set(["invalid", "unknown"]);
+  "Play something in Qobuz, or copy a **Spotify**, **YouTube Music**, or **Qobuz** track link, then run this command.";
 
 const UNRESOLVED_MESSAGE: Record<ResolveFailure, string> = {
   invalid: ["# Nothing to convert", "", SUPPORTED_HINT].join("\n"),
@@ -90,40 +84,36 @@ const convertToQobuz = async (client: QobuzClient, resolved: ResolvedTrack): Pro
   return { mode: "to-qobuz", resolved, track, album, exact };
 };
 
-// Precedence: a usable track link on the clipboard wins, the track Qobuz is
-// currently on fills in otherwise. Qobuz's state file carries no playing flag,
-// only a queue position — so "is something playing" cannot be detected, and
-// putting now-playing first would make the clipboard unreachable on any machine
-// with a queue.
-const convert = async (preferNowPlaying: boolean): Promise<Conversion> => {
+// Precedence: the track Qobuz is currently on wins, a track link on the
+// clipboard is the fallback. Qobuz's state file carries no playing flag, only a
+// queue position, so the current track is present whenever the queue is — the
+// clipboard is reached by choice (the switch action) far more often than by
+// fallback.
+const convert = async (preferred: Source | undefined): Promise<Conversion> => {
   const nowPlayingId = await readNowPlayingTrackId();
-  const convertNowPlaying = async (trackId: number): Promise<Conversion> => ({
-    ...(await convertFromQobuz(await getClient(), trackId)),
-    source: "now-playing",
-  });
-
-  if (preferNowPlaying && nowPlayingId !== undefined) return convertNowPlaying(nowPlayingId);
-
   const url = (await Clipboard.readText())?.trim() || "";
-  const outcome = url ? await resolveLink(url) : undefined;
+  const clipboardUsable = looksLikeTrackLink(url);
 
-  if (outcome?.ok) {
-    const client = await getClient();
-    const converted =
-      outcome.direction === "from-qobuz"
-        ? await convertFromQobuz(client, outcome.qobuzTrackId)
-        : await convertToQobuz(client, outcome.track);
-    return { ...converted, source: "clipboard", nowPlayingId };
+  if (nowPlayingId !== undefined && preferred !== "clipboard") {
+    const converted = await convertFromQobuz(await getClient(), nowPlayingId);
+    return { ...converted, source: "now-playing", alternative: clipboardUsable ? "clipboard" : undefined };
   }
 
-  const reason: ResolveFailure = outcome?.reason ?? "invalid";
-  if (nowPlayingId !== undefined && YIELDS_TO_NOW_PLAYING.has(reason)) return convertNowPlaying(nowPlayingId);
-  return outcome ? { mode: "error", reason } : { mode: "empty" };
+  if (!url) return { mode: "empty" };
+  const outcome = await resolveLink(url);
+  if (!outcome.ok) return { mode: "error", reason: outcome.reason };
+
+  const client = await getClient();
+  const converted =
+    outcome.direction === "from-qobuz"
+      ? await convertFromQobuz(client, outcome.qobuzTrackId)
+      : await convertToQobuz(client, outcome.track);
+  return { ...converted, source: "clipboard", alternative: nowPlayingId !== undefined ? "now-playing" : undefined };
 };
 
 export default function Command() {
-  const [preferNowPlaying, setPreferNowPlaying] = useState(false);
-  const { data, isLoading } = usePromise(convert, [preferNowPlaying], {
+  const [preferred, setPreferred] = useState<Source | undefined>(undefined);
+  const { data, isLoading } = usePromise(convert, [preferred], {
     onError: (error) => {
       showFailureToast(error, { title: "Couldn't convert link" });
     },
@@ -134,7 +124,7 @@ export default function Command() {
       isLoading={isLoading}
       markdown={buildMarkdown(data, isLoading)}
       metadata={renderMetadata(data)}
-      actions={renderActions(data, () => setPreferNowPlaying(true))}
+      actions={renderActions(data, setPreferred)}
     />
   );
 }
@@ -146,14 +136,22 @@ const renderMetadata = (data: Conversion | undefined) => {
   return undefined;
 };
 
-const renderActions = (data: Conversion | undefined, onUseNowPlaying: () => void) => {
+const SWITCH_ACTION: Record<Source, { title: string; icon: Icon }> = {
+  "now-playing": { title: "Use Now Playing Instead", icon: Icon.Music },
+  clipboard: { title: "Use Clipboard Link Instead", icon: Icon.Clipboard },
+};
+
+const renderActions = (data: Conversion | undefined, onSwitch: (source: Source) => void) => {
   if (!data) return undefined;
 
-  const useNowPlaying = (data.mode === "to-qobuz" || data.mode === "from-qobuz") &&
-    data.source === "clipboard" &&
-    data.nowPlayingId !== undefined && (
-      <Action title="Use Now Playing Instead" icon={Icon.Music} onAction={onUseNowPlaying} />
-    );
+  const alternative = data.mode === "to-qobuz" || data.mode === "from-qobuz" ? data.alternative : undefined;
+  const switchAction = alternative && (
+    <Action
+      title={SWITCH_ACTION[alternative].title}
+      icon={SWITCH_ACTION[alternative].icon}
+      onAction={() => onSwitch(alternative)}
+    />
+  );
 
   if (data.mode === "to-qobuz" && data.track) {
     const trackUrl = deepLink.track(data.track.id);
@@ -165,7 +163,7 @@ const renderActions = (data: Conversion | undefined, onUseNowPlaying: () => void
         <Action.OpenInBrowser title="Open in Browser" url={trackUrl} />
         <Action.Open title="Play Track in Qobuz" target={appLink.track(data.track.id)} icon={Icon.Play} />
         <Action.CopyToClipboard title="Copy Qobuz Link" content={trackUrl} />
-        {useNowPlaying}
+        {switchAction}
       </ActionPanel>
     );
   }
@@ -179,7 +177,7 @@ const renderActions = (data: Conversion | undefined, onUseNowPlaying: () => void
           icon={Icon.MagnifyingGlass}
           url={`https://open.qobuz.com/search/${encodeURIComponent(q)}`}
         />
-        {useNowPlaying}
+        {switchAction}
       </ActionPanel>
     );
   }
@@ -199,7 +197,7 @@ const renderActions = (data: Conversion | undefined, onUseNowPlaying: () => void
         />
         {data.deezerUrl && <Action.OpenInBrowser title="Open on Deezer" url={data.deezerUrl} />}
         <Action.CopyToClipboard title="Copy Artist & Title" content={data.query} />
-        {useNowPlaying}
+        {switchAction}
       </ActionPanel>
     );
   }

--- a/extensions/qobuz/src/convert-link.tsx
+++ b/extensions/qobuz/src/convert-link.tsx
@@ -222,7 +222,8 @@ const coverMarkdown = (track: Track, album: Album | null): string => {
 };
 
 const buildMarkdown = (data: Conversion | undefined, isLoading: boolean): string => {
-  if (isLoading || !data || data.mode === "empty") return "";
+  if (isLoading || !data) return "";
+  if (data.mode === "empty") return UNRESOLVED_MESSAGE.invalid;
 
   if (data.mode === "error") return UNRESOLVED_MESSAGE[data.reason];
 

--- a/extensions/qobuz/src/convert-link.tsx
+++ b/extensions/qobuz/src/convert-link.tsx
@@ -1,7 +1,8 @@
 import { Action, ActionPanel, Color, Detail, Icon } from "@raycast/api";
 import { showFailureToast, usePromise } from "@raycast/utils";
 import { Clipboard } from "@raycast/api";
-import type { Album, Track } from "@kud/qobuz";
+import { readNowPlayingTrackId, type Album, type QobuzClient, type Track } from "@kud/qobuz";
+import { useState } from "react";
 import { appLink, BRAND, deepLink, formatDuration, getClient } from "./lib/client";
 import {
   deezerByIsrc,
@@ -14,25 +15,39 @@ import {
   type ResolvedTrack,
 } from "./lib/resolve";
 
-type Conversion =
-  | { mode: "empty" }
-  | { mode: "error"; reason: ResolveFailure }
-  | {
-      mode: "to-qobuz";
-      resolved: ResolvedTrack;
-      track: Track | null;
-      album: Album | null;
-      exact: boolean;
-    }
-  | {
-      mode: "from-qobuz";
-      track: Track;
-      album: Album | null;
-      query: string;
-      deezerUrl?: string;
-    };
+type Source = "clipboard" | "now-playing";
 
-const SUPPORTED_HINT = "Copy a **Spotify**, **YouTube Music**, or **Qobuz** track link, then run this command.";
+// Where the input came from, and whether the other source is available to
+// switch to. nowPlayingId is only set when the clipboard won, so the panel can
+// offer the currently playing track as an alternative.
+type Input = { source: Source; nowPlayingId?: number };
+
+type ToQobuz = Input & {
+  mode: "to-qobuz";
+  resolved: ResolvedTrack;
+  track: Track | null;
+  album: Album | null;
+  exact: boolean;
+};
+
+type FromQobuz = Input & {
+  mode: "from-qobuz";
+  track: Track;
+  album: Album | null;
+  query: string;
+  deezerUrl?: string;
+};
+
+type Conversion = { mode: "empty" } | { mode: "error"; reason: ResolveFailure } | ToQobuz | FromQobuz;
+
+const SUPPORTED_HINT =
+  "Copy a **Spotify**, **YouTube Music**, or **Qobuz** track link — or play something in Qobuz — then run this command.";
+
+// A clipboard that is not a track link from a known service says nothing about
+// intent, so the currently playing track takes over. A link from a known
+// service of the wrong kind (album, playlist) is a deliberate paste and keeps
+// its error instead.
+const YIELDS_TO_NOW_PLAYING: ReadonlySet<ResolveFailure> = new Set(["invalid", "unknown"]);
 
 const UNRESOLVED_MESSAGE: Record<ResolveFailure, string> = {
   invalid: ["# Nothing to convert", "", SUPPORTED_HINT].join("\n"),
@@ -45,64 +60,81 @@ const UNRESOLVED_MESSAGE: Record<ResolveFailure, string> = {
   unknown: ["# Unsupported link", "", SUPPORTED_HINT].join("\n"),
 };
 
+// Reverse: a Qobuz track → links on the other services.
+const convertFromQobuz = async (client: QobuzClient, trackId: number): Promise<Omit<FromQobuz, keyof Input>> => {
+  const track = await client.tracks.get(trackId);
+  const album = track.album?.id ? ((await client.albums.get(track.album.id).catch(() => undefined)) ?? null) : null;
+  const query = `${track.artist?.name ?? ""} ${track.title}`.trim();
+  const deezerUrl = track.isrc ? await deezerByIsrc(track.isrc) : undefined;
+  return { mode: "from-qobuz", track, album, query, deezerUrl };
+};
+
+// Forward: a foreign track → the matching Qobuz track.
+const convertToQobuz = async (client: QobuzClient, resolved: ResolvedTrack): Promise<Omit<ToQobuz, keyof Input>> => {
+  const query = `${resolved.artist} ${resolved.title}`;
+  const isrc = await findIsrc(resolved);
+
+  let track = isrc ? ((await client.tracks.match({ isrc, query })) ?? null) : null;
+  const exact = Boolean(track);
+
+  if (!track) {
+    // Approximate fallback: only trust a candidate that actually resembles
+    // the source, so a track absent from Qobuz reports "no match" rather
+    // than a confident wrong result.
+    const candidates = (await client.search.search(query, { limit: 5 })).tracks;
+    track = candidates.find((c) => isLikelyMatch(resolved, c)) ?? null;
+  }
+
+  const album = track?.album?.id ? ((await client.albums.get(track.album.id).catch(() => undefined)) ?? null) : null;
+
+  return { mode: "to-qobuz", resolved, track, album, exact };
+};
+
+// Precedence: a usable track link on the clipboard wins, the track Qobuz is
+// currently on fills in otherwise. Qobuz's state file carries no playing flag,
+// only a queue position — so "is something playing" cannot be detected, and
+// putting now-playing first would make the clipboard unreachable on any machine
+// with a queue.
+const convert = async (preferNowPlaying: boolean): Promise<Conversion> => {
+  const nowPlayingId = await readNowPlayingTrackId();
+  const convertNowPlaying = async (trackId: number): Promise<Conversion> => ({
+    ...(await convertFromQobuz(await getClient(), trackId)),
+    source: "now-playing",
+  });
+
+  if (preferNowPlaying && nowPlayingId !== undefined) return convertNowPlaying(nowPlayingId);
+
+  const url = (await Clipboard.readText())?.trim() || "";
+  const outcome = url ? await resolveLink(url) : undefined;
+
+  if (outcome?.ok) {
+    const client = await getClient();
+    const converted =
+      outcome.direction === "from-qobuz"
+        ? await convertFromQobuz(client, outcome.qobuzTrackId)
+        : await convertToQobuz(client, outcome.track);
+    return { ...converted, source: "clipboard", nowPlayingId };
+  }
+
+  const reason: ResolveFailure = outcome?.reason ?? "invalid";
+  if (nowPlayingId !== undefined && YIELDS_TO_NOW_PLAYING.has(reason)) return convertNowPlaying(nowPlayingId);
+  return outcome ? { mode: "error", reason } : { mode: "empty" };
+};
+
 export default function Command() {
-  const { data, isLoading } = usePromise(
-    async (): Promise<Conversion> => {
-      const url = (await Clipboard.readText())?.trim() || "";
-      if (!url) return { mode: "empty" };
-
-      const outcome = await resolveLink(url);
-      if (!outcome.ok) return { mode: "error", reason: outcome.reason };
-
-      const client = await getClient();
-
-      // Reverse: a Qobuz track → links on the other services.
-      if (outcome.direction === "from-qobuz") {
-        const track = await client.tracks.get(outcome.qobuzTrackId);
-        const album = track.album?.id
-          ? ((await client.albums.get(track.album.id).catch(() => undefined)) ?? null)
-          : null;
-        const query = `${track.artist?.name ?? ""} ${track.title}`.trim();
-        const deezerUrl = track.isrc ? await deezerByIsrc(track.isrc) : undefined;
-        return { mode: "from-qobuz", track, album, query, deezerUrl };
-      }
-
-      // Forward: a foreign track → the matching Qobuz track.
-      const resolved = outcome.track;
-      const query = `${resolved.artist} ${resolved.title}`;
-      const isrc = await findIsrc(resolved);
-
-      let track = isrc ? ((await client.tracks.match({ isrc, query })) ?? null) : null;
-      const exact = Boolean(track);
-
-      if (!track) {
-        // Approximate fallback: only trust a candidate that actually resembles
-        // the source, so a track absent from Qobuz reports "no match" rather
-        // than a confident wrong result.
-        const candidates = (await client.search.search(query, { limit: 5 })).tracks;
-        track = candidates.find((c) => isLikelyMatch(resolved, c)) ?? null;
-      }
-
-      const album = track?.album?.id
-        ? ((await client.albums.get(track.album.id).catch(() => undefined)) ?? null)
-        : null;
-
-      return { mode: "to-qobuz", resolved, track, album, exact };
+  const [preferNowPlaying, setPreferNowPlaying] = useState(false);
+  const { data, isLoading } = usePromise(convert, [preferNowPlaying], {
+    onError: (error) => {
+      showFailureToast(error, { title: "Couldn't convert link" });
     },
-    [],
-    {
-      onError: (error) => {
-        showFailureToast(error, { title: "Couldn't convert link" });
-      },
-    },
-  );
+  });
 
   return (
     <Detail
       isLoading={isLoading}
       markdown={buildMarkdown(data, isLoading)}
       metadata={renderMetadata(data)}
-      actions={renderActions(data)}
+      actions={renderActions(data, () => setPreferNowPlaying(true))}
     />
   );
 }
@@ -114,8 +146,14 @@ const renderMetadata = (data: Conversion | undefined) => {
   return undefined;
 };
 
-const renderActions = (data: Conversion | undefined) => {
+const renderActions = (data: Conversion | undefined, onUseNowPlaying: () => void) => {
   if (!data) return undefined;
+
+  const useNowPlaying = (data.mode === "to-qobuz" || data.mode === "from-qobuz") &&
+    data.source === "clipboard" &&
+    data.nowPlayingId !== undefined && (
+      <Action title="Use Now Playing Instead" icon={Icon.Music} onAction={onUseNowPlaying} />
+    );
 
   if (data.mode === "to-qobuz" && data.track) {
     const trackUrl = deepLink.track(data.track.id);
@@ -127,6 +165,7 @@ const renderActions = (data: Conversion | undefined) => {
         <Action.OpenInBrowser title="Open in Browser" url={trackUrl} />
         <Action.Open title="Play Track in Qobuz" target={appLink.track(data.track.id)} icon={Icon.Play} />
         <Action.CopyToClipboard title="Copy Qobuz Link" content={trackUrl} />
+        {useNowPlaying}
       </ActionPanel>
     );
   }
@@ -140,6 +179,7 @@ const renderActions = (data: Conversion | undefined) => {
           icon={Icon.MagnifyingGlass}
           url={`https://open.qobuz.com/search/${encodeURIComponent(q)}`}
         />
+        {useNowPlaying}
       </ActionPanel>
     );
   }
@@ -159,6 +199,7 @@ const renderActions = (data: Conversion | undefined) => {
         />
         {data.deezerUrl && <Action.OpenInBrowser title="Open on Deezer" url={data.deezerUrl} />}
         <Action.CopyToClipboard title="Copy Artist & Title" content={data.query} />
+        {useNowPlaying}
       </ActionPanel>
     );
   }
@@ -166,9 +207,12 @@ const renderActions = (data: Conversion | undefined) => {
   return undefined;
 };
 
-function ToQobuzMetadata({ data, track }: { data: Extract<Conversion, { mode: "to-qobuz" }>; track: Track }) {
+const SOURCE_LABEL: Record<Source, string> = { clipboard: "Clipboard", "now-playing": "Now Playing in Qobuz" };
+
+function ToQobuzMetadata({ data, track }: { data: ToQobuz; track: Track }) {
   return (
     <Detail.Metadata>
+      <Detail.Metadata.Label title="Source" text={SOURCE_LABEL[data.source]} />
       <Detail.Metadata.Label title="From" text={`${data.resolved.artist} — ${data.resolved.title}`} />
       <Detail.Metadata.TagList title="Match">
         <Detail.Metadata.TagList.Item
@@ -182,9 +226,11 @@ function ToQobuzMetadata({ data, track }: { data: Extract<Conversion, { mode: "t
   );
 }
 
-function FromQobuzMetadata({ data, track }: { data: Extract<Conversion, { mode: "from-qobuz" }>; track: Track }) {
+function FromQobuzMetadata({ data, track }: { data: FromQobuz; track: Track }) {
   return (
     <Detail.Metadata>
+      <Detail.Metadata.Label title="Source" text={SOURCE_LABEL[data.source]} />
+      <Detail.Metadata.Separator />
       <TrackFacts track={track} />
       <Detail.Metadata.Separator />
       <Detail.Metadata.TagList title="Deezer">

--- a/extensions/qobuz/src/convert-link.tsx
+++ b/extensions/qobuz/src/convert-link.tsx
@@ -166,15 +166,9 @@ const renderActions = (data: Conversion | undefined, onSwitch: (source: Source) 
   );
 
   if (data.mode === "to-qobuz" && data.track) {
-    const trackUrl = deepLink.track(data.track.id);
     return (
       <ActionPanel>
-        {data.track.album?.id && (
-          <Action.Open title="Open in Qobuz" target={appLink.album(data.track.album.id)} icon={Icon.Music} />
-        )}
-        <Action.OpenInBrowser title="Open in Browser" url={trackUrl} />
-        <Action.Open title="Play Track in Qobuz" target={appLink.track(data.track.id)} icon={Icon.Play} />
-        <Action.CopyToClipboard title="Copy Qobuz Link" content={trackUrl} />
+        <QobuzTrackActions track={data.track} />
         {switchAction}
       </ActionPanel>
     );
@@ -209,6 +203,9 @@ const renderActions = (data: Conversion | undefined, onSwitch: (source: Source) 
         />
         {data.deezerUrl && <Action.OpenInBrowser title="Open on Deezer" url={data.deezerUrl} />}
         <Action.CopyToClipboard title="Copy Artist & Title" content={data.query} />
+        <ActionPanel.Section title="Qobuz">
+          <QobuzTrackActions track={data.track} />
+        </ActionPanel.Section>
         {switchAction}
       </ActionPanel>
     );
@@ -216,6 +213,20 @@ const renderActions = (data: Conversion | undefined, onSwitch: (source: Source) 
 
   return undefined;
 };
+
+function QobuzTrackActions({ track }: { track: Track }) {
+  const trackUrl = deepLink.track(track.id);
+  return (
+    <>
+      {track.album?.id && (
+        <Action.Open title="Open in Qobuz" target={appLink.album(track.album.id)} icon={Icon.Music} />
+      )}
+      <Action.OpenInBrowser title="Open in Browser" url={trackUrl} />
+      <Action.Open title="Play Track in Qobuz" target={appLink.track(track.id)} icon={Icon.Play} />
+      <Action.CopyToClipboard title="Copy Qobuz Link" content={trackUrl} />
+    </>
+  );
+}
 
 const SOURCE_LABEL: Record<Source, string> = {
   argument: "Typed link",

--- a/extensions/qobuz/src/lib/resolve.ts
+++ b/extensions/qobuz/src/lib/resolve.ts
@@ -64,6 +64,25 @@ const resolveYouTube = async (url: string): Promise<ResolvedTrack | null> => {
   };
 };
 
+/**
+ * Cheap, offline check that a string is a single-track link from a supported
+ * service — the shape test of resolveLink without its network round-trip, for
+ * deciding whether to offer the clipboard as an alternative input.
+ */
+export const looksLikeTrackLink = (input: string): boolean => {
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    return false;
+  }
+  const host = url.hostname;
+  if (isQobuz(host)) return /\/track\/\d+/.test(url.pathname);
+  if (isSpotify(host)) return url.pathname.includes("/track/");
+  if (isYouTube(host)) return url.pathname === "/watch" || host.endsWith("youtu.be");
+  return false;
+};
+
 export const resolveLink = async (input: string): Promise<ResolveOutcome> => {
   let url: URL;
   try {


### PR DESCRIPTION
## Description

`Convert Track Link` used to read only the clipboard, and rendered a blank view whenever the clipboard was empty.

Now the command converts, in order: a track link typed as the optional command argument; otherwise the track the Qobuz desktop app is currently on, read via `readNowPlayingTrackId()` from `@kud/qobuz`, the same state file the existing Now Playing menu-bar command already reads. When there is no argument and Qobuz has no current track, it falls back to a Spotify / YouTube Music / Qobuz track link on the clipboard, with the existing errors for an empty clipboard or an unsupported link.

When both sources are available, a switch action in the panel moves to the other one ("Use Clipboard Link Instead" or "Use Now Playing Instead"), and the metadata view shows a "Source" row (Now Playing in Qobuz / Clipboard). An empty clipboard with no current track shows a "Nothing to convert" view that lists the three sources in order, instead of a blank view. A typed link is deliberate, so an invalid one shows its error rather than falling through.

The two conversion directions were extracted into `convertFromQobuz` / `convertToQobuz` so the now-playing path reuses them instead of duplicating the lookup logic. `looksLikeTrackLink` in `resolve.ts` is the offline shape check of `resolveLink`, used only to decide whether the clipboard is worth offering as the alternative.

In the Qobuz → other services direction, the panel now also offers the Qobuz actions (Open in Qobuz, Play Track in Qobuz, Open in Browser, Copy Qobuz Link) under a "Qobuz" section, since the input is often the now-playing track rather than a link already in hand.

## Screencast

No UI layout changed (same detail view), so no screencast: this is a logic change to an existing command. Happy to add a screenshot of the new "Source" metadata row if useful for review.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

`ray build` and `ray lint` both pass. This has **not** been click-tested inside Raycast yet, which is why this is opening as a draft; I'll convert it to ready for review once it has been.
