### PR TITLE
Orion: add configurable suggestions and tab fallback

### DIFF
--- a/extensions/orion/CHANGELOG.md
+++ b/extensions/orion/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Orion Changelog
 
+## [Command Bar] - {PR_MERGE_DATE}
+
+- Add a configurable limit for live search suggestions; setting it to zero hides suggestions and prevents suggestion requests.
+- Add fuzzy and pinyin matching as a labeled fallback for open tabs when there is no exact local tab match. Fallback matches are not eligible for Top Hit.
+
 ## [Command Bar] - 2026-06-22
 
 - Add a "Command Bar" command — an Arc-style unified palette that searches open tabs, bookmarks, reading list, history, and the web from one place. Shows a top hit, a "Search the Web" action, live search-engine autocomplete, and per-source sections. Includes a profile switcher (search bar accessory) and a Search Engine preference (DuckDuckGo, Google, Brave, or Kagi). Results open in Orion rather than the system default browser.

--- a/extensions/orion/package-lock.json
+++ b/extensions/orion/package-lock.json
@@ -9,7 +9,9 @@
       "dependencies": {
         "@raycast/api": "^1.104.9",
         "@raycast/utils": "^2.2.6",
-        "bplist-parser": "^0.3.2"
+        "bplist-parser": "^0.3.2",
+        "fuse.js": "^7.1.0",
+        "pinyin-pro": "^3.27.0"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.1.1",
@@ -2073,6 +2075,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fuse.js": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.5.0.tgz",
+      "integrity": "sha512-sQtrEfA+ez/3G0cCZecF70oqpCRttCexYUG4mUrtWL49ULUzUyxokt5kyqwtKzj1270RaKih+hcP3qLcumccow==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -2449,6 +2464,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/pinyin-pro": {
+      "version": "3.29.4",
+      "resolved": "https://registry.npmjs.org/pinyin-pro/-/pinyin-pro-3.29.4.tgz",
+      "integrity": "sha512-SPXpDT2cHEy+d26V1RXYMlVzXN42hotFAak1fzyWPi4o2dKXb61UqD4pzxDJHwk6gbv8vQ6EfErd+hYX0Qhzug==",
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/extensions/orion/package.json
+++ b/extensions/orion/package.json
@@ -7,7 +7,8 @@
   "author": "plonq",
   "contributors": [
     "erics118",
-    "gianni_sanrochman"
+    "gianni_sanrochman",
+    "ponyma"
   ],
   "categories": [
     "Web"
@@ -91,6 +92,36 @@
       ]
     },
     {
+      "name": "suggestionLimit",
+      "title": "Suggestions",
+      "description": "Number of live search suggestions shown in Command Bar. Set to 0 to disable suggestions and their network requests.",
+      "type": "dropdown",
+      "required": false,
+      "default": "6",
+      "data": [
+        {
+          "title": "Disabled (0)",
+          "value": "0"
+        },
+        {
+          "title": "3 suggestions",
+          "value": "3"
+        },
+        {
+          "title": "6 suggestions",
+          "value": "6"
+        },
+        {
+          "title": "9 suggestions",
+          "value": "9"
+        },
+        {
+          "title": "12 suggestions",
+          "value": "12"
+        }
+      ]
+    },
+    {
       "name": "autoCloseLauncherTabs",
       "title": "Command Bar",
       "label": "Auto-close launcher tabs",
@@ -103,7 +134,9 @@
   "dependencies": {
     "@raycast/api": "^1.104.9",
     "@raycast/utils": "^2.2.6",
-    "bplist-parser": "^0.3.2"
+    "bplist-parser": "^0.3.2",
+    "fuse.js": "^7.1.0",
+    "pinyin-pro": "^3.27.0"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.1.1",

--- a/extensions/orion/src/command-bar.tsx
+++ b/extensions/orion/src/command-bar.tsx
@@ -13,6 +13,7 @@ import TabListItem from "./components/TabListItem";
 import UrlListItem, { UrlItem } from "./components/UrlListItem";
 import SuggestionListItem from "./components/SuggestionListItem";
 import OpenInOrionAction from "./components/OpenInOrionAction";
+import { searchTabsWithFallback } from "./tabSearch";
 
 import { Bookmark, HistoryItem, Tab } from "./types";
 import { buildSearchUrl, extractDomainName, getSearchEngineName, isLauncherTab, splitSearchTerms } from "./utils";
@@ -117,7 +118,11 @@ export default function Command() {
   const topTabKey = topHit?.kind === "tab" ? topHit.key : undefined;
   const topUrlKey = topHit?.kind === "url" ? topHit.key : undefined;
 
-  const tabSection = tabHits.filter((t) => tabKey(t) !== topTabKey).slice(0, hasQuery ? LIMITS.tabs : tabHits.length);
+  const exactTabSection = tabHits
+    .filter((t) => tabKey(t) !== topTabKey)
+    .slice(0, hasQuery ? LIMITS.tabs : tabHits.length);
+  const fuzzyTabSection = hasQuery && tabHits.length === 0 ? searchTabsWithFallback(openTabs, query, LIMITS.tabs) : [];
+  const tabSection = exactTabSection.length > 0 ? exactTabSection : fuzzyTabSection;
   const bookmarkSection = bookmarkHits.filter((b) => `bm-${b.uuid}` !== topUrlKey).slice(0, LIMITS.bookmarks);
   const readingSection = readingHits.filter((b) => `rl-${b.uuid}` !== topUrlKey).slice(0, LIMITS.reading);
   const historySection = historyHits.filter((h) => `hist-${h.id}` !== topUrlKey).slice(0, LIMITS.history);
@@ -170,7 +175,7 @@ export default function Command() {
       )}
 
       {tabSection.length > 0 && (
-        <List.Section title="Open Tabs">
+        <List.Section title={fuzzyTabSection.length > 0 ? "Open Tabs (Fuzzy Matches)" : "Open Tabs"}>
           {tabSection.map((t) => (
             <TabListItem key={tabKey(t)} tab={t} refresh={refresh} closeLaunchers />
           ))}

--- a/extensions/orion/src/hooks/useSuggestions.ts
+++ b/extensions/orion/src/hooks/useSuggestions.ts
@@ -1,16 +1,23 @@
+import { getPreferenceValues } from "@raycast/api";
 import { useFetch } from "@raycast/utils";
 
 import { buildSuggestUrl, getSearchEngine } from "../utils";
 
-const MAX_SUGGESTIONS = 6;
+const DEFAULT_SUGGESTION_LIMIT = 6;
+
+function getSuggestionLimit(): number {
+  const configured = Number(getPreferenceValues<Preferences>().suggestionLimit);
+  return Number.isInteger(configured) && configured >= 0 && configured <= 12 ? configured : DEFAULT_SUGGESTION_LIMIT;
+}
 
 // Live search-engine autocomplete for the Command Bar. Engines return the
 // OpenSearch format `[query, [suggestion, ...], ...]`, so we read element [1].
 // Engines without a public suggest endpoint (e.g. Kagi) yield no suggestions.
 const useSuggestions = (query: string) => {
   const engine = getSearchEngine();
+  const suggestionLimit = getSuggestionLimit();
   const trimmed = query.trim();
-  const url = trimmed.length > 0 ? buildSuggestUrl(trimmed, engine) : null;
+  const url = suggestionLimit > 0 && trimmed.length > 0 ? buildSuggestUrl(trimmed, engine) : null;
 
   const { data, isLoading } = useFetch<string[]>(url ?? "", {
     execute: !!url,
@@ -22,7 +29,7 @@ const useSuggestions = (query: string) => {
       try {
         const parsed = JSON.parse(await response.text());
         const list = Array.isArray(parsed) && Array.isArray(parsed[1]) ? (parsed[1] as string[]) : [];
-        return list.filter((s) => typeof s === "string").slice(0, MAX_SUGGESTIONS);
+        return list.filter((s) => typeof s === "string").slice(0, suggestionLimit);
       } catch {
         return [];
       }

--- a/extensions/orion/src/tabSearch.ts
+++ b/extensions/orion/src/tabSearch.ts
@@ -1,0 +1,45 @@
+import Fuse from "fuse.js";
+import { pinyin } from "pinyin-pro";
+
+import { Tab } from "./types";
+
+type SearchableTab = Tab & { titlePinyin: string };
+
+const normalize = (value: string) => value.trim().toLocaleLowerCase();
+
+function toPinyin(value: string): string {
+  return pinyin(value, { toneType: "none" }).replace(/\s+/g, "").toLocaleLowerCase();
+}
+
+// Exact title/URL matches remain the primary results. Fuzzy and pinyin results
+// are intentionally returned only as a fallback, so they never affect Top Hit.
+export function searchTabsWithFallback(tabs: Tab[], query: string, limit?: number): Tab[] {
+  const normalizedQuery = normalize(query);
+  if (!normalizedQuery) return tabs;
+
+  const exact = tabs.filter((tab) => {
+    const title = normalize(tab.title);
+    const url = normalize(tab.url);
+    return title.includes(normalizedQuery) || url.includes(normalizedQuery);
+  });
+  if (exact.length > 0) return limit ? exact.slice(0, limit) : exact;
+
+  const searchableTabs: SearchableTab[] = tabs.map((tab) => ({ ...tab, titlePinyin: toPinyin(tab.title) }));
+  const fuse = new Fuse(searchableTabs, {
+    keys: [
+      { name: "title", weight: 0.4 },
+      { name: "titlePinyin", weight: 0.35 },
+      { name: "url", weight: 0.25 },
+    ],
+    threshold: 0.3,
+    includeScore: true,
+    shouldSort: true,
+    minMatchCharLength: 1,
+    ignoreLocation: true,
+  });
+
+  return fuse
+    .search(normalizedQuery)
+    .slice(0, limit)
+    .map((result) => result.item);
+}

--- a/extensions/orion/src/tabs.tsx
+++ b/extensions/orion/src/tabs.tsx
@@ -3,8 +3,8 @@ import { List } from "@raycast/api";
 
 import useTabs from "src/hooks/useTabs";
 import { Tab } from "./types";
-import { search } from "./utils";
 import TabListItem from "src/components/TabListItem";
+import { searchTabsWithFallback } from "./tabSearch";
 
 const Command = () => {
   const { tabs, refresh } = useTabs();
@@ -12,7 +12,7 @@ const Command = () => {
 
   return (
     <List isLoading={!tabs} onSearchTextChange={setSearchText}>
-      {search(tabs ?? [], ["title", "url"], searchText).map((tab: Tab) => {
+      {searchTabsWithFallback(tabs ?? [], searchText).map((tab: Tab) => {
         return <TabListItem tab={tab} key={tab.url} refresh={refresh} />;
       })}
     </List>


### PR DESCRIPTION
## Summary
- add a Command Bar preference for 0, 3, 6, 9, or 12 live suggestions
- disable suggestion network requests when the limit is zero
- add Fuse and pinyin-based open-tab fallback only when exact local tab matching has no result
- label fallback matches and keep them out of Top Hit

## Validation
- `npm ci`
- `npm run lint`
- `npm run build`
- `npm run dev`
- local Fuse/pinyin dependency check using `网易首页` and `wangyi`
- reviewed the fully staged diff, including the new source file, for credentials, local Orion data, personal paths, and email addresses

## Privacy
No user data, database files, credentials, or screenshots are included. When enabled, live suggestions continue to send only the text typed into Command Bar to the user-selected search engine; selecting a limit of zero prevents those requests.