### PR TITLE
Update graphcalc extension

### DIFF
--- a/extensions/graphcalc/CHANGELOG.md
+++ b/extensions/graphcalc/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GraphCalc Changelog
 
-## [Fix missing graph line on Windows] - {PR_MERGE_DATE}
+## [Fix missing graph line on Windows] - 2026-09-13
 
 - Fixed the plotted line not being rendered on Windows. The SVG used Raycast `Color` tokens (e.g. `raycast-yellow`) as the stroke color, which the image renderer cannot interpret; they are now resolved to concrete hex colors adapted to light/dark appearance
 - Fixes https://github.com/raycast/extensions/issues/24231

--- a/extensions/graphcalc/CHANGELOG.md
+++ b/extensions/graphcalc/CHANGELOG.md
@@ -1,5 +1,10 @@
 # GraphCalc Changelog
 
+## [Fix missing graph line on Windows] - {PR_MERGE_DATE}
+
+- Fixed the plotted line not being rendered on Windows. The SVG used Raycast `Color` tokens (e.g. `raycast-yellow`) as the stroke color, which the image renderer cannot interpret; they are now resolved to concrete hex colors adapted to light/dark appearance
+- Fixes https://github.com/raycast/extensions/issues/24231
+
 ## [SVG Rendering Rewrite and Dependency Cleanup] - 2025-12-12
 
 - Replaced recharts library with custom pure SVG rendering for better compatibility

--- a/extensions/graphcalc/src/components/Graph.tsx
+++ b/extensions/graphcalc/src/components/Graph.tsx
@@ -85,10 +85,10 @@ const Graph: React.FC<GraphProps> = ({ expression }) => {
         !error &&
         result === null && (
           <ActionPanel>
-            <Action title="Zoom In" onAction={zoomIn} />
-            <Action title="Zoom Out" onAction={zoomOut} />
+            <Action title="Zoom in" onAction={zoomIn} />
+            <Action title="Zoom out" onAction={zoomOut} />
             <Action
-              title="Move Up"
+              title="Move up"
               onAction={moveUp}
               shortcut={{ modifiers: ["cmd", "shift"], key: "arrowUp" }}
             />

--- a/extensions/graphcalc/src/constants/index.ts
+++ b/extensions/graphcalc/src/constants/index.ts
@@ -24,3 +24,23 @@ export const INITIAL_Y_MAX = 5;
 export const NUM_POINTS = 1000;
 
 export const DEFAULT_LINE_COLOR = Color.Yellow;
+
+/**
+ * Raycast `Color` values are opaque tokens (e.g. "raycast-yellow"), not real
+ * CSS colors. They work in Raycast-managed UI (icons, tags, ...) but the
+ * markdown image renderer does not resolve them inside an inline SVG, so a
+ * `stroke="raycast-yellow"` path is simply invisible (notably on Windows).
+ * This maps each token to a concrete hex color per appearance.
+ *
+ * Values are chosen so every color keeps a contrast ratio >= 3:1 (WCAG AA
+ * for graphics) against typical light (#F2F2F7) and dark (#1E1E1E) backgrounds.
+ */
+export const LINE_COLOR_HEX: Record<string, { light: string; dark: string }> = {
+  [Color.Blue]: { light: "#0A7AFF", dark: "#3B9EFF" },
+  [Color.Green]: { light: "#1F9D55", dark: "#30D158" },
+  [Color.Magenta]: { light: "#E0338A", dark: "#FF5FA0" },
+  [Color.Orange]: { light: "#D46500", dark: "#FF9F0A" },
+  [Color.Purple]: { light: "#8E44D9", dark: "#BF5AF2" },
+  [Color.Red]: { light: "#E5352B", dark: "#FF453A" },
+  [Color.Yellow]: { light: "#A67C00", dark: "#FFD60A" },
+};

--- a/extensions/graphcalc/src/utils/renderUtils.tsx
+++ b/extensions/graphcalc/src/utils/renderUtils.tsx
@@ -1,4 +1,19 @@
 import { DataPoint } from "../types";
+import { LINE_COLOR_HEX } from "../constants";
+
+/**
+ * Resolves a line color to something an SVG renderer understands.
+ * Raycast `Color` tokens ("raycast-yellow", ...) are mapped to hex values;
+ * anything else (hex, rgb(), named colors) is passed through untouched.
+ */
+export function resolveLineColor(
+  lineColor: string,
+  theme: "light" | "dark" | null,
+): string {
+  const mapped = LINE_COLOR_HEX[lineColor];
+  if (!mapped) return lineColor;
+  return theme === "dark" ? mapped.dark : mapped.light;
+}
 
 export function renderGraphToSVG(
   expression: string,
@@ -18,6 +33,7 @@ export function renderGraphToSVG(
   const gridColor =
     theme === "dark" ? "rgba(255, 255, 255, 0.1)" : "rgba(0, 0, 0, 0.1)";
   const textColor = theme === "dark" ? "#FFFFFF" : "#000000";
+  const strokeColor = resolveLineColor(lineColor, theme);
 
   const [xMin, xMax] = xDomain;
   const [yMin, yMax] = yDomain;
@@ -80,7 +96,7 @@ export function renderGraphToSVG(
           })
           .join(" ");
 
-        return `<path d="${pathData}" stroke="${lineColor}" stroke-width="2" fill="none" />`;
+        return `<path d="${pathData}" stroke="${strokeColor}" stroke-width="2" fill="none" />`;
       })
       .filter((p) => p !== "");
 


### PR DESCRIPTION
## Description

Fix: https://github.com/raycast/extensions/issues/24231

On Windows the graph rendered its grid and axes but no curve, because the plotted line's stroke was set to a Raycast Color token (e.g. raycast-yellow) that isn't a valid SVG color; macOS happened to resolve it, Windows didn't. The fix resolves those tokens to concrete hex colors (with light/dark variants) when generating the SVG.

Also clean up some warnings.

If I have time I will create a better system of themes and the ability to copy/paste the image. But I keep this pr focus in the issue.


## Screencast

<img width="777" height="495" alt="Screenshot 2026-09-12 at 3 29 10 PM" src="https://github.com/user-attachments/assets/dd5f659c-4f3c-4861-8828-c5ffb05b4ad7" />


## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used by the `README` are placed outside of the `metadata` folder
