### PR TITLE
[Dokploy] Add View Logs action to Services

### DIFF
--- a/extensions/dokploy/CHANGELOG.md
+++ b/extensions/dokploy/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [View Service Logs] - {PR_MERGE_DATE}
 
-- Add a `View Logs` action to the **Services** screen, showing the last 200 lines of a service's logs with `Refresh` and `Copy Logs` actions.
+- Add a `View Logs` action to the **Services** screen, showing the last 200 lines of a service's logs with `Refresh` and `Copy Logs` actions. Not yet available for Compose stacks, which need a container to be picked first.
 
 ## [Service Lifecycle Actions] - 2026-09-13
 

--- a/extensions/dokploy/CHANGELOG.md
+++ b/extensions/dokploy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Dokploy Changelog
 
+## [View Service Logs] - {PR_MERGE_DATE}
+
+- Add a `View Logs` action to the **Services** screen, showing the last 200 lines of a service's logs with `Refresh` and `Copy Logs` actions.
+
 ## [Service Lifecycle Actions] - 2026-09-13
 
 - Add `Deploy`, `Redeploy`/`Rebuild`, `Start`, `Stop` and `Reload` actions to the **Services** screen, so a service can be managed without leaving Raycast.

--- a/extensions/dokploy/README.md
+++ b/extensions/dokploy/README.md
@@ -12,6 +12,7 @@ This is a Raycast extension for [Dokploy](https://dokploy.com/) - _Deploy Anywhe
         - Create Database
         - Deploy / Redeploy / Rebuild Service
         - Start / Stop / Reload Service
+        - View Service Logs
         - Delete Service
     - View Docker (Containers)
         - View Docker Config

--- a/extensions/dokploy/src/service-logs.tsx
+++ b/extensions/dokploy/src/service-logs.tsx
@@ -25,7 +25,12 @@ export default function ServiceLogs({ service }: { service: { id: string; type: 
     url + `${service.type}.readLogs?${ID_FIELDS[service.type]}=${service.id}&tail=${LOG_TAIL}`,
     {
       headers,
-      parseResponse: (response) => response.text(),
+      parseResponse: async (response) => {
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+        return response.text();
+      },
       initialData: "",
       keepPreviousData: true,
     },
@@ -35,7 +40,7 @@ export default function ServiceLogs({ service }: { service: { id: string; type: 
     <Detail
       navigationTitle={`${service.name} Logs`}
       isLoading={isLoading}
-      markdown={logs ? `\`\`\`\n${logs}\n\`\`\`` : "No logs yet."}
+      markdown={logs ? `\`\`\`\n${logs.replace(/```/g, "\\`\\`\\`")}\n\`\`\`` : "No logs yet."}
       actions={
         <ActionPanel>
           <Action icon={Icon.ArrowClockwise} title="Refresh" onAction={() => revalidate()} />

--- a/extensions/dokploy/src/service-logs.tsx
+++ b/extensions/dokploy/src/service-logs.tsx
@@ -1,0 +1,47 @@
+import { Action, ActionPanel, Detail, Icon } from "@raycast/api";
+import { useFetch } from "@raycast/utils";
+import { useToken } from "./instances";
+
+const ID_FIELDS: Record<string, string> = {
+  application: "applicationId",
+  mariadb: "mariadbId",
+  mongo: "mongoId",
+  mysql: "mysqlId",
+  postgres: "postgresId",
+  redis: "redisId",
+  compose: "composeId",
+};
+
+const LOG_TAIL = 200;
+
+export default function ServiceLogs({ service }: { service: { id: string; type: string; name: string } }) {
+  const { url, headers } = useToken();
+
+  const {
+    isLoading,
+    data: logs,
+    revalidate,
+  } = useFetch<string, string>(
+    url + `${service.type}.readLogs?${ID_FIELDS[service.type]}=${service.id}&tail=${LOG_TAIL}`,
+    {
+      headers,
+      parseResponse: (response) => response.text(),
+      initialData: "",
+      keepPreviousData: true,
+    },
+  );
+
+  return (
+    <Detail
+      navigationTitle={`${service.name} Logs`}
+      isLoading={isLoading}
+      markdown={logs ? `\`\`\`\n${logs}\n\`\`\`` : "No logs yet."}
+      actions={
+        <ActionPanel>
+          <Action icon={Icon.ArrowClockwise} title="Refresh" onAction={() => revalidate()} />
+          <Action.CopyToClipboard icon={Icon.Clipboard} title="Copy Logs" content={logs} />
+        </ActionPanel>
+      }
+    />
+  );
+}

--- a/extensions/dokploy/src/services.tsx
+++ b/extensions/dokploy/src/services.tsx
@@ -14,6 +14,7 @@ import {
 import { useFetch, useForm, FormValidation } from "@raycast/utils";
 import { useToken } from "./instances";
 import { Server, Service, ErrorResult } from "./interfaces";
+import ServiceLogs from "./service-logs";
 import type { ServiceScope } from "./utils";
 import { getTotalServices } from "./utils";
 
@@ -292,6 +293,7 @@ export default function Services({
                       onAction={() => runServiceAction(service, action)}
                     />
                   ))}
+                  <Action.Push icon={Icon.Terminal} title="View Logs" target={<ServiceLogs service={service} />} />
                 </ActionPanel.Section>
                 <Action
                   icon={Icon.Trash}

--- a/extensions/dokploy/src/services.tsx
+++ b/extensions/dokploy/src/services.tsx
@@ -293,7 +293,10 @@ export default function Services({
                       onAction={() => runServiceAction(service, action)}
                     />
                   ))}
-                  <Action.Push icon={Icon.Terminal} title="View Logs" target={<ServiceLogs service={service} />} />
+                  {/* compose.readLogs requires a containerId, which this screen doesn't have; leave compose out until that's picked. */}
+                  {service.type !== "compose" && (
+                    <Action.Push icon={Icon.Terminal} title="View Logs" target={<ServiceLogs service={service} />} />
+                  )}
                 </ActionPanel.Section>
                 <Action
                   icon={Icon.Trash}


### PR DESCRIPTION
## Description

Adds a `View Logs` action to the **Services** screen, showing the last 200 lines of a service's logs (via its `readLogs` route) in a Detail view, with `Refresh` and `Copy Logs` actions.

Uses the same per-kind id field lookup already used for the lifecycle actions added in #31048. Compose stacks can scope logs to one container on Dokploy's side, but this first version calls the same route uniformly across all kinds and leaves per-container scoping for a follow-up if it turns out to be needed.

This is another small, focused piece following up on #29418.

## Screencast

Adds one new action and screen off the existing Services list. Happy to add a screencast if it helps review.

## Checklist

- [x] I read the extension guidelines
- [x] I read the documentation about publishing
- [x] I ran `npm run build` and tested this distribution build in Raycast
- [x] I checked that files in the assets folder are used by the extension itself
- [x] I checked that assets used in the README are located outside the metadata folder