### PR TITLE
[Pomodoro] Add Skip to Next interval

### DIFF
--- a/extensions/pomodoro/CHANGELOG.md
+++ b/extensions/pomodoro/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Skip to Next] - {PR_MERGE_DATE}
 
 - Add Skip to Next (⌘N) to jump from the current interval to the next one in the control command, menu bar, Slack variant, and Raycast AI
+- Fix interval history entries being overwritten when the pomodoro counter resets
 
 ## [Updated contributor] - 2026-08-18
 

--- a/extensions/pomodoro/CHANGELOG.md
+++ b/extensions/pomodoro/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Pomodoro Changelog
 
+## [Skip to Next] - {PR_MERGE_DATE}
+
+- Add Skip to Next (⌘N) to jump from the current interval to the next one in the control command, menu bar, Slack variant, and Raycast AI
+
 ## [Updated contributor] - 2026-08-18
 
 ## [Fixes] - 2026-05-16

--- a/extensions/pomodoro/CHANGELOG.md
+++ b/extensions/pomodoro/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Pomodoro Changelog
 
-## [Skip to Next] - {PR_MERGE_DATE}
+## [Skip to Next] - 2026-09-13
 
 - Add Skip to Next (⌘N) to jump from the current interval to the next one in the control command, menu bar, Slack variant, and Raycast AI
 - Fix interval history entries being overwritten when the pomodoro counter resets

--- a/extensions/pomodoro/package.json
+++ b/extensions/pomodoro/package.json
@@ -113,6 +113,11 @@
       "name": "continue-timer",
       "title": "Continue Timer",
       "description": "Continues the paused pomodoro timer"
+    },
+    {
+      "name": "skip-timer",
+      "title": "Skip Timer",
+      "description": "Skips the current interval and starts the next one"
     }
   ],
   "ai": {
@@ -203,6 +208,19 @@
           }
         ],
         "input": "@pomodoro continue the timer"
