### PR TITLE
Orion: improve Command Bar Top Hit selection

### DIFF
--- a/extensions/orion/CHANGELOG.md
+++ b/extensions/orion/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Improve Top Hit ranking with deterministic match tiers and source precedence: open tabs, bookmarks, reading list, then history. Deduplicate matching destinations and use history frecency only to resolve ties within history.
 - Keep Top Hit selected as local sources resolve, while preserving an explicit Ctrl+N/Ctrl+P selection when later results arrive.
 - Reset the selection session whenever the query or profile changes, so deleting or appending text cannot leave Web Search focused after a prior candidate disappears.
+- After the first Ctrl+N/Ctrl+P navigation, release selection to Raycast's native list so repeated navigation remains smooth while later results do not steal focus.
 - Recognize typed web addresses and offer opening them in the system default browser. Add the same default-browser action to local Orion results.
 
 ## [Command Bar] - 2026-06-22

--- a/extensions/orion/CHANGELOG.md
+++ b/extensions/orion/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Command Bar] - {PR_MERGE_DATE}
 
 - Improve Top Hit ranking with deterministic match tiers and source precedence: open tabs, bookmarks, reading list, then history. Deduplicate matching destinations and use history frecency only to resolve ties within history.
-- Keep Top Hit selected after asynchronous local results arrive while preserving native Ctrl+N/Ctrl+P navigation.
+- Keep Top Hit selected as local sources resolve, while preserving an explicit Ctrl+N/Ctrl+P selection when later results arrive.
 - Recognize typed web addresses and offer opening them in the system default browser. Add the same default-browser action to local Orion results.
 
 ## [Command Bar] - 2026-06-22

--- a/extensions/orion/CHANGELOG.md
+++ b/extensions/orion/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Command Bar] - {PR_MERGE_DATE}
 
 - Improve Top Hit ranking with deterministic match tiers and source precedence: open tabs, bookmarks, reading list, then history. Deduplicate matching destinations and use history frecency only to resolve ties within history.
-- Focus the initial Top Hit without taking control of subsequent native list navigation.
+- Keep Top Hit selected after asynchronous local results arrive while preserving native Ctrl+N/Ctrl+P navigation.
 - Recognize typed web addresses and offer opening them in the system default browser. Add the same default-browser action to local Orion results.
 
 ## [Command Bar] - 2026-06-22

--- a/extensions/orion/CHANGELOG.md
+++ b/extensions/orion/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Orion Changelog
 
+## [Command Bar] - {PR_MERGE_DATE}
+
+- Improve Top Hit ranking with deterministic match tiers and source precedence: open tabs, bookmarks, reading list, then history. Deduplicate matching destinations and use history frecency only to resolve ties within history.
+- Focus the initial Top Hit without taking control of subsequent native list navigation.
+- Recognize typed web addresses and offer opening them in the system default browser. Add the same default-browser action to local Orion results.
+
 ## [Command Bar] - 2026-06-22
 
 - Add a "Command Bar" command — an Arc-style unified palette that searches open tabs, bookmarks, reading list, history, and the web from one place. Shows a top hit, a "Search the Web" action, live search-engine autocomplete, and per-source sections. Includes a profile switcher (search bar accessory) and a Search Engine preference (DuckDuckGo, Google, Brave, or Kagi). Results open in Orion rather than the system default browser.

--- a/extensions/orion/CHANGELOG.md
+++ b/extensions/orion/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Improve Top Hit ranking with deterministic match tiers and source precedence: open tabs, bookmarks, reading list, then history. Deduplicate matching destinations and use history frecency only to resolve ties within history.
 - Keep Top Hit selected as local sources resolve, while preserving an explicit Ctrl+N/Ctrl+P selection when later results arrive.
+- Reset the selection session whenever the query or profile changes, so deleting or appending text cannot leave Web Search focused after a prior candidate disappears.
 - Recognize typed web addresses and offer opening them in the system default browser. Add the same default-browser action to local Orion results.
 
 ## [Command Bar] - 2026-06-22