+      },
+      {
+        "mocks": {
+          "skip-timer": "Skipped to Short Break"
+        },
+        "expected": [
+          {
+            "callsTool": {
+              "name": "skip-timer"
+            }
+          }
+        ],
+        "input": "@pomodoro skip to the next interval"
       },
       {
         "input": "@pomodoro start a 4min 30 sec timer",

--- a/extensions/pomodoro/src/lib/constants.ts
+++ b/extensions/pomodoro/src/lib/constants.ts
@@ -1,4 +1,12 @@
+import { IntervalType } from "./types";
+
 export const FocusText = "Focus";
 export const ShortBreakText = "Short Break";
 export const LongBreakText = "Long Break";
 export const TimeStoppedPlaceholder = "--:--";
+
+export const IntervalTitles: Record<IntervalType, string> = {
+  focus: FocusText,
+  "short-break": ShortBreakText,
+  "long-break": LongBreakText,
+};

--- a/extensions/pomodoro/src/lib/intervals.tsx
+++ b/extensions/pomodoro/src/lib/intervals.tsx
@@ -63,7 +63,8 @@ export function createInterval(type: IntervalType, isFreshStart?: boolean, custo
 
   const interval: Interval = {
     type,
-    id: completedCount,
+    // Unique per interval so history upserts never overwrite an earlier entry when the counter resets.
+    id: Date.now(),
     length: customDuration || intervalDurations[type],
     parts: [
       {

--- a/extensions/pomodoro/src/lib/intervals.tsx
+++ b/extensions/pomodoro/src/lib/intervals.tsx
@@ -8,8 +8,17 @@ const cache = new Cache();
 const CURRENT_INTERVAL_CACHE_KEY = "pomodoro-interval/1.1";
 const COMPLETED_POMODORO_COUNT_CACHE_KEY = "pomodoro-interval/completed-pomodoro-count";
 const POMODORO_INTERVAL_HISTORY = "pomodoro-interval/history";
+const LAST_INTERVAL_ID_CACHE_KEY = "pomodoro-interval/last-id";
 
 const currentTimestamp = () => Math.round(new Date().valueOf() / 1000);
+
+// Monotonic, so history upserts never overwrite an earlier entry even if two intervals start in the same millisecond.
+function nextIntervalId(): number {
+  const lastId = parseInt(cache.get(LAST_INTERVAL_ID_CACHE_KEY) ?? "0", 10);
+  const id = Math.max(Date.now(), lastId + 1);
+  cache.set(LAST_INTERVAL_ID_CACHE_KEY, id.toString());
+  return id;
+}
 
 export async function getIntervalHistory(): Promise<Interval[]> {
   const history = await LocalStorage.getItem(POMODORO_INTERVAL_HISTORY);
@@ -63,8 +72,7 @@ export function createInterval(type: IntervalType, isFreshStart?: boolean, custo
 
   const interval: Interval = {
     type,
-    // Unique per interval so history upserts never overwrite an earlier entry when the counter resets.
-    id: Date.now(),
+    id: nextIntervalId(),
     length: customDuration || intervalDurations[type],
     parts: [
       {

--- a/extensions/pomodoro/src/lib/intervals.tsx
+++ b/extensions/pomodoro/src/lib/intervals.tsx
@@ -1,5 +1,5 @@
 import { Cache, LaunchType, LocalStorage, getPreferenceValues, launchCommand } from "@raycast/api";
-import { FocusText, LongBreakText, ShortBreakText } from "./constants";
+import { IntervalTitles } from "./constants";
 import { enableFocusWhileFocused, setDND } from "./doNotDisturb";
 import { Interval, IntervalExecutor, IntervalType } from "./types";
 
@@ -120,6 +120,29 @@ export function restartInterval() {
   }
 }
 
+export function getNextIntervalType(currentType?: IntervalType): IntervalType {
+  if (currentType === "short-break" || currentType === "long-break") {
+    return "focus";
+  }
+
+  const completedCount = getCompletedPomodoroCount();
+  const longBreakThreshold = parseInt(preferences.longBreakStartThreshold, 10);
+  return completedCount === longBreakThreshold ? "long-break" : "short-break";
+}
+
+export function skipInterval(): Interval | undefined {
+  const currentInterval = getCurrentInterval();
+  if (!currentInterval) {
+    return;
+  }
+
+  const interval = createInterval(getNextIntervalType(currentInterval.type), false);
+  if (currentInterval.type === "focus") {
+    setDND(false);
+  }
+  return interval;
+}
+
 export function getCurrentInterval(): Interval | undefined {
   const result = cache.get(CURRENT_INTERVAL_CACHE_KEY);
   if (result) {
@@ -159,37 +182,14 @@ export function getCompletedPomodoroCount(): number {
 
 export function getNextIntervalExecutor(): IntervalExecutor {
   const currentInterval = getCurrentInterval();
+  const nextType = getNextIntervalType(currentInterval?.type);
   resetInterval();
 
-  const completedCount = getCompletedPomodoroCount();
-  const longBreakThreshold = parseInt(preferences.longBreakStartThreshold, 10);
-  let executor: IntervalExecutor | undefined;
-  switch (currentInterval?.type) {
-    case "short-break":
-      executor = {
-        title: FocusText,
-        onStart: () => createInterval("focus", false),
-      };
-      break;
-    case "long-break":
-      executor = { title: FocusText, onStart: () => createInterval("focus") };
-      break;
-    default:
-      if (completedCount === longBreakThreshold) {
-        executor = {
-          title: LongBreakText,
-          onStart: () => createInterval("long-break"),
-        };
-      } else {
-        executor = {
-          title: ShortBreakText,
-          onStart: () => createInterval("short-break", false),
-        };
-      }
-      break;
-  }
-
-  return executor;
+  return {
+    title: IntervalTitles[nextType],
+    // Auto-advance keeps counting toward the long-break threshold; only an explicit fresh start resets the counter.
+    onStart: () => createInterval(nextType, false),
+  };
 }
 
 export const preferences = getPreferenceValues<Preferences>();

--- a/extensions/pomodoro/src/lib/slack/slackIntervals.ts
+++ b/extensions/pomodoro/src/lib/slack/slackIntervals.ts
@@ -1,16 +1,16 @@
-import { getPreferenceValues } from "@raycast/api";
+import { setDND } from "../doNotDisturb";
 import {
   continueInterval,
   createInterval,
-  getCompletedPomodoroCount,
   getCurrentInterval,
+  getNextIntervalType,
   intervalDurations,
   pauseInterval,
   resetInterval,
 } from "../intervals";
 import { Interval, IntervalType } from "../types";
 import { clearStatus, endSnooze, setSnooze, setStatus } from "./slackAPI";
-import { FocusText, LongBreakText, ShortBreakText } from "../constants";
+import { IntervalTitles } from "../constants";
 
 export async function slackCreateInterval(intervalType: IntervalType, slackToken: string, isFreshStart = true) {
   const intervalMinutes = intervalDurations[intervalType] / 60;
@@ -61,47 +61,36 @@ export async function slackRestartInterval(slackToken: string) {
   }
 }
 
-export function getNextSlackIntervalExecutor() {
+export async function slackSkipInterval(slackToken: string) {
   const currentInterval = getCurrentInterval();
-  resetInterval();
-
-  const preferences = getPreferenceValues();
-  const completedCount = getCompletedPomodoroCount();
-  const longBreakThreshold = parseInt(preferences.longBreakStartThreshold, 10);
-  let executor: {
-    title: string;
-    onStart: (slackToken: string) => Promise<Interval | undefined>;
-  };
-
-  switch (currentInterval?.type) {
-    case "short-break":
-      executor = {
-        title: FocusText,
-        onStart: async (slackToken) => await slackCreateInterval("focus", slackToken, false),
-      };
-      break;
-    case "long-break":
-      executor = {
-        title: FocusText,
-        onStart: async (slackToken) => slackCreateInterval("focus", slackToken),
-      };
-      break;
-    default:
-      if (completedCount === longBreakThreshold) {
-        executor = {
-          title: LongBreakText,
-          onStart: async (slackToken) => await slackCreateInterval("long-break", slackToken),
-        };
-      } else {
-        executor = {
-          title: ShortBreakText,
-          onStart: async (slackToken) => await slackCreateInterval("short-break", slackToken, false),
-        };
-      }
-      break;
+  if (!currentInterval) {
+    return;
   }
 
-  return executor;
+  const nextType = getNextIntervalType(currentInterval.type);
+  const interval = await slackCreateInterval(nextType, slackToken, isFreshStart(currentInterval.type, nextType));
+  if (currentInterval.type === "focus") {
+    setDND(false);
+  }
+  return interval;
+}
+
+export function getNextSlackIntervalExecutor() {
+  const currentInterval = getCurrentInterval();
+  const nextType = getNextIntervalType(currentInterval?.type);
+  resetInterval();
+
+  return {
+    title: IntervalTitles[nextType],
+    onStart: async (slackToken: string) =>
+      slackCreateInterval(nextType, slackToken, isFreshStart(currentInterval?.type, nextType)),
+  };
+}
+
+// The Slack flow resets the completed-pomodoro counter whenever a long break starts or ends.
+// Shared by skip and auto-advance so both transitions count identically.
+function isFreshStart(currentType: IntervalType | undefined, nextType: IntervalType): boolean {
+  return currentType === "long-break" || nextType === "long-break";
 }
 
 const getRemainingTime = (interval: Interval): number => {

--- a/extensions/pomodoro/src/lib/timer.ts
+++ b/extensions/pomodoro/src/lib/timer.ts
@@ -1,6 +1,6 @@
 import { launchCommand, LaunchType } from "@raycast/api";
 import { checkDNDExtensionInstall, setDND } from "./doNotDisturb";
-import { continueInterval, createInterval, pauseInterval, resetInterval } from "./intervals";
+import { continueInterval, createInterval, pauseInterval, resetInterval, skipInterval } from "./intervals";
 import { IntervalType } from "./types";
 
 export async function startTimer(type: IntervalType, duration?: number) {
@@ -27,6 +27,13 @@ export async function stopTimer() {
   setDND(false);
   await refreshMenuBar();
   return "Timer stopped";
+}
+
+export async function skipTimer() {
+  await checkDNDExtensionInstall();
+  const interval = skipInterval();
+  await refreshMenuBar();
+  return interval;
 }
 
 async function refreshMenuBar() {

--- a/extensions/pomodoro/src/pomodoro-control-timer.tsx
+++ b/extensions/pomodoro/src/pomodoro-control-timer.tsx
@@ -7,13 +7,15 @@ import {
   createInterval,
   getCurrentInterval,
   getNextIntervalExecutor,
+  getNextIntervalType,
   isPaused,
   pauseInterval,
   preferences,
   resetInterval,
   restartInterval,
+  skipInterval,
 } from "./lib/intervals";
-import { FocusText, ShortBreakText, LongBreakText } from "./lib/constants";
+import { FocusText, IntervalTitles, ShortBreakText, LongBreakText } from "./lib/constants";
 import { GiphyResponse, Interval, Quote } from "./lib/types";
 import { checkDNDExtensionInstall } from "./lib/doNotDisturb";
 
@@ -36,6 +38,9 @@ const createAction = (action: () => void) => () => {
 const ActionsList = () => {
   const currentInterval = getCurrentInterval();
   checkDNDExtensionInstall();
+  const skipAction = currentInterval ? (
+    <Action onAction={createAction(skipInterval)} title={"Skip to Next"} shortcut={{ modifiers: ["cmd"], key: "n" }} />
+  ) : null;
 
   return (
     <List navigationTitle="Control Pomodoro Timers">
@@ -48,6 +53,7 @@ const ActionsList = () => {
               actions={
                 <ActionPanel>
                   <Action onAction={createAction(continueInterval)} title={"Continue"} />
+                  {skipAction}
                 </ActionPanel>
               }
             />
@@ -58,6 +64,7 @@ const ActionsList = () => {
               actions={
                 <ActionPanel>
                   <Action onAction={createAction(pauseInterval)} title={"Pause"} />
+                  {skipAction}
                 </ActionPanel>
               }
             />
@@ -68,6 +75,7 @@ const ActionsList = () => {
             actions={
               <ActionPanel>
                 <Action onAction={createAction(resetInterval)} title={"Reset"} />
+                {skipAction}
               </ActionPanel>
             }
           />
@@ -77,8 +85,15 @@ const ActionsList = () => {
             actions={
               <ActionPanel>
                 <Action onAction={createAction(restartInterval)} title={"Restart Current"} />
+                {skipAction}
               </ActionPanel>
             }
+          />
+          <List.Item
+            title="Skip to Next"
+            subtitle={IntervalTitles[getNextIntervalType(currentInterval.type)]}
+            icon={Icon.Forward}
+            actions={<ActionPanel>{skipAction}</ActionPanel>}
           />
         </>
       ) : (

--- a/extensions/pomodoro/src/pomodoro-menu-bar.tsx
+++ b/extensions/pomodoro/src/pomodoro-menu-bar.tsx
@@ -1,9 +1,10 @@
 import { MenuBarExtra, Icon, Image, Color } from "@raycast/api";
 import { useState } from "react";
-import { FocusText, LongBreakText, ShortBreakText, TimeStoppedPlaceholder } from "./lib/constants";
+import { FocusText, IntervalTitles, LongBreakText, ShortBreakText, TimeStoppedPlaceholder } from "./lib/constants";
 import {
   createInterval,
   getCurrentInterval,
+  getNextIntervalType,
   resetInterval,
   restartInterval,
   pauseInterval,
@@ -13,6 +14,7 @@ import {
   preferences,
   progress,
   endOfInterval,
+  skipInterval,
 } from "./lib/intervals";
 import { secondsToTime } from "./lib/secondsToTime";
 import { Interval, IntervalType } from "./lib/types";
@@ -53,6 +55,11 @@ export default function TogglePomodoroTimer() {
   function onRestart() {
     restartInterval();
     setCurrentInterval(getCurrentInterval());
+  }
+
+  async function onSkip() {
+    await checkDNDExtensionInstall();
+    setCurrentInterval(skipInterval());
   }
 
   let icon: Image.ImageLike;
@@ -100,6 +107,13 @@ export default function TogglePomodoroTimer() {
             icon={Icon.Repeat}
             onAction={onRestart}
             shortcut={{ modifiers: ["cmd"], key: "t" }}
+          />
+          <MenuBarExtra.Item
+            title="Skip to Next"
+            subtitle={IntervalTitles[getNextIntervalType(currentInterval.type)]}
+            icon={Icon.Forward}
+            onAction={onSkip}
+            shortcut={{ modifiers: ["cmd"], key: "n" }}
           />
         </>
       ) : (

--- a/extensions/pomodoro/src/slack-pomodoro-control-timer.tsx
+++ b/extensions/pomodoro/src/slack-pomodoro-control-timer.tsx
@@ -2,8 +2,8 @@ import { Detail, launchCommand, LaunchType, closeMainWindow, popToRoot, List, Ic
 import { ActionPanel, Action } from "@raycast/api";
 import { OAuthService, getAccessToken, useFetch, withAccessToken } from "@raycast/utils";
 import { exec } from "child_process";
-import { getCurrentInterval, isPaused, preferences } from "./lib/intervals";
-import { FocusText, ShortBreakText, LongBreakText } from "./lib/constants";
+import { getCurrentInterval, getNextIntervalType, isPaused, preferences } from "./lib/intervals";
+import { FocusText, IntervalTitles, ShortBreakText, LongBreakText } from "./lib/constants";
 import { GiphyResponse, Interval } from "./lib/types";
 import {
   getNextSlackIntervalExecutor,
@@ -12,6 +12,7 @@ import {
   slackPauseInterval,
   slackResetInterval,
   slackRestartInterval,
+  slackSkipInterval,
 } from "./lib/slack/slackIntervals";
 
 const createAction = (action: () => Promise<void> | Promise<Interval | undefined>) => async () => {
@@ -33,6 +34,14 @@ const createAction = (action: () => Promise<void> | Promise<Interval | undefined
 const ActionsList = () => {
   const currentInterval = getCurrentInterval();
   const { token } = getAccessToken();
+  const skipAction = currentInterval ? (
+    <Action
+      onAction={createAction(async () => slackSkipInterval(token))}
+      title={"Skip to Next"}
+      shortcut={{ modifiers: ["cmd"], key: "n" }}
+    />
+  ) : null;
+
   return (
     <List navigationTitle="Control Pomodoro Timers">
       {currentInterval ? (
@@ -44,6 +53,7 @@ const ActionsList = () => {
               actions={
                 <ActionPanel>
                   <Action onAction={createAction(async () => slackContinueInterval(token))} title={"Continue"} />
+                  {skipAction}
                 </ActionPanel>
               }
             />
@@ -54,6 +64,7 @@ const ActionsList = () => {
               actions={
                 <ActionPanel>
                   <Action onAction={createAction(async () => slackPauseInterval(token))} title={"Pause"} />
+                  {skipAction}
                 </ActionPanel>
               }
             />
@@ -64,6 +75,7 @@ const ActionsList = () => {
             actions={
               <ActionPanel>
                 <Action onAction={createAction(async () => slackResetInterval(token))} title={"Reset"} />
+                {skipAction}
               </ActionPanel>
             }
           />
@@ -73,8 +85,15 @@ const ActionsList = () => {
             actions={
               <ActionPanel>
                 <Action onAction={createAction(async () => slackRestartInterval(token))} title={"Restart Current"} />
+                {skipAction}
               </ActionPanel>
             }
+          />
+          <List.Item
+            title="Skip to Next"
+            subtitle={IntervalTitles[getNextIntervalType(currentInterval.type)]}
+            icon={Icon.Forward}
+            actions={<ActionPanel>{skipAction}</ActionPanel>}
           />
         </>
       ) : (

--- a/extensions/pomodoro/src/slack-pomodoro-menu-bar.tsx
+++ b/extensions/pomodoro/src/slack-pomodoro-menu-bar.tsx
@@ -1,7 +1,15 @@
 import { MenuBarExtra, Icon, launchCommand, LaunchType, Image, Color } from "@raycast/api";
 import { useState } from "react";
-import { FocusText, LongBreakText, ShortBreakText, TimeStoppedPlaceholder } from "./lib/constants";
-import { getCurrentInterval, isPaused, duration, preferences, progress, resetInterval } from "./lib/intervals";
+import { FocusText, IntervalTitles, LongBreakText, ShortBreakText, TimeStoppedPlaceholder } from "./lib/constants";
+import {
+  getCurrentInterval,
+  getNextIntervalType,
+  isPaused,
+  duration,
+  preferences,
+  progress,
+  resetInterval,
+} from "./lib/intervals";
 import { secondsToTime } from "./lib/secondsToTime";
 import { Interval, IntervalType } from "./lib/types";
 import { OAuthService, usePromise } from "@raycast/utils";
@@ -11,6 +19,7 @@ import {
   slackPauseInterval,
   slackResetInterval,
   slackRestartInterval,
+  slackSkipInterval,
 } from "./lib/slack/slackIntervals";
 
 const IconTint: Color.Dynamic = {
@@ -78,6 +87,14 @@ export default function TogglePomodoroTimer() {
       return;
     }
     await slackRestartInterval(token);
+    setCurrentInterval(getCurrentInterval());
+  }
+
+  async function onSkip() {
+    if (!token) {
+      return;
+    }
+    await slackSkipInterval(token);
     setCurrentInterval(getCurrentInterval());
   }
 
@@ -153,6 +170,13 @@ export default function TogglePomodoroTimer() {
             icon={Icon.Repeat}
             onAction={onRestart}
             shortcut={{ modifiers: ["cmd"], key: "t" }}
+          />
+          <MenuBarExtra.Item
+            title="Skip to Next"
+            subtitle={IntervalTitles[getNextIntervalType(currentInterval.type)]}
+            icon={Icon.Forward}
+            onAction={onSkip}
+            shortcut={{ modifiers: ["cmd"], key: "n" }}
           />
         </>
       ) : (

--- a/extensions/pomodoro/src/tools/skip-timer.ts
+++ b/extensions/pomodoro/src/tools/skip-timer.ts
@@ -1,0 +1,13 @@
+import { IntervalTitles } from "../lib/constants";
+import { getCurrentInterval } from "../lib/intervals";
+import { skipTimer } from "../lib/timer";
+
+export default async function () {
+  const currentInterval = getCurrentInterval();
+  if (!currentInterval) {
+    return "No active timer";
+  }
+
+  const nextInterval = await skipTimer();
+  return nextInterval ? `Skipped to ${IntervalTitles[nextInterval.type]}` : "No active timer";
+}


### PR DESCRIPTION
## Description

Adds **Skip to Next** (⌘N) so you can jump from the current Pomodoro interval to the next one in the cycle (focus → short/long break → focus).

Available from:
- Control Pomodoro Timer (and the Slack variant)
- The menu bar extra
- Raycast AI via a new `skip-timer` tool

Skipped intervals are not counted as completed in stats. Slack snooze/status and Do Not Disturb follow the same next-interval rules as auto-advance.

## Screencast

Not a new command — this is an action on the existing control/menu-bar commands. Happy to add a short recording if useful for review.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)

## Test plan

- [x] Start a focus interval, then **Skip to Next** / ⌘N from the menu bar — should start a short (or long) break
- [x] Skip a break — should start focus
- [x] Confirm the same from **Control Pomodoro Timer**
- [x] Confirm Slack variant updates snooze/status when skipping
- [x] Ask Raycast AI to skip the current interval