--- a/extensions/orion/package.json
+++ b/extensions/orion/package.json
@@ -7,7 +7,8 @@
   "author": "plonq",
   "contributors": [
     "erics118",
-    "gianni_sanrochman"
+    "gianni_sanrochman",
+    "ponyma"
   ],
   "categories": [
     "Web"

--- a/extensions/orion/src/command-bar.tsx
+++ b/extensions/orion/src/command-bar.tsx
@@ -182,6 +182,20 @@ export default function Command() {
   } = useHistorySearch(selectedProfileId, hasQuery ? query : undefined);
   const { suggestions, isLoading: suggestionsLoading } = useSuggestions(query);
 
+  // A result ID from the previous query can disappear while typing (for
+  // example, the "Open Address" item vanishes when `sina.com.cn` becomes
+  // `sina`). Reset the session synchronously with the input change so
+  // Raycast's fallback selection cannot be mistaken for manual navigation.
+  const resetSelectionSession = (profileId: string, nextQuery: string) => {
+    selectionSessionRef.current = {
+      key: `${profileId}\u0000${nextQuery}`,
+      target: undefined,
+      awaitingTarget: false,
+      userNavigated: false,
+    };
+    setSelectedItemId(undefined);
+  };
+
   const isLoading = !profiles || tabs === undefined || bookmarksLoading || historyLoading || suggestionsLoading;
 
   // Never show the launcher tabs in the list itself.
@@ -291,7 +305,12 @@ export default function Command() {
       isLoading={isLoading}
       filtering={false}
       throttle
-      onSearchTextChange={setQuery}
+      onSearchTextChange={(nextQuery) => {
+        if (nextQuery !== query) {
+          resetSelectionSession(selectedProfileId, nextQuery);
+        }
+        setQuery(nextQuery);
+      }}
       {...(selectedItemId ? { selectedItemId } : {})}
       onSelectionChange={(id) => {
         const session = selectionSessionRef.current;
@@ -321,7 +340,12 @@ export default function Command() {
         <ProfileDropdown
           profiles={profiles}
           selectedProfileId={selectedProfileId}
-          onProfileSelected={setSelectedProfileId}
+          onProfileSelected={(profileId) => {
+            if (profileId !== selectedProfileId) {
+              resetSelectionSession(profileId, query);
+            }
+            setSelectedProfileId(profileId);
+          }}
         />
       }
     >

--- a/extensions/orion/src/command-bar.tsx
+++ b/extensions/orion/src/command-bar.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { ActionPanel, Icon, List } from "@raycast/api";
+import { useEffect, useState } from "react";
+import { Action, ActionPanel, Icon, List } from "@raycast/api";
 
 import useTabs from "./hooks/useTabs";
 import useBookmarks from "./hooks/useBookmarks";
@@ -15,24 +15,47 @@ import SuggestionListItem from "./components/SuggestionListItem";
 import OpenInOrionAction from "./components/OpenInOrionAction";
 
 import { Bookmark, HistoryItem, Tab } from "./types";
-import { buildSearchUrl, extractDomainName, getSearchEngineName, isLauncherTab, splitSearchTerms } from "./utils";
+import {
+  buildSearchUrl,
+  extractDomainName,
+  getSearchEngineName,
+  isLauncherTab,
+  isWebAddress,
+  normalizeWebAddress,
+  splitSearchTerms,
+} from "./utils";
 
 const LIMITS = { tabs: 6, bookmarks: 6, reading: 4, history: 8 };
+const TOP_HIT_ITEM_ID = "top-hit";
+const OPEN_ADDRESS_ITEM_ID = "open-address";
 
-// 3 = prefix match on title/domain, 2 = substring of title/domain, 1 = substring of url.
+// Exact navigation intent has higher tiers than general text matching. These
+// tiers deliberately dominate source preferences and frecency in Top Hit.
 function scoreTerm(term: string, title: string, domain: string, url: string): number {
-  if (title.startsWith(term) || domain.startsWith(term)) return 3;
-  if (title.includes(term) || domain.includes(term)) return 2;
+  if (domain === term || url === term) return 7;
+  if (domain.startsWith(term)) return 6;
+  if (title.startsWith(term)) return 5;
+  if (title.includes(term) || domain.includes(term)) return 3;
   if (url.includes(term)) return 1;
   return 0;
+}
+
+function normalizedAddress(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, "")
+    .replace(/^www\./, "")
+    .replace(/\/$/, "");
 }
 
 function relevance(query: string, title: string | undefined, url: string): number {
   const t = (title ?? "").toLowerCase();
   const d = extractDomainName(url).toLowerCase();
-  const u = url.toLowerCase();
+  const u = normalizedAddress(url);
+  const addressQuery = normalizedAddress(query);
 
-  const phraseScore = scoreTerm(query, t, d, u);
+  const phraseScore = scoreTerm(addressQuery, t, d, u);
   if (phraseScore > 0) return phraseScore;
 
   const terms = splitSearchTerms(query);
@@ -49,12 +72,95 @@ function textMatchesQuery(query: string, text: string): boolean {
   return splitSearchTerms(query).every((term) => haystack.includes(term));
 }
 
-type Hit = { kind: "tab"; tab: Tab; key: string } | { kind: "url"; item: UrlItem; source: string; key: string };
+type Hit =
+  | { kind: "tab"; tab: Tab; key: string }
+  | { kind: "url"; item: UrlItem; source: string; key: string; visitCount?: number; lastVisitTime?: string };
 
 const tabKey = (t: Tab) => `tab-${t.window_id}-${t.url}`;
 
+function sourcePriority(hit: Hit): number {
+  if (hit.kind === "tab") return 4;
+  if (hit.source === "Bookmark") return 3;
+  if (hit.source === "Reading List") return 2;
+  return 1;
+}
+
+function historyFrecency(hit: Hit): number {
+  if (hit.kind !== "url" || hit.source !== "History") return 0;
+
+  const visitBoost = Math.min(0.45, Math.log2((hit.visitCount ?? 0) + 1) * 0.07);
+  const lastVisited = hit.lastVisitTime ? new Date(hit.lastVisitTime).getTime() : 0;
+  const ageDays = lastVisited > 0 ? Math.max(0, (Date.now() - lastVisited) / 86_400_000) : Number.POSITIVE_INFINITY;
+  const recencyBoost = Number.isFinite(ageDays) ? 0.35 * Math.exp(-ageDays / 14) : 0;
+  return visitBoost + recencyBoost;
+}
+
+type RankedHit = { hit: Hit; tier: number };
+
+function canonicalUrl(url: string): string {
+  return normalizedAddress(url);
+}
+
+function compareRankedHits(a: RankedHit, b: RankedHit): number {
+  // Exactness always wins. Source priority only resolves candidates in the
+  // same matching tier.
+  if (a.tier !== b.tier) return b.tier - a.tier;
+
+  const aSource = sourcePriority(a.hit);
+  const bSource = sourcePriority(b.hit);
+  if (aSource !== bSource) return bSource - aSource;
+
+  // Frecency is intentionally limited to History-vs-History comparisons. A
+  // frequently visited page must not outrank an equally relevant open tab or
+  // explicit bookmark.
+  const aFrecency = historyFrecency(a.hit);
+  const bFrecency = historyFrecency(b.hit);
+  if (aFrecency !== bFrecency) return bFrecency - aFrecency;
+
+  const aLastVisit = a.hit.kind === "url" ? (a.hit.lastVisitTime ?? "") : "";
+  const bLastVisit = b.hit.kind === "url" ? (b.hit.lastVisitTime ?? "") : "";
+  if (aLastVisit !== bLastVisit) return bLastVisit.localeCompare(aLastVisit);
+  return a.hit.key.localeCompare(b.hit.key);
+}
+
+function deduplicateRankedHits(candidates: RankedHit[]): RankedHit[] {
+  const grouped = new Map<string, RankedHit[]>();
+  candidates.forEach((candidate) => {
+    const url = candidate.hit.kind === "tab" ? candidate.hit.tab.url : candidate.hit.item.url;
+    const key = canonicalUrl(url);
+    const existing = grouped.get(key) ?? [];
+    existing.push(candidate);
+    grouped.set(key, existing);
+  });
+
+  return Array.from(grouped.values()).map((group) => {
+    // A duplicate URL represents the same destination. Keep its strongest
+    // match tier, but choose the interaction source by intent: resume an open
+    // tab before opening an explicit bookmark, reading-list item, or history.
+    const tier = Math.max(...group.map((candidate) => candidate.tier));
+    const representative = [...group].sort((a, b) => {
+      const sourceDifference = sourcePriority(b.hit) - sourcePriority(a.hit);
+      return sourceDifference || compareRankedHits(a, b);
+    })[0];
+    return { ...representative, tier };
+  });
+}
+
+function uniqueUrls<T extends { url: string }>(items: T[], seen: Set<string>): T[] {
+  return items.filter((item) => {
+    const key = canonicalUrl(item.url);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
 export default function Command() {
   const [query, setQuery] = useState("");
+  // This is deliberately only an initial focus request. Keeping the current
+  // selection in React state makes List controlled, which disrupts Raycast's
+  // native Ctrl+N/Ctrl+P scrolling behavior.
+  const [autoSelectedItemId, setAutoSelectedItemId] = useState<string>();
   const q = query.trim().toLowerCase();
   const hasQuery = q.length > 0;
 
@@ -85,42 +191,87 @@ export default function Command() {
   const historyHits: HistoryItem[] = hasQuery ? (history ?? []).filter((h) => relevance(q, h.title, h.url) > 0) : [];
   const suggestionHits: string[] = hasQuery ? suggestions : [];
 
-  // Pick the single best local match as the Top Hit, preferring tabs > bookmarks > reading list > history.
+  // Pick the single best local match as Top Hit.
   let topHit: Hit | undefined;
   if (hasQuery) {
-    const candidates: { hit: Hit; score: number }[] = [];
+    const candidates: RankedHit[] = [];
     tabHits.forEach((t) =>
-      candidates.push({ hit: { kind: "tab", tab: t, key: tabKey(t) }, score: relevance(q, t.title, t.url) + 0.4 }),
+      candidates.push({ hit: { kind: "tab", tab: t, key: tabKey(t) }, tier: relevance(q, t.title, t.url) }),
     );
     bookmarkHits.forEach((b) =>
       candidates.push({
         hit: { kind: "url", item: b, source: "Bookmark", key: `bm-${b.uuid}` },
-        score: relevance(q, b.title, b.url) + 0.3,
+        tier: relevance(q, b.title, b.url),
       }),
     );
     readingHits.forEach((b) =>
       candidates.push({
         hit: { kind: "url", item: b, source: "Reading List", key: `rl-${b.uuid}` },
-        score: relevance(q, b.title, b.url) + 0.2,
+        tier: relevance(q, b.title, b.url),
       }),
     );
     historyHits.forEach((h) =>
       candidates.push({
-        hit: { kind: "url", item: h, source: "History", key: `hist-${h.id}` },
-        score: relevance(q, h.title, h.url) + 0.1,
+        hit: {
+          kind: "url",
+          item: h,
+          source: "History",
+          key: `hist-${h.id}`,
+          visitCount: h.visitCount,
+          lastVisitTime: h.lastVisitTime,
+        },
+        tier: relevance(q, h.title, h.url),
       }),
     );
-    topHit = candidates.sort((a, b) => b.score - a.score)[0]?.hit;
+    topHit = deduplicateRankedHits(candidates).sort(compareRankedHits)[0]?.hit;
   }
 
   // Drop the top hit from its own section to avoid showing it twice.
   const topTabKey = topHit?.kind === "tab" ? topHit.key : undefined;
   const topUrlKey = topHit?.kind === "url" ? topHit.key : undefined;
 
-  const tabSection = tabHits.filter((t) => tabKey(t) !== topTabKey).slice(0, hasQuery ? LIMITS.tabs : tabHits.length);
-  const bookmarkSection = bookmarkHits.filter((b) => `bm-${b.uuid}` !== topUrlKey).slice(0, LIMITS.bookmarks);
-  const readingSection = readingHits.filter((b) => `rl-${b.uuid}` !== topUrlKey).slice(0, LIMITS.reading);
-  const historySection = historyHits.filter((h) => `hist-${h.id}` !== topUrlKey).slice(0, LIMITS.history);
+  const topUrl = topHit?.kind === "tab" ? topHit.tab.url : topHit?.item.url;
+  const seenUrls = new Set(topUrl ? [canonicalUrl(topUrl)] : []);
+  const exactTabSection = uniqueUrls(
+    tabHits.filter((t) => tabKey(t) !== topTabKey),
+    seenUrls,
+  ).slice(0, hasQuery ? LIMITS.tabs : tabHits.length);
+  const tabSection = exactTabSection;
+  const bookmarkSection = uniqueUrls(
+    bookmarkHits.filter((b) => `bm-${b.uuid}` !== topUrlKey),
+    seenUrls,
+  ).slice(0, LIMITS.bookmarks);
+  const readingSection = uniqueUrls(
+    readingHits.filter((b) => `rl-${b.uuid}` !== topUrlKey),
+    seenUrls,
+  ).slice(0, LIMITS.reading);
+  const historySection = uniqueUrls(
+    historyHits.filter((h) => `hist-${h.id}` !== topUrlKey),
+    seenUrls,
+  ).slice(0, LIMITS.history);
+  const address = isWebAddress(query) ? normalizeWebAddress(query) : undefined;
+
+  // Local data arrives asynchronously. First render the new result set, then
+  // request focus on the next tick. Without the two phases, Raycast can report
+  // the old web-search selection and cancel the Top Hit focus request.
+  useEffect(() => {
+    const target = topHit ? TOP_HIT_ITEM_ID : address ? OPEN_ADDRESS_ITEM_ID : undefined;
+    setAutoSelectedItemId(undefined);
+    if (!target) return;
+
+    let releaseTimer: ReturnType<typeof setTimeout> | undefined;
+    const focusTimer = setTimeout(() => {
+      setAutoSelectedItemId(target);
+      // Give Raycast time to apply the programmatic focus, then immediately
+      // return navigation ownership so Ctrl+N/Ctrl+P stays native.
+      releaseTimer = setTimeout(() => setAutoSelectedItemId(undefined), 125);
+    }, 0);
+
+    return () => {
+      clearTimeout(focusTimer);
+      if (releaseTimer) clearTimeout(releaseTimer);
+    };
+  }, [query, topHit?.key, address]);
 
   return (
     <List
@@ -128,6 +279,7 @@ export default function Command() {
       filtering={false}
       throttle
       onSearchTextChange={setQuery}
+      selectedItemId={autoSelectedItemId}
       searchBarPlaceholder="Search tabs, bookmarks, history, or the web"
       searchBarAccessory={
         <ProfileDropdown
@@ -140,10 +292,26 @@ export default function Command() {
       {topHit && (
         <List.Section title="Top Hit">
           {topHit.kind === "tab" ? (
-            <TabListItem tab={topHit.tab} refresh={refresh} closeLaunchers />
+            <TabListItem id={TOP_HIT_ITEM_ID} tab={topHit.tab} refresh={refresh} closeLaunchers />
           ) : (
-            <UrlListItem item={topHit.item} accessory={topHit.source} />
+            <UrlListItem id={TOP_HIT_ITEM_ID} item={topHit.item} accessory={topHit.source} />
           )}
+        </List.Section>
+      )}
+
+      {address && (
+        <List.Section title="Open Address">
+          <List.Item
+            id={OPEN_ADDRESS_ITEM_ID}
+            icon={Icon.Globe}
+            title={`Open “${query.trim()}” in Default Browser`}
+            subtitle={address}
+            actions={
+              <ActionPanel>
+                <Action.OpenInBrowser title="Open in Default Browser" url={address} />
+              </ActionPanel>
+            }
+          />
         </List.Section>
       )}
 

--- a/extensions/orion/src/command-bar.tsx
+++ b/extensions/orion/src/command-bar.tsx
@@ -29,6 +29,13 @@ const LIMITS = { tabs: 6, bookmarks: 6, reading: 4, history: 8 };
 const TOP_HIT_ITEM_ID = "top-hit";
 const OPEN_ADDRESS_ITEM_ID = "open-address";
 
+type SelectionSession = {
+  key: string;
+  target?: string;
+  awaitingTarget: boolean;
+  userNavigated: boolean;
+};
+
 // Exact navigation intent has higher tiers than general text matching. These
 // tiers deliberately dominate source preferences and frecency in Top Hit.
 function scoreTerm(term: string, title: string, domain: string, url: string): number {
@@ -158,8 +165,7 @@ function uniqueUrls<T extends { url: string }>(items: T[], seen: Set<string>): T
 export default function Command() {
   const [query, setQuery] = useState("");
   const [selectedItemId, setSelectedItemId] = useState<string>();
-  const selectionLockRef = useRef<string | undefined>(undefined);
-  const selectionEpochRef = useRef(0);
+  const selectionSessionRef = useRef<SelectionSession | undefined>(undefined);
   const q = query.trim().toLowerCase();
   const hasQuery = q.length > 0;
 
@@ -250,28 +256,35 @@ export default function Command() {
   ).slice(0, LIMITS.history);
   const address = isWebAddress(query) ? normalizeWebAddress(query) : undefined;
 
-  // Keep the selection controlled after local data arrives. Releasing
-  // selectedItemId makes Raycast fall back to its default web-search item.
-  // Stable item IDs let native Ctrl+N/Ctrl+P report their new selection back
-  // through onSelectionChange without moving the list.
+  // Keep selection controlled while the local sources resolve. A session lasts
+  // for one query/profile pair: it auto-selects a Top Hit until the user
+  // navigates, after which slower data must not steal their selection.
   useEffect(() => {
     const target = topHit ? TOP_HIT_ITEM_ID : address ? OPEN_ADDRESS_ITEM_ID : undefined;
-    const epoch = ++selectionEpochRef.current;
-    selectionLockRef.current = target;
-    setSelectedItemId(target);
-    if (!target) return;
+    const key = `${selectedProfileId}\u0000${query}`;
+    const previous = selectionSessionRef.current;
+    const isNewSession = previous?.key !== key;
 
-    // Raycast can emit the old selection while new local results are mounting.
-    // Ignore it briefly; the controlled selectedItemId already points at the
-    // new Top Hit. The lock is only for this asynchronous render window.
-    const releaseTimer = setTimeout(() => {
-      if (selectionEpochRef.current === epoch) selectionLockRef.current = undefined;
-    }, 250);
+    if (isNewSession) {
+      selectionSessionRef.current = {
+        key,
+        target,
+        awaitingTarget: !!target,
+        userNavigated: false,
+      };
+      setSelectedItemId(target);
+      return;
+    }
 
-    return () => {
-      clearTimeout(releaseTimer);
-    };
-  }, [query, topHit?.key, address]);
+    // Local tabs, bookmarks, and history resolve at different times. Keep
+    // following the best candidate only until the user has made a choice.
+    if (!previous.userNavigated && previous.target !== target) {
+      previous.target = target;
+      previous.awaitingTarget = !!target;
+      setSelectedItemId(target);
+      return;
+    }
+  }, [query, selectedProfileId, topHit?.key, address]);
 
   return (
     <List
@@ -281,10 +294,26 @@ export default function Command() {
       onSearchTextChange={setQuery}
       {...(selectedItemId ? { selectedItemId } : {})}
       onSelectionChange={(id) => {
-        if (selectionLockRef.current) {
-          if (id !== selectionLockRef.current) return;
-          selectionLockRef.current = undefined;
+        const session = selectionSessionRef.current;
+        if (session?.awaitingTarget) {
+          // Ignore the stale selection that Raycast can report while replacing
+          // an older result set. The matching callback acknowledges the new
+          // controlled selection without relying on a timing threshold.
+          if (id !== session.target) return;
+          session.awaitingTarget = false;
+          setSelectedItemId(id ?? undefined);
+          return;
         }
+
+        // Web Search is Raycast's initial fallback item. Seeing it selected
+        // does not prove that the user navigated, so a Top Hit which resolves
+        // later must still be allowed to take focus. Moving past it does prove
+        // an explicit navigation choice.
+        if (!session?.target && !session?.userNavigated && id === "web-search") {
+          setSelectedItemId(id);
+          return;
+        }
+        if (session) session.userNavigated = true;
         setSelectedItemId(id ?? undefined);
       }}
       searchBarPlaceholder="Search tabs, bookmarks, history, or the web"

--- a/extensions/orion/src/command-bar.tsx
+++ b/extensions/orion/src/command-bar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
 
 import useTabs from "./hooks/useTabs";
@@ -157,10 +157,9 @@ function uniqueUrls<T extends { url: string }>(items: T[], seen: Set<string>): T
 
 export default function Command() {
   const [query, setQuery] = useState("");
-  // This is deliberately only an initial focus request. Keeping the current
-  // selection in React state makes List controlled, which disrupts Raycast's
-  // native Ctrl+N/Ctrl+P scrolling behavior.
-  const [autoSelectedItemId, setAutoSelectedItemId] = useState<string>();
+  const [selectedItemId, setSelectedItemId] = useState<string>();
+  const selectionLockRef = useRef<string | undefined>(undefined);
+  const selectionEpochRef = useRef(0);
   const q = query.trim().toLowerCase();
   const hasQuery = q.length > 0;
 
@@ -251,25 +250,26 @@ export default function Command() {
   ).slice(0, LIMITS.history);
   const address = isWebAddress(query) ? normalizeWebAddress(query) : undefined;
 
-  // Local data arrives asynchronously. First render the new result set, then
-  // request focus on the next tick. Without the two phases, Raycast can report
-  // the old web-search selection and cancel the Top Hit focus request.
+  // Keep the selection controlled after local data arrives. Releasing
+  // selectedItemId makes Raycast fall back to its default web-search item.
+  // Stable item IDs let native Ctrl+N/Ctrl+P report their new selection back
+  // through onSelectionChange without moving the list.
   useEffect(() => {
     const target = topHit ? TOP_HIT_ITEM_ID : address ? OPEN_ADDRESS_ITEM_ID : undefined;
-    setAutoSelectedItemId(undefined);
+    const epoch = ++selectionEpochRef.current;
+    selectionLockRef.current = target;
+    setSelectedItemId(target);
     if (!target) return;
 
-    let releaseTimer: ReturnType<typeof setTimeout> | undefined;
-    const focusTimer = setTimeout(() => {
-      setAutoSelectedItemId(target);
-      // Give Raycast time to apply the programmatic focus, then immediately
-      // return navigation ownership so Ctrl+N/Ctrl+P stays native.
-      releaseTimer = setTimeout(() => setAutoSelectedItemId(undefined), 125);
-    }, 0);
+    // Raycast can emit the old selection while new local results are mounting.
+    // Ignore it briefly; the controlled selectedItemId already points at the
+    // new Top Hit. The lock is only for this asynchronous render window.
+    const releaseTimer = setTimeout(() => {
+      if (selectionEpochRef.current === epoch) selectionLockRef.current = undefined;
+    }, 250);
 
     return () => {
-      clearTimeout(focusTimer);
-      if (releaseTimer) clearTimeout(releaseTimer);
+      clearTimeout(releaseTimer);
     };
   }, [query, topHit?.key, address]);
 
@@ -279,7 +279,14 @@ export default function Command() {
       filtering={false}
       throttle
       onSearchTextChange={setQuery}
-      selectedItemId={autoSelectedItemId}
+      {...(selectedItemId ? { selectedItemId } : {})}
+      onSelectionChange={(id) => {
+        if (selectionLockRef.current) {
+          if (id !== selectionLockRef.current) return;
+          selectionLockRef.current = undefined;
+        }
+        setSelectedItemId(id ?? undefined);
+      }}
       searchBarPlaceholder="Search tabs, bookmarks, history, or the web"
       searchBarAccessory={
         <ProfileDropdown
@@ -318,6 +325,7 @@ export default function Command() {
       {hasQuery && (
         <List.Section title="Search the Web">
           <List.Item
+            id="web-search"
             icon={Icon.MagnifyingGlass}
             title={`Search ${getSearchEngineName()} for “${query}”`}
             actions={
@@ -332,7 +340,7 @@ export default function Command() {
       {suggestionHits.length > 0 && (
         <List.Section title="Suggestions">
           {suggestionHits.map((s, i) => (
-            <SuggestionListItem key={`sugg-${i}-${s}`} suggestion={s} />
+            <SuggestionListItem id={`suggestion-${i}-${s}`} key={`sugg-${i}-${s}`} suggestion={s} />
           ))}
         </List.Section>
       )}
@@ -340,7 +348,7 @@ export default function Command() {
       {tabSection.length > 0 && (
         <List.Section title="Open Tabs">
           {tabSection.map((t) => (
-            <TabListItem key={tabKey(t)} tab={t} refresh={refresh} closeLaunchers />
+            <TabListItem id={tabKey(t)} key={tabKey(t)} tab={t} refresh={refresh} closeLaunchers />
           ))}
         </List.Section>
       )}
@@ -348,7 +356,7 @@ export default function Command() {
       {bookmarkSection.length > 0 && (
         <List.Section title="Bookmarks">
           {bookmarkSection.map((b) => (
-            <UrlListItem key={`bm-${b.uuid}`} item={b} />
+            <UrlListItem id={`bm-${b.uuid}`} key={`bm-${b.uuid}`} item={b} />
           ))}
         </List.Section>
       )}
@@ -356,7 +364,7 @@ export default function Command() {
       {readingSection.length > 0 && (
         <List.Section title="Reading List">
           {readingSection.map((b) => (
-            <UrlListItem key={`rl-${b.uuid}`} item={b} />
+            <UrlListItem id={`rl-${b.uuid}`} key={`rl-${b.uuid}`} item={b} />
           ))}
         </List.Section>
       )}
@@ -364,7 +372,7 @@ export default function Command() {
       {!permissionView && historySection.length > 0 && (
         <List.Section title="History">
           {historySection.map((h) => (
-            <UrlListItem key={`hist-${h.id}`} item={h} />
+            <UrlListItem id={`hist-${h.id}`} key={`hist-${h.id}`} item={h} />
           ))}
         </List.Section>
       )}

--- a/extensions/orion/src/command-bar.tsx
+++ b/extensions/orion/src/command-bar.tsx
@@ -329,11 +329,16 @@ export default function Command() {
         // later must still be allowed to take focus. Moving past it does prove
         // an explicit navigation choice.
         if (!session?.target && !session?.userNavigated && id === "web-search") {
-          setSelectedItemId(id);
+          setSelectedItemId(undefined);
           return;
         }
+
+        // Automatic Top Hit selection needs a controlled List only until the
+        // user starts navigating. From then on, defer to Raycast's native
+        // focus and scroll handling; continually controlling selectedItemId
+        // causes visible scroll jumps after repeated Ctrl+N/Ctrl+P cycles.
         if (session) session.userNavigated = true;
-        setSelectedItemId(id ?? undefined);
+        setSelectedItemId(undefined);
       }}
       searchBarPlaceholder="Search tabs, bookmarks, history, or the web"
       searchBarAccessory={

--- a/extensions/orion/src/components/BookmarkListItem.tsx
+++ b/extensions/orion/src/components/BookmarkListItem.tsx
@@ -5,11 +5,13 @@ import { extractDomainName } from "../utils";
 import CopyMarkdownLinkAction from "./CopyMarkdownLinkAction";
 import CopyTitleAction from "./CopyTitleAction";
 import CopyUrlAction from "./CopyUrlAction";
+import OpenInOrionAction from "./OpenInOrionAction";
 
 const Actions = (props: { bookmark: Bookmark }) => (
   <ActionPanel title={props.bookmark.url}>
     <ActionPanel.Section>
-      <Action.OpenInBrowser url={props.bookmark.url} />
+      <OpenInOrionAction url={props.bookmark.url} />
+      <Action.OpenInBrowser title="Open in Default Browser" url={props.bookmark.url} />
     </ActionPanel.Section>
     <ActionPanel.Section>
       <CopyUrlAction url={props.bookmark.url} />

--- a/extensions/orion/src/components/HistoryListItem.tsx
+++ b/extensions/orion/src/components/HistoryListItem.tsx
@@ -5,12 +5,14 @@ import { extractDomainName } from "../utils";
 import CopyMarkdownLinkAction from "./CopyMarkdownLinkAction";
 import CopyTitleAction from "./CopyTitleAction";
 import CopyUrlAction from "./CopyUrlAction";
+import OpenInOrionAction from "./OpenInOrionAction";
 
 const Actions = (props: { entry: HistoryItem; searchText?: string }) => {
   return (
     <ActionPanel>
       <ActionPanel.Section>
-        <Action.OpenInBrowser url={props.entry.url} />
+        <OpenInOrionAction url={props.entry.url} />
+        <Action.OpenInBrowser title="Open in Default Browser" url={props.entry.url} />
       </ActionPanel.Section>
       <ActionPanel.Section>
         <CopyUrlAction url={props.entry.url} />

--- a/extensions/orion/src/components/SuggestionListItem.tsx
+++ b/extensions/orion/src/components/SuggestionListItem.tsx
@@ -3,10 +3,11 @@ import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { buildSearchUrl, getSearchEngineName } from "../utils";
 import OpenInOrionAction from "./OpenInOrionAction";
 
-const SuggestionListItem = (props: { suggestion: string }) => {
-  const { suggestion } = props;
+const SuggestionListItem = (props: { suggestion: string; id?: string }) => {
+  const { suggestion, id } = props;
   return (
     <List.Item
+      id={id}
       icon={Icon.MagnifyingGlass}
       title={suggestion}
       accessories={[{ text: getSearchEngineName() }]}

--- a/extensions/orion/src/components/TabListItem.tsx
+++ b/extensions/orion/src/components/TabListItem.tsx
@@ -12,6 +12,7 @@ const Actions = (props: { tab: Tab; refresh: () => void; closeLaunchers?: boolea
   <ActionPanel>
     <ActionPanel.Section>
       <OpenTabAction tab={props.tab} closeLaunchers={props.closeLaunchers} />
+      <Action.OpenInBrowser title="Open in Default Browser" url={props.tab.url} />
     </ActionPanel.Section>
     <ActionPanel.Section>
       <CopyUrlAction url={props.tab.url} />
@@ -30,11 +31,12 @@ const Actions = (props: { tab: Tab; refresh: () => void; closeLaunchers?: boolea
   </ActionPanel>
 );
 
-const TabListItem = (props: { tab: Tab; refresh: () => void; closeLaunchers?: boolean }) => {
+const TabListItem = (props: { tab: Tab; refresh: () => void; closeLaunchers?: boolean; id?: string }) => {
   const url = props.tab.url;
 
   return (
     <List.Item
+      id={props.id}
       title={getTitle(props.tab)}
       icon={getFavicon(props.tab.url)}
       actions={<Actions tab={props.tab} refresh={props.refresh} closeLaunchers={props.closeLaunchers} />}

--- a/extensions/orion/src/components/UrlListItem.tsx
+++ b/extensions/orion/src/components/UrlListItem.tsx
@@ -1,4 +1,4 @@
-import { ActionPanel, List } from "@raycast/api";
+import { Action, ActionPanel, List } from "@raycast/api";
 import { getFavicon } from "@raycast/utils";
 
 import { extractDomainName } from "../utils";
@@ -9,10 +9,11 @@ import OpenInOrionAction from "./OpenInOrionAction";
 
 export type UrlItem = { title?: string; url: string };
 
-const UrlListItem = (props: { item: UrlItem; accessory?: string }) => {
-  const { item, accessory } = props;
+const UrlListItem = (props: { item: UrlItem; accessory?: string; id?: string }) => {
+  const { item, accessory, id } = props;
   return (
     <List.Item
+      id={id}
       icon={getFavicon(item.url)}
       title={item.title || item.url}
       subtitle={extractDomainName(item.url)}
@@ -21,6 +22,7 @@ const UrlListItem = (props: { item: UrlItem; accessory?: string }) => {
         <ActionPanel>
           <ActionPanel.Section>
             <OpenInOrionAction url={item.url} />
+            <Action.OpenInBrowser title="Open in Default Browser" url={item.url} />
           </ActionPanel.Section>
           <ActionPanel.Section>
             <CopyUrlAction url={item.url} />

--- a/extensions/orion/src/hooks/useHistorySearch.ts
+++ b/extensions/orion/src/hooks/useHistorySearch.ts
@@ -23,16 +23,16 @@ const getHistoryQuery = (searchText?: string) => {
         .join(" AND ")
     : undefined;
   return `
-      SELECT DISTINCT history_items.ID as id,
-                      TITLE            as title,
-                      URL              as url,
-                      LAST_VISIT_TIME  as lastVisitTime, DATE (LAST_VISIT_TIME) as lastVisitDate
+      SELECT ID as id,
+             TITLE as title,
+             URL as url,
+             LAST_VISIT_TIME as lastVisitTime,
+             DATE(LAST_VISIT_TIME) as lastVisitDate,
+             COALESCE(VISIT_COUNT, 0) as visitCount
       FROM history_items
-          INNER JOIN visits
-      ON visits.HISTORY_ITEM_ID = history_items.ID
-          ${whereClause ? `WHERE ${whereClause}` : ""}
+      ${whereClause ? `WHERE ${whereClause}` : ""}
       ORDER BY LAST_VISIT_TIME DESC
-          LIMIT ${LIMIT}
+      LIMIT ${LIMIT}
   `;
 };
 

--- a/extensions/orion/src/types.ts
+++ b/extensions/orion/src/types.ts
@@ -42,6 +42,7 @@ export interface HistoryItem {
   url: string;
   lastVisitTime: string;
   lastVisitDate: string;
+  visitCount: number;
 }
 
 // Tabs

--- a/extensions/orion/src/utils.ts
+++ b/extensions/orion/src/utils.ts
@@ -189,6 +189,32 @@ export function buildSearchUrl(query: string, engine: SearchEngine = getSearchEn
   return SEARCH_ENGINES[engine].search + encodeURIComponent(query);
 }
 
+// Accept the same kinds of address users commonly enter in a browser's address
+// bar: a hostname (with an optional protocol, port, or path), localhost, or an
+// IPv4 address. A space means this is a search query, not an address.
+export function isWebAddress(value: string): boolean {
+  const candidate = value.trim();
+  if (!candidate || /\s/.test(candidate)) return false;
+
+  const url = parseUrl(/^https?:\/\//i.test(candidate) ? candidate : `https://${candidate}`);
+  if (!url) return false;
+
+  const hostname = url.hostname;
+  if (hostname === "localhost") return true;
+  if (/^(?:\d{1,3}\.){3}\d{1,3}$/.test(hostname)) {
+    return hostname.split(".").every((part) => Number(part) <= 255);
+  }
+
+  // This deliberately mirrors Arc's "hostname with a TLD" behavior while
+  // allowing modern TLD lengths and hyphenated labels.
+  return /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/i.test(hostname);
+}
+
+export function normalizeWebAddress(value: string): string {
+  const candidate = value.trim();
+  return /^https?:\/\//i.test(candidate) ? candidate : `https://${candidate}`;
+}
+
 // Returns null for engines (e.g. Kagi) that have no public autocomplete endpoint.
 export function buildSuggestUrl(query: string, engine: SearchEngine = getSearchEngine()): string | null {
   const base = SEARCH_ENGINES[engine].suggest;


### PR DESCRIPTION
## Summary
- rank local candidates by match tier, then open tab, bookmark, reading list, and history
- collapse identical destinations and use history frecency only within history ties
- focus a newly resolved Top Hit without controlling later native list navigation
- recognize typed web addresses and add explicit default-browser actions

## Validation
- `npm ci`
- `npm run lint`
- `npm run build`
- `npm run dev`
- reviewed the staged diff for credentials, local Orion data, personal paths, and email addresses

## Privacy
This change reads the existing local Orion data sources only at runtime. It does not add telemetry, upload local data, or include any user data, database files, credentials, or screenshots.